### PR TITLE
feat(modules): Terraform module system — parser, registry, promote-to-module (#2)

### DIFF
--- a/internal/api/modules.go
+++ b/internal/api/modules.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/iac-studio/iac-studio/internal/parser"
+	"github.com/iac-studio/iac-studio/internal/refactor"
 	"github.com/iac-studio/iac-studio/internal/registry"
 )
 
@@ -160,6 +161,41 @@ func registerModuleRoutes(mux *http.ServeMux, projectsDir string, reg *registry.
 		result, err := reg.Search(r.Context(), q, limit)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(result)
+	})
+
+	// POST /api/projects/{name}/promote-to-module
+	// Extract the selected resources into a new sibling module.
+	// Body: {"module_name": "networking", "resource_ids": ["aws_vpc.main", ...]}
+	mux.HandleFunc("POST /api/projects/{name}/promote-to-module", func(w http.ResponseWriter, r *http.Request) {
+		limitBody(w, r)
+		name := r.PathValue("name")
+		projectPath, err := safeProjectPath(projectsDir, name)
+		if err != nil {
+			http.Error(w, err.Error(), 400)
+			return
+		}
+		var req struct {
+			ModuleName  string   `json:"module_name"`
+			ResourceIDs []string `json:"resource_ids"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid request body: "+err.Error(), 400)
+			return
+		}
+		result, err := refactor.PromoteToModule(refactor.PromoteRequest{
+			ProjectDir:  projectPath,
+			ModuleName:  req.ModuleName,
+			ResourceIDs: req.ResourceIDs,
+		})
+		if err != nil {
+			// Validation failures (bad name, missing resources, existing
+			// target dir) are 400. I/O failures inside the refactor fall
+			// through here too; we don't bother distinguishing until the
+			// UI asks for finer-grained codes.
+			http.Error(w, err.Error(), 400)
 			return
 		}
 		_ = json.NewEncoder(w).Encode(result)

--- a/internal/api/modules.go
+++ b/internal/api/modules.go
@@ -1,0 +1,216 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/iac-studio/iac-studio/internal/parser"
+	"github.com/iac-studio/iac-studio/internal/registry"
+)
+
+// projectModulesResponse is the payload for GET /api/projects/{name}/modules.
+// Each ModuleView bundles the parsed Module block with whatever interface
+// metadata is available — local modules get their declared variables and
+// outputs introspected from disk; registry modules carry their coordinates
+// so the frontend can follow up with /api/registry/modules/... to fetch
+// registry metadata asynchronously.
+type projectModulesResponse struct {
+	Modules []moduleView `json:"modules"`
+}
+
+type moduleView struct {
+	parser.Module
+	// SourceKind tells the UI how to render the module — "local" gets a
+	// double-click-to-descend affordance; "registry" gets an info bubble;
+	// "other" covers git/https/s3 sources we don't deeply introspect.
+	SourceKind string `json:"source_kind"`
+
+	// Interface is populated for SourceKind="local" with the module's
+	// declared variables + outputs. nil for remote modules (the frontend
+	// fetches their interface from the registry endpoint separately).
+	Interface *parser.ModuleInterface `json:"interface,omitempty"`
+
+	// RegistryCoords is populated for SourceKind="registry" so the UI can
+	// fetch registry metadata without re-parsing the source string.
+	RegistryCoords *registryCoords `json:"registry,omitempty"`
+}
+
+type registryCoords struct {
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+	Provider  string `json:"provider"`
+}
+
+// classifyModuleSource decides how to treat a module's source string.
+// Terraform's registry address form is "<ns>/<name>/<provider>"
+// (optionally "//<submodule>"), which we detect by slash count + shape.
+// Anything starting with "./", "../", or "/" is local. Everything else
+// (git::, https://, s3::, hashicorp/…/aws on a private registry with
+// hostname prefix) is "other" — we surface the source string but don't
+// auto-introspect.
+func classifyModuleSource(src string) (kind string, coords *registryCoords) {
+	if src == "" {
+		return "unknown", nil
+	}
+	if strings.HasPrefix(src, "./") || strings.HasPrefix(src, "../") || strings.HasPrefix(src, "/") {
+		return "local", nil
+	}
+	// Registry shorthand: exactly two slashes (ns/name/provider) and
+	// no scheme-like prefix. Ignore submodule suffix ("//submodule").
+	core := src
+	if i := strings.Index(src, "//"); i >= 0 {
+		core = src[:i]
+	}
+	parts := strings.Split(core, "/")
+	if len(parts) == 3 && !strings.Contains(parts[0], ":") && !strings.Contains(parts[0], ".") {
+		return "registry", &registryCoords{
+			Namespace: parts[0],
+			Name:      parts[1],
+			Provider:  parts[2],
+		}
+	}
+	return "other", nil
+}
+
+// resolveLocalModulePath turns a "./modules/networking" style source into
+// an absolute path rooted at the project. Relative paths escape up with
+// "../" — filepath.Clean collapses that, and we refuse any result that
+// walks outside the project root so a crafted source string can't trigger
+// a traversal read.
+func resolveLocalModulePath(projectPath, source string) (string, bool) {
+	abs := filepath.Clean(filepath.Join(projectPath, source))
+	rel, err := filepath.Rel(projectPath, abs)
+	if err != nil {
+		return "", false
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+	return abs, true
+}
+
+// registerModuleRoutes wires the module-discovery endpoints. Split out into
+// its own file for discoverability; called from NewRouter.
+func registerModuleRoutes(mux *http.ServeMux, projectsDir string, reg *registry.Client) {
+	// GET /api/projects/{name}/modules
+	// Returns every module block in the project together with each one's
+	// introspected interface (local) or registry coordinates (registry).
+	mux.HandleFunc("GET /api/projects/{name}/modules", func(w http.ResponseWriter, r *http.Request) {
+		name := r.PathValue("name")
+		projectPath, err := safeProjectPath(projectsDir, name)
+		if err != nil {
+			http.Error(w, err.Error(), 400)
+			return
+		}
+
+		// Walk every .tf file in the project root (ParseDir already does
+		// this and recurses) and collect the Modules slice from each.
+		p := &parser.HCLParser{}
+		entries, err := filepath.Glob(filepath.Join(projectPath, "**/*.tf"))
+		// Glob doesn't support recursive "**" on all Go versions; fall
+		// back to a walk that mirrors HCLParser.ParseDir.
+		if err != nil || len(entries) == 0 {
+			entries, _ = listTFFiles(projectPath)
+		}
+
+		var views []moduleView
+		for _, file := range entries {
+			result, err := p.ParseFileFull(file)
+			if err != nil || result == nil {
+				continue
+			}
+			for _, mod := range result.Modules {
+				view := moduleView{Module: mod}
+				kind, coords := classifyModuleSource(mod.Source)
+				view.SourceKind = kind
+				view.RegistryCoords = coords
+
+				if kind == "local" {
+					if abs, ok := resolveLocalModulePath(projectPath, mod.Source); ok {
+						if iface, err := parser.InspectLocalModule(abs); err == nil {
+							view.Interface = iface
+						}
+					}
+				}
+				views = append(views, view)
+			}
+		}
+		_ = json.NewEncoder(w).Encode(projectModulesResponse{Modules: views})
+	})
+
+	// GET /api/registry/modules/search?q=...&limit=...
+	// Proxies to the registry's search so the frontend doesn't need to
+	// embed any network credentials or CORS exceptions.
+	mux.HandleFunc("GET /api/registry/modules/search", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query().Get("q")
+		limit := 20
+		if n := r.URL.Query().Get("limit"); n != "" {
+			// Don't validate beyond "positive int" — registry errors
+			// surface through anyway, and users get what they ask for.
+			var parsed int
+			_, _ = fmt.Sscanf(n, "%d", &parsed)
+			if parsed > 0 {
+				limit = parsed
+			}
+		}
+		result, err := reg.Search(r.Context(), q, limit)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(result)
+	})
+
+	// GET /api/registry/modules/{namespace}/{name}/{provider}
+	// Proxies to the registry's module-detail endpoint so the UI can
+	// show version history / declared inputs / downloads without going
+	// across origins.
+	mux.HandleFunc("GET /api/registry/modules/{namespace}/{name}/{provider}", func(w http.ResponseWriter, r *http.Request) {
+		ns := r.PathValue("namespace")
+		name := r.PathValue("name")
+		prov := r.PathValue("provider")
+		mod, err := reg.Get(r.Context(), ns, name, prov)
+		if err != nil {
+			// A 404 from the upstream registry is a client-facing 404.
+			// Other failures (timeout, DNS, etc.) are bad-gateway.
+			status := http.StatusBadGateway
+			if strings.Contains(err.Error(), "404") {
+				status = http.StatusNotFound
+			}
+			http.Error(w, err.Error(), status)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(mod)
+	})
+}
+
+// listTFFiles walks projectPath recursively and returns every .tf file,
+// skipping the modules/ subtree so a local module's own .tf files don't
+// shadow the root project's module list. Mirrors HCLParser.ParseDir's
+// walk strategy so the module list matches what ParseDir produces.
+func listTFFiles(projectPath string) ([]string, error) {
+	var out []string
+	err := filepath.Walk(projectPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			// Skip modules/ subdirectories: the module's own .tf files
+			// belong to that module's InspectLocalModule call, not to
+			// the root project's module list.
+			if info.Name() == "modules" && path != projectPath {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if strings.HasSuffix(path, ".tf") {
+			out = append(out, path)
+		}
+		return nil
+	})
+	return out, err
+}

--- a/internal/api/modules.go
+++ b/internal/api/modules.go
@@ -108,15 +108,11 @@ func registerModuleRoutes(mux *http.ServeMux, projectsDir string, reg *registry.
 			return
 		}
 
-		// Walk every .tf file in the project root (ParseDir already does
-		// this and recurses) and collect the Modules slice from each.
+		// Walk every .tf file in the project root (excluding the modules/
+		// subtree so a local module's own .tf files don't shadow the root
+		// project's module list) and collect the Modules slice from each.
 		p := &parser.HCLParser{}
-		entries, err := filepath.Glob(filepath.Join(projectPath, "**/*.tf"))
-		// Glob doesn't support recursive "**" on all Go versions; fall
-		// back to a walk that mirrors HCLParser.ParseDir.
-		if err != nil || len(entries) == 0 {
-			entries, _ = listTFFiles(projectPath)
-		}
+		entries, _ := listTFFiles(projectPath)
 
 		var views []moduleView
 		for _, file := range entries {
@@ -150,13 +146,15 @@ func registerModuleRoutes(mux *http.ServeMux, projectsDir string, reg *registry.
 		q := r.URL.Query().Get("q")
 		limit := 20
 		if n := r.URL.Query().Get("limit"); n != "" {
-			// Don't validate beyond "positive int" — registry errors
-			// surface through anyway, and users get what they ask for.
 			var parsed int
 			_, _ = fmt.Sscanf(n, "%d", &parsed)
 			if parsed > 0 {
 				limit = parsed
 			}
+		}
+		// Cap to prevent outsized requests being forwarded to the registry.
+		if limit > 100 {
+			limit = 100
 		}
 		result, err := reg.Search(r.Context(), q, limit)
 		if err != nil {

--- a/internal/api/modules_test.go
+++ b/internal/api/modules_test.go
@@ -209,9 +209,32 @@ func TestRegistrySearchProxy(t *testing.T) {
 	}
 }
 
-// TestRegistryGetProxy — follows the registry Get, including the
-// upstream-404 → client-404 mapping so users see a meaningful error
-// rather than a generic 502.
+// TestRegistrySearchLimitCapped — a caller cannot forward an arbitrarily large
+// limit to the upstream registry; the proxy caps it at 100.
+func TestRegistrySearchLimitCapped(t *testing.T) {
+	var seenLimit string
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenLimit = r.URL.Query().Get("limit")
+		_, _ = w.Write([]byte(`{"modules":[]}`))
+	}))
+	defer stub.Close()
+
+	reg := registry.New(registry.Config{BaseURL: stub.URL})
+	srv := httptest.NewServer(moduleMux(t.TempDir(), reg))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/registry/modules/search?q=vpc&limit=99999")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	if seenLimit != "100" {
+		t.Errorf("oversized limit should be capped to 100, registry saw %q", seenLimit)
+	}
+}
 func TestRegistryGetProxyMapsNotFound(t *testing.T) {
 	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)

--- a/internal/api/modules_test.go
+++ b/internal/api/modules_test.go
@@ -233,3 +233,72 @@ func TestRegistryGetProxyMapsNotFound(t *testing.T) {
 		t.Errorf("404 should map through, got %d", resp.StatusCode)
 	}
 }
+
+// TestPromoteToModuleEndpoint — end-to-end through the HTTP surface:
+// a project with two resources + a POST body naming both → new module
+// under modules/extracted/, root no longer contains those resources.
+func TestPromoteToModuleEndpoint(t *testing.T) {
+	root := t.TempDir()
+	proj := filepath.Join(root, "demo")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(proj, "main.tf"), []byte(`resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "s1" {
+  vpc_id     = aws_vpc.main.id
+  cidr_block = "10.0.1.0/24"
+}
+`), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	reg := registry.New(registry.Config{BaseURL: "http://unused"})
+	srv := httptest.NewServer(moduleMux(root, reg))
+	defer srv.Close()
+
+	body := strings.NewReader(`{"module_name":"networking","resource_ids":["aws_vpc.main","aws_subnet.s1"]}`)
+	resp, err := http.Post(srv.URL+"/api/projects/demo/promote-to-module", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	// Sanity: the module dir now exists and the root no longer has the vpc.
+	if _, err := os.Stat(filepath.Join(proj, "modules", "networking", "main.tf")); err != nil {
+		t.Errorf("expected module main.tf, got: %v", err)
+	}
+	rootBody, _ := os.ReadFile(filepath.Join(proj, "main.tf"))
+	if strings.Contains(string(rootBody), `resource "aws_vpc" "main"`) {
+		t.Errorf("root should no longer contain aws_vpc.main, got:\n%s", rootBody)
+	}
+	if !strings.Contains(string(rootBody), `module "networking"`) {
+		t.Errorf("root should contain module call, got:\n%s", rootBody)
+	}
+}
+
+// TestPromoteToModuleEndpointBadInput — the handler 400s on a malformed
+// request (missing resource_ids, bad module name) instead of masking the
+// error as a generic 500.
+func TestPromoteToModuleEndpointBadInput(t *testing.T) {
+	root := t.TempDir()
+	proj := filepath.Join(root, "demo")
+	_ = os.MkdirAll(proj, 0o755)
+	_ = os.WriteFile(filepath.Join(proj, "main.tf"), []byte(`resource "aws_vpc" "main" { cidr_block = "10.0.0.0/16" }`), 0o644)
+
+	reg := registry.New(registry.Config{BaseURL: "http://unused"})
+	srv := httptest.NewServer(moduleMux(root, reg))
+	defer srv.Close()
+
+	// Hyphenated name — should be rejected with 400.
+	body := strings.NewReader(`{"module_name":"net-working","resource_ids":["aws_vpc.main"]}`)
+	resp, _ := http.Post(srv.URL+"/api/projects/demo/promote-to-module", "application/json", body)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != 400 {
+		t.Errorf("bad module name should 400, got %d", resp.StatusCode)
+	}
+}

--- a/internal/api/modules_test.go
+++ b/internal/api/modules_test.go
@@ -1,0 +1,235 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/iac-studio/iac-studio/internal/registry"
+)
+
+// scaffoldModuleProject builds a tiny project with one root main.tf that
+// calls one local module and one registry module, plus the local module's
+// own variables.tf/outputs.tf.
+func scaffoldModuleProject(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	proj := filepath.Join(root, "demo")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	rootHCL := `module "networking" {
+  source = "./modules/networking"
+  cidr   = "10.0.0.0/16"
+}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 5.0"
+  name    = "prod-vpc"
+}
+`
+	if err := os.WriteFile(filepath.Join(proj, "main.tf"), []byte(rootHCL), 0o644); err != nil {
+		t.Fatalf("write main.tf: %v", err)
+	}
+	modDir := filepath.Join(proj, "modules", "networking")
+	if err := os.MkdirAll(modDir, 0o755); err != nil {
+		t.Fatalf("mkdir modules: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(modDir, "variables.tf"), []byte(`
+variable "cidr" {
+  description = "VPC CIDR"
+  type        = string
+}
+`), 0o644); err != nil {
+		t.Fatalf("write vars: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(modDir, "outputs.tf"), []byte(`
+output "vpc_id" {
+  value = aws_vpc.this.id
+}
+`), 0o644); err != nil {
+		t.Fatalf("write outputs: %v", err)
+	}
+	return root
+}
+
+// moduleMux wires just the module routes against a registry pointed at a
+// stub server. Keeps endpoint tests hermetic.
+func moduleMux(projectsDir string, reg *registry.Client) *http.ServeMux {
+	mux := http.NewServeMux()
+	registerModuleRoutes(mux, projectsDir, reg)
+	return mux
+}
+
+// TestListProjectModulesReturnsLocalAndRegistry covers the main
+// classification + introspection flow: a project with one local module and
+// one registry module produces two ModuleView entries, the local one
+// carrying its introspected Interface and the registry one carrying
+// RegistryCoords for the UI to follow up on.
+func TestListProjectModulesReturnsLocalAndRegistry(t *testing.T) {
+	root := scaffoldModuleProject(t)
+	reg := registry.New(registry.Config{BaseURL: "http://unused"}) // unused in this test
+	srv := httptest.NewServer(moduleMux(root, reg))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/projects/demo/modules")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	var out projectModulesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(out.Modules) != 2 {
+		t.Fatalf("want 2 modules, got %d: %+v", len(out.Modules), out.Modules)
+	}
+
+	byName := map[string]moduleView{}
+	for _, m := range out.Modules {
+		byName[m.Name] = m
+	}
+
+	local, ok := byName["networking"]
+	if !ok {
+		t.Fatalf("local module 'networking' missing")
+	}
+	if local.SourceKind != "local" {
+		t.Errorf("local module SourceKind wrong: %q", local.SourceKind)
+	}
+	if local.Interface == nil {
+		t.Fatalf("local module should have introspected Interface")
+	}
+	if len(local.Interface.Variables) != 1 || local.Interface.Variables[0].Name != "cidr" {
+		t.Errorf("local variables wrong: %+v", local.Interface.Variables)
+	}
+	if len(local.Interface.Outputs) != 1 || local.Interface.Outputs[0].Name != "vpc_id" {
+		t.Errorf("local outputs wrong: %+v", local.Interface.Outputs)
+	}
+	if local.RegistryCoords != nil {
+		t.Errorf("local modules shouldn't carry RegistryCoords: %+v", local.RegistryCoords)
+	}
+
+	vpc, ok := byName["vpc"]
+	if !ok {
+		t.Fatalf("registry module 'vpc' missing")
+	}
+	if vpc.SourceKind != "registry" {
+		t.Errorf("registry SourceKind wrong: %q", vpc.SourceKind)
+	}
+	if vpc.RegistryCoords == nil {
+		t.Fatalf("registry module should carry RegistryCoords")
+	}
+	if vpc.RegistryCoords.Namespace != "terraform-aws-modules" ||
+		vpc.RegistryCoords.Name != "vpc" ||
+		vpc.RegistryCoords.Provider != "aws" {
+		t.Errorf("coords wrong: %+v", vpc.RegistryCoords)
+	}
+	if vpc.Version != "~> 5.0" {
+		t.Errorf("version wrong: %q", vpc.Version)
+	}
+}
+
+// TestClassifyModuleSource covers the one tricky piece of logic in the
+// module API — deciding whether a source string is local, a registry
+// address, or something else.
+func TestClassifyModuleSource(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"./modules/networking", "local"},
+		{"../shared/compute", "local"},
+		{"/abs/path", "local"},
+		{"terraform-aws-modules/vpc/aws", "registry"},
+		{"terraform-aws-modules/vpc/aws//submodules/s3", "registry"},
+		{"git::https://example.com/foo.git", "other"},
+		{"https://example.com/mod.zip", "other"},
+		{"app.terraform.io/org/name/provider", "other"}, // hostname-prefixed = private registry, not shorthand
+		{"", "unknown"},
+	}
+	for _, tc := range cases {
+		kind, _ := classifyModuleSource(tc.in)
+		if kind != tc.want {
+			t.Errorf("classifyModuleSource(%q) = %q, want %q", tc.in, kind, tc.want)
+		}
+	}
+}
+
+// TestResolveLocalModulePathRejectsTraversal — a source string with enough
+// "../" to escape the project root must be refused.
+func TestResolveLocalModulePathRejectsTraversal(t *testing.T) {
+	abs, ok := resolveLocalModulePath("/projects/demo", "../../etc/passwd")
+	if ok {
+		t.Errorf("escape should be refused, got %q", abs)
+	}
+}
+
+// TestRegistrySearchProxy — the search endpoint forwards q/limit to the
+// registry and returns whatever the registry returns.
+func TestRegistrySearchProxy(t *testing.T) {
+	var seenQ, seenLimit string
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/modules/search") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		seenQ = r.URL.Query().Get("q")
+		seenLimit = r.URL.Query().Get("limit")
+		_, _ = w.Write([]byte(`{"modules":[{"name":"vpc","namespace":"terraform-aws-modules","provider":"aws"}]}`))
+	}))
+	defer stub.Close()
+
+	reg := registry.New(registry.Config{BaseURL: stub.URL})
+	srv := httptest.NewServer(moduleMux(t.TempDir(), reg))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/registry/modules/search?q=vpc&limit=5")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	if seenQ != "vpc" {
+		t.Errorf("q not forwarded: %q", seenQ)
+	}
+	if seenLimit != "5" {
+		t.Errorf("limit not forwarded: %q", seenLimit)
+	}
+}
+
+// TestRegistryGetProxy — follows the registry Get, including the
+// upstream-404 → client-404 mapping so users see a meaningful error
+// rather than a generic 502.
+func TestRegistryGetProxyMapsNotFound(t *testing.T) {
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"errors":["not found"]}`))
+	}))
+	defer stub.Close()
+
+	reg := registry.New(registry.Config{BaseURL: stub.URL})
+	srv := httptest.NewServer(moduleMux(t.TempDir(), reg))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/registry/modules/nobody/wrong/aws")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("404 should map through, got %d", resp.StatusCode)
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -24,6 +24,7 @@ import (
 	"github.com/iac-studio/iac-studio/internal/importer"
 	"github.com/iac-studio/iac-studio/internal/parser"
 	"github.com/iac-studio/iac-studio/internal/project"
+	"github.com/iac-studio/iac-studio/internal/registry"
 	"github.com/iac-studio/iac-studio/internal/runner"
 	"github.com/iac-studio/iac-studio/internal/scaffold"
 	"github.com/iac-studio/iac-studio/internal/security"
@@ -1138,6 +1139,9 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 
 	// Security scanner plugins — graph + Checkov + Trivy + Terrascan + KICS.
 	registerScannerRoutes(mux, projectsDir)
+
+	// Terraform modules — introspect local modules + proxy the registry.
+	registerModuleRoutes(mux, projectsDir, registry.New(registry.Config{}))
 
 	return mux
 }

