### PR TITLE
feat(security): Checkov/Trivy/Terrascan/KICS scanner plugins (#4)

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1136,6 +1136,9 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 	// Policy engines — builtin + OPA (embedded) + Conftest + Sentinel (shell-out).
 	registerPolicyRoutes(mux, projectsDir)
 
+	// Security scanner plugins — graph + Checkov + Trivy + Terrascan + KICS.
+	registerScannerRoutes(mux, projectsDir)
+
 	return mux
 }
 

--- a/internal/api/scanners.go
+++ b/internal/api/scanners.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -147,10 +146,6 @@ func filterScanners(scans []scanners.Scanner, filter []string) []scanners.Scanne
 	}
 	return out
 }
-
-// Keep context referenced so goimports can't strip the import through the
-// indirect r.Context() usage above.
-var _ = context.Background
 
 // ciWorkflowYAML is the GitHub Actions workflow template emitted by
 // /api/security/scanners/ci-workflow. Runs each scanner independently with

--- a/internal/api/scanners.go
+++ b/internal/api/scanners.go
@@ -1,0 +1,223 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/iac-studio/iac-studio/internal/parser"
+	"github.com/iac-studio/iac-studio/internal/security/scanners"
+	"github.com/iac-studio/iac-studio/internal/security/scanners/checkov"
+	"github.com/iac-studio/iac-studio/internal/security/scanners/kics"
+	"github.com/iac-studio/iac-studio/internal/security/scanners/terrascan"
+	"github.com/iac-studio/iac-studio/internal/security/scanners/trivy"
+)
+
+// defaultSecurityScanners is the list of scanners registered on startup.
+// Order controls the UI's default presentation — graph first because it's
+// always available and IaC Studio's differentiated capability; the wrapped
+// third-party tools follow alphabetically so the list is stable.
+func defaultSecurityScanners() []scanners.Scanner {
+	return []scanners.Scanner{
+		scanners.NewGraph(),
+		checkov.New(),
+		kics.New(),
+		terrascan.New(),
+		trivy.New(),
+	}
+}
+
+// scannersRunRequest is the body for POST /api/projects/{name}/security/scanners/run.
+// ScannerFilter, when non-empty, limits the run to the named scanners.
+// Unknown names are dropped silently — they're informational (maybe the UI
+// is behind a server upgrade that added a scanner), not a client bug.
+type scannersRunRequest struct {
+	ScannerFilter []string `json:"scanners,omitempty"`
+	Tool          string   `json:"tool,omitempty"`
+}
+
+// scannersRunResponse carries the per-scanner Results plus a merged
+// Findings feed already sorted severity-first so the UI renders a single
+// list without re-sorting.
+type scannersRunResponse struct {
+	Results  []scanners.Result  `json:"results"`
+	Findings []scanners.Finding `json:"findings"`
+	Blocking bool               `json:"blocking"`
+}
+
+// registerScannerRoutes wires the scanner endpoints onto mux. Called from
+// NewRouter so the HTTP surface is discovered in one place.
+func registerScannerRoutes(mux *http.ServeMux, projectsDir string) {
+	scans := defaultSecurityScanners()
+
+	// Lists every registered scanner plus its availability. The UI uses this
+	// to render "Checkov: not installed" hints next to greyed-out toggles.
+	mux.HandleFunc("GET /api/security/scanners", func(w http.ResponseWriter, r *http.Request) {
+		type scannerView struct {
+			Name      string `json:"name"`
+			Available bool   `json:"available"`
+		}
+		out := make([]scannerView, 0, len(scans))
+		for _, s := range scans {
+			out = append(out, scannerView{Name: s.Name(), Available: s.Available()})
+		}
+		_ = json.NewEncoder(w).Encode(out)
+	})
+
+	// Runs every registered scanner (optionally filtered) against the project
+	// and returns a unified Findings feed.
+	mux.HandleFunc("POST /api/projects/{name}/security/scanners/run", func(w http.ResponseWriter, r *http.Request) {
+		limitBody(w, r)
+		name := r.PathValue("name")
+		projectPath, err := safeProjectPath(projectsDir, name)
+		if err != nil {
+			http.Error(w, err.Error(), 400)
+			return
+		}
+
+		var req scannersRunRequest
+		// Empty body (EOF) is fine — means "run all scanners, parse code for
+		// resources". Malformed JSON is a client bug that should 400.
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err != io.EOF {
+			http.Error(w, "invalid request body: "+err.Error(), 400)
+			return
+		}
+
+		tool := req.Tool
+		if tool == "" {
+			tool = "terraform"
+		}
+		var resources []parser.Resource
+		if p := parser.ForTool(tool); p != nil {
+			if parsed, perr := p.ParseDir(projectPath); perr == nil {
+				resources = parsed
+			}
+		}
+
+		selected := filterScanners(scans, req.ScannerFilter)
+		results := scanners.RunAll(r.Context(), selected, scanners.ScanInput{
+			ProjectDir: projectPath,
+			Resources:  resources,
+			Tool:       tool,
+		})
+		findings := scanners.MergeFindings(results)
+
+		blocking := false
+		for _, f := range findings {
+			if scanners.IsBlocking(f.Severity) {
+				blocking = true
+				break
+			}
+		}
+
+		_ = json.NewEncoder(w).Encode(scannersRunResponse{
+			Results:  results,
+			Findings: findings,
+			Blocking: blocking,
+		})
+	})
+
+	// Generates a .github/workflows/iac-scan.yml that runs the same scanner
+	// set in CI. Keeps local and CI output identical so CI doesn't flag
+	// something users haven't already seen locally.
+	mux.HandleFunc("GET /api/security/scanners/ci-workflow", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/yaml; charset=utf-8")
+		w.Header().Set("Content-Disposition", `attachment; filename="iac-scan.yml"`)
+		_, _ = io.WriteString(w, ciWorkflowYAML)
+	})
+}
+
+// filterScanners returns the subset of scans whose Name matches one of the
+// names in filter. An empty filter returns the full list unchanged. Unknown
+// filter entries are dropped silently.
+func filterScanners(scans []scanners.Scanner, filter []string) []scanners.Scanner {
+	if len(filter) == 0 {
+		return scans
+	}
+	wanted := make(map[string]struct{}, len(filter))
+	for _, n := range filter {
+		wanted[n] = struct{}{}
+	}
+	out := make([]scanners.Scanner, 0, len(scans))
+	for _, s := range scans {
+		if _, ok := wanted[s.Name()]; ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// Keep context referenced so goimports can't strip the import through the
+// indirect r.Context() usage above.
+var _ = context.Background
+
+// ciWorkflowYAML is the GitHub Actions workflow template emitted by
+// /api/security/scanners/ci-workflow. Runs each scanner independently with
+// continue-on-error so one missing CLI doesn't block the rest, then uploads
+// each tool's native report as an artifact for auditors.
+const ciWorkflowYAML = `# Generated by IaC Studio — runs the same scanner set the studio does locally.
+# Drop into .github/workflows/iac-scan.yml and commit to enforce parity between
+# local development and CI.
+
+name: IaC Security Scan
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Checkov
+        uses: bridgecrewio/checkov-action@master
+        continue-on-error: true
+        with:
+          directory: .
+          output_format: json
+          output_file_path: checkov-report.json
+          soft_fail: true
+
+      - name: Trivy (config / IaC)
+        uses: aquasecurity/trivy-action@master
+        continue-on-error: true
+        with:
+          scan-type: config
+          scan-ref: .
+          format: json
+          output: trivy-report.json
+          exit-code: '0'
+
+      - name: Terrascan
+        uses: tenable/terrascan-action@main
+        continue-on-error: true
+        with:
+          iac_type: terraform
+          only_warn: true
+
+      - name: KICS
+        uses: checkmarx/kics-github-action@master
+        continue-on-error: true
+        with:
+          path: .
+          output_path: kics-report
+          output_formats: json
+          fail_on: high
+
+      - name: Upload reports
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: iac-security-reports
+          path: |
+            checkov-report.json
+            trivy-report.json
+            kics-report/
+            terrascan.sarif.json
+          if-no-files-found: ignore
+`

--- a/internal/api/scanners_test.go
+++ b/internal/api/scanners_test.go
@@ -1,0 +1,178 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/iac-studio/iac-studio/internal/security/scanners"
+)
+
+// scaffoldScannerProject writes a tiny project tree with the given HCL — all
+// we need for the API-level tests to exercise the route and the parser.
+func scaffoldScannerProject(t *testing.T, hcl string) string {
+	t.Helper()
+	root := t.TempDir()
+	project := filepath.Join(root, "demo")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(project, "main.tf"), []byte(hcl), 0o644); err != nil {
+		t.Fatalf("write main.tf: %v", err)
+	}
+	return root
+}
+
+// scannerMux wires just the scanner routes onto a fresh mux — enough for
+// endpoint-level tests without the full NewRouter stack.
+func scannerMux(projectsDir string) *http.ServeMux {
+	mux := http.NewServeMux()
+	registerScannerRoutes(mux, projectsDir)
+	return mux
+}
+
+// TestScannersListReportsAvailability — every registered scanner shows up
+// and the graph scanner always reports Available=true.
+func TestScannersListReportsAvailability(t *testing.T) {
+	srv := httptest.NewServer(scannerMux(t.TempDir()))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/security/scanners")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	var out []struct {
+		Name      string `json:"name"`
+		Available bool   `json:"available"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	avail := map[string]bool{}
+	for _, s := range out {
+		avail[s.Name] = s.Available
+	}
+	for _, want := range []string{"graph", "checkov", "kics", "terrascan", "trivy"} {
+		if _, ok := avail[want]; !ok {
+			t.Errorf("scanner %q missing from response: %+v", want, out)
+		}
+	}
+	if !avail["graph"] {
+		t.Error("graph scanner must always be available")
+	}
+}
+
+// TestScannersRunGraphOnly — an exposed S3 bucket triggers the graph
+// scanner's cross-resource checks; the response should surface those
+// findings with Blocking=true if severity is high/critical.
+func TestScannersRunGraphOnly(t *testing.T) {
+	hcl := `resource "aws_s3_bucket" "public_data" {
+  bucket = "demo"
+  acl    = "public-read"
+}
+`
+	root := scaffoldScannerProject(t, hcl)
+	srv := httptest.NewServer(scannerMux(root))
+	defer srv.Close()
+
+	body, _ := json.Marshal(map[string]any{"scanners": []string{"graph"}})
+	resp, err := http.Post(srv.URL+"/api/projects/demo/security/scanners/run", "application/json", strings.NewReader(string(body)))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var got scannersRunResponse
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Results) != 1 || got.Results[0].Scanner != "graph" {
+		t.Fatalf("expected a single graph result, got %+v", got.Results)
+	}
+	if len(got.Findings) == 0 {
+		t.Fatal("graph scanner should have produced findings for public-read bucket")
+	}
+	// Findings list is sorted severity-first so the UI renders a stable feed.
+	if got.Findings[0].Severity == scanners.SeverityInfo {
+		t.Errorf("first finding should not be info when exposed buckets are present: %+v", got.Findings[0])
+	}
+}
+
+// TestScannersRunUnknownFilterDropsSilently — an unknown scanner name in the
+// filter should NOT 400 (filters are informational) — it just drops that
+// name and runs the rest.
+func TestScannersRunUnknownFilterDropsSilently(t *testing.T) {
+	root := scaffoldScannerProject(t, `# empty`)
+	srv := httptest.NewServer(scannerMux(root))
+	defer srv.Close()
+
+	body, _ := json.Marshal(map[string]any{"scanners": []string{"made-up", "graph"}})
+	resp, err := http.Post(srv.URL+"/api/projects/demo/security/scanners/run", "application/json", strings.NewReader(string(body)))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var got scannersRunResponse
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Results) != 1 || got.Results[0].Scanner != "graph" {
+		t.Errorf("expected only graph result, got: %+v", got.Results)
+	}
+}
+
+// TestScannersRunMalformedBody400 — guards the contract we agreed with
+// reviewers: empty body is fine, malformed JSON is a client bug that 400s.
+func TestScannersRunMalformedBody400(t *testing.T) {
+	root := scaffoldScannerProject(t, `# empty`)
+	srv := httptest.NewServer(scannerMux(root))
+	defer srv.Close()
+
+	resp, _ := http.Post(srv.URL+"/api/projects/demo/security/scanners/run", "application/json", strings.NewReader("{not json"))
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != 400 {
+		t.Errorf("malformed JSON should 400, got %d", resp.StatusCode)
+	}
+}
+
+// TestCIWorkflowExportServesYAML — the generator endpoint returns a non-empty
+// YAML body with the right Content-Type and filename.
+func TestCIWorkflowExportServesYAML(t *testing.T) {
+	srv := httptest.NewServer(scannerMux(t.TempDir()))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/security/scanners/ci-workflow")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != 200 {
+		t.Errorf("status = %d", resp.StatusCode)
+	}
+	ct := resp.Header.Get("Content-Type")
+	if !strings.HasPrefix(ct, "text/yaml") {
+		t.Errorf("Content-Type should be text/yaml, got %q", ct)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "name: IaC Security Scan") {
+		t.Errorf("workflow body missing expected header:\n%s", string(body))
+	}
+	// Every scanner we ship should have a step in the emitted workflow.
+	for _, tool := range []string{"Checkov", "Trivy", "Terrascan", "KICS"} {
+		if !strings.Contains(string(body), tool) {
+			t.Errorf("workflow missing step for %s", tool)
+		}
+	}
+}

