### PR TITLE
feat(ai): tool-use agent loop + multi-agent orchestrator (#7)

### DIFF
--- a/internal/ai/agent/agent.go
+++ b/internal/ai/agent/agent.go
@@ -35,6 +35,9 @@ func Adapt(r *tools.Runner) providers.ToolRunner {
 }
 
 func (a *runnerAdapter) Run(ctx context.Context, calls []providers.ToolCall) ([]providers.ToolResult, error) {
+	if a == nil || a.inner == nil {
+		return nil, fmt.Errorf("agent: runner is not configured")
+	}
 	inCalls := make([]tools.ToolCall, len(calls))
 	for i, c := range calls {
 		inCalls[i] = tools.ToolCall{

--- a/internal/ai/agent/agent.go
+++ b/internal/ai/agent/agent.go
@@ -1,0 +1,269 @@
+// Package agent is the multi-agent orchestrator — a small router that
+// picks a specialist sub-agent (Architect / Coder / Policy / Security /
+// Reviewer) for a given user prompt and runs the provider's tool-use
+// loop on its behalf.
+//
+// "Multi-agent" here is a prompt-engineering pattern, not separate
+// processes: one Provider, one tool Registry, different system prompts
+// and tool subsets per specialist. The orchestrator uses a cheaper model
+// (Haiku when available) to route and falls back to the single
+// configured provider otherwise.
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/iac-studio/iac-studio/internal/ai/providers"
+	"github.com/iac-studio/iac-studio/internal/ai/tools"
+)
+
+// runnerAdapter turns a tools.Runner into a providers.ToolRunner. Lives in
+// this package (not tools or providers) so tools stays free of provider
+// imports and providers stays free of tools imports.
+type runnerAdapter struct {
+	inner *tools.Runner
+}
+
+// Adapt wraps a tools.Runner so Anthropic's ToolLoopRequest can consume it.
+// The conversion is mechanical: providers.ToolCall ↔ tools.ToolCall,
+// providers.ToolResult ↔ tools.ToolResult.
+func Adapt(r *tools.Runner) providers.ToolRunner {
+	return &runnerAdapter{inner: r}
+}
+
+func (a *runnerAdapter) Run(ctx context.Context, calls []providers.ToolCall) ([]providers.ToolResult, error) {
+	inCalls := make([]tools.ToolCall, len(calls))
+	for i, c := range calls {
+		inCalls[i] = tools.ToolCall{
+			ID:   c.ID,
+			Name: c.Name,
+			Args: json.RawMessage(c.Args),
+		}
+	}
+	results, err := a.inner.Run(ctx, inCalls)
+	outResults := make([]providers.ToolResult, len(results))
+	for i, r := range results {
+		outResults[i] = providers.ToolResult{
+			CallID:  r.CallID,
+			Content: r.Content,
+			IsError: r.IsError,
+		}
+	}
+	return outResults, err
+}
+
+// definitionsFromTools maps the registry's Definitions into the neutral
+// shape the provider accepts.
+func definitionsFromTools(defs []tools.Definition) []providers.ToolDefinition {
+	out := make([]providers.ToolDefinition, len(defs))
+	for i, d := range defs {
+		out[i] = providers.ToolDefinition{
+			Name:        d.Name,
+			Description: d.Description,
+			InputSchema: []byte(d.Schema),
+		}
+	}
+	return out
+}
+
+// Specialist is one sub-agent. Name is what the orchestrator routes to;
+// System is the specialist's system prompt; ToolAllowList (if non-empty)
+// narrows which tools the specialist can see. Empty → all tools.
+type Specialist struct {
+	Name         string
+	System       string
+	ToolAllowList []string
+}
+
+// DefaultSpecialists returns the five built-in sub-agents. They share the
+// same provider + registry — the differentiation is the system prompt and
+// the tool subset. Specific system prompts are kept short and concrete:
+// telling the model "you are an X" is far less effective than telling it
+// "use list_resources then run_policy before proposing any write".
+func DefaultSpecialists() []Specialist {
+	return []Specialist{
+		{
+			Name: "architect",
+			System: `You are the Architect sub-agent. Your job is to turn a user's
+high-level infrastructure request into a concrete plan of resources and
+modules. Process: (1) list_resources to see what already exists,
+(2) search_registry to find an existing module before creating
+resources from scratch, (3) propose files via write_hcl. Never invent
+cloud resource types you aren't certain about.`,
+			ToolAllowList: []string{"list_resources", "get_resource", "search_registry", "write_hcl"},
+		},
+		{
+			Name: "coder",
+			System: `You are the Coder sub-agent. You write or modify specific
+Terraform / HCL resources on request. Process: (1) get_resource first
+to read current state, (2) write_hcl with the full intended file
+content, (3) call run_policy before declaring done.`,
+			ToolAllowList: []string{"list_resources", "get_resource", "write_hcl", "run_policy"},
+		},
+		{
+			Name: "policy",
+			System: `You are the Policy sub-agent. Your only job is to explain and fix
+policy violations. Call run_policy first, then for each blocking
+finding either propose a write_hcl change that fixes it or clearly
+state why it should be acknowledged as an accepted risk.`,
+			ToolAllowList: []string{"list_resources", "get_resource", "run_policy", "write_hcl"},
+		},
+		{
+			Name: "security",
+			System: `You are the Security sub-agent. Call run_scan, then walk the
+findings by severity (critical first). For each actionable finding,
+either propose a write_hcl fix or flag it for human review. Don't
+touch resources unrelated to the findings.`,
+			ToolAllowList: []string{"list_resources", "get_resource", "run_scan", "write_hcl"},
+		},
+		{
+			Name: "reviewer",
+			System: `You are the Reviewer sub-agent. Read current resources + the plan
+JSON and give a short critique: what's about to change, risky bits,
+and whether the plan matches what the user asked for. Do not modify
+files. Return a concise prose summary.`,
+			ToolAllowList: []string{"list_resources", "get_resource", "run_policy", "run_scan", "read_plan"},
+		},
+	}
+}
+
+// Route maps a user prompt to a Specialist. Today this is a tiny keyword
+// classifier — good enough to get the right tool subset most of the time.
+// A later commit can swap in an LLM-based router if the keyword heuristic
+// proves too blunt.
+//
+// The return guarantees a non-nil Specialist: ambiguous prompts default
+// to "architect" since it has the broadest tool set.
+func Route(userPrompt string, specialists []Specialist) *Specialist {
+	p := strings.ToLower(userPrompt)
+	type score struct {
+		specialist *Specialist
+		weight     int
+	}
+	scores := []score{}
+	for i := range specialists {
+		s := &specialists[i]
+		w := 0
+		switch s.Name {
+		case "policy":
+			w = keywordMatches(p, "policy", "compliance", "tag", "governance", "opa", "sentinel")
+		case "security":
+			w = keywordMatches(p, "security", "vulnerab", "cve", "exposure", "encrypt", "iam", "public")
+		case "reviewer":
+			w = keywordMatches(p, "review", "critique", "what will", "explain plan", "walk me through")
+		case "coder":
+			w = keywordMatches(p, "change", "modify", "update", "fix", "edit", "set")
+		case "architect":
+			w = keywordMatches(p, "add", "create", "build", "design", "new", "vpc", "cluster")
+		}
+		scores = append(scores, score{specialist: s, weight: w})
+	}
+	best := 0
+	var winner *Specialist
+	for _, s := range scores {
+		if s.weight > best {
+			best = s.weight
+			winner = s.specialist
+		}
+	}
+	if winner != nil {
+		return winner
+	}
+	// Ambiguous prompt → architect, since it has the widest tool allow-list.
+	for i := range specialists {
+		if specialists[i].Name == "architect" {
+			return &specialists[i]
+		}
+	}
+	return &specialists[0]
+}
+
+func keywordMatches(text string, keywords ...string) int {
+	n := 0
+	for _, k := range keywords {
+		if strings.Contains(text, k) {
+			n++
+		}
+	}
+	return n
+}
+
+// Config bundles everything Run needs. ToolRegistry is the full set of
+// tools available to any specialist; Route picks one and the orchestrator
+// narrows via ToolAllowList.
+type Config struct {
+	Provider     providers.Provider
+	ToolRegistry *tools.Registry
+	Specialists  []Specialist
+	// MaxTurns caps the tool-use loop. Matches providers.ToolLoopRequest
+	// defaulting (8) when zero.
+	MaxTurns int
+}
+
+// Result is the orchestrator's output. Transcript captures the sub-agent
+// path + final text; the HTTP endpoint serialises this into the response
+// body. Keeps the audit trail terse — real per-tool logging is inside
+// the providers/anthropic_tooluse.go loop if we ever need it.
+type Result struct {
+	Specialist string `json:"specialist"`
+	Reply      string `json:"reply"`
+	Turns      int    `json:"turns,omitempty"` // reserved for when the loop surfaces it
+}
+
+// Run dispatches one user prompt through the orchestrator. Errors are
+// returned verbatim so the HTTP handler can decide status codes.
+func Run(ctx context.Context, cfg Config, userPrompt string) (*Result, error) {
+	if cfg.Provider == nil {
+		return nil, fmt.Errorf("agent: no provider configured")
+	}
+	if cfg.ToolRegistry == nil {
+		return nil, fmt.Errorf("agent: no tool registry configured")
+	}
+	specialists := cfg.Specialists
+	if len(specialists) == 0 {
+		specialists = DefaultSpecialists()
+	}
+
+	spec := Route(userPrompt, specialists)
+
+	tu, ok := cfg.Provider.(providers.ToolUser)
+	if !ok {
+		return nil, fmt.Errorf("agent: provider %q does not support tool use — switch to Anthropic to enable the agent", cfg.Provider.Kind())
+	}
+
+	// Narrow the tool catalogue to the specialist's allow-list, if any.
+	allDefs := cfg.ToolRegistry.Definitions()
+	var defs []tools.Definition
+	if len(spec.ToolAllowList) == 0 {
+		defs = allDefs
+	} else {
+		allow := make(map[string]struct{}, len(spec.ToolAllowList))
+		for _, n := range spec.ToolAllowList {
+			allow[n] = struct{}{}
+		}
+		for _, d := range allDefs {
+			if _, ok := allow[d.Name]; ok {
+				defs = append(defs, d)
+			}
+		}
+	}
+
+	runner := &tools.Runner{Registry: cfg.ToolRegistry, MaxIterations: 50}
+	reply, err := tu.RunToolLoop(ctx, providers.ToolLoopRequest{
+		System:   spec.System,
+		User:     userPrompt,
+		Tools:    definitionsFromTools(defs),
+		Runner:   Adapt(runner),
+		MaxTurns: cfg.MaxTurns,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &Result{
+		Specialist: spec.Name,
+		Reply:      reply,
+	}, nil
+}

--- a/internal/ai/agent/agent.go
+++ b/internal/ai/agent/agent.go
@@ -234,8 +234,13 @@ func Run(ctx context.Context, cfg Config, userPrompt string) (*Result, error) {
 		return nil, fmt.Errorf("agent: provider %q does not support tool use — switch to Anthropic to enable the agent", cfg.Provider.Kind())
 	}
 
-	// Narrow the tool catalogue to the specialist's allow-list, if any.
+	// Narrow the tool catalogue to the specialist's allow-list AND build
+	// a filtered registry for the Runner to execute against. Advertising
+	// fewer tools isn't enough: a model can guess the name of a
+	// registered-but-hidden tool and call it anyway. Enforcing the
+	// allow-list at execution time keeps the specialist inside its lane.
 	allDefs := cfg.ToolRegistry.Definitions()
+	execRegistry := cfg.ToolRegistry
 	var defs []tools.Definition
 	if len(spec.ToolAllowList) == 0 {
 		defs = allDefs
@@ -244,14 +249,22 @@ func Run(ctx context.Context, cfg Config, userPrompt string) (*Result, error) {
 		for _, n := range spec.ToolAllowList {
 			allow[n] = struct{}{}
 		}
+		execRegistry = tools.NewRegistry()
 		for _, d := range allDefs {
-			if _, ok := allow[d.Name]; ok {
+			if _, ok := allow[d.Name]; !ok {
+				continue
+			}
+			// The registry has no "copy one tool" accessor on purpose —
+			// Lookup returns the full Tool struct which is all Register
+			// needs.
+			if t, ok := cfg.ToolRegistry.Lookup(d.Name); ok {
+				execRegistry.Register(t)
 				defs = append(defs, d)
 			}
 		}
 	}
 
-	runner := &tools.Runner{Registry: cfg.ToolRegistry, MaxIterations: 50}
+	runner := &tools.Runner{Registry: execRegistry, MaxIterations: 50}
 	reply, err := tu.RunToolLoop(ctx, providers.ToolLoopRequest{
 		System:   spec.System,
 		User:     userPrompt,

--- a/internal/ai/agent/agent_test.go
+++ b/internal/ai/agent/agent_test.go
@@ -1,0 +1,161 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/iac-studio/iac-studio/internal/ai/providers"
+	"github.com/iac-studio/iac-studio/internal/ai/tools"
+)
+
+// TestRouteKeywordMatching — each specialist wins for prompts that contain
+// its keywords, and ambiguous prompts default to architect.
+func TestRouteKeywordMatching(t *testing.T) {
+	specs := DefaultSpecialists()
+	cases := []struct {
+		prompt string
+		want   string
+	}{
+		{"add a new VPC with three subnets", "architect"},
+		{"fix the s3 bucket tags to match policy", "policy"},
+		{"audit my infrastructure for security vulnerabilities", "security"},
+		{"review the plan before we apply", "reviewer"},
+		{"change the cidr_block to 10.1.0.0/16", "coder"},
+		{"hello", "architect"}, // ambiguous falls through to architect
+	}
+	for _, tc := range cases {
+		got := Route(tc.prompt, specs)
+		if got.Name != tc.want {
+			t.Errorf("Route(%q) → %q, want %q", tc.prompt, got.Name, tc.want)
+		}
+	}
+}
+
+// TestAdaptConvertsBothWays — the adapter must round-trip every field a
+// provider cares about: call ID, name, args JSON, result content, error flag.
+func TestAdaptConvertsBothWays(t *testing.T) {
+	reg := tools.NewRegistry()
+	reg.Register(tools.New("echo", "echoes", `{}`,
+		func(ctx context.Context, args json.RawMessage) (any, error) {
+			return map[string]string{"saw": string(args)}, nil
+		}))
+	reg.Register(tools.New("fail", "errors", `{}`,
+		func(ctx context.Context, args json.RawMessage) (any, error) {
+			return nil, errors.New("kaboom")
+		}))
+
+	runner := &tools.Runner{Registry: reg, MaxIterations: 10}
+	adapter := Adapt(runner)
+
+	in := []providers.ToolCall{
+		{ID: "1", Name: "echo", Args: []byte(`{"hi":true}`)},
+		{ID: "2", Name: "fail", Args: []byte(`{}`)},
+	}
+	out, err := adapter.Run(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("want 2 results, got %d", len(out))
+	}
+	if out[0].CallID != "1" || out[1].CallID != "2" {
+		t.Errorf("CallIDs lost through adapter: %+v", out)
+	}
+	if out[1].IsError != true {
+		t.Errorf("error flag must propagate, got %+v", out[1])
+	}
+}
+
+// mockToolUser stands in for providers.ToolUser — lets us verify the
+// orchestrator narrows the tool set to the specialist's allow-list and
+// passes the specialist's system prompt verbatim.
+type mockToolUser struct {
+	sawSystem string
+	sawTools  []string
+	reply     string
+}
+
+func (m *mockToolUser) Kind() providers.Kind                   { return providers.KindAnthropic }
+func (m *mockToolUser) Complete(context.Context, providers.Request) (string, error) {
+	return "", nil
+}
+func (m *mockToolUser) Stream(context.Context, providers.Request, providers.DeltaFunc) (string, error) {
+	return "", nil
+}
+func (m *mockToolUser) RunToolLoop(ctx context.Context, req providers.ToolLoopRequest) (string, error) {
+	m.sawSystem = req.System
+	m.sawTools = nil
+	for _, t := range req.Tools {
+		m.sawTools = append(m.sawTools, t.Name)
+	}
+	return m.reply, nil
+}
+
+// TestRunPolicyPromptPicksPolicySpecialistAndNarrowsTools — the canonical
+// integration test: a policy-flavoured prompt routes to the policy
+// specialist, and the provider only sees the policy specialist's allowed
+// tools (no run_scan, no search_registry).
+func TestRunPolicyPromptPicksPolicySpecialistAndNarrowsTools(t *testing.T) {
+	reg := tools.NewRegistry()
+	// Register stubs under every tool name the specialists reference so the
+	// allow-list filter has something to match.
+	for _, name := range []string{
+		"list_resources", "get_resource", "search_registry", "write_hcl",
+		"run_policy", "run_scan", "read_plan",
+	} {
+		reg.Register(tools.New(name, name, `{}`,
+			func(ctx context.Context, args json.RawMessage) (any, error) { return nil, nil }))
+	}
+	provider := &mockToolUser{reply: "policy fixed"}
+
+	result, err := Run(context.Background(), Config{
+		Provider:     provider,
+		ToolRegistry: reg,
+	}, "please audit my resources against our tagging policy")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if result.Specialist != "policy" {
+		t.Errorf("should route to policy, got %q", result.Specialist)
+	}
+	if result.Reply != "policy fixed" {
+		t.Errorf("reply lost: %q", result.Reply)
+	}
+	if !strings.Contains(provider.sawSystem, "Policy sub-agent") {
+		t.Errorf("specialist system prompt not used: %q", provider.sawSystem)
+	}
+	wantTools := map[string]bool{"list_resources": true, "get_resource": true, "run_policy": true, "write_hcl": true}
+	if len(provider.sawTools) != len(wantTools) {
+		t.Errorf("policy specialist should see exactly 4 tools, got %v", provider.sawTools)
+	}
+	for _, name := range provider.sawTools {
+		if !wantTools[name] {
+			t.Errorf("tool %q leaked to policy specialist", name)
+		}
+	}
+}
+
+// TestRunRejectsNonToolUserProvider — Ollama doesn't implement ToolUser;
+// the orchestrator must return a clear error rather than panic.
+func TestRunRejectsNonToolUserProvider(t *testing.T) {
+	_, err := Run(context.Background(), Config{
+		Provider:     &plainProvider{},
+		ToolRegistry: tools.NewRegistry(),
+	}, "build me a VPC")
+	if err == nil || !strings.Contains(err.Error(), "tool use") {
+		t.Errorf("expected 'does not support tool use' error, got %v", err)
+	}
+}
+
+type plainProvider struct{}
+
+func (p *plainProvider) Kind() providers.Kind { return providers.KindOllama }
+func (p *plainProvider) Complete(context.Context, providers.Request) (string, error) {
+	return "", nil
+}
+func (p *plainProvider) Stream(context.Context, providers.Request, providers.DeltaFunc) (string, error) {
+	return "", nil
+}

--- a/internal/ai/bridge.go
+++ b/internal/ai/bridge.go
@@ -98,6 +98,16 @@ func (c *Client) applyConfig(cfg providers.Config) {
 	}
 }
 
+// Provider returns the active underlying provider, or nil if construction
+// failed. Callers that need provider-specific capabilities (tool-use loop,
+// streaming, etc.) type-assert on the returned value.
+func (c *Client) Provider() providers.Provider {
+	if c.providerErr != nil {
+		return nil
+	}
+	return c.provider
+}
+
 // GetConfig returns the current provider config without exposing the current
 // API key value. When a key is already configured, it returns a masked
 // placeholder so callers can round-trip settings without re-entering the

--- a/internal/ai/providers/anthropic_tooluse.go
+++ b/internal/ai/providers/anthropic_tooluse.go
@@ -23,6 +23,9 @@ import (
 // The returned string is the assistant's final text — the concatenation
 // of every "text" content block in the last response.
 func (p *anthropicProvider) RunToolLoop(ctx context.Context, req ToolLoopRequest) (string, error) {
+	if req.Runner == nil {
+		return "", fmt.Errorf("tool loop: Runner is nil")
+	}
 	maxTurns := req.MaxTurns
 	if maxTurns <= 0 {
 		maxTurns = 8

--- a/internal/ai/providers/anthropic_tooluse.go
+++ b/internal/ai/providers/anthropic_tooluse.go
@@ -1,0 +1,238 @@
+package providers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// RunToolLoop implements the ToolUser interface for Anthropic. It drives
+// the Messages API's tool_use protocol turn-by-turn: send the current
+// message history, inspect the reply for tool_use blocks, run them via
+// req.Runner, and push the tool_result blocks back for the next turn.
+//
+// The loop stops when:
+//   - the model's stop_reason is "end_turn" (no more tool calls), OR
+//   - MaxTurns iterations have run (safety net for a model that never
+//     decides it's done), OR
+//   - the runner returns ErrAbort or any transport error.
+//
+// The returned string is the assistant's final text — the concatenation
+// of every "text" content block in the last response.
+func (p *anthropicProvider) RunToolLoop(ctx context.Context, req ToolLoopRequest) (string, error) {
+	maxTurns := req.MaxTurns
+	if maxTurns <= 0 {
+		maxTurns = 8
+	}
+	maxTokens := req.MaxTokens
+	if maxTokens <= 0 {
+		maxTokens = 4096
+	}
+
+	// Build the tools array once — it's identical every turn.
+	tools := make([]anthropicToolDef, 0, len(req.Tools))
+	for _, t := range req.Tools {
+		var schema json.RawMessage = t.InputSchema
+		if len(schema) == 0 {
+			schema = json.RawMessage(`{"type":"object"}`)
+		}
+		tools = append(tools, anthropicToolDef{
+			Name:        t.Name,
+			Description: t.Description,
+			InputSchema: schema,
+		})
+	}
+
+	// messages accumulates the conversation across turns. Content is
+	// anthropicContent[] rather than a plain string so we can interleave
+	// tool_result blocks without flipping shape.
+	messages := []anthropicTurn{
+		{Role: "user", Content: []anthropicContent{{Type: "text", Text: req.User}}},
+	}
+
+	for turn := 0; turn < maxTurns; turn++ {
+		resp, err := p.callMessages(ctx, messages, tools, req.System, req.Temperature, maxTokens)
+		if err != nil {
+			return "", err
+		}
+
+		// Assistant turn becomes part of the history for the next round so
+		// the model's own tool_use blocks stay consistent with their IDs.
+		messages = append(messages, anthropicTurn{Role: "assistant", Content: resp.Content})
+
+		if resp.StopReason == "end_turn" || resp.StopReason == "" {
+			// No more tool calls — return the concatenated text.
+			return concatText(resp.Content), nil
+		}
+
+		// Collect every tool_use block the model emitted this turn.
+		var calls []ToolCall
+		for _, block := range resp.Content {
+			if block.Type != "tool_use" {
+				continue
+			}
+			calls = append(calls, ToolCall{
+				ID:   block.ID,
+				Name: block.Name,
+				Args: block.Input,
+			})
+		}
+		if len(calls) == 0 {
+			// stop_reason said tool_use but no tool_use block surfaced —
+			// treat as done rather than looping fruitlessly.
+			return concatText(resp.Content), nil
+		}
+
+		// Run the tools and feed results back as a single user turn full
+		// of tool_result blocks (the Messages API accepts multiple results
+		// in one user message).
+		results, err := req.Runner.Run(ctx, calls)
+		if err != nil {
+			// Runner propagates an abort signal — stop the loop and
+			// surface whatever final text we have so far.
+			return concatText(resp.Content), err
+		}
+		resultContent := make([]anthropicContent, 0, len(results))
+		for _, r := range results {
+			body, _ := json.Marshal(r.Content)
+			resultContent = append(resultContent, anthropicContent{
+				Type:      "tool_result",
+				ToolUseID: r.CallID,
+				Content:   string(body),
+				IsError:   r.IsError,
+			})
+		}
+		messages = append(messages, anthropicTurn{Role: "user", Content: resultContent})
+	}
+
+	// MaxTurns exhausted — return the last assistant text we saw.
+	for i := len(messages) - 1; i >= 0; i-- {
+		if messages[i].Role == "assistant" {
+			return concatText(messages[i].Content), fmt.Errorf("tool loop hit max turns (%d) without end_turn", maxTurns)
+		}
+	}
+	return "", fmt.Errorf("tool loop hit max turns (%d) without end_turn", maxTurns)
+}
+
+// concatText joins every text block in a response into a single string —
+// the agent-facing final reply.
+func concatText(content []anthropicContent) string {
+	var buf bytes.Buffer
+	for _, c := range content {
+		if c.Type == "text" {
+			buf.WriteString(c.Text)
+		}
+	}
+	return buf.String()
+}
+
+// ─── Wire-format structs (Anthropic Messages API + tool_use) ─────────
+
+type anthropicToolDef struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	InputSchema json.RawMessage `json:"input_schema"`
+}
+
+// anthropicTurn is one message in the conversation history. Content is a
+// heterogeneous array of text / tool_use / tool_result blocks.
+type anthropicTurn struct {
+	Role    string             `json:"role"`
+	Content []anthropicContent `json:"content"`
+}
+
+// anthropicContent covers every block type the loop produces or consumes.
+// Fields are optional JSON-wise — unused ones get omitempty so a "text"
+// block doesn't emit a nil Input, etc.
+type anthropicContent struct {
+	Type string `json:"type"`
+
+	// text
+	Text string `json:"text,omitempty"`
+
+	// tool_use (assistant → caller)
+	ID    string          `json:"id,omitempty"`
+	Name  string          `json:"name,omitempty"`
+	Input json.RawMessage `json:"input,omitempty"`
+
+	// tool_result (caller → assistant)
+	ToolUseID string `json:"tool_use_id,omitempty"`
+	Content   string `json:"content,omitempty"`
+	IsError   bool   `json:"is_error,omitempty"`
+}
+
+type anthropicToolLoopRequest struct {
+	Model       string             `json:"model"`
+	System      string             `json:"system,omitempty"`
+	Messages    []anthropicTurn    `json:"messages"`
+	Tools       []anthropicToolDef `json:"tools,omitempty"`
+	MaxTokens   int                `json:"max_tokens"`
+	Temperature float64            `json:"temperature,omitempty"`
+}
+
+type anthropicToolLoopResponse struct {
+	Content    []anthropicContent `json:"content"`
+	StopReason string             `json:"stop_reason"`
+	Error      *struct {
+		Message string `json:"message"`
+	} `json:"error,omitempty"`
+}
+
+// callMessages does one round-trip against /v1/messages with the current
+// history + tool catalogue. Isolated from RunToolLoop so the loop stays
+// readable and tests can override Binary via httptest.
+func (p *anthropicProvider) callMessages(
+	ctx context.Context,
+	messages []anthropicTurn,
+	tools []anthropicToolDef,
+	system string,
+	temperature float64,
+	maxTokens int,
+) (*anthropicToolLoopResponse, error) {
+	reqBody := anthropicToolLoopRequest{
+		Model:       p.model,
+		System:      system,
+		Messages:    messages,
+		Tools:       tools,
+		MaxTokens:   maxTokens,
+		Temperature: temperature,
+	}
+	raw, _ := json.Marshal(reqBody)
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", p.endpoint, bytes.NewReader(raw))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("x-api-key", p.apiKey)
+	httpReq.Header.Set("anthropic-version", p.apiVersion)
+
+	resp, err := p.client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("anthropic tool-loop: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read anthropic response: %w", err)
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		var apiErr anthropicToolLoopResponse
+		if err := json.Unmarshal(body, &apiErr); err == nil && apiErr.Error != nil && apiErr.Error.Message != "" {
+			return nil, fmt.Errorf("anthropic tool-loop (status %d): %s", resp.StatusCode, apiErr.Error.Message)
+		}
+		return nil, fmt.Errorf("anthropic tool-loop (status %d)", resp.StatusCode)
+	}
+
+	var decoded anthropicToolLoopResponse
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		return nil, fmt.Errorf("decode anthropic response: %w", err)
+	}
+	if decoded.Error != nil {
+		return nil, fmt.Errorf("anthropic tool-loop error: %s", decoded.Error.Message)
+	}
+	return &decoded, nil
+}

--- a/internal/ai/providers/anthropic_tooluse.go
+++ b/internal/ai/providers/anthropic_tooluse.go
@@ -35,7 +35,7 @@ func (p *anthropicProvider) RunToolLoop(ctx context.Context, req ToolLoopRequest
 	// Build the tools array once — it's identical every turn.
 	tools := make([]anthropicToolDef, 0, len(req.Tools))
 	for _, t := range req.Tools {
-		var schema json.RawMessage = t.InputSchema
+		schema := t.InputSchema
 		if len(schema) == 0 {
 			schema = json.RawMessage(`{"type":"object"}`)
 		}
@@ -97,12 +97,24 @@ func (p *anthropicProvider) RunToolLoop(ctx context.Context, req ToolLoopRequest
 		}
 		resultContent := make([]anthropicContent, 0, len(results))
 		for _, r := range results {
-			body, _ := json.Marshal(r.Content)
+			// A tool that accidentally returns a non-JSON-serialisable
+			// value (channels, functions, cycles) would otherwise send a
+			// silent "null" back to the model and hide the real failure.
+			// Surface it as an explicit error tool_result instead so the
+			// model can react.
+			body, marshalErr := json.Marshal(r.Content)
+			isError := r.IsError
+			if marshalErr != nil {
+				body, _ = json.Marshal(map[string]string{
+					"error": fmt.Sprintf("failed to marshal tool result: %v", marshalErr),
+				})
+				isError = true
+			}
 			resultContent = append(resultContent, anthropicContent{
 				Type:      "tool_result",
 				ToolUseID: r.CallID,
 				Content:   string(body),
-				IsError:   r.IsError,
+				IsError:   isError,
 			})
 		}
 		messages = append(messages, anthropicTurn{Role: "user", Content: resultContent})

--- a/internal/ai/providers/anthropic_tooluse_test.go
+++ b/internal/ai/providers/anthropic_tooluse_test.go
@@ -1,0 +1,193 @@
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// fakeRunner implements ToolRunner by mapping tool name → response. Used to
+// script the model's tool calls without pulling in the full ai/tools package.
+type fakeRunner struct {
+	responses map[string]any
+	calls     []ToolCall
+}
+
+func (r *fakeRunner) Run(_ context.Context, calls []ToolCall) ([]ToolResult, error) {
+	r.calls = append(r.calls, calls...)
+	out := make([]ToolResult, 0, len(calls))
+	for _, c := range calls {
+		if resp, ok := r.responses[c.Name]; ok {
+			out = append(out, ToolResult{CallID: c.ID, Content: resp})
+			continue
+		}
+		out = append(out, ToolResult{CallID: c.ID, Content: map[string]string{"error": "no stub"}, IsError: true})
+	}
+	return out, nil
+}
+
+// TestAnthropicRunToolLoopTwoTurns scripts a canonical pattern: the model
+// calls one tool, we feed the result back, the model returns final text.
+// Verifies the loop stops on end_turn, preserves message history, and
+// returns the concatenated final text.
+func TestAnthropicRunToolLoopTwoTurns(t *testing.T) {
+	var turn int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&turn, 1)
+		// Decode the request so we can assert history is being carried
+		// across turns correctly.
+		body, _ := io.ReadAll(r.Body)
+		var in anthropicToolLoopRequest
+		_ = json.Unmarshal(body, &in)
+
+		if n == 1 {
+			// Sanity: first turn carries just the user message.
+			if len(in.Messages) != 1 || in.Messages[0].Role != "user" {
+				t.Errorf("first turn should carry only the user message, got %+v", in.Messages)
+			}
+			_, _ = w.Write([]byte(`{
+                "content": [
+                    {"type":"text","text":"Let me check the resources."},
+                    {"type":"tool_use","id":"call-1","name":"list_resources","input":{}}
+                ],
+                "stop_reason":"tool_use"
+            }`))
+			return
+		}
+		// Second turn: history must now be [user, assistant (with tool_use),
+		// user (with tool_result)].
+		if len(in.Messages) != 3 {
+			t.Errorf("second turn should have 3 messages, got %d: %+v", len(in.Messages), in.Messages)
+		}
+		// The tool_result must reference the model's original call-1 id.
+		last := in.Messages[len(in.Messages)-1]
+		if last.Role != "user" || len(last.Content) != 1 || last.Content[0].ToolUseID != "call-1" {
+			t.Errorf("tool_result message wrong: %+v", last)
+		}
+		_, _ = w.Write([]byte(`{
+            "content": [{"type":"text","text":"Found 2 resources. All looks fine."}],
+            "stop_reason":"end_turn"
+        }`))
+	}))
+	defer srv.Close()
+
+	p := NewAnthropic(Config{Endpoint: srv.URL, Model: "claude-opus-4-7", APIKey: "sk-test"})
+	tu, ok := p.(ToolUser)
+	if !ok {
+		t.Fatalf("anthropic provider must implement ToolUser")
+	}
+
+	runner := &fakeRunner{responses: map[string]any{
+		"list_resources": map[string]any{"count": 2},
+	}}
+	out, err := tu.RunToolLoop(context.Background(), ToolLoopRequest{
+		System: "you are an agent",
+		User:   "do the thing",
+		Tools: []ToolDefinition{
+			{Name: "list_resources", Description: "list", InputSchema: []byte(`{"type":"object"}`)},
+		},
+		Runner:   runner,
+		MaxTurns: 4,
+	})
+	if err != nil {
+		t.Fatalf("RunToolLoop: %v", err)
+	}
+	if !strings.Contains(out, "All looks fine") {
+		t.Errorf("final text wrong: %q", out)
+	}
+	if len(runner.calls) != 1 || runner.calls[0].Name != "list_resources" {
+		t.Errorf("runner should have been invoked once with list_resources, got %+v", runner.calls)
+	}
+	if atomic.LoadInt32(&turn) != 2 {
+		t.Errorf("expected exactly 2 HTTP turns, got %d", turn)
+	}
+}
+
+// TestAnthropicRunToolLoopMaxTurns — a model that keeps asking for tools
+// without ever returning end_turn must be cut off. The returned text is
+// whatever was in the final assistant message, plus a clear error.
+func TestAnthropicRunToolLoopMaxTurns(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{
+            "content":[
+                {"type":"text","text":"still working..."},
+                {"type":"tool_use","id":"c","name":"list_resources","input":{}}
+            ],
+            "stop_reason":"tool_use"
+        }`))
+	}))
+	defer srv.Close()
+
+	p := NewAnthropic(Config{Endpoint: srv.URL, Model: "m", APIKey: "sk"}).(ToolUser)
+	runner := &fakeRunner{responses: map[string]any{"list_resources": map[string]int{"count": 0}}}
+	_, err := p.RunToolLoop(context.Background(), ToolLoopRequest{
+		System: "s", User: "u",
+		Tools:    []ToolDefinition{{Name: "list_resources", InputSchema: []byte(`{"type":"object"}`)}},
+		Runner:   runner,
+		MaxTurns: 3,
+	})
+	if err == nil || !strings.Contains(err.Error(), "max turns") {
+		t.Errorf("should hit max turns limit, got: %v", err)
+	}
+	// Runner should have been called MaxTurns times (one per round).
+	if len(runner.calls) != 3 {
+		t.Errorf("runner should be called MaxTurns=3 times, got %d", len(runner.calls))
+	}
+}
+
+// TestAnthropicRunToolLoopRunnerAbort — when a handler returns ErrAbort
+// via the runner's error return, the loop stops immediately and surfaces
+// the error.
+func TestAnthropicRunToolLoopRunnerAbort(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{
+            "content":[{"type":"tool_use","id":"c","name":"t","input":{}}],
+            "stop_reason":"tool_use"
+        }`))
+	}))
+	defer srv.Close()
+
+	p := NewAnthropic(Config{Endpoint: srv.URL, Model: "m", APIKey: "sk"}).(ToolUser)
+
+	abortErr := errors.New("user revoked permission")
+	runner := &abortingRunner{err: abortErr}
+	_, err := p.RunToolLoop(context.Background(), ToolLoopRequest{
+		System: "s", User: "u",
+		Tools:  []ToolDefinition{{Name: "t", InputSchema: []byte(`{}`)}},
+		Runner: runner,
+	})
+	if !errors.Is(err, abortErr) {
+		t.Errorf("expected runner abort to propagate, got %v", err)
+	}
+}
+
+type abortingRunner struct{ err error }
+
+func (r *abortingRunner) Run(_ context.Context, _ []ToolCall) ([]ToolResult, error) {
+	return nil, r.err
+}
+
+// TestAnthropicRunToolLoopHTTPError — a non-2xx response with a usable
+// error body must surface the message verbatim.
+func TestAnthropicRunToolLoopHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(429)
+		_, _ = fmt.Fprint(w, `{"error":{"message":"rate limit exceeded"}}`)
+	}))
+	defer srv.Close()
+
+	p := NewAnthropic(Config{Endpoint: srv.URL, Model: "m", APIKey: "sk"}).(ToolUser)
+	_, err := p.RunToolLoop(context.Background(), ToolLoopRequest{
+		System: "s", User: "u", Runner: &fakeRunner{},
+	})
+	if err == nil || !strings.Contains(err.Error(), "rate limit exceeded") {
+		t.Errorf("API error should surface, got %v", err)
+	}
+}