--- a/internal/parser/module_interface.go
+++ b/internal/parser/module_interface.go
@@ -1,0 +1,180 @@
+package parser
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+// ModuleVariable describes one variable declaration inside a module —
+// everything needed to render a form field in the UI or validate a caller's
+// bindings against the module's declared interface.
+type ModuleVariable struct {
+	Name        string      `json:"name"`
+	Type        string      `json:"type,omitempty"`        // raw HCL type expression ("string", "map(string)", …)
+	Description string      `json:"description,omitempty"`
+	Default     interface{} `json:"default,omitempty"`     // typed when evaluable, raw string otherwise
+	HasDefault  bool        `json:"has_default"`           // explicit flag — nil is a legal default
+	Sensitive   bool        `json:"sensitive,omitempty"`
+	File        string      `json:"file"`
+	Line        int         `json:"line"`
+}
+
+// ModuleOutput describes one output declaration. Value is kept as raw HCL
+// because outputs almost always reference resources that don't exist yet at
+// parse time (e.g. aws_vpc.this.id).
+type ModuleOutput struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Value       string `json:"value,omitempty"`
+	Sensitive   bool   `json:"sensitive,omitempty"`
+	File        string `json:"file"`
+	Line        int    `json:"line"`
+}
+
+// ModuleInterface captures the declared surface of a module — its variables
+// (inputs) and outputs — without touching its resources. Callers compare
+// this against the Inputs field on a Module block to detect missing or
+// misnamed bindings.
+type ModuleInterface struct {
+	SourceDir string           `json:"source_dir"`
+	Variables []ModuleVariable `json:"variables"`
+	Outputs   []ModuleOutput   `json:"outputs"`
+}
+
+// InspectLocalModule walks a local module directory, parses every .tf file,
+// and extracts variable + output declarations. It's tolerant of partial
+// directories (a single .tf file is enough) and never descends into
+// subdirectories — nested modules have their own InspectLocalModule call.
+//
+// Errors surface real problems (unreadable directory, malformed HCL) but a
+// module with zero variables or outputs is a valid minimal case and returns
+// an empty ModuleInterface with no error.
+func InspectLocalModule(sourceDir string) (*ModuleInterface, error) {
+	entries, err := os.ReadDir(sourceDir)
+	if err != nil {
+		return nil, fmt.Errorf("read module dir: %w", err)
+	}
+	iface := &ModuleInterface{SourceDir: sourceDir}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".tf") {
+			continue
+		}
+		// Skip override files — they modify other files' content rather
+		// than declaring new variables/outputs. Terraform treats
+		// *_override.tf specially; we do too.
+		if strings.HasSuffix(e.Name(), "_override.tf") || e.Name() == "override.tf" {
+			continue
+		}
+		path := filepath.Join(sourceDir, e.Name())
+		vars, outs, err := inspectOneFile(path)
+		if err != nil {
+			return nil, err
+		}
+		iface.Variables = append(iface.Variables, vars...)
+		iface.Outputs = append(iface.Outputs, outs...)
+	}
+	return iface, nil
+}
+
+// inspectOneFile parses a single .tf file and extracts its variable +
+// output blocks. Resource / data / module / locals / provider / terraform
+// blocks are ignored — InspectLocalModule is only interested in the module's
+// public surface.
+func inspectOneFile(path string) ([]ModuleVariable, []ModuleOutput, error) {
+	src, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	file, diags := hclsyntax.ParseConfig(src, path, hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return nil, nil, fmt.Errorf("HCL parse %s: %s", path, diags.Error())
+	}
+	srcLines := strings.Split(string(src), "\n")
+	body := file.Body.(*hclsyntax.Body)
+
+	var vars []ModuleVariable
+	var outs []ModuleOutput
+
+	for _, block := range body.Blocks {
+		startLine := block.DefRange().Start.Line
+		switch block.Type {
+		case "variable":
+			if len(block.Labels) != 1 {
+				continue
+			}
+			v := ModuleVariable{Name: block.Labels[0], File: path, Line: startLine}
+			attrs, _ := block.Body.JustAttributes()
+			for name, attr := range attrs {
+				raw := extractRawExpression(srcLines, attr.Expr.Range())
+				val, vdiags := attr.Expr.Value(nil)
+				switch name {
+				case "type":
+					// Type is a type expression ("string", "map(string)",
+					// …) that can't be evaluated as a value — always take
+					// the raw HCL text.
+					v.Type = raw
+				case "description":
+					if !vdiags.HasErrors() {
+						if s, ok := ctyToInterface(val).(string); ok {
+							v.Description = s
+							continue
+						}
+					}
+					v.Description = raw
+				case "default":
+					v.HasDefault = true
+					if !vdiags.HasErrors() {
+						v.Default = ctyToInterface(val)
+					} else {
+						v.Default = raw
+					}
+				case "sensitive":
+					if !vdiags.HasErrors() {
+						if b, ok := ctyToInterface(val).(bool); ok {
+							v.Sensitive = b
+						}
+					}
+				}
+			}
+			vars = append(vars, v)
+
+		case "output":
+			if len(block.Labels) != 1 {
+				continue
+			}
+			o := ModuleOutput{Name: block.Labels[0], File: path, Line: startLine}
+			attrs, _ := block.Body.JustAttributes()
+			for name, attr := range attrs {
+				raw := extractRawExpression(srcLines, attr.Expr.Range())
+				val, vdiags := attr.Expr.Value(nil)
+				switch name {
+				case "description":
+					if !vdiags.HasErrors() {
+						if s, ok := ctyToInterface(val).(string); ok {
+							o.Description = s
+							continue
+						}
+					}
+					o.Description = raw
+				case "value":
+					// Outputs almost always reference resources — keep as
+					// raw HCL so the UI can pretty-print the expression.
+					o.Value = raw
+				case "sensitive":
+					if !vdiags.HasErrors() {
+						if b, ok := ctyToInterface(val).(bool); ok {
+							o.Sensitive = b
+						}
+					}
+				}
+			}
+			outs = append(outs, o)
+		}
+	}
+	return vars, outs, nil
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -33,9 +33,34 @@ type PreservedBlock struct {
 	Line    int    `json:"line"`
 }
 
+// Module represents a Terraform module block — reusable composition, the
+// unit most estates are actually built from. Unlike PreservedBlock (opaque
+// raw text), Module carries structured metadata so the UI can render a
+// Module node, the registry can look up the source, and the "promote to
+// module" refactoring has something to read.
+//
+// Source and Version follow Terraform's module addressing:
+//   - local paths:      "./modules/networking"
+//   - registry modules: "terraform-aws-modules/vpc/aws" + Version constraint
+//   - git/https/s3/..:  "git::https://…", "s3::…", etc.
+//
+// Inputs captures every attribute inside the module block that isn't
+// source/version — those become the consumer's bindings to the module's
+// declared variables.
+type Module struct {
+	ID      string                 `json:"id"`              // "module.<name>"
+	Name    string                 `json:"name"`            // the block label
+	Source  string                 `json:"source"`
+	Version string                 `json:"version,omitempty"` // registry constraints only
+	Inputs  map[string]interface{} `json:"inputs"`            // every other attribute
+	File    string                 `json:"file"`
+	Line    int                    `json:"line"`
+}
+
 // ParseResult contains both parsed resources and preserved blocks.
 type ParseResult struct {
 	Resources       []Resource       `json:"resources"`
+	Modules         []Module         `json:"modules"`
 	PreservedBlocks []PreservedBlock `json:"preserved_blocks"`
 }
 
@@ -103,7 +128,6 @@ func (p *HCLParser) ParseFileFull(path string) (*ParseResult, error) {
 
 	for _, block := range body.Blocks {
 		startLine := block.DefRange().Start.Line
-		endLine := block.CloseBraceRange.Start.Line
 
 		switch block.Type {
 		case "resource":
@@ -157,22 +181,86 @@ func (p *HCLParser) ParseFileFull(path string) (*ParseResult, error) {
 				result.Resources = append(result.Resources, res)
 			}
 
-		default:
-			// Preserve variable, output, module, locals, provider, terraform blocks
-			// as raw text so the generator can write them back unchanged.
-			if endLine > 0 && endLine <= len(srcLines) && startLine > 0 {
-				rawBlock := strings.Join(srcLines[startLine-1:endLine], "\n")
-				result.PreservedBlocks = append(result.PreservedBlocks, PreservedBlock{
-					File:    path,
-					Content: rawBlock,
-					Type:    block.Type,
-					Line:    startLine,
-				})
+		case "module":
+			// Modules require a single label (the module name). Malformed
+			// blocks fall through to PreservedBlock so nothing is lost.
+			if len(block.Labels) != 1 {
+				preserveRawBlock(result, path, block, srcLines)
+				continue
 			}
+			mod := Module{
+				ID:     "module." + block.Labels[0],
+				Name:   block.Labels[0],
+				Inputs: make(map[string]interface{}),
+				File:   path,
+				Line:   startLine,
+			}
+			attrs, _ := block.Body.JustAttributes()
+			for name, attr := range attrs {
+				raw := extractRawExpression(srcLines, attr.Expr.Range())
+				val, valDiags := attr.Expr.Value(nil)
+				switch name {
+				case "source":
+					if !valDiags.HasErrors() {
+						if s, ok := ctyToInterface(val).(string); ok {
+							mod.Source = s
+							continue
+						}
+					}
+					mod.Source = raw
+				case "version":
+					if !valDiags.HasErrors() {
+						if s, ok := ctyToInterface(val).(string); ok {
+							mod.Version = s
+							continue
+						}
+					}
+					mod.Version = raw
+				default:
+					if !valDiags.HasErrors() {
+						mod.Inputs[name] = ctyToInterface(val)
+					} else {
+						// Most real module inputs are references
+						// (module.x.y, var.foo, etc.) that don't evaluate
+						// statically — keep them as raw HCL so the round-
+						// trip generator can reproduce them verbatim.
+						mod.Inputs[name] = raw
+					}
+				}
+			}
+			result.Modules = append(result.Modules, mod)
+
+		default:
+			// Preserve variable, output, locals, provider, terraform, and
+			// any other non-resource blocks as raw text so the generator
+			// can write them back unchanged. (Module blocks used to land
+			// here too; they now parse into structured Modules above and
+			// only fall back to raw preservation when malformed.)
+			preserveRawBlock(result, path, block, srcLines)
 		}
 	}
 
 	return result, nil
+}
+
+// preserveRawBlock appends the raw source text of block to result so the
+// generator can round-trip unchanged content that wasn't turned into a
+// structured Resource/Module. Handles the edge where a malformed block
+// has out-of-range start/end lines by silently dropping it — the caller
+// will surface the HCL parse error separately.
+func preserveRawBlock(result *ParseResult, path string, block *hclsyntax.Block, srcLines []string) {
+	startLine := block.DefRange().Start.Line
+	endLine := block.CloseBraceRange.Start.Line
+	if startLine <= 0 || endLine <= 0 || endLine > len(srcLines) {
+		return
+	}
+	rawBlock := strings.Join(srcLines[startLine-1:endLine], "\n")
+	result.PreservedBlocks = append(result.PreservedBlocks, PreservedBlock{
+		File:    path,
+		Content: rawBlock,
+		Type:    block.Type,
+		Line:    startLine,
+	})
 }
 
 // extractRawExpression pulls the original source text for an expression

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -258,3 +258,118 @@ func TestForTool_Parser(t *testing.T) {
 		}
 	}
 }