--- a/internal/security/scanners/checkov/checkov.go
+++ b/internal/security/scanners/checkov/checkov.go
@@ -1,0 +1,180 @@
+// Package checkov shells out to the Checkov CLI against the project directory.
+//
+// Checkov is one of the most widely deployed IaC security scanners in CI
+// pipelines. It ships hundreds of built-in policies covering CIS / NIST /
+// PCI / HIPAA / SOC2 plus custom policy support. The adapter runs
+//
+//	checkov -d <projectDir> -o json --quiet --skip-path ...
+//
+// and normalises the failed_checks array into the unified Finding shape.
+// A graceful "not installed" path returns an informative Error so the
+// multi-scanner pass keeps working for users who only have the built-in
+// graph scanner.
+package checkov
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/iac-studio/iac-studio/internal/security/scanners"
+)
+
+// Binary is the name (or full path) of the checkov CLI. Overridable for
+// tests that stand in a shell-scripted fake on disk.
+var Binary = "checkov"
+
+type checkovScanner struct{}
+
+// New constructs the Checkov scanner. Available() probes the binary at Scan
+// time so a fresh install during server runtime is picked up on the next
+// scan.
+func New() scanners.Scanner { return &checkovScanner{} }
+
+func (c *checkovScanner) Name() string { return "checkov" }
+
+func (c *checkovScanner) Available() bool {
+	_, err := exec.LookPath(Binary)
+	return err == nil
+}
+
+// checkovReport mirrors the relevant subset of Checkov's --output json shape.
+// Checkov emits either a single object (when only one framework runs) or an
+// array of one object per framework. We always normalise to the array form.
+type checkovReport struct {
+	CheckType string        `json:"check_type"`
+	Results   checkovCheckset `json:"results"`
+}
+
+type checkovCheckset struct {
+	FailedChecks []checkovCheck `json:"failed_checks"`
+	// passed_checks / parsing_errors / skipped_checks intentionally not
+	// modeled — findings are the only thing we surface today.
+}
+
+type checkovCheck struct {
+	CheckID      string          `json:"check_id"`
+	CheckName    string          `json:"check_name"`
+	Severity     string          `json:"severity"` // uppercase in Checkov output
+	Guideline    string          `json:"guideline"`
+	FilePath     string          `json:"file_path"`
+	FileLineRange []int          `json:"file_line_range"`
+	Resource     string          `json:"resource"` // e.g., "aws_s3_bucket.data"
+	Description  string          `json:"description,omitempty"`
+	BCCheckID    string          `json:"bc_check_id,omitempty"`
+	Details      json.RawMessage `json:"details,omitempty"`
+}
+
+func (c *checkovScanner) Scan(ctx context.Context, in scanners.ScanInput) (scanners.Result, error) {
+	res := scanners.Result{Scanner: c.Name()}
+	if !c.Available() {
+		res.Error = "checkov CLI not found on PATH — install from https://www.checkov.io to enable this scanner"
+		return res, nil
+	}
+	res.Available = true
+
+	if in.ProjectDir == "" {
+		res.Error = "checkov scanner requires a project directory"
+		return res, nil
+	}
+	// Short-circuit for Ansible-only projects. Checkov supports Ansible but
+	// that isn't the primary use case here, and running Checkov against a
+	// pure-Ansible project produces noise without findings. Tool is
+	// informational — we still scan when empty.
+	if in.Tool == "ansible" {
+		return res, nil
+	}
+
+	cmd := exec.CommandContext(ctx, Binary,
+		"-d", in.ProjectDir,
+		"--output", "json",
+		"--quiet",                        // drop framing banners
+		"--soft-fail",                    // exit 0 even when findings exist
+		"--framework", "terraform_plan,terraform",
+	)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil && stdout.Len() == 0 {
+		res.Error = formatExecError(err, stderr.Bytes())
+		return res, err
+	}
+
+	reports, err := decodeReports(stdout.Bytes())
+	if err != nil {
+		res.Error = fmt.Sprintf("checkov output not valid JSON: %v", err)
+		return res, err
+	}
+	for _, rep := range reports {
+		for _, check := range rep.Results.FailedChecks {
+			res.Findings = append(res.Findings, scanners.Finding{
+				ID:          check.CheckID,
+				Severity:    normaliseSeverity(check.Severity),
+				Category:    "compliance",
+				Framework:   "Checkov",
+				Title:       check.CheckName,
+				Description: check.Description,
+				Resources:   []string{check.Resource},
+				Remediation: check.Guideline,
+			})
+		}
+	}
+	return res, nil
+}
+
+// decodeReports accepts Checkov's dual output shape (single object OR array)
+// and always returns an array, so downstream code has one case to handle.
+func decodeReports(data []byte) ([]checkovReport, error) {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 {
+		return nil, nil
+	}
+	// Array form.
+	if trimmed[0] == '[' {
+		var out []checkovReport
+		if err := json.Unmarshal(trimmed, &out); err != nil {
+			return nil, err
+		}
+		return out, nil
+	}
+	// Single-object form.
+	var single checkovReport
+	if err := json.Unmarshal(trimmed, &single); err != nil {
+		return nil, err
+	}
+	return []checkovReport{single}, nil
+}
+
+// normaliseSeverity maps Checkov's uppercase labels to the scanner-world
+// lowercase vocabulary defined in scanners/scanners.go. "CRITICAL" → "critical".
+// Unknown values fall through to "info" so a missing severity never blocks
+// apply accidentally.
+func normaliseSeverity(s string) string {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "critical":
+		return scanners.SeverityCritical
+	case "high":
+		return scanners.SeverityHigh
+	case "medium":
+		return scanners.SeverityMedium
+	case "low":
+		return scanners.SeverityLow
+	}
+	return scanners.SeverityInfo
+}
+
+// formatExecError prefers the explicit stderr buffer so users see Checkov's
+// actual complaint instead of a bare exit code. ExitError.Stderr is used as
+// a last-resort fallback.
+func formatExecError(err error, stderr []byte) string {
+	if len(stderr) > 0 {
+		return fmt.Sprintf("checkov: %s", strings.TrimSpace(string(stderr)))
+	}
+	if ee, ok := err.(*exec.ExitError); ok && len(ee.Stderr) > 0 {
+		return fmt.Sprintf("checkov: %s", strings.TrimSpace(string(ee.Stderr)))
+	}
+	return fmt.Sprintf("checkov: %v", err)
+}