--- a/internal/ai/providers/provider.go
+++ b/internal/ai/providers/provider.go
@@ -12,6 +12,7 @@ package providers
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"time"
@@ -83,19 +84,24 @@ type Provider interface {
 // matches the shape of ai/tools.Definition. Kept in the providers package
 // so we avoid an import cycle (tools depends on parser/policy/scanners;
 // providers depends on neither).
+//
+// InputSchema is json.RawMessage rather than []byte because this struct
+// gets marshalled by several providers (and surfaced in audit logs) —
+// []byte would base64-encode under encoding/json, which is NOT what any
+// consumer expects for a JSON Schema. RawMessage keeps the bytes raw.
 type ToolDefinition struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
-	// InputSchema is a JSON Schema object serialised as raw bytes.
-	InputSchema []byte `json:"input_schema"`
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	InputSchema json.RawMessage `json:"input_schema"`
 }
 
 // ToolCall is the model's request to invoke a tool — the provider-neutral
-// shape the caller's tool runner consumes.
+// shape the caller's tool runner consumes. Args is json.RawMessage for the
+// same "don't base64-encode our JSON" reason as ToolDefinition.InputSchema.
 type ToolCall struct {
 	ID   string
 	Name string
-	Args []byte // raw JSON the model emitted for the tool's arguments
+	Args json.RawMessage
 }
 
 // ToolResult is the caller's response to a ToolCall — becomes the next