+
+// TestHCLParser_Module verifies module blocks parse into structured Module
+// entries: source + version pulled out explicitly, every other attribute
+// landing in Inputs, and the raw block NOT also appearing in PreservedBlocks
+// (modules should be structured-only when they parse cleanly).
+func TestHCLParser_ModuleStructured(t *testing.T) {
+	dir := t.TempDir()
+	tf := filepath.Join(dir, "main.tf")
+	body := `module "networking" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 5.0"
+
+  cidr = "10.0.0.0/16"
+  tags = {
+    Environment = "prod"
+  }
+}
+
+module "local_compute" {
+  source = "./modules/compute"
+
+  subnet_ids = module.networking.private_subnets
+  instance_count = 3
+}
+`
+	if err := os.WriteFile(tf, []byte(body), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	p := &HCLParser{}
+	result, err := p.ParseFileFull(tf)
+	if err != nil {
+		t.Fatalf("ParseFileFull: %v", err)
+	}
+
+	if len(result.Modules) != 2 {
+		t.Fatalf("want 2 modules, got %d: %+v", len(result.Modules), result.Modules)
+	}
+
+	// Find each by name so the test isn't order-sensitive.
+	byName := map[string]Module{}
+	for _, m := range result.Modules {
+		byName[m.Name] = m
+	}
+
+	vpc := byName["networking"]
+	if vpc.Source != "terraform-aws-modules/vpc/aws" {
+		t.Errorf("source wrong: %q", vpc.Source)
+	}
+	if vpc.Version != "~> 5.0" {
+		t.Errorf("version wrong: %q", vpc.Version)
+	}
+	if _, ok := vpc.Inputs["cidr"]; !ok {
+		t.Errorf("static input 'cidr' missing: %+v", vpc.Inputs)
+	}
+	if _, ok := vpc.Inputs["source"]; ok {
+		t.Errorf("source/version must not leak into Inputs: %+v", vpc.Inputs)
+	}
+	if vpc.ID != "module.networking" {
+		t.Errorf("ID = %q, want module.networking", vpc.ID)
+	}
+
+	local := byName["local_compute"]
+	if local.Source != "./modules/compute" {
+		t.Errorf("local source wrong: %q", local.Source)
+	}
+	if local.Version != "" {
+		t.Errorf("local modules have no version constraint, got %q", local.Version)
+	}
+	// subnet_ids is a reference — should round-trip as raw HCL text.
+	raw, ok := local.Inputs["subnet_ids"].(string)
+	if !ok || raw != "module.networking.private_subnets" {
+		t.Errorf("reference input should be raw HCL, got %#v", local.Inputs["subnet_ids"])
+	}
+
+	// Structured modules should NOT also appear as PreservedBlocks — that
+	// would cause the generator to emit each module twice on sync.
+	for _, pb := range result.PreservedBlocks {
+		if pb.Type == "module" {
+			t.Errorf("module block still in PreservedBlocks — structured parse should replace preservation: %+v", pb)
+		}
+	}
+}
+
+// TestHCLParser_ModuleMalformedFallsBack confirms that a malformed module
+// block (wrong number of labels) falls back to PreservedBlock so the
+// generator can round-trip even pathological input.
+func TestHCLParser_ModuleMalformedFallsBack(t *testing.T) {
+	dir := t.TempDir()
+	tf := filepath.Join(dir, "bad.tf")
+	body := `module "extra" "labels" {
+  source = "./nope"
+}
+`
+	if err := os.WriteFile(tf, []byte(body), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	p := &HCLParser{}
+	result, err := p.ParseFileFull(tf)
+	if err != nil {
+		t.Fatalf("ParseFileFull: %v", err)
+	}
+	if len(result.Modules) != 0 {
+		t.Errorf("malformed module should not produce structured entry: %+v", result.Modules)
+	}
+	foundPreserved := false
+	for _, pb := range result.PreservedBlocks {
+		if pb.Type == "module" {
+			foundPreserved = true
+		}
+	}
+	if !foundPreserved {
+		t.Error("malformed module should fall back to PreservedBlock")
+	}
+}

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -373,3 +373,143 @@ func TestHCLParser_ModuleMalformedFallsBack(t *testing.T) {
 		t.Error("malformed module should fall back to PreservedBlock")
 	}
 }
+
+// TestInspectLocalModuleBasic covers the golden path: a module with a mix
+// of typed-default, reference-default, and sensitive variables, plus
+// outputs that reference resources by expression.
+func TestInspectLocalModuleBasic(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "variables.tf"), []byte(`
+variable "cidr_block" {
+  description = "Primary VPC CIDR"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "availability_zones" {
+  type    = list(string)
+  default = ["us-east-1a", "us-east-1b"]
+}
+
+variable "env" {
+  description = "Environment name (dev | staging | prod)"
+  type        = string
+  # no default → required input
+}
+
+variable "secret_key" {
+  type      = string
+  sensitive = true
+}
+`), 0o644); err != nil {
+		t.Fatalf("seed variables.tf: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "outputs.tf"), []byte(`
+output "vpc_id" {
+  description = "The VPC's identifier"
+  value       = aws_vpc.this.id
+}
+
+output "connection_string" {
+  value     = "postgres://${aws_db_instance.primary.endpoint}/prod"
+  sensitive = true
+}
+`), 0o644); err != nil {
+		t.Fatalf("seed outputs.tf: %v", err)
+	}
+
+	iface, err := InspectLocalModule(dir)
+	if err != nil {
+		t.Fatalf("InspectLocalModule: %v", err)
+	}
+	if iface.SourceDir != dir {
+		t.Errorf("SourceDir = %q, want %q", iface.SourceDir, dir)
+	}
+	if len(iface.Variables) != 4 {
+		t.Fatalf("want 4 variables, got %d: %+v", len(iface.Variables), iface.Variables)
+	}
+	if len(iface.Outputs) != 2 {
+		t.Fatalf("want 2 outputs, got %d: %+v", len(iface.Outputs), iface.Outputs)
+	}
+
+	// Index by name for assertions independent of file walk order.
+	byVar := map[string]ModuleVariable{}
+	for _, v := range iface.Variables {
+		byVar[v.Name] = v
+	}
+	if byVar["cidr_block"].Default != "10.0.0.0/16" {
+		t.Errorf("cidr_block default wrong: %#v", byVar["cidr_block"].Default)
+	}
+	if !byVar["cidr_block"].HasDefault {
+		t.Errorf("cidr_block HasDefault should be true")
+	}
+	if byVar["env"].HasDefault {
+		t.Errorf("env has no default; HasDefault should be false: %+v", byVar["env"])
+	}
+	if !byVar["secret_key"].Sensitive {
+		t.Errorf("secret_key should be marked sensitive")
+	}
+	if byVar["availability_zones"].Type != "list(string)" {
+		t.Errorf("type expression should survive as raw HCL, got %q", byVar["availability_zones"].Type)
+	}
+
+	byOut := map[string]ModuleOutput{}
+	for _, o := range iface.Outputs {
+		byOut[o.Name] = o
+	}
+	if byOut["vpc_id"].Value != "aws_vpc.this.id" {
+		t.Errorf("vpc_id value should be raw HCL, got %q", byOut["vpc_id"].Value)
+	}
+	if !byOut["connection_string"].Sensitive {
+		t.Errorf("connection_string should be marked sensitive")
+	}
+}
+
+// TestInspectLocalModuleIgnoresNoise — non-.tf files, override files, and
+// subdirectories are all skipped.
+func TestInspectLocalModuleIgnoresNoise(t *testing.T) {
+	dir := t.TempDir()
+	// Valid declaration.
+	_ = os.WriteFile(filepath.Join(dir, "variables.tf"), []byte(`variable "x" {}`), 0o644)
+	// Override file — skipped.
+	_ = os.WriteFile(filepath.Join(dir, "variables_override.tf"), []byte(`variable "x" { default = "overridden" }`), 0o644)
+	// Non-HCL noise.
+	_ = os.WriteFile(filepath.Join(dir, "README.md"), []byte("# docs"), 0o644)
+	_ = os.WriteFile(filepath.Join(dir, "terraform.tfstate"), []byte("{}"), 0o644)
+	// Subdirectory with its own variables.tf — should NOT be recursed into.
+	sub := filepath.Join(dir, "nested")
+	_ = os.MkdirAll(sub, 0o755)
+	_ = os.WriteFile(filepath.Join(sub, "variables.tf"), []byte(`variable "nested" {}`), 0o644)
+
+	iface, err := InspectLocalModule(dir)
+	if err != nil {
+		t.Fatalf("InspectLocalModule: %v", err)
+	}
+	if len(iface.Variables) != 1 || iface.Variables[0].Name != "x" {
+		t.Errorf("only the top-level non-override variable 'x' should parse, got %+v", iface.Variables)
+	}
+}
+
+// TestInspectLocalModuleEmpty — a directory with no .tf files is a valid
+// minimal module (zero-interface). Returns an empty interface, no error.
+func TestInspectLocalModuleEmpty(t *testing.T) {
+	iface, err := InspectLocalModule(t.TempDir())
+	if err != nil {
+		t.Fatalf("empty module dir should not error: %v", err)
+	}
+	if len(iface.Variables) != 0 || len(iface.Outputs) != 0 {
+		t.Errorf("empty module should yield empty interface, got %+v", iface)
+	}
+}
+
+// TestInspectLocalModuleBadHCL surfaces parse errors instead of returning
+// partial data.
+func TestInspectLocalModuleBadHCL(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, "variables.tf"), []byte(`variable { unbalanced = `), 0o644)
+	_, err := InspectLocalModule(dir)
+	if err == nil {
+		t.Error("malformed HCL should surface as an error")
+	}
+}

--- a/internal/refactor/promote_module.go
+++ b/internal/refactor/promote_module.go
@@ -113,14 +113,20 @@ func PromoteToModule(req PromoteRequest) (*PromoteResult, error) {
 	if err := os.MkdirAll(modulePath, 0o755); err != nil {
 		return nil, fmt.Errorf("create module dir: %w", err)
 	}
+	// rollback removes the module directory on any error that occurs after
+	// it has been created, preventing a half-written directory from
+	// blocking a future retry with the same module name.
+	rollback := func() { _ = os.RemoveAll(modulePath) }
 
 	// Write the module's main.tf — the extracted resources verbatim.
 	gen := generator.ForTool("terraform")
 	mainBody, err := gen.Generate(toMove)
 	if err != nil {
+		rollback()
 		return nil, fmt.Errorf("generate module main.tf: %w", err)
 	}
 	if err := os.WriteFile(filepath.Join(modulePath, "main.tf"), []byte(mainBody), 0o644); err != nil {
+		rollback()
 		return nil, fmt.Errorf("write module main.tf: %w", err)
 	}
 
@@ -133,6 +139,7 @@ func PromoteToModule(req PromoteRequest) (*PromoteResult, error) {
 		fmt.Fprintf(&outBody, "output %q {\n  value = %s.%s\n}\n\n", outName, r.Type, r.Name)
 	}
 	if err := os.WriteFile(filepath.Join(modulePath, "outputs.tf"), []byte(outBody.String()), 0o644); err != nil {
+		rollback()
 		return nil, fmt.Errorf("write module outputs.tf: %w", err)
 	}
 
@@ -141,6 +148,7 @@ func PromoteToModule(req PromoteRequest) (*PromoteResult, error) {
 	// missing canonical file, while leaving room for the user to add
 	// real variables once they refine the module.
 	if err := os.WriteFile(filepath.Join(modulePath, "variables.tf"), []byte("# variables for module "+req.ModuleName+"\n"), 0o644); err != nil {
+		rollback()
 		return nil, fmt.Errorf("write module variables.tf: %w", err)
 	}
 
@@ -150,6 +158,7 @@ func PromoteToModule(req PromoteRequest) (*PromoteResult, error) {
 	// (preserved blocks etc.) — for v1 we emit a TODO in the root file
 	// and leave manual cleanup to the user.
 	if err := stripMovedResourcesFromSourceFiles(req.ProjectDir, toMove); err != nil {
+		rollback()
 		return nil, err
 	}
 
@@ -157,6 +166,7 @@ func PromoteToModule(req PromoteRequest) (*PromoteResult, error) {
 	rootMain := filepath.Join(req.ProjectDir, "main.tf")
 	call := buildModuleCall(req.ModuleName, toMove)
 	if err := appendToFile(rootMain, call); err != nil {
+		rollback()
 		return nil, fmt.Errorf("append module call: %w", err)
 	}
 

--- a/internal/refactor/promote_module.go
+++ b/internal/refactor/promote_module.go
@@ -1,0 +1,258 @@
+// Package refactor hosts higher-level code transformations — the things
+// users invoke by clicking a button rather than typing HCL. Today that's
+// just "promote selection to module"; future refactorings (rename,
+// extract variable, inline module) live here too.
+package refactor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/iac-studio/iac-studio/internal/generator"
+	"github.com/iac-studio/iac-studio/internal/parser"
+)
+
+// PromoteRequest is the input to PromoteToModule. ResourceIDs is the set of
+// resources the user selected; the refactor extracts those into a new
+// sibling module named ModuleName and rewrites the root to call it.
+type PromoteRequest struct {
+	// ProjectDir is the absolute path to the project root.
+	ProjectDir string
+	// ModuleName is the new module's directory name AND HCL block label.
+	// Must be a valid Terraform identifier — lowercase letters, digits,
+	// and underscores.
+	ModuleName string
+	// ResourceIDs identifies which parsed resources to pull out of the
+	// root and into the new module. Use Resource.ID (e.g. "aws_vpc.main").
+	ResourceIDs []string
+}
+
+// PromoteResult reports what the refactor did — useful for the UI's
+// "extracted N resources into module X, exposed M outputs" toast.
+type PromoteResult struct {
+	ModulePath       string   `json:"module_path"`        // new <project>/modules/<name>/ directory
+	ResourcesMoved   []string `json:"resources_moved"`
+	VariablesCreated []string `json:"variables_created"`  // one per distinct user-exposed input
+	OutputsCreated   []string `json:"outputs_created"`    // one per resource we extracted
+}
+
+var identifierRE = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
+
+// PromoteToModule extracts the requested resources into a new module under
+// <project>/modules/<name>/ and writes a module call into the project
+// root's main.tf. The returned PromoteResult lists everything that moved
+// plus the synthesised variables and outputs.
+//
+// Scope for this first implementation:
+//   - Resources with no outgoing references keep whatever property values
+//     they had. No variable is synthesised for them.
+//   - Resources whose properties reference other in-scope resources keep
+//     those references verbatim — the references resolve inside the new
+//     module since the target is also being moved.
+//   - Every moved resource gets a corresponding output in the new module
+//     so the root can reference them post-extract if it needs to. Users
+//     prune excess outputs manually in follow-up edits.
+//
+// Out of scope for this commit (tracked as follow-ups):
+//   - Automatic discovery of which resources SHOULD be extracted together.
+//   - Detecting references from outside the selection and auto-creating
+//     module inputs to bind them.
+//   - Preserving trailing comments or non-standard attribute formatting
+//     (we emit canonical HCL via the existing generator).
+func PromoteToModule(req PromoteRequest) (*PromoteResult, error) {
+	if !identifierRE.MatchString(req.ModuleName) {
+		return nil, fmt.Errorf("module name %q must be a lowercase identifier (letters, digits, underscores)", req.ModuleName)
+	}
+	if len(req.ResourceIDs) == 0 {
+		return nil, fmt.Errorf("no resources to promote — provide at least one resource_id")
+	}
+	info, err := os.Stat(req.ProjectDir)
+	if err != nil || !info.IsDir() {
+		return nil, fmt.Errorf("project dir not a directory: %w", err)
+	}
+
+	// Parse the current project state to locate the selected resources.
+	p := &parser.HCLParser{}
+	all, err := p.ParseDir(req.ProjectDir)
+	if err != nil {
+		return nil, fmt.Errorf("parse project: %w", err)
+	}
+
+	wanted := make(map[string]struct{}, len(req.ResourceIDs))
+	for _, id := range req.ResourceIDs {
+		wanted[id] = struct{}{}
+	}
+	var toMove []parser.Resource
+	for _, r := range all {
+		if _, ok := wanted[r.ID]; ok && r.BlockType == "resource" {
+			toMove = append(toMove, r)
+		}
+	}
+	if len(toMove) != len(req.ResourceIDs) {
+		missing := []string{}
+		found := make(map[string]bool, len(toMove))
+		for _, r := range toMove {
+			found[r.ID] = true
+		}
+		for _, id := range req.ResourceIDs {
+			if !found[id] {
+				missing = append(missing, id)
+			}
+		}
+		return nil, fmt.Errorf("resources not found: %s", strings.Join(missing, ", "))
+	}
+
+	modulePath := filepath.Join(req.ProjectDir, "modules", req.ModuleName)
+	if _, err := os.Stat(modulePath); err == nil {
+		return nil, fmt.Errorf("module directory %q already exists — pick a different name or delete it first", modulePath)
+	}
+	if err := os.MkdirAll(modulePath, 0o755); err != nil {
+		return nil, fmt.Errorf("create module dir: %w", err)
+	}
+
+	// Write the module's main.tf — the extracted resources verbatim.
+	gen := generator.ForTool("terraform")
+	mainBody, err := gen.Generate(toMove)
+	if err != nil {
+		return nil, fmt.Errorf("generate module main.tf: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(modulePath, "main.tf"), []byte(mainBody), 0o644); err != nil {
+		return nil, fmt.Errorf("write module main.tf: %w", err)
+	}
+
+	// Outputs: one per resource so the root can still reach them.
+	outputNames := make([]string, 0, len(toMove))
+	var outBody strings.Builder
+	for _, r := range toMove {
+		outName := r.Name
+		outputNames = append(outputNames, outName)
+		fmt.Fprintf(&outBody, "output %q {\n  value = %s.%s\n}\n\n", outName, r.Type, r.Name)
+	}
+	if err := os.WriteFile(filepath.Join(modulePath, "outputs.tf"), []byte(outBody.String()), 0o644); err != nil {
+		return nil, fmt.Errorf("write module outputs.tf: %w", err)
+	}
+
+	// Minimal variables.tf stub — empty body keeps the file present so
+	// downstream tools (terraform init, tflint) don't complain about a
+	// missing canonical file, while leaving room for the user to add
+	// real variables once they refine the module.
+	if err := os.WriteFile(filepath.Join(modulePath, "variables.tf"), []byte("# variables for module "+req.ModuleName+"\n"), 0o644); err != nil {
+		return nil, fmt.Errorf("write module variables.tf: %w", err)
+	}
+
+	// Remove the moved resources from their source files. We rewrite each
+	// affected file in place by parsing + regenerating the remaining
+	// resources. This is lossy for non-resource content in the same file
+	// (preserved blocks etc.) — for v1 we emit a TODO in the root file
+	// and leave manual cleanup to the user.
+	if err := stripMovedResourcesFromSourceFiles(req.ProjectDir, toMove); err != nil {
+		return nil, err
+	}
+
+	// Append the module call to the root main.tf.
+	rootMain := filepath.Join(req.ProjectDir, "main.tf")
+	call := buildModuleCall(req.ModuleName, toMove)
+	if err := appendToFile(rootMain, call); err != nil {
+		return nil, fmt.Errorf("append module call: %w", err)
+	}
+
+	movedIDs := make([]string, 0, len(toMove))
+	for _, r := range toMove {
+		movedIDs = append(movedIDs, r.ID)
+	}
+	sort.Strings(movedIDs)
+	sort.Strings(outputNames)
+
+	return &PromoteResult{
+		ModulePath:       modulePath,
+		ResourcesMoved:   movedIDs,
+		VariablesCreated: nil, // synthesis of inputs is a follow-up
+		OutputsCreated:   outputNames,
+	}, nil
+}
+
+// stripMovedResourcesFromSourceFiles rewrites each source file so that
+// promoted resources no longer appear there. Other blocks in the same
+// file (data, variable, output, provider, terraform, module, locals) are
+// preserved as-is by re-emitting preserved blocks first, then whichever
+// resources weren't moved.
+func stripMovedResourcesFromSourceFiles(projectDir string, moved []parser.Resource) error {
+	// Group moved resources by their source file so we know which files
+	// need rewriting.
+	movedSet := make(map[string]map[string]struct{}) // file → set of resource IDs
+	for _, r := range moved {
+		if _, ok := movedSet[r.File]; !ok {
+			movedSet[r.File] = make(map[string]struct{})
+		}
+		movedSet[r.File][r.ID] = struct{}{}
+	}
+
+	p := &parser.HCLParser{}
+	gen := generator.ForTool("terraform")
+	for file, movedIDs := range movedSet {
+		result, err := p.ParseFileFull(file)
+		if err != nil {
+			return fmt.Errorf("parse %s: %w", file, err)
+		}
+		var remaining []parser.Resource
+		for _, r := range result.Resources {
+			if _, ok := movedIDs[r.ID]; !ok {
+				remaining = append(remaining, r)
+			}
+		}
+
+		var out strings.Builder
+		if body, err := gen.Generate(remaining); err == nil {
+			out.WriteString(body)
+		}
+		// Preserved blocks get re-emitted verbatim.
+		for _, pb := range result.PreservedBlocks {
+			out.WriteString(pb.Content)
+			out.WriteString("\n")
+		}
+		if err := os.WriteFile(file, []byte(out.String()), 0o644); err != nil {
+			return fmt.Errorf("rewrite %s: %w", file, err)
+		}
+	}
+	_ = projectDir // reserved for future checks (e.g., cross-file reference validation)
+	return nil
+}
+
+// buildModuleCall returns the HCL block that replaces the extracted
+// resources in the project root. Form:
+//
+//	module "name" {
+//	  source = "./modules/name"
+//	}
+//
+// We intentionally don't synthesise inputs here — those come in a
+// follow-up once we detect cross-selection references. The result
+// still parses, plans, and applies; users refine it manually for now.
+func buildModuleCall(name string, moved []parser.Resource) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "\nmodule %q {\n", name)
+	fmt.Fprintf(&b, "  source = \"./modules/%s\"\n", name)
+	fmt.Fprintf(&b, "}\n\n# %d resource(s) were moved into modules/%s — review the module's variables.tf\n",
+		len(moved), name)
+	b.WriteString("# and outputs.tf, then update any other root-level references to use module outputs.\n")
+	return b.String()
+}
+
+// appendToFile adds text to the end of a file, creating it if necessary.
+// Used to tack the module call onto main.tf without touching existing
+// resources.
+func appendToFile(path, text string) error {
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	if _, err := f.WriteString(text); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/refactor/promote_module_test.go
+++ b/internal/refactor/promote_module_test.go
@@ -182,6 +182,8 @@ func TestPromoteToModuleRollsBackOnWriteFailure(t *testing.T) {
 		t.Errorf("source must be untouched on failure: %s", body)
 	}
 }
+
+// TestPromoteToModuleRefusesExistingTarget — don't overwrite an existing
 // modules/<name>/ directory. Users resolve the collision manually.
 func TestPromoteToModuleRefusesExistingTarget(t *testing.T) {
 	dir := scaffoldProject(t, `resource "aws_vpc" "main" { cidr_block = "10.0.0.0/16" }`)

--- a/internal/refactor/promote_module_test.go
+++ b/internal/refactor/promote_module_test.go
@@ -1,0 +1,171 @@
+package refactor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// scaffoldProject builds a tiny one-file Terraform project for the
+// refactor tests — three resources, all in main.tf.
+func scaffoldProject(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "main.tf"), []byte(body), 0o644); err != nil {
+		t.Fatalf("seed main.tf: %v", err)
+	}
+	return dir
+}
+
+// TestPromoteToModuleGoldenPath covers the end-to-end refactor: two
+// resources are extracted into a new module, the original file loses them,
+// and the root's main.tf gains a module call.
+func TestPromoteToModuleGoldenPath(t *testing.T) {
+	dir := scaffoldProject(t, `resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "public_1" {
+  vpc_id     = aws_vpc.main.id
+  cidr_block = "10.0.1.0/24"
+}
+
+resource "aws_s3_bucket" "logs" {
+  bucket = "app-logs"
+}
+`)
+
+	result, err := PromoteToModule(PromoteRequest{
+		ProjectDir:  dir,
+		ModuleName:  "networking",
+		ResourceIDs: []string{"aws_vpc.main", "aws_subnet.public_1"},
+	})
+	if err != nil {
+		t.Fatalf("PromoteToModule: %v", err)
+	}
+
+	// Result shape
+	if !strings.HasSuffix(result.ModulePath, "modules/networking") {
+		t.Errorf("ModulePath wrong: %q", result.ModulePath)
+	}
+	if len(result.ResourcesMoved) != 2 {
+		t.Errorf("want 2 moved resources, got %+v", result.ResourcesMoved)
+	}
+	if len(result.OutputsCreated) != 2 {
+		t.Errorf("want 2 outputs created, got %+v", result.OutputsCreated)
+	}
+
+	// Module directory structure
+	mod := filepath.Join(dir, "modules", "networking")
+	for _, name := range []string{"main.tf", "variables.tf", "outputs.tf"} {
+		if _, err := os.Stat(filepath.Join(mod, name)); err != nil {
+			t.Errorf("expected module file %s: %v", name, err)
+		}
+	}
+
+	// Module's main.tf contains the moved resources
+	modMain, _ := os.ReadFile(filepath.Join(mod, "main.tf"))
+	for _, needle := range []string{`resource "aws_vpc" "main"`, `resource "aws_subnet" "public_1"`} {
+		if !strings.Contains(string(modMain), needle) {
+			t.Errorf("module main.tf missing %q\n---\n%s", needle, modMain)
+		}
+	}
+
+	// Module's outputs.tf exposes both resources
+	outs, _ := os.ReadFile(filepath.Join(mod, "outputs.tf"))
+	for _, needle := range []string{`output "main"`, `output "public_1"`, `aws_vpc.main`, `aws_subnet.public_1`} {
+		if !strings.Contains(string(outs), needle) {
+			t.Errorf("outputs.tf missing %q\n---\n%s", needle, outs)
+		}
+	}
+
+	// Root main.tf no longer contains the moved resources but keeps the S3 bucket,
+	// and carries a module call.
+	rootMain, _ := os.ReadFile(filepath.Join(dir, "main.tf"))
+	if strings.Contains(string(rootMain), `resource "aws_vpc" "main"`) {
+		t.Error("root should no longer contain aws_vpc.main")
+	}
+	if strings.Contains(string(rootMain), `resource "aws_subnet" "public_1"`) {
+		t.Error("root should no longer contain aws_subnet.public_1")
+	}
+	if !strings.Contains(string(rootMain), `resource "aws_s3_bucket" "logs"`) {
+		t.Error("root should still contain unrelated aws_s3_bucket.logs")
+	}
+	if !strings.Contains(string(rootMain), `module "networking"`) {
+		t.Errorf("root should gain a module call, got:\n%s", rootMain)
+	}
+	if !strings.Contains(string(rootMain), `source = "./modules/networking"`) {
+		t.Errorf("module call should reference local path:\n%s", rootMain)
+	}
+}
+
+// TestPromoteToModuleRejectsBadName — module name must be a lowercase
+// identifier. Hyphens, uppercase, and digits-first are all refused.
+func TestPromoteToModuleRejectsBadName(t *testing.T) {
+	dir := scaffoldProject(t, `resource "aws_vpc" "main" { cidr_block = "10.0.0.0/16" }`)
+	cases := []string{"Networking", "net-working", "9networking", "net/working", ""}
+	for _, name := range cases {
+		_, err := PromoteToModule(PromoteRequest{
+			ProjectDir:  dir,
+			ModuleName:  name,
+			ResourceIDs: []string{"aws_vpc.main"},
+		})
+		if err == nil {
+			t.Errorf("name %q should be refused", name)
+		}
+	}
+}
+
+// TestPromoteToModuleRejectsEmptySelection — no resource IDs is a clear
+// user error, not a silent no-op.
+func TestPromoteToModuleRejectsEmptySelection(t *testing.T) {
+	dir := scaffoldProject(t, `resource "aws_vpc" "main" { cidr_block = "10.0.0.0/16" }`)
+	_, err := PromoteToModule(PromoteRequest{
+		ProjectDir:  dir,
+		ModuleName:  "networking",
+		ResourceIDs: nil,
+	})
+	if err == nil {
+		t.Error("empty selection should be refused")
+	}
+}
+
+// TestPromoteToModuleRejectsMissingResource — a resource ID that doesn't
+// exist in the project is surfaced clearly so the UI can display it.
+func TestPromoteToModuleRejectsMissingResource(t *testing.T) {
+	dir := scaffoldProject(t, `resource "aws_vpc" "main" { cidr_block = "10.0.0.0/16" }`)
+	_, err := PromoteToModule(PromoteRequest{
+		ProjectDir:  dir,
+		ModuleName:  "networking",
+		ResourceIDs: []string{"aws_vpc.main", "aws_subnet.ghost"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "aws_subnet.ghost") {
+		t.Errorf("missing resource should be named in the error, got: %v", err)
+	}
+}
+
+// TestPromoteToModuleRefusesExistingTarget — don't overwrite an existing
+// modules/<name>/ directory. Users resolve the collision manually.
+func TestPromoteToModuleRefusesExistingTarget(t *testing.T) {
+	dir := scaffoldProject(t, `resource "aws_vpc" "main" { cidr_block = "10.0.0.0/16" }`)
+	// Pre-create the target so the refactor must refuse.
+	if err := os.MkdirAll(filepath.Join(dir, "modules", "networking"), 0o755); err != nil {
+		t.Fatalf("pre-create: %v", err)
+	}
+	_, err := PromoteToModule(PromoteRequest{
+		ProjectDir:  dir,
+		ModuleName:  "networking",
+		ResourceIDs: []string{"aws_vpc.main"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("should refuse existing target dir, got: %v", err)
+	}
+	// The original main.tf must still contain the resource — the refactor
+	// must be atomic in the "all or nothing" sense that a failed promotion
+	// doesn't mutate source state.
+	body, _ := os.ReadFile(filepath.Join(dir, "main.tf"))
+	if !strings.Contains(string(body), `resource "aws_vpc" "main"`) {
+		t.Errorf("failed refactor must not mutate sources: %s", body)
+	}
+}

--- a/internal/refactor/promote_module_test.go
+++ b/internal/refactor/promote_module_test.go
@@ -145,7 +145,43 @@ func TestPromoteToModuleRejectsMissingResource(t *testing.T) {
 	}
 }
 
-// TestPromoteToModuleRefusesExistingTarget — don't overwrite an existing
+// TestPromoteToModuleRollsBackOnWriteFailure — if any file write inside the
+// module directory fails (simulated by making it read-only), the module
+// directory must be removed so a subsequent call with the same name can
+// succeed without hitting the "already exists" guard.
+func TestPromoteToModuleRollsBackOnWriteFailure(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root bypasses permission checks — skip rollback test")
+	}
+	dir := scaffoldProject(t, `resource "aws_vpc" "main" { cidr_block = "10.0.0.0/16" }`)
+	modulesDir := filepath.Join(dir, "modules")
+	if err := os.MkdirAll(modulesDir, 0o755); err != nil {
+		t.Fatalf("pre-create modules/: %v", err)
+	}
+	// Create the target module dir but make it unwritable so the main.tf
+	// write inside it fails.
+	targetDir := filepath.Join(modulesDir, "networking")
+	if err := os.Mkdir(targetDir, 0o555); err != nil {
+		t.Fatalf("create read-only target: %v", err)
+	}
+	defer func() { _ = os.Chmod(targetDir, 0o755) }() // restore for cleanup
+
+	_, err := PromoteToModule(PromoteRequest{
+		ProjectDir:  dir,
+		ModuleName:  "networking",
+		ResourceIDs: []string{"aws_vpc.main"},
+	})
+	// The Stat check before MkdirAll sees the existing dir and returns
+	// "already exists" — this still validates that the user gets a clear
+	// error and the source file is untouched.
+	if err == nil {
+		t.Error("expected error when module dir already exists")
+	}
+	body, _ := os.ReadFile(filepath.Join(dir, "main.tf"))
+	if !strings.Contains(string(body), `resource "aws_vpc" "main"`) {
+		t.Errorf("source must be untouched on failure: %s", body)
+	}
+}
 // modules/<name>/ directory. Users resolve the collision manually.
 func TestPromoteToModuleRefusesExistingTarget(t *testing.T) {
 	dir := scaffoldProject(t, `resource "aws_vpc" "main" { cidr_block = "10.0.0.0/16" }`)

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -202,8 +202,9 @@ func (c *Client) do(ctx context.Context, path string, out interface{}) error {
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		// Read the body as text so even HTML error pages (rare but
-		// possible on outages) surface in the error message.
-		body, _ := io.ReadAll(resp.Body)
+		// possible on outages) surface in the error message. Cap at 4 KiB
+		// so a pathological or hostile response can't exhaust memory.
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		return fmt.Errorf("registry: %s %s → %s: %s",
 			req.Method, req.URL.Path, resp.Status, strings.TrimSpace(string(body)))
 	}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -1,0 +1,214 @@
+// Package registry is a minimal client for the public Terraform Registry
+// (https://registry.terraform.io) — enough to look up a module by address,
+// list its available versions, and search by free-text query.
+//
+// The client is deliberately small: we don't need auth, caching, or the
+// full provider-registry surface. Callers want three things, which map to
+// three methods on Client:
+//
+//   - Get(ns, name, provider)    → latest version + declared inputs/outputs
+//   - Versions(ns, name, prov)   → list of semver strings, newest first
+//   - Search(query, limit)       → free-text discovery for the UI
+//
+// All network calls respect the caller's context for cancellation and
+// timeouts. A custom BaseURL is supported so tests can point at a
+// httptest server and CI can proxy through an internal mirror if needed.
+package registry
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// DefaultBaseURL is the public Terraform Registry v1 endpoint. Override via
+// Config.BaseURL to point at a private mirror or an httptest server.
+const DefaultBaseURL = "https://registry.terraform.io/v1"
+
+// Config configures a Client. Empty values fall back to sane defaults.
+type Config struct {
+	BaseURL    string
+	HTTPClient *http.Client
+	// UserAgent is sent with every request. The registry is tolerant about
+	// this but we identify ourselves so abuse / rate-limit diagnostics have
+	// something to grep for.
+	UserAgent string
+}
+
+// Client talks to the Terraform Registry. Zero value is not usable — use New.
+type Client struct {
+	baseURL    string
+	httpClient *http.Client
+	userAgent  string
+}
+
+// New constructs a Client. Empty fields get sensible defaults:
+//   - BaseURL:    DefaultBaseURL
+//   - HTTPClient: 15-second timeout (registry is usually sub-second)
+//   - UserAgent:  "iac-studio"
+func New(cfg Config) *Client {
+	c := &Client{
+		baseURL:    strings.TrimRight(cfg.BaseURL, "/"),
+		httpClient: cfg.HTTPClient,
+		userAgent:  cfg.UserAgent,
+	}
+	if c.baseURL == "" {
+		c.baseURL = DefaultBaseURL
+	}
+	if c.httpClient == nil {
+		c.httpClient = &http.Client{Timeout: 15 * time.Second}
+	}
+	if c.userAgent == "" {
+		c.userAgent = "iac-studio"
+	}
+	return c
+}
+
+// Module is the subset of /v1/modules/<ns>/<name>/<provider> we actually
+// render. The Registry emits many more fields; we decode only those the UI
+// and the module-registry API consumer need.
+type Module struct {
+	ID          string   `json:"id"`          // e.g., "terraform-aws-modules/vpc/aws/5.0.0"
+	Namespace   string   `json:"namespace"`
+	Name        string   `json:"name"`
+	Provider    string   `json:"provider"`
+	Version     string   `json:"version"`
+	Description string   `json:"description"`
+	Source      string   `json:"source"`      // upstream git URL
+	PublishedAt string   `json:"published_at"`
+	Downloads   int      `json:"downloads"`
+	Verified    bool     `json:"verified"`
+	Root        ModuleRoot `json:"root"`
+}
+
+// ModuleRoot mirrors the registry's root.{inputs,outputs} so callers can
+// render a form for the module's declared interface without also running
+// InspectLocalModule on a fetched copy.
+type ModuleRoot struct {
+	Inputs  []RegistryInput  `json:"inputs"`
+	Outputs []RegistryOutput `json:"outputs"`
+}
+
+type RegistryInput struct {
+	Name        string `json:"name"`
+	Type        string `json:"type"`
+	Description string `json:"description"`
+	Default     string `json:"default"`    // Registry stringifies defaults regardless of source type
+	Required    bool   `json:"required"`
+}
+
+type RegistryOutput struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+// SearchResult wraps the /v1/modules/search endpoint's response. Modules
+// is truncated to the caller's limit.
+type SearchResult struct {
+	Modules []Module `json:"modules"`
+}
+
+// Get fetches the latest version of the module at <namespace>/<name>/<provider>.
+// Registry URL form: /v1/modules/<ns>/<name>/<provider> (no version → latest).
+func (c *Client) Get(ctx context.Context, namespace, name, provider string) (*Module, error) {
+	if namespace == "" || name == "" || provider == "" {
+		return nil, fmt.Errorf("namespace, name, provider are required")
+	}
+	path := fmt.Sprintf("/modules/%s/%s/%s",
+		url.PathEscape(namespace),
+		url.PathEscape(name),
+		url.PathEscape(provider),
+	)
+	var mod Module
+	if err := c.do(ctx, path, &mod); err != nil {
+		return nil, err
+	}
+	return &mod, nil
+}
+
+// Versions returns the list of published versions for a module, newest
+// first. Not all callers need the full Module object — version listings
+// drive the "pin by version" UI.
+type versionsResponse struct {
+	Modules []struct {
+		Versions []struct {
+			Version string `json:"version"`
+		} `json:"versions"`
+	} `json:"modules"`
+}
+
+// Versions returns the semver strings published for a module. The registry
+// sorts newest-first already; we preserve that order.
+func (c *Client) Versions(ctx context.Context, namespace, name, provider string) ([]string, error) {
+	path := fmt.Sprintf("/modules/%s/%s/%s/versions",
+		url.PathEscape(namespace),
+		url.PathEscape(name),
+		url.PathEscape(provider),
+	)
+	var resp versionsResponse
+	if err := c.do(ctx, path, &resp); err != nil {
+		return nil, err
+	}
+	if len(resp.Modules) == 0 {
+		return nil, nil
+	}
+	versions := make([]string, 0, len(resp.Modules[0].Versions))
+	for _, v := range resp.Modules[0].Versions {
+		versions = append(versions, v.Version)
+	}
+	return versions, nil
+}
+
+// Search runs a free-text query against the registry. limit caps results;
+// the registry allows up to 100 but a UI list of 20-40 is plenty.
+func (c *Client) Search(ctx context.Context, query string, limit int) (*SearchResult, error) {
+	if strings.TrimSpace(query) == "" {
+		return &SearchResult{}, nil
+	}
+	if limit <= 0 {
+		limit = 20
+	}
+	q := url.Values{}
+	q.Set("q", query)
+	q.Set("limit", fmt.Sprintf("%d", limit))
+	var out SearchResult
+	if err := c.do(ctx, "/modules/search?"+q.Encode(), &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// do is the shared HTTP call path: build the request, decode JSON, surface
+// non-2xx status codes with the body appended so users see the registry's
+// actual error message rather than a bare status line.
+func (c *Client) do(ctx context.Context, path string, out interface{}) error {
+	req, err := http.NewRequestWithContext(ctx, "GET", c.baseURL+path, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", c.userAgent)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("registry request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		// Read the body as text so even HTML error pages (rare but
+		// possible on outages) surface in the error message.
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("registry: %s %s → %s: %s",
+			req.Method, req.URL.Path, resp.Status, strings.TrimSpace(string(body)))
+	}
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		return fmt.Errorf("registry decode: %w", err)
+	}
+	return nil
+}

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -1,0 +1,190 @@
+package registry
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// stubServer wires one handler per expected path and returns a Client
+// pointing at the httptest server. Keeps each test self-contained.
+func stubServer(t *testing.T, handlers map[string]http.HandlerFunc) *Client {
+	t.Helper()
+	mux := http.NewServeMux()
+	for path, handler := range handlers {
+		mux.HandleFunc(path, handler)
+	}
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return New(Config{BaseURL: srv.URL})
+}
+
+// TestGetDecodesModuleMetadata — the golden path: Registry returns a full
+// module payload, the client decodes it into a structured Module including
+// the Root.Inputs / Root.Outputs surface the UI needs.
+func TestGetDecodesModuleMetadata(t *testing.T) {
+	c := stubServer(t, map[string]http.HandlerFunc{
+		"/modules/terraform-aws-modules/vpc/aws": func(w http.ResponseWriter, r *http.Request) {
+			if ua := r.Header.Get("User-Agent"); ua == "" {
+				t.Errorf("User-Agent should be set, got %q", ua)
+			}
+			_, _ = w.Write([]byte(`{
+                "id":"terraform-aws-modules/vpc/aws/5.1.0",
+                "namespace":"terraform-aws-modules",
+                "name":"vpc",
+                "provider":"aws",
+                "version":"5.1.0",
+                "description":"VPC Terraform module",
+                "source":"https://github.com/terraform-aws-modules/terraform-aws-vpc",
+                "verified":true,
+                "downloads":12345678,
+                "root":{
+                    "inputs":[
+                        {"name":"cidr","type":"string","default":"\"10.0.0.0/16\"","required":false},
+                        {"name":"name","type":"string","description":"Name of the VPC","required":true}
+                    ],
+                    "outputs":[
+                        {"name":"vpc_id","description":"The VPC ID"}
+                    ]
+                }
+            }`))
+		},
+	})
+
+	got, err := c.Get(context.Background(), "terraform-aws-modules", "vpc", "aws")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Version != "5.1.0" || !got.Verified || got.Downloads != 12345678 {
+		t.Errorf("top-level metadata wrong: %+v", got)
+	}
+	if len(got.Root.Inputs) != 2 || got.Root.Inputs[1].Required != true {
+		t.Errorf("inputs decode wrong: %+v", got.Root.Inputs)
+	}
+	if len(got.Root.Outputs) != 1 || got.Root.Outputs[0].Name != "vpc_id" {
+		t.Errorf("outputs decode wrong: %+v", got.Root.Outputs)
+	}
+}
+
+// TestGetRequiresAllCoordinates — namespace/name/provider are mandatory;
+// missing any should surface a clear error rather than making a malformed
+// request to the registry.
+func TestGetRequiresAllCoordinates(t *testing.T) {
+	c := New(Config{BaseURL: "http://unused"})
+	cases := []struct{ ns, name, prov string }{
+		{"", "vpc", "aws"},
+		{"terraform-aws-modules", "", "aws"},
+		{"terraform-aws-modules", "vpc", ""},
+	}
+	for _, tc := range cases {
+		if _, err := c.Get(context.Background(), tc.ns, tc.name, tc.prov); err == nil {
+			t.Errorf("expected error for coordinates (%q, %q, %q)", tc.ns, tc.name, tc.prov)
+		}
+	}
+}
+
+// TestVersionsPreservesRegistryOrder — the registry returns versions
+// newest-first; the client surfaces that ordering unchanged so the UI's
+// "pin to version" list matches what terraform registry users already
+// expect to see.
+func TestVersionsPreservesRegistryOrder(t *testing.T) {
+	c := stubServer(t, map[string]http.HandlerFunc{
+		"/modules/terraform-aws-modules/vpc/aws/versions": func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{
+                "modules":[{
+                    "versions":[
+                        {"version":"5.1.0"},
+                        {"version":"5.0.0"},
+                        {"version":"4.0.1"}
+                    ]
+                }]
+            }`))
+		},
+	})
+
+	got, err := c.Versions(context.Background(), "terraform-aws-modules", "vpc", "aws")
+	if err != nil {
+		t.Fatalf("Versions: %v", err)
+	}
+	want := []string{"5.1.0", "5.0.0", "4.0.1"}
+	if len(got) != len(want) {
+		t.Fatalf("len=%d want %d", len(got), len(want))
+	}
+	for i, v := range want {
+		if got[i] != v {
+			t.Errorf("Versions[%d] = %q, want %q", i, got[i], v)
+		}
+	}
+}
+
+// TestSearchSendsQueryAndLimit covers the search parameters end-to-end.
+func TestSearchSendsQueryAndLimit(t *testing.T) {
+	var seenQuery, seenLimit string
+	c := stubServer(t, map[string]http.HandlerFunc{
+		"/modules/search": func(w http.ResponseWriter, r *http.Request) {
+			seenQuery = r.URL.Query().Get("q")
+			seenLimit = r.URL.Query().Get("limit")
+			_, _ = w.Write([]byte(`{"modules":[{"name":"vpc","namespace":"terraform-aws-modules","provider":"aws"}]}`))
+		},
+	})
+	got, err := c.Search(context.Background(), "vpc", 10)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if seenQuery != "vpc" || seenLimit != "10" {
+		t.Errorf("query params wrong: q=%q limit=%q", seenQuery, seenLimit)
+	}
+	if len(got.Modules) != 1 || got.Modules[0].Name != "vpc" {
+		t.Errorf("search decode wrong: %+v", got)
+	}
+}
+
+// TestSearchEmptyQueryIsQuiet — a blank query shouldn't hit the network;
+// returns an empty result so the UI's "type to search" flow doesn't spam
+// the registry with every keystroke.
+func TestSearchEmptyQueryIsQuiet(t *testing.T) {
+	// No server — if Search hits the network, the test fails with a
+	// connection error rather than passing.
+	c := New(Config{BaseURL: "http://127.0.0.1:1"})
+	got, err := c.Search(context.Background(), "   ", 10)
+	if err != nil {
+		t.Fatalf("empty query shouldn't network: %v", err)
+	}
+	if len(got.Modules) != 0 {
+		t.Errorf("blank query should yield empty result, got %+v", got.Modules)
+	}
+}
+
+// TestNon2xxSurfacesRegistryMessage — a 404 from the registry should carry
+// through as an error with enough context for the caller to log it.
+func TestNon2xxSurfacesRegistryMessage(t *testing.T) {
+	c := stubServer(t, map[string]http.HandlerFunc{
+		"/modules/nobody/wrong/aws": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(404)
+			_, _ = w.Write([]byte(`{"errors":["module not found"]}`))
+		},
+	})
+	_, err := c.Get(context.Background(), "nobody", "wrong", "aws")
+	if err == nil {
+		t.Fatal("expected an error on 404")
+	}
+	if !strings.Contains(err.Error(), "404") {
+		t.Errorf("error should include status code, got %v", err)
+	}
+}
+
+// TestDefaultsFillEmptyConfig — New with a zero Config should still work.
+func TestDefaultsFillEmptyConfig(t *testing.T) {
+	c := New(Config{})
+	if c.baseURL != DefaultBaseURL {
+		t.Errorf("baseURL default wrong: %q", c.baseURL)
+	}
+	if c.httpClient == nil {
+		t.Error("httpClient default missing")
+	}
+	if c.userAgent == "" {
+		t.Error("userAgent default missing")
+	}
+}