--- a/internal/security/scanners/checkov/checkov_test.go
+++ b/internal/security/scanners/checkov/checkov_test.go
@@ -1,0 +1,210 @@
+package checkov
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"testing"
+
+	"github.com/iac-studio/iac-studio/internal/security/scanners"
+)
+
+// fakeBinary writes a POSIX shell script that echoes stdout and exits with
+// the given code. Skipped on Windows — the whole adapter shells out, so the
+// tests are inherently POSIX-only on our CI.
+func fakeBinary(t *testing.T, stdout string, exitCode int) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-scripted fake binary not supported on Windows")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "checkov")
+	// Single-quoted heredoc delimiter → body emitted verbatim, no expansion.
+	script := "#!/usr/bin/env bash\ncat <<'IAC_EOF'\n" + stdout + "\nIAC_EOF\nexit " + strconv.Itoa(exitCode) + "\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake: %v", err)
+	}
+	return path
+}
+
+// TestCheckovNotAvailable — the binary-missing path must not crash the
+// multi-scanner pass; Available() returns false and Result.Error explains.
+func TestCheckovNotAvailable(t *testing.T) {
+	orig := Binary
+	t.Cleanup(func() { Binary = orig })
+	Binary = "/nonexistent/checkov-please-dont-exist"
+
+	res, err := New().Scan(context.Background(), scanners.ScanInput{ProjectDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Available {
+		t.Error("Available() should be false when binary is missing")
+	}
+	if res.Error == "" {
+		t.Error("Result.Error should explain the missing binary")
+	}
+}
+
+// TestCheckovParsesArrayOutput verifies the dual-shape decoder handles the
+// array form Checkov emits when multiple frameworks run, mapping each
+// failed_check to a Finding with the right severity and framework.
+func TestCheckovParsesArrayOutput(t *testing.T) {
+	body := `[
+      {
+        "check_type": "terraform",
+        "results": {
+          "failed_checks": [
+            {
+              "check_id": "CKV_AWS_18",
+              "check_name": "Ensure the S3 bucket has access logging enabled",
+              "severity": "MEDIUM",
+              "guideline": "https://docs.bridgecrew.io/docs/s3_13",
+              "file_path": "/demo/main.tf",
+              "file_line_range": [1, 6],
+              "resource": "aws_s3_bucket.data",
+              "description": "logging is required"
+            },
+            {
+              "check_id": "CKV_AWS_20",
+              "check_name": "Ensure the S3 bucket does not allow public access",
+              "severity": "HIGH",
+              "resource": "aws_s3_bucket.data"
+            }
+          ]
+        }
+      }
+    ]`
+	orig := Binary
+	t.Cleanup(func() { Binary = orig })
+	Binary = fakeBinary(t, body, 0)
+
+	res, err := New().Scan(context.Background(), scanners.ScanInput{ProjectDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if !res.Available {
+		t.Fatalf("available should be true with fake binary: %+v", res)
+	}
+	if len(res.Findings) != 2 {
+		t.Fatalf("want 2 findings, got %d: %+v", len(res.Findings), res.Findings)
+	}
+	var sawHigh, sawMedium bool
+	for _, f := range res.Findings {
+		if f.Framework != "Checkov" {
+			t.Errorf("framework should be Checkov, got %q", f.Framework)
+		}
+		switch f.Severity {
+		case scanners.SeverityHigh:
+			sawHigh = true
+		case scanners.SeverityMedium:
+			sawMedium = true
+		}
+		if len(f.Resources) == 0 {
+			t.Errorf("finding should carry resource address: %+v", f)
+		}
+	}
+	if !sawHigh || !sawMedium {
+		t.Errorf("severity map missed expected inputs: %+v", res.Findings)
+	}
+}
+
+// TestCheckovParsesSingleObjectOutput — when only one framework runs,
+// Checkov emits a bare object rather than an array. The decoder must
+// handle both shapes.
+func TestCheckovParsesSingleObjectOutput(t *testing.T) {
+	body := `{
+      "check_type": "terraform",
+      "results": {
+        "failed_checks": [
+          {
+            "check_id": "CKV_AWS_21",
+            "check_name": "Ensure all data stored in the S3 bucket is securely encrypted at rest",
+            "severity": "CRITICAL",
+            "resource": "aws_s3_bucket.data"
+          }
+        ]
+      }
+    }`
+	orig := Binary
+	t.Cleanup(func() { Binary = orig })
+	Binary = fakeBinary(t, body, 0)
+
+	res, err := New().Scan(context.Background(), scanners.ScanInput{ProjectDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(res.Findings) != 1 {
+		t.Fatalf("want 1 finding, got %d", len(res.Findings))
+	}
+	if res.Findings[0].Severity != scanners.SeverityCritical {
+		t.Errorf("severity should be critical, got %q", res.Findings[0].Severity)
+	}
+}
+
+// TestCheckovAnsibleShortCircuit — Ansible-only projects return a clean
+// empty Result instead of running Checkov unnecessarily.
+func TestCheckovAnsibleShortCircuit(t *testing.T) {
+	orig := Binary
+	t.Cleanup(func() { Binary = orig })
+	// Fake that would crash if actually invoked — ensures we short-circuit
+	// before exec.
+	Binary = fakeBinary(t, "should not be called", 99)
+
+	res, err := New().Scan(context.Background(), scanners.ScanInput{ProjectDir: t.TempDir(), Tool: "ansible"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.Available {
+		t.Error("Available should be true — binary exists even though we skip")
+	}
+	if len(res.Findings) != 0 {
+		t.Errorf("Ansible project should produce no Checkov findings, got %+v", res.Findings)
+	}
+}
+
+// TestCheckovRequiresProjectDir — the adapter surfaces a clear message when
+// called without a project directory.
+func TestCheckovRequiresProjectDir(t *testing.T) {
+	orig := Binary
+	t.Cleanup(func() { Binary = orig })
+	Binary = fakeBinary(t, "[]", 0)
+
+	res, _ := New().Scan(context.Background(), scanners.ScanInput{})
+	if res.Error == "" {
+		t.Error("Result.Error should explain missing project dir")
+	}
+}
+
+// TestCheckovMalformedOutput — when stdout isn't JSON, surface the decode
+// error on Result.Error instead of crashing.
+func TestCheckovMalformedOutput(t *testing.T) {
+	orig := Binary
+	t.Cleanup(func() { Binary = orig })
+	Binary = fakeBinary(t, "not json at all", 0)
+
+	_, err := New().Scan(context.Background(), scanners.ScanInput{ProjectDir: t.TempDir()})
+	if err == nil {
+		t.Error("malformed JSON should surface as an error")
+	}
+}
+
+// TestCheckovNormaliseSeverity pins the uppercase → lowercase mapping so a
+// future adapter edit can't silently drop severity classifications.
+func TestCheckovNormaliseSeverity(t *testing.T) {
+	cases := map[string]string{
+		"CRITICAL": scanners.SeverityCritical,
+		"High":     scanners.SeverityHigh,
+		"medium":   scanners.SeverityMedium,
+		"LOW":      scanners.SeverityLow,
+		"":         scanners.SeverityInfo, // empty severity → info, never blocking
+		"weird":    scanners.SeverityInfo,
+	}
+	for in, want := range cases {
+		if got := normaliseSeverity(in); got != want {
+			t.Errorf("normaliseSeverity(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/security/scanners/graph.go
+++ b/internal/security/scanners/graph.go
@@ -1,0 +1,39 @@
+package scanners
+
+import (
+	"context"
+
+	"github.com/iac-studio/iac-studio/internal/security"
+)
+
+// graphScanner wraps the legacy internal/security.Scanner — the graph-based
+// cross-resource attack-path analyzer — behind the Scanner interface so it
+// runs alongside the shell-out adapters in a unified multi-scanner pass.
+//
+// It's the one scanner that's genuinely unique to IaC Studio (others are
+// thin wrappers around third-party tools), so we keep it registered first
+// and always-available.
+type graphScanner struct {
+	inner *security.Scanner
+}
+
+// NewGraph constructs the default-built-in graph scanner. No arguments because
+// the underlying Scanner is stateless.
+func NewGraph() Scanner {
+	return &graphScanner{inner: security.New()}
+}
+
+func (g *graphScanner) Name() string    { return "graph" }
+func (g *graphScanner) Available() bool { return true }
+
+func (g *graphScanner) Scan(_ context.Context, in ScanInput) (Result, error) {
+	res := Result{Scanner: g.Name(), Available: true}
+	if len(in.Resources) == 0 {
+		// Empty project → nothing to analyse. Not an error — keeps the
+		// multi-scanner pass quiet on fresh projects.
+		return res, nil
+	}
+	report := g.inner.Scan(in.Resources)
+	res.Findings = append(res.Findings, report.Findings...)
+	return res, nil
+}

--- a/internal/security/scanners/kics/kics.go
+++ b/internal/security/scanners/kics/kics.go
@@ -1,0 +1,188 @@
+// Package kics shells out to the KICS CLI against the project.
+//
+// KICS (Keeping Infrastructure as Code Secure) is Checkmarx's open-source
+// IaC scanner — broad rule coverage across Terraform, CloudFormation,
+// Kubernetes manifests, Dockerfile, and more. Rule coverage overlaps with
+// Checkov and Trivy but often catches distinct issues, so running all
+// three in a multi-scanner pass is the intended use case.
+//
+// Runs:
+//
+//	kics scan -p <projectDir> -o <tmpdir> --report-formats json
+//
+// KICS writes the report to a file (no stdout option for json), so we
+// stage a tempdir, let it write, then read + parse results.json.
+package kics
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/iac-studio/iac-studio/internal/security/scanners"
+)
+
+// Binary is the name (or full path) of the kics CLI. Overridable for tests.
+var Binary = "kics"
+
+type kicsScanner struct{}
+
+// New constructs the KICS scanner.
+func New() scanners.Scanner { return &kicsScanner{} }
+
+func (k *kicsScanner) Name() string { return "kics" }
+
+func (k *kicsScanner) Available() bool {
+	_, err := exec.LookPath(Binary)
+	return err == nil
+}
+
+// kicsReport mirrors the subset of KICS's results.json we consume. Findings
+// are nested under queries[].files[] — one query can fire on multiple files.
+type kicsReport struct {
+	Queries []kicsQuery `json:"queries"`
+}
+
+type kicsQuery struct {
+	QueryName  string     `json:"query_name"`
+	QueryID    string     `json:"query_id"`
+	Severity   string     `json:"severity"` // HIGH|MEDIUM|LOW|INFO
+	Category   string     `json:"category"`
+	CISDescription string `json:"cis_description_title"`
+	Description string    `json:"description"`
+	Files      []kicsFile `json:"files"`
+}
+
+type kicsFile struct {
+	FileName       string `json:"file_name"`
+	Line           int    `json:"line"`
+	ResourceType   string `json:"resource_type"`
+	ResourceName   string `json:"resource_name"`
+	IssueType      string `json:"issue_type"`
+	ExpectedValue  string `json:"expected_value"`
+	ActualValue    string `json:"actual_value"`
+}
+
+func (k *kicsScanner) Scan(ctx context.Context, in scanners.ScanInput) (scanners.Result, error) {
+	res := scanners.Result{Scanner: k.Name()}
+	if !k.Available() {
+		res.Error = "kics CLI not found on PATH — install from https://kics.io to enable this scanner"
+		return res, nil
+	}
+	res.Available = true
+
+	if in.ProjectDir == "" {
+		res.Error = "kics scanner requires a project directory"
+		return res, nil
+	}
+	if in.Tool == "ansible" {
+		return res, nil
+	}
+
+	// KICS writes its JSON report to a file; stage a tempdir we can clean
+	// up unconditionally on return.
+	tmp, err := os.MkdirTemp("", "kics-report-*")
+	if err != nil {
+		res.Error = fmt.Sprintf("kics tempdir: %v", err)
+		return res, err
+	}
+	defer func() { _ = os.RemoveAll(tmp) }()
+
+	cmd := exec.CommandContext(ctx, Binary,
+		"scan",
+		"-p", in.ProjectDir,
+		"-o", tmp,
+		"--report-formats", "json",
+		"--silent",
+	)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	// KICS exits 50 when it finds issues — that's the documented
+	// "vulnerabilities found" code, not a runtime error. We distinguish
+	// by checking whether the results file exists.
+	_ = cmd.Run()
+
+	reportPath := filepath.Join(tmp, "results.json")
+	data, readErr := os.ReadFile(reportPath)
+	if readErr != nil {
+		// No results file means the run genuinely failed — surface stderr
+		// so the user sees KICS's actual complaint.
+		res.Error = formatExecError(readErr, stderr.Bytes())
+		return res, readErr
+	}
+
+	var report kicsReport
+	if err := json.Unmarshal(bytes.TrimSpace(data), &report); err != nil {
+		res.Error = fmt.Sprintf("kics results.json not valid JSON: %v", err)
+		return res, err
+	}
+	for _, q := range report.Queries {
+		for _, f := range q.Files {
+			resource := f.ResourceType + "." + f.ResourceName
+			if f.ResourceName == "" {
+				resource = f.FileName
+			}
+			res.Findings = append(res.Findings, scanners.Finding{
+				ID:          q.QueryID,
+				Severity:    normaliseSeverity(q.Severity),
+				Category:    firstNonEmpty(strings.ToLower(q.Category), "compliance"),
+				Framework:   "KICS",
+				Title:       q.QueryName,
+				Description: firstNonEmpty(q.CISDescription, q.Description),
+				Resources:   []string{resource},
+				Remediation: formatKICSRemediation(f),
+			})
+		}
+	}
+	return res, nil
+}
+
+// formatKICSRemediation composes a readable hint from expected/actual values
+// when present. KICS doesn't have a free-text Remediation field the way
+// Checkov/Trivy do; the expected-vs-actual pair is the closest surrogate.
+func formatKICSRemediation(f kicsFile) string {
+	if f.ExpectedValue != "" && f.ActualValue != "" {
+		return fmt.Sprintf("expected %s, got %s", f.ExpectedValue, f.ActualValue)
+	}
+	if f.ExpectedValue != "" {
+		return "expected " + f.ExpectedValue
+	}
+	return ""
+}
+
+// normaliseSeverity: KICS emits HIGH / MEDIUM / LOW / INFO. Note there's no
+// CRITICAL in KICS's scheme — its HIGH already covers what other tools call
+// critical, so we map HIGH → "high" rather than "critical" to stay consistent
+// with the IsBlocking threshold.
+func normaliseSeverity(s string) string {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "high":
+		return scanners.SeverityHigh
+	case "medium":
+		return scanners.SeverityMedium
+	case "low":
+		return scanners.SeverityLow
+	}
+	return scanners.SeverityInfo
+}
+
+func firstNonEmpty(ss ...string) string {
+	for _, s := range ss {
+		if strings.TrimSpace(s) != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+func formatExecError(readErr error, stderr []byte) string {
+	if len(stderr) > 0 {
+		return fmt.Sprintf("kics: %s", strings.TrimSpace(string(stderr)))
+	}
+	return fmt.Sprintf("kics: no results file written (%v)", readErr)
+}

--- a/internal/security/scanners/kics/kics_test.go
+++ b/internal/security/scanners/kics/kics_test.go
@@ -1,0 +1,196 @@
+package kics
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/iac-studio/iac-studio/internal/security/scanners"
+)
+
+// fakeBinary writes a shell script that receives KICS-style flags, writes a
+// pre-specified results.json into the -o output directory, and exits with
+// the KICS convention (50 when findings exist, 0 when clean). The stdout
+// argument is unused by KICS itself — we pass it via a synthetic file write
+// path instead.
+func fakeBinary(t *testing.T, resultsJSON string, exitCode int) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-scripted fake binary not supported on Windows")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kics")
+	// The fake parses its own CLI to find the value after `-o`, writes
+	// results.json there, then exits. Keeps the fake faithful to real KICS
+	// behaviour without needing us to mock the flag parser in Go.
+	script := fmt.Sprintf(`#!/usr/bin/env bash
+outdir=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o) outdir="$2"; shift 2;;
+    *)  shift;;
+  esac
+done
+mkdir -p "$outdir"
+cat > "$outdir/results.json" <<'IAC_EOF'
+%s
+IAC_EOF
+exit %d
+`, resultsJSON, exitCode)
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake: %v", err)
+	}
+	return path
+}
+
+func TestKICSNotAvailable(t *testing.T) {
+	orig := Binary
+	t.Cleanup(func() { Binary = orig })
+	Binary = "/nonexistent/kics"
+
+	res, err := New().Scan(context.Background(), scanners.ScanInput{ProjectDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Available || res.Error == "" {
+		t.Errorf("expected unavailable + Error, got %+v", res)
+	}
+}
+
+// TestKICSParsesQueriesAndFiles — each query.files[] entry becomes a
+// Finding. KICS has a many-to-many shape (one query, many files) that the
+// adapter flattens correctly.
+func TestKICSParsesQueriesAndFiles(t *testing.T) {
+	body := `{
+      "queries": [
+        {
+          "query_name": "S3 Bucket ACL Allows Read to All Users",
+          "query_id": "38c5ee0d-7f22-4260-ab72-5073048df100",
+          "severity": "HIGH",
+          "category": "Access Control",
+          "description": "S3 bucket ACL must not grant public read",
+          "files": [
+            {
+              "file_name": "main.tf",
+              "line": 5,
+              "resource_type": "aws_s3_bucket",
+              "resource_name": "data",
+              "expected_value": "acl should not be 'public-read'",
+              "actual_value": "acl = 'public-read'"
+            },
+            {
+              "file_name": "logs.tf",
+              "line": 3,
+              "resource_type": "aws_s3_bucket",
+              "resource_name": "access_logs",
+              "expected_value": "acl should not be 'public-read'",
+              "actual_value": "acl = 'public-read'"
+            }
+          ]
+        },
+        {
+          "query_name": "RDS instance without encryption",
+          "query_id": "abc-123",
+          "severity": "MEDIUM",
+          "files": [
+            {
+              "file_name": "database.tf",
+              "resource_type": "aws_db_instance",
+              "resource_name": "primary"
+            }
+          ]
+        }
+      ]
+    }`
+	orig := Binary
+	t.Cleanup(func() { Binary = orig })
+	Binary = fakeBinary(t, body, 50) // KICS exits 50 when vulnerabilities found
+
+	res, err := New().Scan(context.Background(), scanners.ScanInput{ProjectDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(res.Findings) != 3 {
+		t.Fatalf("want 3 findings (2 from first query + 1 from second), got %d: %+v", len(res.Findings), res.Findings)
+	}
+	var sawHigh, sawMedium bool
+	for _, f := range res.Findings {
+		if f.Framework != "KICS" {
+			t.Errorf("framework should be KICS, got %q", f.Framework)
+		}
+		switch f.Severity {
+		case scanners.SeverityHigh:
+			sawHigh = true
+		case scanners.SeverityMedium:
+			sawMedium = true
+		}
+	}
+	if !sawHigh || !sawMedium {
+		t.Errorf("severity map missed expected inputs: %+v", res.Findings)
+	}
+	// Remediation should be composed from expected/actual when present.
+	for _, f := range res.Findings {
+		if f.Severity == scanners.SeverityHigh && f.Remediation == "" {
+			t.Errorf("HIGH findings had expected/actual values — remediation should be populated: %+v", f)
+		}
+	}
+}
+
+// TestKICSNoResultsFile — if KICS crashed before writing results.json, the
+// adapter should surface a clear error instead of pretending the scan passed.
+func TestKICSNoResultsFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-scripted fake binary not supported on Windows")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kics")
+	// A fake that exits non-zero without writing results.json.
+	script := "#!/usr/bin/env bash\necho 'boom' >&2\nexit 1\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake: %v", err)
+	}
+	orig := Binary
+	t.Cleanup(func() { Binary = orig })
+	Binary = path
+
+	_, err := New().Scan(context.Background(), scanners.ScanInput{ProjectDir: t.TempDir()})
+	if err == nil {
+		t.Error("missing results.json should surface as an error")
+	}
+}
+
+func TestKICSAnsibleShortCircuit(t *testing.T) {
+	orig := Binary
+	t.Cleanup(func() { Binary = orig })
+	Binary = fakeBinary(t, "{}", 0)
+
+	res, err := New().Scan(context.Background(), scanners.ScanInput{ProjectDir: t.TempDir(), Tool: "ansible"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res.Findings) != 0 {
+		t.Errorf("Ansible project should short-circuit, got %+v", res.Findings)
+	}
+}
+
+// TestKICSNormaliseSeverity — KICS has no CRITICAL; HIGH is its top tier.
+// We map it to "high" (not "critical") so IsBlocking still gates, but the
+// unified display reflects the tool's own hierarchy.
+func TestKICSNormaliseSeverity(t *testing.T) {
+	cases := map[string]string{
+		"HIGH":   scanners.SeverityHigh,
+		"Medium": scanners.SeverityMedium,
+		"low":    scanners.SeverityLow,
+		"":       scanners.SeverityInfo,
+		"INFO":   scanners.SeverityInfo,
+		"weird":  scanners.SeverityInfo,
+	}
+	for in, want := range cases {
+		if got := normaliseSeverity(in); got != want {
+			t.Errorf("normaliseSeverity(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/security/scanners/scanners.go
+++ b/internal/security/scanners/scanners.go
@@ -119,7 +119,7 @@ func RunAll(ctx context.Context, scanners []Scanner, in ScanInput) []Result {
 
 // MergeFindings flattens results into a single fully-ordered finding slice.
 // The sort is layered so ties are broken deterministically across runs:
-// severity → scanner → id → title → resources.
+// severity → framework → id → title → resources.
 func MergeFindings(results []Result) []Finding {
 	var all []Finding
 	for _, r := range results {
@@ -129,6 +129,9 @@ func MergeFindings(results []Result) []Finding {
 		a, b := all[i], all[j]
 		if a.Severity != b.Severity {
 			return severityRank(a.Severity) < severityRank(b.Severity)
+		}
+		if a.Framework != b.Framework {
+			return a.Framework < b.Framework
 		}
 		if a.ID != b.ID {
 			return a.ID < b.ID

--- a/internal/security/scanners/scanners.go
+++ b/internal/security/scanners/scanners.go
@@ -1,0 +1,167 @@
+// Package scanners is the multi-scanner IaC security surface.
+//
+// A Scanner takes a ScanInput (project directory, parsed resources) and
+// produces a Result of [security.Finding] values. The interface is
+// deliberately minimal so a wide range of tools fit:
+//
+//   - the built-in graph scanner (no external binary, walks cross-resource
+//     attack paths — the differentiated capability we already had);
+//   - Checkov / Trivy / Terrascan / KICS shelled out against the project
+//     directory, each with its own JSON output format normalised to the
+//     shared Finding shape.
+//
+// Scanners that don't apply to the current project return an empty Result
+// without error — for example, Checkov returns nothing when run against a
+// directory with no .tf files.
+//
+// All scanners flow into the same Findings slice so the API, UI, and
+// potential CI export can reason about results uniformly.
+package scanners
+
+import (
+	"context"
+	"sort"
+
+	"github.com/iac-studio/iac-studio/internal/parser"
+	"github.com/iac-studio/iac-studio/internal/security"
+)
+
+// Finding is the engine-agnostic representation used by every scanner, aliased
+// to the existing security.Finding so the API response shape doesn't change.
+type Finding = security.Finding
+
+// Severity string constants match the values the existing security package
+// already emits so aggregating across scanners keeps a single vocabulary.
+const (
+	SeverityCritical = "critical"
+	SeverityHigh     = "high"
+	SeverityMedium   = "medium"
+	SeverityLow      = "low"
+	SeverityInfo     = "info"
+)
+
+// IsBlocking reports whether a finding with this severity should gate apply.
+// "critical" and "high" both block; "medium" and below are surfaced but do
+// not gate. The threshold is opinionated — callers that want a stricter or
+// looser bar can read severity directly.
+func IsBlocking(sev string) bool {
+	return sev == SeverityCritical || sev == SeverityHigh
+}
+
+// Result is what one scanner returns from a single Scan call.
+type Result struct {
+	Scanner   string    `json:"scanner"`             // "graph" | "checkov" | "trivy" | ...
+	Available bool      `json:"available"`           // false → scanner present but not runnable (e.g. binary missing)
+	Findings  []Finding `json:"findings,omitempty"`
+	Error     string    `json:"error,omitempty"`     // surface-able error message
+}
+
+// HasBlocking is a quick check callers use to gate apply without re-scanning
+// the findings.
+func (r Result) HasBlocking() bool {
+	for _, f := range r.Findings {
+		if IsBlocking(f.Severity) {
+			return true
+		}
+	}
+	return false
+}
+
+// ScanInput is the data every scanner receives. Scanners use whichever fields
+// they need and ignore the rest — the built-in graph scanner walks Resources
+// directly, while shell-out scanners walk ProjectDir.
+type ScanInput struct {
+	// ProjectDir is the absolute path to the project root. Shell-out
+	// scanners (Checkov, Trivy, …) point their CLI here.
+	ProjectDir string
+	// Resources is the parsed resource graph. The built-in graph scanner
+	// consumes this directly.
+	Resources []parser.Resource
+	// Tool narrows what's on disk ("terraform" | "opentofu" | "ansible").
+	// Scanners that only target Terraform use this to short-circuit on
+	// non-Terraform projects rather than failing with noisy output.
+	Tool string
+}
+
+// Scanner is the contract every scanner implementation satisfies.
+type Scanner interface {
+	// Name returns the stable identifier ("graph", "checkov", "trivy", …).
+	Name() string
+	// Available reports whether the scanner can actually run in the current
+	// environment. Shell-out scanners return false when their CLI isn't on
+	// PATH; the built-in graph scanner is always available.
+	Available() bool
+	// Scan runs the scanner against the input. It must always return a
+	// Result populated with at least Scanner + Available. Missing-binary
+	// scenarios are NOT errors — they surface via Available=false plus
+	// Result.Error. Reserve the error return for truly unexpected failures
+	// (malformed output from the CLI, I/O errors, etc.).
+	Scan(ctx context.Context, in ScanInput) (Result, error)
+}
+
+// RunAll evaluates the input against every scanner in order and returns one
+// Result per scanner. A scanner that fails still produces a Result so the UI
+// can render "Checkov crashed" alongside findings from other scanners.
+func RunAll(ctx context.Context, scanners []Scanner, in ScanInput) []Result {
+	out := make([]Result, 0, len(scanners))
+	for _, s := range scanners {
+		r, err := s.Scan(ctx, in)
+		if r.Scanner == "" {
+			r.Scanner = s.Name()
+		}
+		if err != nil && r.Error == "" {
+			r.Error = err.Error()
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+// MergeFindings flattens results into a single fully-ordered finding slice.
+// The sort is layered so ties are broken deterministically across runs:
+// severity → scanner → id → title → resources.
+func MergeFindings(results []Result) []Finding {
+	var all []Finding
+	for _, r := range results {
+		all = append(all, r.Findings...)
+	}
+	sort.SliceStable(all, func(i, j int) bool {
+		a, b := all[i], all[j]
+		if a.Severity != b.Severity {
+			return severityRank(a.Severity) < severityRank(b.Severity)
+		}
+		if a.ID != b.ID {
+			return a.ID < b.ID
+		}
+		if a.Title != b.Title {
+			return a.Title < b.Title
+		}
+		return resourceKey(a) < resourceKey(b)
+	})
+	return all
+}
+
+func severityRank(s string) int {
+	switch s {
+	case SeverityCritical:
+		return 0
+	case SeverityHigh:
+		return 1
+	case SeverityMedium:
+		return 2
+	case SeverityLow:
+		return 3
+	case SeverityInfo:
+		return 4
+	}
+	return 5
+}
+
+// resourceKey returns the first affected resource address for stable sorting.
+// Findings with no resources sort last in their severity band.
+func resourceKey(f Finding) string {
+	if len(f.Resources) == 0 {
+		return "\uffff" // sorts after real resource addresses
+	}
+	return f.Resources[0]
+}

--- a/internal/security/scanners/scanners_test.go
+++ b/internal/security/scanners/scanners_test.go
@@ -85,7 +85,7 @@ func TestMergeFindingsSortsBySeverity(t *testing.T) {
 }
 
 // TestMergeFindingsTieBreakersAreDeterministic — two findings with identical
-// severity + scanner + id + title should still sort deterministically via
+// severity + framework + id + title should still sort deterministically via
 // resource key, so CI output doesn't flap.
 func TestMergeFindingsTieBreakersAreDeterministic(t *testing.T) {
 	results := []Result{
@@ -97,6 +97,27 @@ func TestMergeFindingsTieBreakersAreDeterministic(t *testing.T) {
 	merged := MergeFindings(results)
 	if merged[0].Resources[0] != "a-res" {
 		t.Errorf("resource tie-breaker should sort a-res first, got %+v", merged)
+	}
+}
+
+// TestMergeFindingsSortsByFramework — within the same severity band, findings
+// from different frameworks are sorted by Framework alphabetically so that
+// the unified feed is stable across scanner ordering changes.
+func TestMergeFindingsSortsByFramework(t *testing.T) {
+	results := []Result{
+		{Scanner: "trivy", Findings: []Finding{
+			{ID: "X1", Severity: SeverityHigh, Framework: "Trivy", Title: "t"},
+		}},
+		{Scanner: "checkov", Findings: []Finding{
+			{ID: "X1", Severity: SeverityHigh, Framework: "Checkov", Title: "t"},
+		}},
+	}
+	merged := MergeFindings(results)
+	if len(merged) != 2 {
+		t.Fatalf("want 2 findings, got %d", len(merged))
+	}
+	if merged[0].Framework != "Checkov" || merged[1].Framework != "Trivy" {
+		t.Errorf("framework tie-breaker should sort Checkov before Trivy, got %+v", merged)
 	}
 }
 

--- a/internal/security/scanners/scanners_test.go
+++ b/internal/security/scanners/scanners_test.go
@@ -1,0 +1,146 @@
+package scanners
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/iac-studio/iac-studio/internal/parser"
+)
+
+// stubScanner is a controllable Scanner for the RunAll / MergeFindings tests.
+type stubScanner struct {
+	name      string
+	available bool
+	findings  []Finding
+	err       error
+}
+
+func (s *stubScanner) Name() string   { return s.name }
+func (s *stubScanner) Available() bool { return s.available }
+func (s *stubScanner) Scan(context.Context, ScanInput) (Result, error) {
+	return Result{Scanner: s.name, Available: s.available, Findings: s.findings}, s.err
+}
+
+func TestIsBlocking(t *testing.T) {
+	if !IsBlocking(SeverityCritical) || !IsBlocking(SeverityHigh) {
+		t.Error("critical and high must block")
+	}
+	if IsBlocking(SeverityMedium) || IsBlocking(SeverityLow) || IsBlocking(SeverityInfo) {
+		t.Error("medium/low/info must NOT block — the threshold is opinionated on purpose")
+	}
+}
+
+func TestResultHasBlocking(t *testing.T) {
+	r := Result{Findings: []Finding{{Severity: SeverityMedium}, {Severity: SeverityLow}}}
+	if r.HasBlocking() {
+		t.Error("no high/critical findings, should not block")
+	}
+	r.Findings = append(r.Findings, Finding{Severity: SeverityHigh})
+	if !r.HasBlocking() {
+		t.Error("a high finding should block")
+	}
+}
+
+// TestRunAllPreservesErrors — a scanner that returns an error still produces
+// a Result with that error on it, so UI can render partial output.
+func TestRunAllPreservesErrors(t *testing.T) {
+	a := &stubScanner{name: "a", available: true, findings: []Finding{{ID: "a1", Severity: SeverityMedium}}}
+	b := &stubScanner{name: "b", available: true, err: errors.New("boom")}
+	c := &stubScanner{name: "c", available: false}
+
+	results := RunAll(context.Background(), []Scanner{a, b, c}, ScanInput{})
+	if len(results) != 3 {
+		t.Fatalf("want 3 results, got %d", len(results))
+	}
+	if results[0].Scanner != "a" || len(results[0].Findings) != 1 {
+		t.Errorf("scanner a result wrong: %+v", results[0])
+	}
+	if results[1].Scanner != "b" || results[1].Error == "" {
+		t.Errorf("scanner b should surface its error, got: %+v", results[1])
+	}
+	if results[2].Scanner != "c" || results[2].Available {
+		t.Errorf("scanner c should report available=false, got: %+v", results[2])
+	}
+}
+
+// TestMergeFindingsSortsBySeverity verifies critical comes before high comes
+// before medium, regardless of scanner ordering.
+func TestMergeFindingsSortsBySeverity(t *testing.T) {
+	results := []Result{
+		{Scanner: "z", Findings: []Finding{{ID: "z-info", Severity: SeverityInfo}}},
+		{Scanner: "a", Findings: []Finding{
+			{ID: "a-medium", Severity: SeverityMedium},
+			{ID: "a-critical", Severity: SeverityCritical},
+			{ID: "a-high", Severity: SeverityHigh},
+		}},
+	}
+	merged := MergeFindings(results)
+	want := []string{SeverityCritical, SeverityHigh, SeverityMedium, SeverityInfo}
+	for i, s := range want {
+		if merged[i].Severity != s {
+			t.Errorf("at index %d want severity %q, got %q (%+v)", i, s, merged[i].Severity, merged[i])
+		}
+	}
+}
+
+// TestMergeFindingsTieBreakersAreDeterministic — two findings with identical
+// severity + scanner + id + title should still sort deterministically via
+// resource key, so CI output doesn't flap.
+func TestMergeFindingsTieBreakersAreDeterministic(t *testing.T) {
+	results := []Result{
+		{Scanner: "s", Findings: []Finding{
+			{ID: "dup", Severity: SeverityHigh, Title: "same", Resources: []string{"z-res"}},
+			{ID: "dup", Severity: SeverityHigh, Title: "same", Resources: []string{"a-res"}},
+		}},
+	}
+	merged := MergeFindings(results)
+	if merged[0].Resources[0] != "a-res" {
+		t.Errorf("resource tie-breaker should sort a-res first, got %+v", merged)
+	}
+}
+
+// TestGraphScannerEmptyProjectIsQuiet — an empty project produces a clean
+// Result, matching the "no noise for fresh projects" contract.
+func TestGraphScannerEmptyProjectIsQuiet(t *testing.T) {
+	s := NewGraph()
+	res, err := s.Scan(context.Background(), ScanInput{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.Name() != "graph" || !s.Available() {
+		t.Errorf("graph scanner metadata wrong")
+	}
+	if len(res.Findings) != 0 {
+		t.Errorf("empty input should yield zero findings, got %+v", res.Findings)
+	}
+}
+
+// TestGraphScannerFlagsExposedResource end-to-ends the wrap: a resource that
+// the legacy graph scanner considers exposed should still surface as a
+// scanners.Finding with Scanner="graph".
+func TestGraphScannerFlagsExposedResource(t *testing.T) {
+	// A classic bad pattern: an S3 bucket with public-read ACL.
+	s := NewGraph()
+	res, err := s.Scan(context.Background(), ScanInput{
+		Resources: []parser.Resource{
+			{
+				ID:   "r1",
+				Type: "aws_s3_bucket",
+				Name: "public_data",
+				Properties: map[string]any{
+					"acl": "public-read",
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(res.Findings) == 0 {
+		t.Fatal("public-read S3 bucket should produce at least one finding")
+	}
+	if res.Scanner != "graph" {
+		t.Errorf("wrong scanner name on result: %q", res.Scanner)
+	}
+}

--- a/internal/security/scanners/terrascan/terrascan.go
+++ b/internal/security/scanners/terrascan/terrascan.go
@@ -1,0 +1,160 @@
+// Package terrascan shells out to the Terrascan CLI against the project.
+//
+// Terrascan is a CNCF sandbox project focused on compliance checks — CIS
+// benchmarks, NIST, PCI, HIPAA, SOC2. Its rule set complements Checkov's
+// and Trivy's, so users running all three get broader coverage than any
+// single tool provides.
+//
+// Runs:
+//
+//	terrascan scan -d <projectDir> -o json --silent
+//
+// and normalises violations into the unified Finding shape.
+package terrascan
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/iac-studio/iac-studio/internal/security/scanners"
+)
+
+// Binary is the name (or full path) of the terrascan CLI. Overridable for tests.
+var Binary = "terrascan"
+
+type terrascanScanner struct{}
+
+// New constructs the Terrascan scanner.
+func New() scanners.Scanner { return &terrascanScanner{} }
+
+func (t *terrascanScanner) Name() string { return "terrascan" }
+
+func (t *terrascanScanner) Available() bool {
+	_, err := exec.LookPath(Binary)
+	return err == nil
+}
+
+// terrascanOutput mirrors the relevant subset of `terrascan scan -o json`.
+// The CLI emits {"results": {"violations": [...]}} — we only consume the
+// violations array.
+type terrascanOutput struct {
+	Results struct {
+		Violations []terrascanViolation `json:"violations"`
+	} `json:"results"`
+}
+
+type terrascanViolation struct {
+	RuleName    string `json:"rule_name"`
+	Description string `json:"description"`
+	RuleID      string `json:"rule_id"`
+	Severity    string `json:"severity"` // HIGH|MEDIUM|LOW in Terrascan
+	Category    string `json:"category"`
+	ResourceName string `json:"resource_name"`
+	ResourceType string `json:"resource_type"`
+	File        string `json:"file"`
+	LineNumber  int    `json:"line"`
+}
+
+func (t *terrascanScanner) Scan(ctx context.Context, in scanners.ScanInput) (scanners.Result, error) {
+	res := scanners.Result{Scanner: t.Name()}
+	if !t.Available() {
+		res.Error = "terrascan CLI not found on PATH — install from https://runterrascan.io to enable this scanner"
+		return res, nil
+	}
+	res.Available = true
+
+	if in.ProjectDir == "" {
+		res.Error = "terrascan scanner requires a project directory"
+		return res, nil
+	}
+	if in.Tool == "ansible" {
+		// Terrascan does support Ansible (iac-type k8s/ansible), but running
+		// the default Terraform scan against a pure-Ansible project is
+		// noise — skip for now and revisit when we add iac-type flag
+		// plumbing.
+		return res, nil
+	}
+
+	cmd := exec.CommandContext(ctx, Binary,
+		"scan",
+		"-d", in.ProjectDir,
+		"-o", "json",
+		"--silent",
+	)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	// Terrascan exits non-zero when violations exist. Only treat non-zero
+	// exit with no JSON body as a real failure.
+	if err := cmd.Run(); err != nil && stdout.Len() == 0 {
+		res.Error = formatExecError("terrascan", err, stderr.Bytes())
+		return res, err
+	}
+
+	trimmed := bytes.TrimSpace(stdout.Bytes())
+	if len(trimmed) == 0 {
+		return res, nil
+	}
+	var out terrascanOutput
+	if err := json.Unmarshal(trimmed, &out); err != nil {
+		res.Error = fmt.Sprintf("terrascan output not valid JSON: %v", err)
+		return res, err
+	}
+	for _, v := range out.Results.Violations {
+		resource := v.ResourceType + "." + v.ResourceName
+		if v.ResourceName == "" {
+			resource = v.File
+		}
+		res.Findings = append(res.Findings, scanners.Finding{
+			ID:          v.RuleID,
+			Severity:    normaliseSeverity(v.Severity),
+			Category:    firstNonEmpty(strings.ToLower(v.Category), "compliance"),
+			Framework:   "Terrascan",
+			Title:       v.RuleName,
+			Description: v.Description,
+			Resources:   []string{resource},
+		})
+	}
+	return res, nil
+}
+
+// normaliseSeverity: Terrascan only emits HIGH/MEDIUM/LOW. Map to the
+// scanner-world vocabulary; treat anything unrecognised as "info" so a
+// missing severity never blocks apply.
+func normaliseSeverity(s string) string {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "high":
+		return scanners.SeverityHigh
+	case "medium":
+		return scanners.SeverityMedium
+	case "low":
+		return scanners.SeverityLow
+	}
+	return scanners.SeverityInfo
+}
+
+// firstNonEmpty returns the first non-blank string in order.
+func firstNonEmpty(ss ...string) string {
+	for _, s := range ss {
+		if strings.TrimSpace(s) != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+// formatExecError surfaces the explicit stderr buffer when available so
+// callers see Terrascan's actual complaint rather than a bare exit code.
+func formatExecError(tool string, err error, stderr []byte) string {
+	if len(stderr) > 0 {
+		return fmt.Sprintf("%s: %s", tool, strings.TrimSpace(string(stderr)))
+	}
+	if ee, ok := err.(*exec.ExitError); ok && len(ee.Stderr) > 0 {
+		return fmt.Sprintf("%s: %s", tool, strings.TrimSpace(string(ee.Stderr)))
+	}
+	return fmt.Sprintf("%s: %v", tool, err)
+}

--- a/internal/security/scanners/terrascan/terrascan_test.go
+++ b/internal/security/scanners/terrascan/terrascan_test.go
@@ -1,0 +1,144 @@
+package terrascan
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"testing"
+
+	"github.com/iac-studio/iac-studio/internal/security/scanners"
+)
+
+func fakeBinary(t *testing.T, stdout string, exitCode int) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-scripted fake binary not supported on Windows")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "terrascan")
+	script := "#!/usr/bin/env bash\ncat <<'IAC_EOF'\n" + stdout + "\nIAC_EOF\nexit " + strconv.Itoa(exitCode) + "\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake: %v", err)
+	}
+	return path
+}
+
+func TestTerrascanNotAvailable(t *testing.T) {
+	orig := Binary
+	t.Cleanup(func() { Binary = orig })
+	Binary = "/nonexistent/terrascan"
+
+	res, err := New().Scan(context.Background(), scanners.ScanInput{ProjectDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Available || res.Error == "" {
+		t.Errorf("expected unavailable + Error, got %+v", res)
+	}
+}
+
+// TestTerrascanParsesViolations covers the core mapping: each violation
+// becomes a Finding with the right severity, framework="Terrascan", and
+// resource wiring (ResourceType.ResourceName).
+func TestTerrascanParsesViolations(t *testing.T) {
+	body := `{
+      "results": {
+        "violations": [
+          {
+            "rule_name": "s3EnforceUserACL",
+            "description": "Ensure S3 buckets have ACLs set",
+            "rule_id": "AC_AWS_0207",
+            "severity": "HIGH",
+            "category": "Identity and Access Management",
+            "resource_name": "data",
+            "resource_type": "aws_s3_bucket",
+            "file": "main.tf",
+            "line": 5
+          },
+          {
+            "rule_name": "noLoggingForRDS",
+            "description": "Ensure RDS backups are enabled",
+            "rule_id": "AC_AWS_0053",
+            "severity": "MEDIUM",
+            "category": "Logging",
+            "resource_name": "primary",
+            "resource_type": "aws_db_instance",
+            "file": "database.tf",
+            "line": 12
+          }
+        ]
+      }
+    }`
+	orig := Binary
+	t.Cleanup(func() { Binary = orig })
+	// Terrascan exits 3 when violations exist — use that exit code so the
+	// non-zero-with-stdout success path is exercised.
+	Binary = fakeBinary(t, body, 3)
+
+	res, err := New().Scan(context.Background(), scanners.ScanInput{ProjectDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(res.Findings) != 2 {
+		t.Fatalf("want 2 findings, got %d: %+v", len(res.Findings), res.Findings)
+	}
+	for _, f := range res.Findings {
+		if f.Framework != "Terrascan" {
+			t.Errorf("framework should be Terrascan, got %q", f.Framework)
+		}
+		if !filepath.IsAbs(f.Resources[0]) && len(f.Resources[0]) == 0 {
+			t.Errorf("resource address should be populated: %+v", f)
+		}
+	}
+	if res.Findings[0].Resources[0] != "aws_s3_bucket.data" {
+		t.Errorf("first finding resource should be the composed TYPE.NAME, got %q", res.Findings[0].Resources[0])
+	}
+}
+
+// TestTerrascanEmptyViolations — a clean scan (empty violations array)
+// returns no findings and no error.
+func TestTerrascanEmptyViolations(t *testing.T) {
+	orig := Binary
+	t.Cleanup(func() { Binary = orig })
+	Binary = fakeBinary(t, `{"results":{"violations":[]}}`, 0)
+
+	res, err := New().Scan(context.Background(), scanners.ScanInput{ProjectDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(res.Findings) != 0 || res.Error != "" {
+		t.Errorf("clean scan should yield empty findings, got %+v", res)
+	}
+}
+
+func TestTerrascanAnsibleShortCircuit(t *testing.T) {
+	orig := Binary
+	t.Cleanup(func() { Binary = orig })
+	Binary = fakeBinary(t, "should not be called", 99)
+
+	res, err := New().Scan(context.Background(), scanners.ScanInput{ProjectDir: t.TempDir(), Tool: "ansible"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res.Findings) != 0 {
+		t.Errorf("Ansible project should produce no Terrascan findings, got %+v", res.Findings)
+	}
+}
+
+func TestTerrascanNormaliseSeverity(t *testing.T) {
+	cases := map[string]string{
+		"HIGH":    scanners.SeverityHigh,
+		"Medium":  scanners.SeverityMedium,
+		"low":     scanners.SeverityLow,
+		"":        scanners.SeverityInfo,
+		"weird":   scanners.SeverityInfo,
+		"CRITICAL": scanners.SeverityInfo, // Terrascan doesn't emit CRITICAL; stays info until/unless we learn otherwise
+	}
+	for in, want := range cases {
+		if got := normaliseSeverity(in); got != want {
+			t.Errorf("normaliseSeverity(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/security/scanners/trivy/trivy.go
+++ b/internal/security/scanners/trivy/trivy.go
@@ -1,0 +1,181 @@
+// Package trivy shells out to the Trivy CLI in config-scan mode against the
+// project directory. Trivy absorbed tfsec in 2023, so a single adapter now
+// covers both toolchains — users who had tfsec installed should install
+// Trivy instead; the rule IDs are largely unchanged (AVD-xxx).
+//
+// The adapter runs:
+//
+//	trivy config <projectDir> --format json --quiet --severity CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN
+//
+// and normalises the Misconfigurations array into the unified Finding shape.
+package trivy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/iac-studio/iac-studio/internal/security/scanners"
+)
+
+// Binary is the name (or full path) of the trivy CLI. Overridable for tests.
+var Binary = "trivy"
+
+type trivyScanner struct{}
+
+// New constructs the Trivy scanner. Available() probes the binary per Scan
+// call so a fresh install during server runtime is picked up immediately.
+func New() scanners.Scanner { return &trivyScanner{} }
+
+func (t *trivyScanner) Name() string { return "trivy" }
+
+func (t *trivyScanner) Available() bool {
+	_, err := exec.LookPath(Binary)
+	return err == nil
+}
+
+// trivyReport models the subset of Trivy's JSON output we consume. Trivy
+// emits a top-level object with ArtifactName / ArtifactType and a Results
+// array; each entry carries a Misconfigurations array for IaC findings.
+type trivyReport struct {
+	Results []trivyResult `json:"Results"`
+}
+
+type trivyResult struct {
+	Target            string                    `json:"Target"` // e.g., "main.tf"
+	Class             string                    `json:"Class"`  // "config" for IaC
+	Type              string                    `json:"Type"`   // "terraform", "cloudformation", etc.
+	Misconfigurations []trivyMisconfiguration   `json:"Misconfigurations"`
+}
+
+type trivyMisconfiguration struct {
+	Type           string `json:"Type"`
+	ID             string `json:"ID"`       // e.g., "AVD-AWS-0088"
+	AVDID          string `json:"AVDID"`    // same as ID on recent versions
+	Title          string `json:"Title"`
+	Description    string `json:"Description"`
+	Message        string `json:"Message"`
+	Resolution     string `json:"Resolution"`
+	Severity       string `json:"Severity"` // uppercase
+	PrimaryURL     string `json:"PrimaryURL"`
+	CauseMetadata  struct {
+		Resource string `json:"Resource"`
+		Provider string `json:"Provider"`
+		Service  string `json:"Service"`
+	} `json:"CauseMetadata"`
+}
+
+func (t *trivyScanner) Scan(ctx context.Context, in scanners.ScanInput) (scanners.Result, error) {
+	res := scanners.Result{Scanner: t.Name()}
+	if !t.Available() {
+		res.Error = "trivy CLI not found on PATH — install from https://trivy.dev to enable this scanner (replaces tfsec)"
+		return res, nil
+	}
+	res.Available = true
+
+	if in.ProjectDir == "" {
+		res.Error = "trivy scanner requires a project directory"
+		return res, nil
+	}
+	if in.Tool == "ansible" {
+		// Trivy config doesn't target Ansible playbooks — short-circuit
+		// quietly so the multi-scanner pass doesn't emit noise.
+		return res, nil
+	}
+
+	cmd := exec.CommandContext(ctx, Binary,
+		"config",
+		in.ProjectDir,
+		"--format", "json",
+		"--quiet",
+		"--severity", "CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN",
+	)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	// Trivy exits 0 even with findings (unlike Checkov's default). An actual
+	// error is a non-zero exit with no JSON body.
+	if err := cmd.Run(); err != nil && stdout.Len() == 0 {
+		res.Error = formatExecError(err, stderr.Bytes())
+		return res, err
+	}
+
+	var report trivyReport
+	trimmed := bytes.TrimSpace(stdout.Bytes())
+	if len(trimmed) == 0 {
+		// No findings → Trivy can emit empty stdout. Treat as clean.
+		return res, nil
+	}
+	if err := json.Unmarshal(trimmed, &report); err != nil {
+		res.Error = fmt.Sprintf("trivy output not valid JSON: %v", err)
+		return res, err
+	}
+	for _, r := range report.Results {
+		for _, m := range r.Misconfigurations {
+			id := m.AVDID
+			if id == "" {
+				id = m.ID
+			}
+			resource := m.CauseMetadata.Resource
+			if resource == "" {
+				// Fall back to the target file so the UI can at least
+				// deep-link to the right file even when Trivy can't name
+				// the specific resource.
+				resource = r.Target
+			}
+			res.Findings = append(res.Findings, scanners.Finding{
+				ID:          id,
+				Severity:    normaliseSeverity(m.Severity),
+				Category:    "compliance",
+				Framework:   "Trivy",
+				Title:       m.Title,
+				Description: firstNonEmpty(m.Description, m.Message),
+				Resources:   []string{resource},
+				Remediation: firstNonEmpty(m.Resolution, m.PrimaryURL),
+			})
+		}
+	}
+	return res, nil
+}
+
+// normaliseSeverity maps Trivy's UPPERCASE labels to the scanner-world
+// lowercase vocabulary. UNKNOWN severities fall through to "info" so they
+// surface but don't block apply.
+func normaliseSeverity(s string) string {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "critical":
+		return scanners.SeverityCritical
+	case "high":
+		return scanners.SeverityHigh
+	case "medium":
+		return scanners.SeverityMedium
+	case "low":
+		return scanners.SeverityLow
+	}
+	return scanners.SeverityInfo
+}
+
+// firstNonEmpty picks the first string argument that isn't empty after trim.
+// Trivy fills Description / Message / Resolution inconsistently by rule, so
+// the UI-facing fields fall back across multiple source attributes.
+func firstNonEmpty(ss ...string) string {
+	for _, s := range ss {
+		if strings.TrimSpace(s) != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+func formatExecError(err error, stderr []byte) string {
+	if len(stderr) > 0 {
+		return fmt.Sprintf("trivy: %s", strings.TrimSpace(string(stderr)))
+	}
+	if ee, ok := err.(*exec.ExitError); ok && len(ee.Stderr) > 0 {
+		return fmt.Sprintf("trivy: %s", strings.TrimSpace(string(ee.Stderr)))
+	}
+	return fmt.Sprintf("trivy: %v", err)
+}

--- a/internal/security/scanners/trivy/trivy_test.go
+++ b/internal/security/scanners/trivy/trivy_test.go
@@ -1,0 +1,202 @@
+package trivy
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"testing"
+
+	"github.com/iac-studio/iac-studio/internal/security/scanners"
+)
+
+func fakeBinary(t *testing.T, stdout string, exitCode int) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-scripted fake binary not supported on Windows")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "trivy")
+	// Single-quoted heredoc delimiter → body emitted verbatim.
+	script := "#!/usr/bin/env bash\ncat <<'IAC_EOF'\n" + stdout + "\nIAC_EOF\nexit " + strconv.Itoa(exitCode) + "\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake: %v", err)
+	}
+	return path
+}
+
+// TestTrivyNotAvailable — missing binary returns a clean, informative Result
+// rather than crashing the multi-scanner pass.
+func TestTrivyNotAvailable(t *testing.T) {
+	orig := Binary
+	t.Cleanup(func() { Binary = orig })
+	Binary = "/nonexistent/trivy-please-dont-exist"
+
+	res, err := New().Scan(context.Background(), scanners.ScanInput{ProjectDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Available {
+		t.Error("Available() should be false when binary is missing")
+	}
+	if res.Error == "" {
+		t.Error("Result.Error should explain the missing binary")
+	}
+}
+
+// TestTrivyParsesMisconfigurations covers the core mapping: each
+// misconfiguration becomes a Finding with the right severity, framework,
+// and resource wiring.
+func TestTrivyParsesMisconfigurations(t *testing.T) {
+	body := `{
+      "ArtifactName": ".",
+      "ArtifactType": "filesystem",
+      "Results": [
+        {
+          "Target": "main.tf",
+          "Class": "config",
+          "Type": "terraform",
+          "Misconfigurations": [
+            {
+              "Type": "Terraform Security Check",
+              "ID": "AVD-AWS-0088",
+              "AVDID": "AVD-AWS-0088",
+              "Title": "S3 Data should be versioned",
+              "Description": "Bucket does not have versioning enabled.",
+              "Resolution": "Enable versioning",
+              "Severity": "MEDIUM",
+              "PrimaryURL": "https://avd.aquasec.com/misconfig/avd-aws-0088",
+              "CauseMetadata": {
+                "Resource": "aws_s3_bucket.data",
+                "Provider": "aws",
+                "Service": "s3"
+              }
+            },
+            {
+              "ID": "AVD-AWS-0132",
+              "AVDID": "AVD-AWS-0132",
+              "Title": "S3 encryption should use Customer Managed Keys",
+              "Severity": "HIGH",
+              "CauseMetadata": {
+                "Resource": "aws_s3_bucket.data"
+              }
+            }
+          ]
+        }
+      ]
+    }`
+	orig := Binary
+	t.Cleanup(func() { Binary = orig })
+	Binary = fakeBinary(t, body, 0)
+
+	res, err := New().Scan(context.Background(), scanners.ScanInput{ProjectDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(res.Findings) != 2 {
+		t.Fatalf("want 2 findings, got %d: %+v", len(res.Findings), res.Findings)
+	}
+	var sawHigh, sawMedium bool
+	for _, f := range res.Findings {
+		if f.Framework != "Trivy" {
+			t.Errorf("framework should be Trivy, got %q", f.Framework)
+		}
+		if len(f.Resources) == 0 || f.Resources[0] == "" {
+			t.Errorf("resource should be populated: %+v", f)
+		}
+		switch f.Severity {
+		case scanners.SeverityHigh:
+			sawHigh = true
+		case scanners.SeverityMedium:
+			sawMedium = true
+		}
+	}
+	if !sawHigh || !sawMedium {
+		t.Errorf("severity map missed expected inputs: %+v", res.Findings)
+	}
+}
+
+// TestTrivyMissingResourceFallsBackToTarget — when CauseMetadata.Resource is
+// empty, the Finding should still carry a useful address (the file path) so
+// the UI can deep-link.
+func TestTrivyMissingResourceFallsBackToTarget(t *testing.T) {
+	body := `{
+      "Results": [
+        {
+          "Target": "modules/networking/main.tf",
+          "Misconfigurations": [
+            {"ID": "AVD-X", "AVDID": "AVD-X", "Title": "Generic check", "Severity": "LOW"}
+          ]
+        }
+      ]
+    }`
+	orig := Binary
+	t.Cleanup(func() { Binary = orig })
+	Binary = fakeBinary(t, body, 0)
+
+	res, err := New().Scan(context.Background(), scanners.ScanInput{ProjectDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(res.Findings) != 1 || res.Findings[0].Resources[0] != "modules/networking/main.tf" {
+		t.Errorf("fallback to Target failed: %+v", res.Findings)
+	}
+}
+
+// TestTrivyEmptyOutputIsQuiet — Trivy emits empty stdout when there are no
+// findings; the adapter treats that as a clean no-op.
+func TestTrivyEmptyOutputIsQuiet(t *testing.T) {
+	orig := Binary
+	t.Cleanup(func() { Binary = orig })
+	Binary = fakeBinary(t, "", 0)
+
+	res, err := New().Scan(context.Background(), scanners.ScanInput{ProjectDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(res.Findings) != 0 || res.Error != "" {
+		t.Errorf("empty output should yield clean empty result, got %+v", res)
+	}
+}
+
+// TestTrivyAnsibleShortCircuit — Trivy config doesn't target Ansible; skip.
+func TestTrivyAnsibleShortCircuit(t *testing.T) {
+	orig := Binary
+	t.Cleanup(func() { Binary = orig })
+	Binary = fakeBinary(t, "should not be called", 99)
+
+	res, err := New().Scan(context.Background(), scanners.ScanInput{ProjectDir: t.TempDir(), Tool: "ansible"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res.Findings) != 0 {
+		t.Errorf("Ansible project should produce no Trivy findings, got %+v", res.Findings)
+	}
+}
+
+// TestTrivyRequiresProjectDir — match the Checkov adapter's contract on
+// missing project directory.
+func TestTrivyRequiresProjectDir(t *testing.T) {
+	orig := Binary
+	t.Cleanup(func() { Binary = orig })
+	Binary = fakeBinary(t, "{}", 0)
+
+	res, _ := New().Scan(context.Background(), scanners.ScanInput{})
+	if res.Error == "" {
+		t.Error("Result.Error should explain missing project dir")
+	}
+}
+
+// TestTrivyMalformedOutput — non-JSON stdout surfaces as an error rather than
+// being swallowed into an empty Findings list.
+func TestTrivyMalformedOutput(t *testing.T) {
+	orig := Binary
+	t.Cleanup(func() { Binary = orig })
+	Binary = fakeBinary(t, "not json at all", 0)
+
+	_, err := New().Scan(context.Background(), scanners.ScanInput{ProjectDir: t.TempDir()})
+	if err == nil {
+		t.Error("malformed JSON should surface as an error")
+	}
+}


### PR DESCRIPTION
## Summary
Add a pluggable IaC security-scanner layer that wraps best-in-class external tools and exposes a unified Findings feed alongside the existing graph-based analyzer. Landing in sequenced commits on this branch:

- [x] **Commit 1** — \`internal/security/scanners\` package + Scanner interface + graph adapter (wraps the existing cross-resource attack-path analyzer).
- [ ] Commit 2 — Checkov adapter (\`checkov -d . -o json\`).
- [ ] Commit 3 — Trivy adapter (\`trivy config . --format json\`; tfsec is rolled into Trivy).
- [ ] Commit 4 — Terrascan + KICS adapters.
- [ ] Commit 5 — \`GET /api/security/scanners\` + \`POST /api/projects/{name}/security/scanners/run\` + \`.github/workflows/iac-scan.yml\` export.

Closes #4.

## Design
- Finding is a type alias for \`security.Finding\` so the API response shape is unchanged — existing clients keep working.
- Severity vocabulary is the scanner-world \`critical | high | medium | low | info\`; IsBlocking gates on critical + high.
- External-scanner binaries are detected via \`exec.LookPath\` per Scan call, so users can install a CLI while the server is running and see it light up on the next scan.
- Shell-out adapters return clean empty Results when a project has no relevant files (e.g., Checkov against an Ansible-only project), so they don't pollute the multi-scanner output.

## Test plan
- [x] Unit tests for the scanners contract (severity, RunAll, MergeFindings ordering, graph adapter end-to-end).
- [ ] Unit tests per adapter using shell-scripted fake binaries.
- [ ] httptest integration tests for the new API surface.
- [ ] Manual: scan a layered-terraform scaffold with Checkov + Trivy installed; confirm unified Findings feed.