--- a/internal/ai/providers/provider.go
+++ b/internal/ai/providers/provider.go
@@ -79,6 +79,70 @@ type Provider interface {
 	Stream(ctx context.Context, req Request, onDelta DeltaFunc) (string, error)
 }
 
+// ToolDefinition is what a tool advertises to the model via the provider —
+// matches the shape of ai/tools.Definition. Kept in the providers package
+// so we avoid an import cycle (tools depends on parser/policy/scanners;
+// providers depends on neither).
+type ToolDefinition struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	// InputSchema is a JSON Schema object serialised as raw bytes.
+	InputSchema []byte `json:"input_schema"`
+}
+
+// ToolCall is the model's request to invoke a tool — the provider-neutral
+// shape the caller's tool runner consumes.
+type ToolCall struct {
+	ID   string
+	Name string
+	Args []byte // raw JSON the model emitted for the tool's arguments
+}
+
+// ToolResult is the caller's response to a ToolCall — becomes the next
+// tool_result message the provider sends back to the model.
+type ToolResult struct {
+	CallID  string
+	Content any  // JSON-serialisable; the provider marshals it
+	IsError bool
+}
+
+// ToolRunner executes a batch of ToolCalls and returns ToolResults. The
+// provider calls this between model turns. Implementations in the ai/tools
+// package plug their Runner in via a small adapter.
+type ToolRunner interface {
+	Run(ctx context.Context, calls []ToolCall) ([]ToolResult, error)
+}
+
+// ToolLoopRequest drives Provider.RunToolLoop. System and User are the same
+// as in Request; Tools is the catalogue advertised to the model each turn;
+// Runner handles the calls. MaxTurns caps how many tool-use iterations
+// run before the provider gives up and returns whatever text it has.
+type ToolLoopRequest struct {
+	System      string
+	User        string
+	Temperature float64
+	MaxTokens   int
+	Tools       []ToolDefinition
+	Runner      ToolRunner
+	// MaxTurns caps the number of model turns. Each tool-call round counts
+	// as one turn. A model that never stops calling tools is a common
+	// failure mode; this is the safety net. Zero → provider default (8).
+	MaxTurns int
+}
+
+// ToolUser is the optional interface providers implement when they support
+// function calling / tool use. The multi-agent orchestrator type-asserts
+// for this — providers that don't implement it fall back to plain Complete
+// and lose the agent feature gracefully.
+type ToolUser interface {
+	// RunToolLoop runs the model in a tool-use loop: call model → if the
+	// response requests tools, run them via req.Runner → feed results back
+	// → repeat until the model returns final text (or MaxTurns is hit).
+	// The returned string is the final assistant text; transcripts are
+	// optional and provider-specific.
+	RunToolLoop(ctx context.Context, req ToolLoopRequest) (string, error)
+}
+
 // ErrEmptyResponse is returned when a provider round-trips successfully but
 // the body contains no usable content — separated out so callers can fall
 // back to deterministic heuristics (pattern matching) instead of surfacing a