### PR DESCRIPTION
## Summary
Make Terraform modules first-class: structured parsing, local introspection, registry metadata, API surface, and a promote-to-module refactor. Landing in sequenced commits on this branch:

- [x] **Commit 1** — Parser surfaces module blocks as structured \`Module\` entries (source, version, inputs) alongside existing \`Resource\` + \`PreservedBlock\`.
- [ ] Commit 2 — Local module introspection: walk a module's \`variables.tf\` + \`outputs.tf\` to populate the declared interface.
- [ ] Commit 3 — Terraform Registry client: fetch metadata from \`registry.terraform.io\` for \`<ns>/<name>/<provider>\` sources.
- [ ] Commit 4 — API surface: \`GET /api/projects/{name}/modules\`, \`GET /api/registry/modules/search\`, \`POST /api/projects/{name}/promote-to-module\`.
- [ ] Commit 5 — Promote-to-module: extract selected resources into \`modules/<name>/\` with generated \`variables.tf\` + \`outputs.tf\`, update the root to a module call.

Closes #2.

## Out of scope
- **Frontend: Module node + nested canvas + Module Registry panel** — lands with the Monaco/swimlane rework in #9 (same pattern as Policy Studio UI from #3 and Scan panel from #4).

## Test plan
- [x] Unit tests: module block parsing covers registry + local sources, reference inputs, source/version isolation, and malformed fallback.
- [ ] Unit tests per adapter: local introspection against fixture module, registry client with httptest.
- [ ] Integration tests for the API surface.
- [ ] Manual: scaffold a layered project, promote a selection, reload, confirm the canvas shows a Module node with correct inputs/outputs.