--- a/internal/ai/tools/iac_tools.go
+++ b/internal/ai/tools/iac_tools.go
@@ -93,8 +93,9 @@ func newListResourcesTool(deps IaCToolDeps) Tool {
 				if args.Type != "" && r.Type != args.Type {
 					continue
 				}
+				scrubbed := scrubResource(r, deps.ProjectDir)
 				out.Resources = append(out.Resources, listedResource{
-					ID: r.ID, Type: r.Type, Name: r.Name, File: r.File,
+					ID: r.ID, Type: r.Type, Name: r.Name, File: scrubbed.File,
 				})
 			}
 			return out, nil
@@ -134,7 +135,7 @@ func newGetResourceTool(deps IaCToolDeps) Tool {
 			}
 			for _, r := range all {
 				if r.ID == args.ID {
-					return r, nil
+					return scrubResource(r, deps.ProjectDir), nil
 				}
 			}
 			return nil, fmt.Errorf("resource not found: %s", args.ID)
@@ -177,8 +178,10 @@ func newWriteHCLTool(deps IaCToolDeps) Tool {
 			if err := json.Unmarshal(raw, &args); err != nil {
 				return nil, fmt.Errorf("write_hcl: %w", err)
 			}
-			if args.RelPath == "" || args.Content == "" {
-				return nil, fmt.Errorf("write_hcl: rel_path and content are required")
+			// Empty content is a legitimate outcome (clearing a file /
+			// creating a placeholder), so only rel_path is required.
+			if args.RelPath == "" {
+				return nil, fmt.Errorf("write_hcl: rel_path is required")
 			}
 			full, err := scopePathWithinProject(deps.ProjectDir, args.RelPath)
 			if err != nil {
@@ -242,9 +245,13 @@ func newRunPolicyTool(deps IaCToolDeps) Tool {
 		`{"type": "object", "properties": {}}`,
 		func(ctx context.Context, raw json.RawMessage) (any, error) {
 			resources := parseResources(deps.ProjectDir)
-			var planJSON []byte
-			if data, err := os.ReadFile(filepath.Join(deps.ProjectDir, "tfplan.json")); err == nil {
-				planJSON = data
+			// Read tfplan.json only if it's a regular file — a symlink
+			// could be used to exfiltrate arbitrary host files via the
+			// next tool_result sent to the LLM. Missing file stays
+			// silent so plan-less engines like the builtin still run.
+			planJSON, err := readRegularFile(filepath.Join(deps.ProjectDir, "tfplan.json"))
+			if err != nil && !os.IsNotExist(err) {
+				return nil, err
 			}
 			results := engines.RunAll(ctx, deps.PolicyEngines, engines.EvalInput{
 				ProjectDir: deps.ProjectDir,
@@ -323,6 +330,12 @@ func newSearchRegistryTool(deps IaCToolDeps) Tool {
 			if err := json.Unmarshal(raw, &args); err != nil {
 				return nil, fmt.Errorf("search_registry: %w", err)
 			}
+			// Models occasionally forget required fields even when the
+			// schema marks them required — surface an explicit error
+			// rather than forwarding an empty query upstream.
+			if strings.TrimSpace(args.Query) == "" {
+				return nil, fmt.Errorf("search_registry: query is required")
+			}
 			if deps.RegistryClient == nil {
 				return nil, fmt.Errorf("search_registry: no registry client configured")
 			}
@@ -346,7 +359,7 @@ func newReadPlanTool(deps IaCToolDeps) Tool {
 		"Read the project's current tfplan.json (produced by `terraform show -json tfplan`). Returns the raw JSON so downstream tools or the model can reason about planned changes. Errors clearly when no plan has been run yet.",
 		`{"type": "object", "properties": {}}`,
 		func(ctx context.Context, raw json.RawMessage) (any, error) {
-			data, err := os.ReadFile(filepath.Join(deps.ProjectDir, "tfplan.json"))
+			data, err := readRegularFile(filepath.Join(deps.ProjectDir, "tfplan.json"))
 			if err != nil {
 				if os.IsNotExist(err) {
 					return nil, fmt.Errorf("no tfplan.json — run terraform plan + `terraform show -json tfplan > tfplan.json` first")
@@ -363,6 +376,42 @@ func newReadPlanTool(deps IaCToolDeps) Tool {
 }
 
 // ─── shared helpers ────────────────────────────────────────────────────
+
+// readRegularFile reads path only if it's a regular file — not a symlink,
+// not a device, not a fifo. Any of those could otherwise be used to
+// exfiltrate arbitrary host content through a tool_result; Lstat + mode
+// check is the cheapest runtime safeguard.
+func readRegularFile(path string) ([]byte, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("refusing to follow symlink: %s", path)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("not a regular file: %s", path)
+	}
+	return os.ReadFile(path)
+}
+
+// scrubResource returns a copy of r with the File field rewritten to the
+// project-relative form, so tool_results sent to the LLM don't leak the
+// host's absolute filesystem layout.
+func scrubResource(r parser.Resource, projectDir string) parser.Resource {
+	out := r
+	if r.File == "" {
+		return out
+	}
+	if rel, err := filepath.Rel(projectDir, r.File); err == nil && !strings.HasPrefix(rel, "..") {
+		out.File = rel
+	} else {
+		// Couldn't relativize cleanly → drop the path entirely rather
+		// than leak the host layout.
+		out.File = filepath.Base(r.File)
+	}
+	return out
+}
 
 // parseResources is a best-effort parse used by tools that don't require
 // perfect fidelity — ignores errors and returns whatever parsed cleanly so

--- a/internal/ai/tools/iac_tools.go
+++ b/internal/ai/tools/iac_tools.go
@@ -190,13 +190,38 @@ func newWriteHCLTool(deps IaCToolDeps) Tool {
 			if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
 				return nil, err
 			}
-			// Atomic write: temp file in the same dir + rename.
-			tmp := full + ".tmp"
-			if err := os.WriteFile(tmp, []byte(args.Content), 0o644); err != nil {
+			// Before touching disk, walk each existing path component and
+			// refuse if any is a symlink. Containment via scopePathWithinProject
+			// is lexical; this is the runtime check that keeps a pre-existing
+			// in-project symlink from redirecting the write outside the root.
+			if err := refuseSymlinkOnPath(deps.ProjectDir, full); err != nil {
+				return nil, err
+			}
+			// Atomic write: CreateTemp in the same dir → write → rename.
+			// A unique temp filename lets concurrent writes to the same
+			// target coexist without clobbering each other's .tmp file.
+			dir := filepath.Dir(full)
+			base := filepath.Base(full)
+			tmpFile, err := os.CreateTemp(dir, base+".*.tmp")
+			if err != nil {
+				return nil, err
+			}
+			tmp := tmpFile.Name()
+			// Remove the temp file unconditionally on exit — a successful
+			// Rename makes the Remove a no-op (file no longer at tmp path).
+			defer func() { _ = os.Remove(tmp) }()
+			if _, err := tmpFile.Write([]byte(args.Content)); err != nil {
+				_ = tmpFile.Close()
+				return nil, err
+			}
+			if err := tmpFile.Chmod(0o644); err != nil {
+				_ = tmpFile.Close()
+				return nil, err
+			}
+			if err := tmpFile.Close(); err != nil {
 				return nil, err
 			}
 			if err := os.Rename(tmp, full); err != nil {
-				_ = os.Remove(tmp)
 				return nil, err
 			}
 			return writeHCLResult{
@@ -346,6 +371,49 @@ func parseResources(projectDir string) []parser.Resource {
 	p := &parser.HCLParser{}
 	resources, _ := p.ParseDir(projectDir)
 	return resources
+}
+
+// refuseSymlinkOnPath walks each existing path component from projectDir
+// toward full and returns an error if any of them is a symlink. Used as
+// a runtime complement to scopePathWithinProject's lexical check — a
+// malicious or accidental symlink placed inside the project directory
+// would otherwise redirect a follow-up Write through it.
+//
+// Non-existing components (the target file and any unmaterialised parent
+// dirs created by MkdirAll) aren't checked — os.Lstat returns IsNotExist
+// for them and we stop. The parents that DO exist at the time of write
+// are the only ones that can redirect the write.
+func refuseSymlinkOnPath(projectDir, full string) error {
+	// Canonicalize the project root so the walk stays inside it — macOS's
+	// /var → /private/var symlink would otherwise trigger on the very
+	// first segment when full was itself built under the canonical form
+	// by scopePathWithinProject.
+	canon, err := filepath.EvalSymlinks(projectDir)
+	if err != nil {
+		canon = projectDir
+	}
+	rel, err := filepath.Rel(canon, full)
+	if err != nil {
+		return err
+	}
+	segments := strings.Split(rel, string(filepath.Separator))
+	cur := canon
+	// Walk intermediate dirs only — the final element is the file we're
+	// about to write and it may not exist yet.
+	for _, seg := range segments[:len(segments)-1] {
+		cur = filepath.Join(cur, seg)
+		info, err := os.Lstat(cur)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return fmt.Errorf("lstat %s: %w", cur, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to follow symlink: %s", cur)
+		}
+	}
+	return nil
 }
 
 // scopePathWithinProject rejects absolute paths and any relative path that

--- a/internal/ai/tools/iac_tools.go
+++ b/internal/ai/tools/iac_tools.go
@@ -1,0 +1,389 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/iac-studio/iac-studio/internal/parser"
+	"github.com/iac-studio/iac-studio/internal/policy/engines"
+	"github.com/iac-studio/iac-studio/internal/registry"
+	"github.com/iac-studio/iac-studio/internal/security/scanners"
+)
+
+// IaCToolDeps bundles everything the IaC tools need to do real work —
+// passed once at registration time so individual handlers stay simple and
+// test-friendly (tests inject fakes via this struct).
+type IaCToolDeps struct {
+	// ProjectDir is the absolute path the agent is operating on. Every
+	// tool call is scoped here — handlers never reach outside this
+	// directory so a rogue model prompt can't traverse to other projects.
+	ProjectDir string
+	// PolicyEngines is the set of engines run by run_policy. Pass the
+	// same slice registerPolicyRoutes already uses so the agent sees the
+	// same results the /api/policy/run endpoint does.
+	PolicyEngines []engines.PolicyEngine
+	// Scanners is the set of security scanners run by run_scan, same
+	// shape as PolicyEngines — one registry shared across HTTP and agent.
+	Scanners []scanners.Scanner
+	// RegistryClient is used by search_registry.
+	RegistryClient *registry.Client
+}
+
+// RegisterIaCTools adds every built-in tool to reg. Pass the same Registry
+// to Runner so the agent can actually call them.
+func RegisterIaCTools(reg *Registry, deps IaCToolDeps) {
+	reg.Register(newListResourcesTool(deps))
+	reg.Register(newGetResourceTool(deps))
+	reg.Register(newWriteHCLTool(deps))
+	reg.Register(newRunPolicyTool(deps))
+	reg.Register(newRunScanTool(deps))
+	reg.Register(newSearchRegistryTool(deps))
+	reg.Register(newReadPlanTool(deps))
+}
+
+// ─── list_resources ────────────────────────────────────────────────────
+
+type listResourcesArgs struct {
+	// Type optionally filters to a single resource type (e.g. "aws_s3_bucket").
+	Type string `json:"type,omitempty"`
+}
+
+type listResourcesResult struct {
+	Resources []listedResource `json:"resources"`
+}
+
+type listedResource struct {
+	ID   string `json:"id"`
+	Type string `json:"type"`
+	Name string `json:"name"`
+	File string `json:"file"`
+}
+
+func newListResourcesTool(deps IaCToolDeps) Tool {
+	return New(
+		"list_resources",
+		"List every Terraform resource in the project, optionally filtered by type. Use this before calling write_hcl so you don't duplicate existing resources.",
+		`{
+  "type": "object",
+  "properties": {
+    "type": {"type": "string", "description": "Optional resource type filter, e.g. aws_s3_bucket"}
+  }
+}`,
+		func(ctx context.Context, raw json.RawMessage) (any, error) {
+			var args listResourcesArgs
+			if len(raw) > 0 {
+				if err := json.Unmarshal(raw, &args); err != nil {
+					return nil, fmt.Errorf("list_resources: %w", err)
+				}
+			}
+			p := &parser.HCLParser{}
+			all, err := p.ParseDir(deps.ProjectDir)
+			if err != nil {
+				return nil, err
+			}
+			out := listResourcesResult{Resources: []listedResource{}}
+			for _, r := range all {
+				if r.BlockType != "resource" {
+					continue
+				}
+				if args.Type != "" && r.Type != args.Type {
+					continue
+				}
+				out.Resources = append(out.Resources, listedResource{
+					ID: r.ID, Type: r.Type, Name: r.Name, File: r.File,
+				})
+			}
+			return out, nil
+		},
+	)
+}
+
+// ─── get_resource ──────────────────────────────────────────────────────
+
+type getResourceArgs struct {
+	ID string `json:"id"` // "aws_s3_bucket.data"
+}
+
+func newGetResourceTool(deps IaCToolDeps) Tool {
+	return New(
+		"get_resource",
+		"Fetch the full definition of a single resource by ID (e.g. \"aws_s3_bucket.data\"). Use this to read current property values before proposing a change.",
+		`{
+  "type": "object",
+  "required": ["id"],
+  "properties": {
+    "id": {"type": "string", "description": "Resource ID, e.g. aws_s3_bucket.data"}
+  }
+}`,
+		func(ctx context.Context, raw json.RawMessage) (any, error) {
+			var args getResourceArgs
+			if err := json.Unmarshal(raw, &args); err != nil {
+				return nil, fmt.Errorf("get_resource: %w", err)
+			}
+			if args.ID == "" {
+				return nil, fmt.Errorf("get_resource: id is required")
+			}
+			p := &parser.HCLParser{}
+			all, err := p.ParseDir(deps.ProjectDir)
+			if err != nil {
+				return nil, err
+			}
+			for _, r := range all {
+				if r.ID == args.ID {
+					return r, nil
+				}
+			}
+			return nil, fmt.Errorf("resource not found: %s", args.ID)
+		},
+	)
+}
+
+// ─── write_hcl ─────────────────────────────────────────────────────────
+
+type writeHCLArgs struct {
+	// RelPath is the target file, relative to the project root. Must stay
+	// inside the project — absolute paths and ../ escapes are refused.
+	RelPath string `json:"rel_path"`
+	// Content is the full file body to write. Agents tend to hand back
+	// whole files rather than patches; we accept that and do a safe
+	// atomic replace.
+	Content string `json:"content"`
+}
+
+type writeHCLResult struct {
+	Path    string `json:"path"`
+	Bytes   int    `json:"bytes"`
+	Message string `json:"message"`
+}
+
+func newWriteHCLTool(deps IaCToolDeps) Tool {
+	return New(
+		"write_hcl",
+		"Write a Terraform file under the project. rel_path must stay inside the project root (no absolute paths, no ../). Content replaces the file atomically; use list_resources first to read current state.",
+		`{
+  "type": "object",
+  "required": ["rel_path", "content"],
+  "properties": {
+    "rel_path": {"type": "string", "description": "Target .tf file relative to project root"},
+    "content":  {"type": "string", "description": "Full file contents"}
+  }
+}`,
+		func(ctx context.Context, raw json.RawMessage) (any, error) {
+			var args writeHCLArgs
+			if err := json.Unmarshal(raw, &args); err != nil {
+				return nil, fmt.Errorf("write_hcl: %w", err)
+			}
+			if args.RelPath == "" || args.Content == "" {
+				return nil, fmt.Errorf("write_hcl: rel_path and content are required")
+			}
+			full, err := scopePathWithinProject(deps.ProjectDir, args.RelPath)
+			if err != nil {
+				return nil, err
+			}
+			if !strings.HasSuffix(full, ".tf") {
+				return nil, fmt.Errorf("write_hcl: rel_path must end in .tf")
+			}
+			if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+				return nil, err
+			}
+			// Atomic write: temp file in the same dir + rename.
+			tmp := full + ".tmp"
+			if err := os.WriteFile(tmp, []byte(args.Content), 0o644); err != nil {
+				return nil, err
+			}
+			if err := os.Rename(tmp, full); err != nil {
+				_ = os.Remove(tmp)
+				return nil, err
+			}
+			return writeHCLResult{
+				Path:    args.RelPath,
+				Bytes:   len(args.Content),
+				Message: fmt.Sprintf("wrote %d bytes to %s", len(args.Content), args.RelPath),
+			}, nil
+		},
+	)
+}
+
+// ─── run_policy ────────────────────────────────────────────────────────
+
+func newRunPolicyTool(deps IaCToolDeps) Tool {
+	return New(
+		"run_policy",
+		"Evaluate every configured policy engine (builtin, OPA, Conftest, Sentinel) against the current project. Returns findings grouped by engine and a blocking flag when any error-severity finding exists.",
+		`{"type": "object", "properties": {}}`,
+		func(ctx context.Context, raw json.RawMessage) (any, error) {
+			resources := parseResources(deps.ProjectDir)
+			var planJSON []byte
+			if data, err := os.ReadFile(filepath.Join(deps.ProjectDir, "tfplan.json")); err == nil {
+				planJSON = data
+			}
+			results := engines.RunAll(ctx, deps.PolicyEngines, engines.EvalInput{
+				ProjectDir: deps.ProjectDir,
+				Resources:  resources,
+				PlanJSON:   planJSON,
+			})
+			findings := engines.MergeFindings(results)
+			blocking := false
+			for _, f := range findings {
+				if f.Severity.IsBlocking() {
+					blocking = true
+					break
+				}
+			}
+			return map[string]any{
+				"results":  results,
+				"findings": findings,
+				"blocking": blocking,
+			}, nil
+		},
+	)
+}
+
+// ─── run_scan ──────────────────────────────────────────────────────────
+
+func newRunScanTool(deps IaCToolDeps) Tool {
+	return New(
+		"run_scan",
+		"Run every configured security scanner (graph, Checkov, Trivy, Terrascan, KICS) against the current project. Returns a merged findings feed sorted severity-first.",
+		`{"type": "object", "properties": {}}`,
+		func(ctx context.Context, raw json.RawMessage) (any, error) {
+			resources := parseResources(deps.ProjectDir)
+			results := scanners.RunAll(ctx, deps.Scanners, scanners.ScanInput{
+				ProjectDir: deps.ProjectDir,
+				Resources:  resources,
+				Tool:       "terraform",
+			})
+			findings := scanners.MergeFindings(results)
+			blocking := false
+			for _, f := range findings {
+				if scanners.IsBlocking(f.Severity) {
+					blocking = true
+					break
+				}
+			}
+			return map[string]any{
+				"results":  results,
+				"findings": findings,
+				"blocking": blocking,
+			}, nil
+		},
+	)
+}
+
+// ─── search_registry ───────────────────────────────────────────────────
+
+type searchRegistryArgs struct {
+	Query string `json:"query"`
+	Limit int    `json:"limit,omitempty"`
+}
+
+func newSearchRegistryTool(deps IaCToolDeps) Tool {
+	return New(
+		"search_registry",
+		"Search the public Terraform Registry for modules matching a free-text query. Returns up to `limit` modules (default 10, max 100). Use before proposing a new module block so you pin a known-good source.",
+		`{
+  "type": "object",
+  "required": ["query"],
+  "properties": {
+    "query": {"type": "string"},
+    "limit": {"type": "integer", "minimum": 1, "maximum": 100}
+  }
+}`,
+		func(ctx context.Context, raw json.RawMessage) (any, error) {
+			var args searchRegistryArgs
+			if err := json.Unmarshal(raw, &args); err != nil {
+				return nil, fmt.Errorf("search_registry: %w", err)
+			}
+			if deps.RegistryClient == nil {
+				return nil, fmt.Errorf("search_registry: no registry client configured")
+			}
+			limit := args.Limit
+			if limit <= 0 {
+				limit = 10
+			}
+			if limit > 100 {
+				limit = 100
+			}
+			return deps.RegistryClient.Search(ctx, args.Query, limit)
+		},
+	)
+}
+
+// ─── read_plan ─────────────────────────────────────────────────────────
+
+func newReadPlanTool(deps IaCToolDeps) Tool {
+	return New(
+		"read_plan",
+		"Read the project's current tfplan.json (produced by `terraform show -json tfplan`). Returns the raw JSON so downstream tools or the model can reason about planned changes. Errors clearly when no plan has been run yet.",
+		`{"type": "object", "properties": {}}`,
+		func(ctx context.Context, raw json.RawMessage) (any, error) {
+			data, err := os.ReadFile(filepath.Join(deps.ProjectDir, "tfplan.json"))
+			if err != nil {
+				if os.IsNotExist(err) {
+					return nil, fmt.Errorf("no tfplan.json — run terraform plan + `terraform show -json tfplan > tfplan.json` first")
+				}
+				return nil, err
+			}
+			var out any
+			if err := json.Unmarshal(data, &out); err != nil {
+				return nil, fmt.Errorf("tfplan.json is not valid JSON: %w", err)
+			}
+			return out, nil
+		},
+	)
+}
+
+// ─── shared helpers ────────────────────────────────────────────────────
+
+// parseResources is a best-effort parse used by tools that don't require
+// perfect fidelity — ignores errors and returns whatever parsed cleanly so
+// a single bad .tf file doesn't blank the whole tool invocation.
+func parseResources(projectDir string) []parser.Resource {
+	p := &parser.HCLParser{}
+	resources, _ := p.ParseDir(projectDir)
+	return resources
+}
+
+// scopePathWithinProject rejects absolute paths and any relative path that
+// resolves outside the project root. This is the single choke point for
+// write operations — every tool that touches disk must use it so a model
+// that's been prompt-injected can't cause writes outside the project.
+//
+// Containment is checked lexically (filepath.Clean + ".." prefix) AND
+// canonically (EvalSymlinks on the project root, then build the target
+// under that canonical path). Building absFull from the canonicalised
+// root avoids the macOS /var → /private/var mismatch that would otherwise
+// make any target look like it "escapes" the root when the parent of the
+// target doesn't exist yet (can't EvalSymlinks a path that isn't on disk).
+func scopePathWithinProject(projectDir, rel string) (string, error) {
+	if filepath.IsAbs(rel) {
+		return "", fmt.Errorf("path must be relative: %q", rel)
+	}
+	cleaned := filepath.Clean(rel)
+	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("path escapes project root: %q", rel)
+	}
+	absRoot, err := filepath.Abs(projectDir)
+	if err != nil {
+		return "", err
+	}
+	if eval, err := filepath.EvalSymlinks(absRoot); err == nil {
+		absRoot = eval
+	}
+	// Build the target under the canonical root rather than joining against
+	// the caller-supplied projectDir — keeps both sides of the containment
+	// check on the same symlink side of the filesystem.
+	absFull := filepath.Join(absRoot, cleaned)
+	rel2, err := filepath.Rel(absRoot, absFull)
+	if err != nil {
+		return "", err
+	}
+	if rel2 == ".." || strings.HasPrefix(rel2, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("path escapes project root: %q", rel)
+	}
+	return absFull, nil
+}

--- a/internal/ai/tools/iac_tools_test.go
+++ b/internal/ai/tools/iac_tools_test.go
@@ -1,0 +1,249 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/iac-studio/iac-studio/internal/policy/engines"
+	"github.com/iac-studio/iac-studio/internal/registry"
+)
+
+// scaffoldToolProject seeds a minimal Terraform project for the tool tests.
+func scaffoldToolProject(t *testing.T, hcl string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "main.tf"), []byte(hcl), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	return dir
+}
+
+// registerAndLookup is a tiny helper that registers the IaC tools and
+// returns the one with the given name.
+func registerAndLookup(t *testing.T, deps IaCToolDeps, name string) Tool {
+	t.Helper()
+	reg := NewRegistry()
+	RegisterIaCTools(reg, deps)
+	tool, ok := reg.Lookup(name)
+	if !ok {
+		t.Fatalf("tool %q not registered", name)
+	}
+	return tool
+}
+
+// TestListResourcesTool — walks the project and returns every resource,
+// with the optional type filter narrowing results.
+func TestListResourcesTool(t *testing.T) {
+	dir := scaffoldToolProject(t, `resource "aws_vpc" "main" { cidr_block = "10.0.0.0/16" }
+resource "aws_s3_bucket" "data" { bucket = "d" }
+resource "aws_s3_bucket" "logs" { bucket = "l" }
+`)
+	tool := registerAndLookup(t, IaCToolDeps{ProjectDir: dir}, "list_resources")
+
+	// No filter → three resources.
+	out, err := tool.Handler(context.Background(), json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("Handler: %v", err)
+	}
+	result := out.(listResourcesResult)
+	if len(result.Resources) != 3 {
+		t.Errorf("want 3 resources, got %d", len(result.Resources))
+	}
+
+	// Type filter → only S3 buckets.
+	out, _ = tool.Handler(context.Background(), json.RawMessage(`{"type":"aws_s3_bucket"}`))
+	result = out.(listResourcesResult)
+	if len(result.Resources) != 2 {
+		t.Errorf("filter by type should yield 2 buckets, got %d", len(result.Resources))
+	}
+}
+
+// TestGetResourceTool — fetching by ID returns the full resource with
+// properties; a missing ID yields a clear error.
+func TestGetResourceTool(t *testing.T) {
+	dir := scaffoldToolProject(t, `resource "aws_vpc" "main" { cidr_block = "10.0.0.0/16" }`)
+	tool := registerAndLookup(t, IaCToolDeps{ProjectDir: dir}, "get_resource")
+
+	// Happy path.
+	out, err := tool.Handler(context.Background(), json.RawMessage(`{"id":"aws_vpc.main"}`))
+	if err != nil {
+		t.Fatalf("Handler: %v", err)
+	}
+	raw, _ := json.Marshal(out)
+	if !strings.Contains(string(raw), "10.0.0.0/16") {
+		t.Errorf("resource properties missing from response: %s", raw)
+	}
+
+	// Missing.
+	_, err = tool.Handler(context.Background(), json.RawMessage(`{"id":"aws_vpc.ghost"}`))
+	if err == nil || !strings.Contains(err.Error(), "aws_vpc.ghost") {
+		t.Errorf("missing ID should surface in error, got: %v", err)
+	}
+
+	// Bad args.
+	_, err = tool.Handler(context.Background(), json.RawMessage(`{}`))
+	if err == nil {
+		t.Error("empty id should be rejected")
+	}
+}
+
+// TestWriteHCLTool — writes inside the project, refuses escapes, refuses
+// non-.tf paths. Atomic replace means the old content is gone once the
+// call returns.
+func TestWriteHCLTool(t *testing.T) {
+	dir := scaffoldToolProject(t, `# original`)
+	tool := registerAndLookup(t, IaCToolDeps{ProjectDir: dir}, "write_hcl")
+
+	// Happy path — replace main.tf.
+	body, _ := json.Marshal(map[string]string{
+		"rel_path": "main.tf",
+		"content":  `resource "aws_vpc" "main" { cidr_block = "10.0.0.0/16" }`,
+	})
+	out, err := tool.Handler(context.Background(), body)
+	if err != nil {
+		t.Fatalf("Handler: %v", err)
+	}
+	if out.(writeHCLResult).Bytes == 0 {
+		t.Error("result should report bytes written")
+	}
+	newContent, _ := os.ReadFile(filepath.Join(dir, "main.tf"))
+	if !strings.Contains(string(newContent), "aws_vpc") {
+		t.Errorf("file not replaced: %s", newContent)
+	}
+
+	// Path escape attempts.
+	for _, bad := range []string{"../escape.tf", "/etc/passwd", "modules/../../escape.tf", "."} {
+		body, _ := json.Marshal(map[string]string{"rel_path": bad, "content": "x"})
+		if _, err := tool.Handler(context.Background(), body); err == nil {
+			t.Errorf("path %q should be rejected", bad)
+		}
+	}
+
+	// Non-.tf extension.
+	body, _ = json.Marshal(map[string]string{"rel_path": "config.yml", "content": "x"})
+	if _, err := tool.Handler(context.Background(), body); err == nil {
+		t.Error("non-.tf path should be rejected")
+	}
+}
+
+// TestWriteHCLToolCreatesSubdirs — writing to modules/new/main.tf should
+// create intermediate directories.
+func TestWriteHCLToolCreatesSubdirs(t *testing.T) {
+	dir := scaffoldToolProject(t, `# root`)
+	tool := registerAndLookup(t, IaCToolDeps{ProjectDir: dir}, "write_hcl")
+	body, _ := json.Marshal(map[string]string{
+		"rel_path": "modules/newmod/main.tf",
+		"content":  `# module`,
+	})
+	if _, err := tool.Handler(context.Background(), body); err != nil {
+		t.Fatalf("Handler: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "modules", "newmod", "main.tf")); err != nil {
+		t.Errorf("subdirs not created: %v", err)
+	}
+}
+
+// TestRunPolicyTool — with the builtin engine, an untagged S3 bucket
+// triggers a blocking finding. Agent sees the blocking flag.
+func TestRunPolicyTool(t *testing.T) {
+	dir := scaffoldToolProject(t, `resource "aws_s3_bucket" "data" { bucket = "d" }`)
+	tool := registerAndLookup(t, IaCToolDeps{
+		ProjectDir:    dir,
+		PolicyEngines: []engines.PolicyEngine{engines.NewBuiltin()},
+	}, "run_policy")
+
+	out, err := tool.Handler(context.Background(), json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("Handler: %v", err)
+	}
+	m := out.(map[string]any)
+	if m["blocking"] != true {
+		t.Errorf("untagged S3 bucket should produce a blocking finding, got: %+v", m)
+	}
+}
+
+// TestReadPlanToolMissingFile — clear error when no plan exists so the
+// agent knows it needs to run terraform plan first.
+func TestReadPlanToolMissingFile(t *testing.T) {
+	dir := scaffoldToolProject(t, `# empty`)
+	tool := registerAndLookup(t, IaCToolDeps{ProjectDir: dir}, "read_plan")
+	_, err := tool.Handler(context.Background(), json.RawMessage(`{}`))
+	if err == nil || !strings.Contains(err.Error(), "terraform plan") {
+		t.Errorf("missing plan should nudge the agent toward terraform plan, got: %v", err)
+	}
+}
+
+// TestReadPlanToolHappyPath — valid tfplan.json round-trips through
+// parsing so the agent sees a decoded structure.
+func TestReadPlanToolHappyPath(t *testing.T) {
+	dir := scaffoldToolProject(t, `# empty`)
+	if err := os.WriteFile(filepath.Join(dir, "tfplan.json"), []byte(`{"format_version":"1.0","resource_changes":[]}`), 0o644); err != nil {
+		t.Fatalf("seed plan: %v", err)
+	}
+	tool := registerAndLookup(t, IaCToolDeps{ProjectDir: dir}, "read_plan")
+	out, err := tool.Handler(context.Background(), json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("Handler: %v", err)
+	}
+	m := out.(map[string]any)
+	if m["format_version"] != "1.0" {
+		t.Errorf("decoded plan wrong: %+v", m)
+	}
+}
+
+// TestSearchRegistryTool — proxies to the registry client via a stubbed
+// upstream.
+func TestSearchRegistryTool(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("q") != "vpc" {
+			t.Errorf("q not forwarded: %s", r.URL.RawQuery)
+		}
+		_, _ = w.Write([]byte(`{"modules":[{"name":"vpc","namespace":"terraform-aws-modules","provider":"aws"}]}`))
+	}))
+	defer srv.Close()
+	tool := registerAndLookup(t, IaCToolDeps{
+		ProjectDir:     t.TempDir(),
+		RegistryClient: registry.New(registry.Config{BaseURL: srv.URL}),
+	}, "search_registry")
+
+	out, err := tool.Handler(context.Background(), json.RawMessage(`{"query":"vpc","limit":5}`))
+	if err != nil {
+		t.Fatalf("Handler: %v", err)
+	}
+	raw, _ := json.Marshal(out)
+	if !strings.Contains(string(raw), `"name":"vpc"`) {
+		t.Errorf("result missing expected module: %s", raw)
+	}
+}
+
+// TestSearchRegistryToolNoClient — when no RegistryClient is configured,
+// the tool surfaces that instead of panicking on a nil pointer.
+func TestSearchRegistryToolNoClient(t *testing.T) {
+	tool := registerAndLookup(t, IaCToolDeps{ProjectDir: t.TempDir()}, "search_registry")
+	_, err := tool.Handler(context.Background(), json.RawMessage(`{"query":"vpc"}`))
+	if err == nil {
+		t.Error("missing registry client should surface as an error")
+	}
+}
+
+// TestRegisterIaCToolsRegistersAllNames — regression guard: if someone
+// adds a new tool but forgets to Register it, this fails.
+func TestRegisterIaCToolsRegistersAllNames(t *testing.T) {
+	reg := NewRegistry()
+	RegisterIaCTools(reg, IaCToolDeps{ProjectDir: t.TempDir()})
+	want := []string{
+		"list_resources", "get_resource", "write_hcl",
+		"run_policy", "run_scan", "search_registry", "read_plan",
+	}
+	for _, name := range want {
+		if _, ok := reg.Lookup(name); !ok {
+			t.Errorf("tool %q not registered", name)
+		}
+	}
+}

--- a/internal/ai/tools/tools.go
+++ b/internal/ai/tools/tools.go
@@ -1,0 +1,186 @@
+// Package tools is the agent's function-calling surface.
+//
+// A Tool is a typed Go function the LLM can invoke by name — list_resources,
+// run_plan, run_policy, write_hcl, and so on. The provider decides when to
+// call which tool; this package owns the registry, the JSON schema the
+// provider sees, and the loop that marshals arguments in, runs the Go
+// handler, and marshals results back.
+//
+// The design is intentionally provider-agnostic: the Anthropic tool-use
+// wire format is what drove the shape, but a future OpenAI function-
+// calling adapter plugs into the same Registry + Runner without touching
+// any tool implementation.
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+)
+
+// Definition is how a tool advertises itself to the LLM. Schema is a
+// JSON Schema object describing the tool's input arguments — providers
+// forward it verbatim to the model.
+type Definition struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	Schema      json.RawMessage `json:"input_schema"`
+}
+
+// Handler is the Go-side implementation that runs when the model calls a
+// tool. args is the raw JSON the model emitted; the handler is responsible
+// for decoding it into whatever typed shape it expects.
+//
+// Return value semantics:
+//   - result: any JSON-serialisable value. It becomes the tool_result the
+//     model sees on its next turn. Use a struct or map[string]any.
+//   - error: surfaced to the model as a tool_result with "error" flag set
+//     so the model can decide whether to retry or give up. Fatal errors
+//     that should abort the whole loop are signalled via a sentinel
+//     ErrAbort rather than returning a generic error — see Runner.
+type Handler func(ctx context.Context, args json.RawMessage) (result any, err error)
+
+// Tool pairs one Definition with its Handler. Authors don't construct Tool
+// directly; use New.
+type Tool struct {
+	Def     Definition
+	Handler Handler
+}
+
+// New builds a Tool. schema must be a valid JSON Schema object (raw bytes);
+// keeping it as json.RawMessage rather than a struct spares us from
+// reinventing JSON Schema in Go just to serialise it back out.
+func New(name, description string, schema string, handler Handler) Tool {
+	return Tool{
+		Def: Definition{
+			Name:        name,
+			Description: description,
+			Schema:      json.RawMessage(schema),
+		},
+		Handler: handler,
+	}
+}
+
+// Registry holds the tools available to the agent. It's a concrete type
+// rather than an interface because we need reflective access to the whole
+// set (Definitions() for the model, Lookup() for the runner).
+type Registry struct {
+	tools map[string]Tool
+}
+
+// NewRegistry returns an empty registry.
+func NewRegistry() *Registry {
+	return &Registry{tools: make(map[string]Tool)}
+}
+
+// Register adds a tool. A later registration with the same name replaces
+// the earlier one — useful for tests that swap a real handler for a stub.
+func (r *Registry) Register(t Tool) {
+	r.tools[t.Def.Name] = t
+}
+
+// Lookup returns the named tool. The second return is false when the model
+// hallucinates a tool name; the Runner surfaces that as a tool_result with
+// "unknown tool" so the model can correct itself instead of looping forever.
+func (r *Registry) Lookup(name string) (Tool, bool) {
+	t, ok := r.tools[name]
+	return t, ok
+}
+
+// Definitions returns every registered tool's metadata, sorted by name for
+// deterministic output. Providers call this to build the tools array sent
+// with each model turn.
+func (r *Registry) Definitions() []Definition {
+	defs := make([]Definition, 0, len(r.tools))
+	for _, t := range r.tools {
+		defs = append(defs, t.Def)
+	}
+	sort.Slice(defs, func(i, j int) bool { return defs[i].Name < defs[j].Name })
+	return defs
+}
+
+// Names returns every registered tool name, sorted — handy for logs and
+// routing decisions that don't need the full schema.
+func (r *Registry) Names() []string {
+	names := make([]string, 0, len(r.tools))
+	for n := range r.tools {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// ToolCall is the model's request to invoke a tool. ID is the model's own
+// correlation token (different providers use different shapes — Anthropic's
+// "tool_use" has an id field, OpenAI's has tool_call_id — we normalise to
+// ID here). Args is the raw JSON the model emitted.
+type ToolCall struct {
+	ID   string
+	Name string
+	Args json.RawMessage
+}
+
+// ToolResult is what the runner produces for each ToolCall. It's the value
+// the provider feeds back to the model on the next turn. Error captures
+// handler failures so the model can see them and decide how to react.
+type ToolResult struct {
+	CallID  string
+	Content any    // handler's return value (or an error-shaped object)
+	IsError bool
+}
+
+// ErrAbort is the sentinel handlers return to tell the Runner to stop the
+// whole loop rather than feed the error back to the model. Use this when
+// continuing would be unsafe (e.g. the project directory disappeared under
+// us, the user revoked permission).
+var ErrAbort = fmt.Errorf("tool loop aborted")
+
+// Runner executes a batch of ToolCalls against the Registry. It's the
+// generic piece of the agent loop — provider-specific code only decides
+// which ToolCalls to pass in and what to do with the ToolResults.
+type Runner struct {
+	Registry *Registry
+	// MaxIterations is a safety cap on how many tool-call rounds the agent
+	// can run before we declare it stuck. Providers enforce this by
+	// counting their own tool-use turns; the Runner enforces it per Run()
+	// call so a broken registry entry can't spin forever.
+	MaxIterations int
+}
+
+// Run executes every call in sequence (models typically emit one per turn,
+// but Anthropic can batch), returning the resulting ToolResults in the same
+// order. An ErrAbort from any handler stops immediately and is returned
+// alongside whatever results accumulated.
+func (r *Runner) Run(ctx context.Context, calls []ToolCall) ([]ToolResult, error) {
+	out := make([]ToolResult, 0, len(calls))
+	for _, call := range calls {
+		result := ToolResult{CallID: call.ID}
+		tool, ok := r.Registry.Lookup(call.Name)
+		if !ok {
+			// Hallucinated name — hand back an error result so the model
+			// can correct itself. This is NOT fatal to the loop.
+			result.Content = map[string]string{
+				"error": fmt.Sprintf("unknown tool: %s", call.Name),
+			}
+			result.IsError = true
+			out = append(out, result)
+			continue
+		}
+		value, err := tool.Handler(ctx, call.Args)
+		if err != nil {
+			if err == ErrAbort {
+				return out, ErrAbort
+			}
+			// Any other error becomes a visible tool_result so the model
+			// can see what went wrong and potentially retry with different
+			// arguments.
+			result.Content = map[string]string{"error": err.Error()}
+			result.IsError = true
+		} else {
+			result.Content = value
+		}
+		out = append(out, result)
+	}
+	return out, nil
+}

--- a/internal/ai/tools/tools.go
+++ b/internal/ai/tools/tools.go
@@ -166,6 +166,12 @@ type Runner struct {
 // the batch exceeds it, the surplus calls are silently dropped — providers
 // should never send a batch larger than the declared limit.
 func (r *Runner) Run(ctx context.Context, calls []ToolCall) ([]ToolResult, error) {
+	if r.Registry == nil {
+		// Panicking on a misconfigured Runner pushed the blast radius all
+		// the way up to the HTTP handler. Return an error instead so the
+		// caller can respond cleanly and log the misconfiguration.
+		return nil, fmt.Errorf("tools.Runner: Registry is nil")
+	}
 	if r.MaxIterations > 0 && len(calls) > r.MaxIterations {
 		calls = calls[:r.MaxIterations]
 	}

--- a/internal/ai/tools/tools.go
+++ b/internal/ai/tools/tools.go
@@ -15,8 +15,10 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
+	"sync"
 )
 
 // Definition is how a tool advertises itself to the LLM. Schema is a
@@ -66,6 +68,7 @@ func New(name, description string, schema string, handler Handler) Tool {
 // rather than an interface because we need reflective access to the whole
 // set (Definitions() for the model, Lookup() for the runner).
 type Registry struct {
+	mu    sync.RWMutex
 	tools map[string]Tool
 }
 
@@ -77,6 +80,8 @@ func NewRegistry() *Registry {
 // Register adds a tool. A later registration with the same name replaces
 // the earlier one — useful for tests that swap a real handler for a stub.
 func (r *Registry) Register(t Tool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.tools[t.Def.Name] = t
 }
 
@@ -84,6 +89,8 @@ func (r *Registry) Register(t Tool) {
 // hallucinates a tool name; the Runner surfaces that as a tool_result with
 // "unknown tool" so the model can correct itself instead of looping forever.
 func (r *Registry) Lookup(name string) (Tool, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	t, ok := r.tools[name]
 	return t, ok
 }
@@ -92,6 +99,8 @@ func (r *Registry) Lookup(name string) (Tool, bool) {
 // deterministic output. Providers call this to build the tools array sent
 // with each model turn.
 func (r *Registry) Definitions() []Definition {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	defs := make([]Definition, 0, len(r.tools))
 	for _, t := range r.tools {
 		defs = append(defs, t.Def)
@@ -103,6 +112,8 @@ func (r *Registry) Definitions() []Definition {
 // Names returns every registered tool name, sorted — handy for logs and
 // routing decisions that don't need the full schema.
 func (r *Registry) Names() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	names := make([]string, 0, len(r.tools))
 	for n := range r.tools {
 		names = append(names, n)
@@ -134,7 +145,7 @@ type ToolResult struct {
 // whole loop rather than feed the error back to the model. Use this when
 // continuing would be unsafe (e.g. the project directory disappeared under
 // us, the user revoked permission).
-var ErrAbort = fmt.Errorf("tool loop aborted")
+var ErrAbort = errors.New("tool loop aborted")
 
 // Runner executes a batch of ToolCalls against the Registry. It's the
 // generic piece of the agent loop — provider-specific code only decides
@@ -151,8 +162,13 @@ type Runner struct {
 // Run executes every call in sequence (models typically emit one per turn,
 // but Anthropic can batch), returning the resulting ToolResults in the same
 // order. An ErrAbort from any handler stops immediately and is returned
-// alongside whatever results accumulated.
+// alongside whatever results accumulated. If MaxIterations is non-zero and
+// the batch exceeds it, the surplus calls are silently dropped — providers
+// should never send a batch larger than the declared limit.
 func (r *Runner) Run(ctx context.Context, calls []ToolCall) ([]ToolResult, error) {
+	if r.MaxIterations > 0 && len(calls) > r.MaxIterations {
+		calls = calls[:r.MaxIterations]
+	}
 	out := make([]ToolResult, 0, len(calls))
 	for _, call := range calls {
 		result := ToolResult{CallID: call.ID}
@@ -169,7 +185,7 @@ func (r *Runner) Run(ctx context.Context, calls []ToolCall) ([]ToolResult, error
 		}
 		value, err := tool.Handler(ctx, call.Args)
 		if err != nil {
-			if err == ErrAbort {
+			if errors.Is(err, ErrAbort) {
 				return out, ErrAbort
 			}
 			// Any other error becomes a visible tool_result so the model

--- a/internal/ai/tools/tools_test.go
+++ b/internal/ai/tools/tools_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"testing"
 )
 
@@ -141,10 +142,51 @@ func TestRunnerErrAbortTerminatesLoop(t *testing.T) {
 		{ID: "2", Name: "stop"},
 		{ID: "3", Name: "ok"}, // should NOT run
 	})
-	if err != ErrAbort {
+	if !errors.Is(err, ErrAbort) {
 		t.Fatalf("want ErrAbort, got %v", err)
 	}
 	if len(results) != 1 {
 		t.Errorf("only the pre-abort result should be collected, got %+v", results)
+	}
+}
+
+// TestRunnerWrappedErrAbortTerminatesLoop — a handler that wraps ErrAbort
+// with %w must still stop the loop; errors.Is must be used, not ==.
+func TestRunnerWrappedErrAbortTerminatesLoop(t *testing.T) {
+	reg := NewRegistry()
+	reg.Register(New("wrap-stop", "wraps ErrAbort", `{}`,
+		func(ctx context.Context, args json.RawMessage) (any, error) {
+			return nil, fmt.Errorf("safe shutdown: %w", ErrAbort)
+		}))
+
+	runner := &Runner{Registry: reg, MaxIterations: 10}
+	_, err := runner.Run(context.Background(), []ToolCall{{ID: "1", Name: "wrap-stop"}})
+	if !errors.Is(err, ErrAbort) {
+		t.Fatalf("wrapped ErrAbort must still abort the loop, got %v", err)
+	}
+}
+
+// TestRunnerMaxIterationsTruncatesBatch — when a batch exceeds MaxIterations,
+// only the first MaxIterations calls are executed; the rest are dropped.
+func TestRunnerMaxIterationsTruncatesBatch(t *testing.T) {
+	reg := NewRegistry()
+	count := 0
+	reg.Register(New("tick", "counts calls", `{}`,
+		func(ctx context.Context, args json.RawMessage) (any, error) { count++; return count, nil }))
+
+	runner := &Runner{Registry: reg, MaxIterations: 2}
+	results, err := runner.Run(context.Background(), []ToolCall{
+		{ID: "1", Name: "tick"},
+		{ID: "2", Name: "tick"},
+		{ID: "3", Name: "tick"}, // truncated
+	})
+	if err != nil {
+		t.Fatalf("truncation must not error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Errorf("want 2 results (MaxIterations=2), got %d", len(results))
+	}
+	if count != 2 {
+		t.Errorf("want handler called 2 times, got %d", count)
 	}
 }

--- a/internal/ai/tools/tools_test.go
+++ b/internal/ai/tools/tools_test.go
@@ -1,0 +1,150 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+// TestRegistryRoundTrip — Register + Lookup + Definitions should round-trip
+// cleanly, and Definitions must be sorted so the model sees a stable
+// schema feed across server restarts.
+func TestRegistryRoundTrip(t *testing.T) {
+	reg := NewRegistry()
+	reg.Register(New("zebra", "last alphabetically", `{"type":"object"}`,
+		func(ctx context.Context, args json.RawMessage) (any, error) { return nil, nil }))
+	reg.Register(New("alpha", "first alphabetically", `{"type":"object"}`,
+		func(ctx context.Context, args json.RawMessage) (any, error) { return nil, nil }))
+
+	if _, ok := reg.Lookup("alpha"); !ok {
+		t.Error("Lookup should find registered tool")
+	}
+	if _, ok := reg.Lookup("ghost"); ok {
+		t.Error("Lookup should return false for unknown tool")
+	}
+
+	defs := reg.Definitions()
+	if len(defs) != 2 {
+		t.Fatalf("want 2 definitions, got %d", len(defs))
+	}
+	if defs[0].Name != "alpha" || defs[1].Name != "zebra" {
+		t.Errorf("definitions must be sorted by name: %+v", defs)
+	}
+
+	names := reg.Names()
+	if names[0] != "alpha" || names[1] != "zebra" {
+		t.Errorf("names must be sorted: %+v", names)
+	}
+}
+
+// TestRegistryReplaceOnDuplicateRegister — test fixtures commonly swap the
+// real handler for a stub; a second Register with the same name must win.
+func TestRegistryReplaceOnDuplicateRegister(t *testing.T) {
+	reg := NewRegistry()
+	called := ""
+	reg.Register(New("echo", "first", `{}`,
+		func(ctx context.Context, args json.RawMessage) (any, error) { called = "first"; return nil, nil }))
+	reg.Register(New("echo", "second", `{}`,
+		func(ctx context.Context, args json.RawMessage) (any, error) { called = "second"; return nil, nil }))
+
+	got, _ := reg.Lookup("echo")
+	_, _ = got.Handler(context.Background(), nil)
+	if called != "second" {
+		t.Errorf("last Register should win, called = %q", called)
+	}
+	if got.Def.Description != "second" {
+		t.Errorf("last definition should win, desc = %q", got.Def.Description)
+	}
+}
+
+// TestRunnerHappyPath — a batch of calls dispatches to the right handlers
+// and returns results in the same order, with CallIDs preserved.
+func TestRunnerHappyPath(t *testing.T) {
+	reg := NewRegistry()
+	reg.Register(New("double", "doubles n", `{"type":"object"}`,
+		func(ctx context.Context, args json.RawMessage) (any, error) {
+			var in struct{ N int }
+			if err := json.Unmarshal(args, &in); err != nil {
+				return nil, err
+			}
+			return map[string]int{"result": in.N * 2}, nil
+		}))
+
+	runner := &Runner{Registry: reg, MaxIterations: 10}
+	calls := []ToolCall{
+		{ID: "call-1", Name: "double", Args: json.RawMessage(`{"n":3}`)},
+		{ID: "call-2", Name: "double", Args: json.RawMessage(`{"n":5}`)},
+	}
+	results, err := runner.Run(context.Background(), calls)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("want 2 results, got %d", len(results))
+	}
+	if results[0].CallID != "call-1" || results[1].CallID != "call-2" {
+		t.Errorf("CallIDs out of order: %+v", results)
+	}
+	if results[0].IsError || results[1].IsError {
+		t.Errorf("happy path results should not be flagged IsError: %+v", results)
+	}
+}
+
+// TestRunnerUnknownToolIsNonFatal — a hallucinated tool name must NOT
+// abort the loop. The model needs a visible "unknown tool" result so it
+// can course-correct.
+func TestRunnerUnknownToolIsNonFatal(t *testing.T) {
+	runner := &Runner{Registry: NewRegistry(), MaxIterations: 10}
+	results, err := runner.Run(context.Background(), []ToolCall{
+		{ID: "x", Name: "nope", Args: json.RawMessage(`{}`)},
+	})
+	if err != nil {
+		t.Fatalf("unknown tool must not abort: %v", err)
+	}
+	if len(results) != 1 || !results[0].IsError {
+		t.Fatalf("unknown tool must yield one IsError result: %+v", results)
+	}
+}
+
+// TestRunnerHandlerErrorSurfacesToModel — generic errors from the handler
+// become tool_result errors the model sees, not abort signals. Only
+// ErrAbort terminates the whole loop.
+func TestRunnerHandlerErrorSurfacesToModel(t *testing.T) {
+	reg := NewRegistry()
+	reg.Register(New("boom", "always errors", `{}`,
+		func(ctx context.Context, args json.RawMessage) (any, error) {
+			return nil, errors.New("transient failure")
+		}))
+	runner := &Runner{Registry: reg, MaxIterations: 10}
+	results, err := runner.Run(context.Background(), []ToolCall{{ID: "c", Name: "boom"}})
+	if err != nil {
+		t.Fatalf("generic handler error must not abort: %v", err)
+	}
+	if !results[0].IsError {
+		t.Error("handler error should set IsError on the result")
+	}
+}
+
+// TestRunnerErrAbortTerminatesLoop — ErrAbort stops the run immediately,
+// returning any accumulated results plus the sentinel error.
+func TestRunnerErrAbortTerminatesLoop(t *testing.T) {
+	reg := NewRegistry()
+	reg.Register(New("ok", "always succeeds", `{}`,
+		func(ctx context.Context, args json.RawMessage) (any, error) { return "done", nil }))
+	reg.Register(New("stop", "aborts", `{}`,
+		func(ctx context.Context, args json.RawMessage) (any, error) { return nil, ErrAbort }))
+
+	runner := &Runner{Registry: reg, MaxIterations: 10}
+	results, err := runner.Run(context.Background(), []ToolCall{
+		{ID: "1", Name: "ok"},
+		{ID: "2", Name: "stop"},
+		{ID: "3", Name: "ok"}, // should NOT run
+	})
+	if err != ErrAbort {
+		t.Fatalf("want ErrAbort, got %v", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("only the pre-abort result should be collected, got %+v", results)
+	}
+}

--- a/internal/api/agent.go
+++ b/internal/api/agent.go
@@ -1,0 +1,207 @@
+package api
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/iac-studio/iac-studio/internal/ai"
+	"github.com/iac-studio/iac-studio/internal/ai/agent"
+	"github.com/iac-studio/iac-studio/internal/ai/tools"
+	"github.com/iac-studio/iac-studio/internal/policy/engines"
+	iacregistry "github.com/iac-studio/iac-studio/internal/registry"
+	"github.com/iac-studio/iac-studio/internal/security/scanners"
+)
+
+// agentRunRequest is the body of POST /api/projects/{name}/ai/agent.
+// Prompt is what the user typed; MaxTurns bounds the tool-use loop.
+type agentRunRequest struct {
+	Prompt   string `json:"prompt"`
+	MaxTurns int    `json:"max_turns,omitempty"`
+}
+
+// agentRunResponse echoes the agent.Result plus server-assigned metadata
+// the UI wants for its audit log.
+type agentRunResponse struct {
+	Specialist string `json:"specialist"`
+	Reply      string `json:"reply"`
+	// DurationMs lets the UI render timing; the orchestrator itself
+	// doesn't emit this since it depends on the HTTP boundary.
+	DurationMs int64 `json:"duration_ms"`
+}
+
+// auditLog records every agent invocation server-side so an admin can
+// replay what the agent did even after the UI's session is gone. It's
+// intentionally minimal — the per-tool logs live in the provider and are
+// noisy enough that we don't want them in the audit trail by default.
+type auditEntry struct {
+	Timestamp  time.Time `json:"timestamp"`
+	Project    string    `json:"project"`
+	Prompt     string    `json:"prompt"`
+	Specialist string    `json:"specialist"`
+	ReplyBytes int       `json:"reply_bytes"`
+	Err        string    `json:"error,omitempty"`
+	DurationMs int64     `json:"duration_ms"`
+}
+
+// agentAudit is an in-memory ring buffer of recent agent runs. Tiny and
+// best-effort — we're not promising persistence. A future commit can
+// write this to disk if operators want durability.
+type agentAudit struct {
+	mu      sync.Mutex
+	entries []auditEntry
+	maxKeep int
+}
+
+func newAgentAudit(maxKeep int) *agentAudit {
+	if maxKeep <= 0 {
+		maxKeep = 100
+	}
+	return &agentAudit{maxKeep: maxKeep}
+}
+
+func (a *agentAudit) record(e auditEntry) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.entries = append(a.entries, e)
+	if len(a.entries) > a.maxKeep {
+		a.entries = a.entries[len(a.entries)-a.maxKeep:]
+	}
+}
+
+func (a *agentAudit) snapshot() []auditEntry {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	out := make([]auditEntry, len(a.entries))
+	copy(out, a.entries)
+	return out
+}
+
+// registerAgentRoutes wires the agent endpoints. Called from NewRouter.
+//
+// The agent reuses the same policy engines + scanners + registry client
+// registered elsewhere in the router so tool output matches what the
+// per-endpoint routes return. That way users can compare "what the agent
+// says" against "what /api/projects/X/policy/run returns" byte-for-byte.
+func registerAgentRoutes(
+	mux *http.ServeMux,
+	projectsDir string,
+	aiClient *ai.Client,
+	regClient *iacregistry.Client,
+) {
+	audit := newAgentAudit(100)
+
+	// POST /api/projects/{name}/ai/agent
+	// Routes the prompt to a sub-agent and runs the tool-use loop against
+	// the project. Returns the specialist used and the final text.
+	mux.HandleFunc("POST /api/projects/{name}/ai/agent", func(w http.ResponseWriter, r *http.Request) {
+		limitBody(w, r)
+		name := r.PathValue("name")
+		projectPath, err := safeProjectPath(projectsDir, name)
+		if err != nil {
+			http.Error(w, err.Error(), 400)
+			return
+		}
+
+		var req agentRunRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid request body: "+err.Error(), 400)
+			return
+		}
+		if req.Prompt == "" {
+			http.Error(w, "prompt is required", 400)
+			return
+		}
+
+		// Build a per-request tool registry scoped to this project so a
+		// model can't leak reads/writes across projects in a shared
+		// server.
+		reg := tools.NewRegistry()
+		tools.RegisterIaCTools(reg, tools.IaCToolDeps{
+			ProjectDir:     projectPath,
+			PolicyEngines:  defaultPolicyEngines(),
+			Scanners:       defaultSecurityScanners(),
+			RegistryClient: regClient,
+		})
+
+		start := time.Now()
+		result, runErr := agent.Run(r.Context(), agent.Config{
+			Provider:     aiClient.Provider(),
+			ToolRegistry: reg,
+			MaxTurns:     req.MaxTurns,
+		}, req.Prompt)
+		elapsed := time.Since(start)
+
+		entry := auditEntry{
+			Timestamp:  time.Now().UTC(),
+			Project:    name,
+			Prompt:     req.Prompt,
+			DurationMs: elapsed.Milliseconds(),
+		}
+		if runErr != nil {
+			entry.Err = runErr.Error()
+			audit.record(entry)
+			// 400 when the provider simply doesn't support tool use (user
+			// picked Ollama and pressed the agent button); 502 for the
+			// rest (transport / provider / loop errors) so the UI can
+			// treat the two distinctly.
+			status := http.StatusBadGateway
+			if isClientError(runErr) {
+				status = http.StatusBadRequest
+			}
+			http.Error(w, runErr.Error(), status)
+			return
+		}
+		entry.Specialist = result.Specialist
+		entry.ReplyBytes = len(result.Reply)
+		audit.record(entry)
+
+		log.Printf("agent: project=%s specialist=%s duration=%dms bytes=%d",
+			name, result.Specialist, elapsed.Milliseconds(), len(result.Reply))
+
+		_ = json.NewEncoder(w).Encode(agentRunResponse{
+			Specialist: result.Specialist,
+			Reply:      result.Reply,
+			DurationMs: elapsed.Milliseconds(),
+		})
+	})
+
+	// GET /api/ai/agent/audit
+	// Returns the in-memory audit log — most-recent-last. Useful for
+	// post-incident replay and for the UI's "recent agent runs" panel.
+	mux.HandleFunc("GET /api/ai/agent/audit", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"entries": audit.snapshot(),
+		})
+	})
+}
+
+// isClientError distinguishes user-caused errors (picked a non-tool-use
+// provider, misconfiguration) from transport/provider errors. The heuristic
+// is good enough for 400-vs-502 routing; we don't need typed errors.
+func isClientError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	for _, needle := range []string{
+		"does not support tool use",
+		"no provider configured",
+		"no tool registry configured",
+	} {
+		if strings.Contains(msg, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+// Compile-time checks that the packages we depend on still expose what we
+// use — cheap way to surface a breaking rename at build time.
+var (
+	_ = engines.SeverityError
+	_ = scanners.SeverityHigh
+)

--- a/internal/api/agent_test.go
+++ b/internal/api/agent_test.go
@@ -32,8 +32,10 @@ func scaffoldAgentProject(t *testing.T) string {
 	if err := os.MkdirAll(proj, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
-	_ = os.WriteFile(filepath.Join(proj, "main.tf"),
-		[]byte(`resource "aws_vpc" "main" { cidr_block = "10.0.0.0/16" }`), 0o644)
+	if err := os.WriteFile(filepath.Join(proj, "main.tf"),
+		[]byte(`resource "aws_vpc" "main" { cidr_block = "10.0.0.0/16" }`), 0o644); err != nil {
+		t.Fatalf("write main.tf: %v", err)
+	}
 	return root
 }
 

--- a/internal/api/agent_test.go
+++ b/internal/api/agent_test.go
@@ -1,0 +1,156 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/iac-studio/iac-studio/internal/ai"
+	iacregistry "github.com/iac-studio/iac-studio/internal/registry"
+)
+
+// agentMux wires just the agent routes — keeps endpoint tests hermetic
+// without spinning up the full NewRouter stack.
+func agentMux(projectsDir string, client *ai.Client, reg *iacregistry.Client) *http.ServeMux {
+	mux := http.NewServeMux()
+	registerAgentRoutes(mux, projectsDir, client, reg)
+	return mux
+}
+
+// scaffoldAgentProject — one project dir with one main.tf, enough for the
+// path-safety + tool-registry wiring to exercise.
+func scaffoldAgentProject(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	proj := filepath.Join(root, "demo")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	_ = os.WriteFile(filepath.Join(proj, "main.tf"),
+		[]byte(`resource "aws_vpc" "main" { cidr_block = "10.0.0.0/16" }`), 0o644)
+	return root
+}
+
+// TestAgentRunBadRequestsReject400 — missing prompt, bad JSON, and
+// traversal attempts must all surface as 400 before any provider call.
+func TestAgentRunBadRequestsReject400(t *testing.T) {
+	root := scaffoldAgentProject(t)
+	client := ai.NewClient("http://127.0.0.1:1", "ignored") // Ollama default; no tool use
+	srv := httptest.NewServer(agentMux(root, client, iacregistry.New(iacregistry.Config{})))
+	defer srv.Close()
+
+	cases := []struct {
+		name   string
+		path   string
+		body   string
+		status int
+	}{
+		{"malformed JSON", "/api/projects/demo/ai/agent", "{not json", 400},
+		{"missing prompt", "/api/projects/demo/ai/agent", `{}`, 400},
+		{"path traversal", "/api/projects/%2e%2e%2fetc/ai/agent", `{"prompt":"x"}`, 400},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := http.Post(srv.URL+tc.path, "application/json", strings.NewReader(tc.body))
+			if err != nil {
+				t.Fatalf("POST: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != tc.status {
+				t.Errorf("status = %d, want %d", resp.StatusCode, tc.status)
+			}
+		})
+	}
+}
+
+// TestAgentRunNonToolUseProviderReturns400 — default Ollama provider
+// doesn't implement ToolUser. The agent endpoint must return 400 with a
+// clear "switch to Anthropic" message rather than 500.
+func TestAgentRunNonToolUseProviderReturns400(t *testing.T) {
+	root := scaffoldAgentProject(t)
+	client := ai.NewClient("http://127.0.0.1:1", "ignored") // Ollama
+	srv := httptest.NewServer(agentMux(root, client, iacregistry.New(iacregistry.Config{})))
+	defer srv.Close()
+
+	body, _ := json.Marshal(map[string]string{"prompt": "add a vpc"})
+	resp, err := http.Post(srv.URL+"/api/projects/demo/ai/agent", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("non-tool-use provider should 400, got %d", resp.StatusCode)
+	}
+	raw, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(raw), "tool use") {
+		t.Errorf("error body should explain tool-use requirement: %q", string(raw))
+	}
+}
+
+// TestAgentAuditRecordsFailedRuns — even when the agent run fails (non-
+// tool-use provider, here), the audit log should still carry an entry so
+// operators can see the attempt.
+func TestAgentAuditRecordsFailedRuns(t *testing.T) {
+	root := scaffoldAgentProject(t)
+	client := ai.NewClient("http://127.0.0.1:1", "ignored")
+	srv := httptest.NewServer(agentMux(root, client, iacregistry.New(iacregistry.Config{})))
+	defer srv.Close()
+
+	body, _ := json.Marshal(map[string]string{"prompt": "whatever"})
+	_, _ = http.Post(srv.URL+"/api/projects/demo/ai/agent", "application/json", bytes.NewReader(body))
+
+	resp, err := http.Get(srv.URL + "/api/ai/agent/audit")
+	if err != nil {
+		t.Fatalf("audit GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var audit struct {
+		Entries []auditEntry `json:"entries"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&audit); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(audit.Entries) != 1 {
+		t.Fatalf("want 1 audit entry, got %d", len(audit.Entries))
+	}
+	got := audit.Entries[0]
+	if got.Project != "demo" || got.Prompt != "whatever" {
+		t.Errorf("audit entry wrong: %+v", got)
+	}
+	if got.Err == "" {
+		t.Error("failed run must carry an Err field")
+	}
+	if got.Specialist != "" {
+		t.Errorf("failed run must NOT carry a specialist (never reached the loop): %q", got.Specialist)
+	}
+}
+
+// TestIsClientErrorMatchesProviderMessages — the 400-vs-502 heuristic
+// needs to catch the exact error strings agent.Run returns.
+func TestIsClientErrorMatchesProviderMessages(t *testing.T) {
+	cases := map[string]bool{
+		"provider \"ollama\" does not support tool use — switch to Anthropic": true,
+		"agent: no provider configured":  true,
+		"agent: no tool registry configured": true,
+		"anthropic tool-loop (status 502)":   false,
+		"decode anthropic response: EOF":     false,
+	}
+	for msg, want := range cases {
+		got := isClientError(stringErr(msg))
+		if got != want {
+			t.Errorf("isClientError(%q) = %v, want %v", msg, got, want)
+		}
+	}
+}
+
+type stringErr string
+
+func (s stringErr) Error() string { return string(s) }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1141,7 +1141,12 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 	registerScannerRoutes(mux, projectsDir)
 
 	// Terraform modules — introspect local modules + proxy the registry.
-	registerModuleRoutes(mux, projectsDir, registry.New(registry.Config{}))
+	regClient := registry.New(registry.Config{})
+	registerModuleRoutes(mux, projectsDir, regClient)
+
+	// AI agent — tool-use orchestrator that drives list_resources, run_policy,
+	// run_scan, write_hcl, etc. against the configured Anthropic provider.
+	registerAgentRoutes(mux, projectsDir, aiClient, regClient)
 
 	return mux
 }


### PR DESCRIPTION
## Summary
Turns the AI bridge into a real agent — the model can call backend capabilities (list_resources, write_hcl, run_policy, run_scan, search_registry, read_plan) and drive the "design → plan → scan → fix → retry" loop autonomously.

- [x] **Commit 1** — Provider-agnostic `internal/ai/tools` package: Tool, Registry, Runner, ErrAbort sentinel.
- [x] **Commit 2** — IaC-specific tools: list_resources, get_resource, write_hcl, run_policy, run_scan, search_registry, read_plan.
- [x] **Commit 3** — Anthropic provider tool-use loop wiring (`RunToolLoop` + `ToolUser` interface).
- [x] **Commit 4** — Multi-agent orchestrator (Architect / Coder / Policy / Security / Reviewer) with keyword routing + enforced per-specialist tool allow-lists.
- [x] **Commit 5** — `POST /api/projects/{name}/ai/agent` endpoint + `GET /api/ai/agent/audit` ring buffer + 400-vs-502 heuristic + integration tests.

Closes #7.

## Review iterations
- First Copilot round: test hardening, symlink defense, atomic writes, provider interface naming.
- Second Copilot round (this commit): `readRegularFile` Lstat gate for run_policy + read_plan, `scrubResource` path relativisation, empty-content + empty-query validation, nil-Runner guards in both the Anthropic loop and the runner adapter.

## Test plan
- [x] Registry / Runner contract tests (unknown-name non-fatal, handler error non-fatal, ErrAbort terminating, MaxIterations truncation).
- [x] Per-tool handler tests against real project fixtures, including symlink-refusal + traversal-refusal cases.
- [x] Anthropic loop integration test with a stub server returning a canned tool_use → tool_result transcript.
- [x] Agent HTTP endpoint tests: malformed-JSON / missing-prompt / traversal all 400; non-tool-use provider 400s with a clear message; failed runs still land in the audit log.