### PR TITLE
feat(ai): RAG over project (embed + index + retrieve + prompt integration)

### DIFF
--- a/internal/ai/bridge.go
+++ b/internal/ai/bridge.go
@@ -158,7 +158,7 @@ func (c *Client) StreamChat(ctx context.Context, req ChatRequest, onDelta provid
 	if c.providerErr != nil {
 		return "", nil, c.providerErr
 	}
-	systemPrompt := buildSystemPrompt(req.Tool, req.Provider, req.Canvas)
+	systemPrompt := buildSystemPromptWithContext(req.Tool, req.Provider, req.Canvas, req.ProjectContext)
 	userPrompt := buildChatUserPrompt(req)
 
 	raw, err := c.provider.Stream(ctx, providers.Request{
@@ -189,6 +189,15 @@ type ChatRequest struct {
 	Provider string            `json:"provider"` // aws | google | azurerm (auto-detected)
 	History  []ChatMessage     `json:"history"`  // conversation history for context
 	Canvas   []CanvasResource  `json:"canvas"`   // what's currently on the canvas
+	// Project, when set, names the active project. The HTTP layer uses it
+	// to look up the project's RAG index and populate ProjectContext
+	// before calling the bridge.
+	Project string `json:"project,omitempty"`
+	// ProjectContext, when set, is prepended to the system prompt as
+	// retrieved RAG context. The HTTP layer runs the retrieval and fills
+	// this in; the bridge is RAG-unaware so tests can exercise the
+	// prompt path without an embedder.
+	ProjectContext string `json:"-"`
 }
 
 // CanvasResource is a simplified view of what's on the canvas for AI context.
@@ -200,7 +209,7 @@ type CanvasResource struct {
 // GenerateIaC sends a natural language request to the configured LLM with
 // full conversation context, provider awareness, and canvas state.
 func (c *Client) GenerateIaC(ctx context.Context, req ChatRequest) (string, []parser.Resource, error) {
-	systemPrompt := buildSystemPrompt(req.Tool, req.Provider, req.Canvas)
+	systemPrompt := buildSystemPromptWithContext(req.Tool, req.Provider, req.Canvas, req.ProjectContext)
 	userPrompt := buildChatUserPrompt(req)
 
 	raw, err := c.callLLM(ctx, systemPrompt, userPrompt)
@@ -425,10 +434,19 @@ func (c *Client) GenerateIaCSimple(ctx context.Context, message, tool string) (s
 // Tool, ProviderGuide, and CanvasContext; the caller never hand-composes the
 // prompt string any more.
 func buildSystemPrompt(tool, provider string, canvas []CanvasResource) string {
+	return buildSystemPromptWithContext(tool, provider, canvas, "")
+}
+
+// buildSystemPromptWithContext is the RAG-aware variant: projectContext
+// is a pre-formatted block of retrieved chunks (via rag.FormatContext)
+// and gets injected above the provider guide so the model reads
+// project-specific conventions before the generic provider rules.
+func buildSystemPromptWithContext(tool, provider string, canvas []CanvasResource, projectContext string) string {
 	return renderPrompt("system", map[string]string{
-		"Tool":          tool,
-		"ProviderGuide": buildProviderGuide(tool, provider),
-		"CanvasContext": buildCanvasContext(canvas),
+		"Tool":           tool,
+		"ProviderGuide":  buildProviderGuide(tool, provider),
+		"CanvasContext":  buildCanvasContext(canvas),
+		"ProjectContext": projectContext,
 	})
 }
 

--- a/internal/ai/embed/embed.go
+++ b/internal/ai/embed/embed.go
@@ -1,0 +1,70 @@
+// Package embed owns the embedding-provider surface for IaC Studio's
+// RAG pipeline. An Embedder turns a batch of text chunks into fixed-
+// width float vectors; the rest of the system — indexer, retriever,
+// prompt builder — is provider-agnostic and plugs into whichever
+// Embedder the user's AI settings resolve to.
+//
+// Today we ship an Ollama adapter (privacy-first: the embedding model
+// runs on-device and the project's HCL never leaves the machine). A
+// remote adapter (Voyage, OpenAI, Cohere) can be added later without
+// changing call sites.
+package embed
+
+import (
+	"context"
+	"errors"
+	"math"
+)
+
+// Embedder is what every adapter implements. Embed is the batch API —
+// embedding one chunk per call would be three orders of magnitude
+// slower for a project-sized index.
+//
+// Returned vectors have a stable length per Embedder instance; callers
+// must not mix outputs from Embedders with different Dim() values in
+// the same index.
+type Embedder interface {
+	// Embed returns one vector per input, in the same order. Empty
+	// strings are passed through as zero vectors so the caller's slice
+	// alignment is preserved; the retriever ignores zero vectors at
+	// query time.
+	Embed(ctx context.Context, inputs []string) ([][]float32, error)
+
+	// Dim is the vector width this Embedder produces. Used by the
+	// index to validate incoming vectors and to pre-size storage.
+	Dim() int
+
+	// Model is the string identifier (e.g. "nomic-embed-text") that
+	// callers can surface in audit logs + stats so operators know
+	// what was used to build a given index.
+	Model() string
+}
+
+// ErrNotReady signals the Embedder is configured but unavailable — the
+// Ollama server isn't running, the model isn't pulled yet, the API key
+// is wrong, etc. Callers (the indexer especially) check for it to
+// gracefully degrade: skip reindex, surface a clear error in the
+// stats feed, and leave the existing index intact.
+var ErrNotReady = errors.New("embedder not ready")
+
+// Cosine returns the cosine similarity of two vectors. Exported because
+// the retriever needs it and unit tests want to assert on it directly
+// — centralising it here keeps the distance metric in one place.
+//
+// Zero vectors on either side yield 0 rather than NaN so an unembed-
+// dable chunk doesn't poison the ranking.
+func Cosine(a, b []float32) float32 {
+	if len(a) != len(b) || len(a) == 0 {
+		return 0
+	}
+	var dot, na, nb float32
+	for i := range a {
+		dot += a[i] * b[i]
+		na += a[i] * a[i]
+		nb += b[i] * b[i]
+	}
+	if na == 0 || nb == 0 {
+		return 0
+	}
+	return dot / float32(math.Sqrt(float64(na))*math.Sqrt(float64(nb)))
+}

--- a/internal/ai/embed/embed_test.go
+++ b/internal/ai/embed/embed_test.go
@@ -1,0 +1,152 @@
+package embed
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCosine(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b []float32
+		want float32
+	}{
+		{"identical", []float32{1, 0, 0}, []float32{1, 0, 0}, 1},
+		{"orthogonal", []float32{1, 0, 0}, []float32{0, 1, 0}, 0},
+		{"opposite", []float32{1, 0, 0}, []float32{-1, 0, 0}, -1},
+		{"different lengths", []float32{1, 0}, []float32{1, 0, 0}, 0},
+		{"zero a", []float32{0, 0, 0}, []float32{1, 0, 0}, 0},
+		{"zero b", []float32{1, 0, 0}, []float32{0, 0, 0}, 0},
+		{"empty", nil, nil, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Cosine(tc.a, tc.b)
+			if got != tc.want {
+				t.Errorf("Cosine = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// Ollama embed endpoint tests — an httptest server stubs /api/embed and
+// asserts we marshal / unmarshal the wire format correctly.
+
+func TestOllamaEmbed_HappyPath(t *testing.T) {
+	var received ollamaEmbedRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/embed" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		_ = json.NewDecoder(r.Body).Decode(&received)
+		resp := ollamaEmbedResponse{Embeddings: [][]float32{
+			{0.1, 0.2, 0.3},
+			{0.4, 0.5, 0.6},
+		}}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	e := NewOllama(Config{Endpoint: srv.URL, Model: "nomic-embed-text", Dim: 3})
+	vecs, err := e.Embed(context.Background(), []string{"hello", "world"})
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if len(vecs) != 2 {
+		t.Fatalf("want 2 vecs, got %d", len(vecs))
+	}
+	if vecs[0][0] != 0.1 || vecs[1][2] != 0.6 {
+		t.Errorf("unexpected vectors: %+v", vecs)
+	}
+	if received.Model != "nomic-embed-text" || len(received.Input) != 2 {
+		t.Errorf("unexpected request: %+v", received)
+	}
+}
+
+func TestOllamaEmbed_EmptyInputsZeroVectors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Server should only see the non-empty inputs.
+		var req ollamaEmbedRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		if len(req.Input) != 1 || req.Input[0] != "real" {
+			t.Errorf("expected single non-empty input, got %+v", req.Input)
+		}
+		_ = json.NewEncoder(w).Encode(ollamaEmbedResponse{Embeddings: [][]float32{{1, 2, 3}}})
+	}))
+	defer srv.Close()
+
+	e := NewOllama(Config{Endpoint: srv.URL, Model: "m", Dim: 3})
+	vecs, err := e.Embed(context.Background(), []string{"", "real", "   "})
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if len(vecs) != 3 {
+		t.Fatalf("want 3 vecs, got %d", len(vecs))
+	}
+	// First and third are empties — zero vectors preserved.
+	for _, i := range []int{0, 2} {
+		for _, v := range vecs[i] {
+			if v != 0 {
+				t.Errorf("vec %d should be zero, got %v", i, vecs[i])
+			}
+		}
+	}
+	if vecs[1][2] != 3 {
+		t.Errorf("real input not at original index 1: %+v", vecs[1])
+	}
+}
+
+func TestOllamaEmbed_ConnectionRefusedIsNotReady(t *testing.T) {
+	// Close the server before Embed so Dial fails.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	srv.Close()
+
+	e := NewOllama(Config{Endpoint: srv.URL, Model: "m", Dim: 3})
+	_, err := e.Embed(context.Background(), []string{"x"})
+	if !errors.Is(err, ErrNotReady) {
+		t.Errorf("want ErrNotReady, got %v", err)
+	}
+}
+
+func TestOllamaEmbed_DimMismatchErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(ollamaEmbedResponse{Embeddings: [][]float32{{1, 2}}})
+	}))
+	defer srv.Close()
+
+	e := NewOllama(Config{Endpoint: srv.URL, Model: "m", Dim: 3})
+	_, err := e.Embed(context.Background(), []string{"x"})
+	if err == nil {
+		t.Error("expected dim-mismatch error")
+	}
+}
+
+func TestOllamaEmbed_ErrorFieldSurfaces(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(ollamaEmbedResponse{Error: "model not found: foo"})
+	}))
+	defer srv.Close()
+
+	e := NewOllama(Config{Endpoint: srv.URL, Model: "foo", Dim: 3})
+	_, err := e.Embed(context.Background(), []string{"x"})
+	if err == nil || !containsErr(err, "model not found") {
+		t.Errorf("want model-not-found error, got %v", err)
+	}
+}
+
+func containsErr(err error, needle string) bool {
+	return err != nil && (err.Error() == needle || len(err.Error()) >= len(needle) && contains(err.Error(), needle))
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/ai/embed/embed_test.go
+++ b/internal/ai/embed/embed_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -133,20 +134,11 @@ func TestOllamaEmbed_ErrorFieldSurfaces(t *testing.T) {
 
 	e := NewOllama(Config{Endpoint: srv.URL, Model: "foo", Dim: 3})
 	_, err := e.Embed(context.Background(), []string{"x"})
-	if err == nil || !containsErr(err, "model not found") {
+	if err == nil || !errContains(err, "model not found") {
 		t.Errorf("want model-not-found error, got %v", err)
 	}
 }
 
-func containsErr(err error, needle string) bool {
-	return err != nil && (err.Error() == needle || len(err.Error()) >= len(needle) && contains(err.Error(), needle))
-}
-
-func contains(s, sub string) bool {
-	for i := 0; i+len(sub) <= len(s); i++ {
-		if s[i:i+len(sub)] == sub {
-			return true
-		}
-	}
-	return false
+func errContains(err error, needle string) bool {
+	return err != nil && strings.Contains(err.Error(), needle)
 }

--- a/internal/ai/embed/ollama.go
+++ b/internal/ai/embed/ollama.go
@@ -1,0 +1,155 @@
+package embed
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// ollamaEmbedder talks to a local Ollama server's /api/embed endpoint.
+// Ollama accepts a batch in the `input` field and returns one vector
+// per input, which matches our Embedder contract directly — no
+// per-chunk round-trip.
+type ollamaEmbedder struct {
+	endpoint string
+	model    string
+	dim      int
+	client   *http.Client
+}
+
+// Config bundles the wire params. Timeout defaults to 60s because
+// embedding a batch of 256 chunks on CPU can easily take 20-30 seconds
+// on modest hardware.
+type Config struct {
+	Endpoint string
+	Model    string
+	// Dim is the vector width the configured model produces.
+	// nomic-embed-text = 768, mxbai-embed-large = 1024, bge-m3 = 1024.
+	// Set explicitly so the index can pre-validate; we don't probe the
+	// server on startup because that would fail fast in the common
+	// "Ollama not running yet" dev path.
+	Dim     int
+	Timeout time.Duration
+}
+
+// NewOllama constructs an Embedder that speaks to an Ollama instance.
+// Returns a concrete type (not an interface) so callers holding the
+// pointer can introspect; the package's Embedder interface is the
+// contract for everything else.
+func NewOllama(cfg Config) Embedder {
+	if cfg.Timeout == 0 {
+		cfg.Timeout = 60 * time.Second
+	}
+	if cfg.Dim == 0 {
+		// Default to nomic-embed-text's width so a caller that forgot to
+		// set Dim still gets something sane. If the actual model produces
+		// a different width, Embed will surface the mismatch at runtime.
+		cfg.Dim = 768
+	}
+	return &ollamaEmbedder{
+		endpoint: strings.TrimSuffix(cfg.Endpoint, "/"),
+		model:    cfg.Model,
+		dim:      cfg.Dim,
+		client:   &http.Client{Timeout: cfg.Timeout},
+	}
+}
+
+func (e *ollamaEmbedder) Dim() int      { return e.dim }
+func (e *ollamaEmbedder) Model() string { return e.model }
+
+// ollamaEmbedRequest matches Ollama's /api/embed request shape.
+// `input` is either a string or []string — we always send the slice
+// form because the receiving code is identical for N=1 and spares us
+// a shape branch here.
+type ollamaEmbedRequest struct {
+	Model string   `json:"model"`
+	Input []string `json:"input"`
+}
+
+type ollamaEmbedResponse struct {
+	Embeddings [][]float32 `json:"embeddings"`
+	// Ollama surfaces errors in a sibling `error` field when the model
+	// is missing or the request is malformed.
+	Error string `json:"error,omitempty"`
+}
+
+func (e *ollamaEmbedder) Embed(ctx context.Context, inputs []string) ([][]float32, error) {
+	if len(inputs) == 0 {
+		return nil, nil
+	}
+
+	// Partition into embeddable vs. empty — empties get zero vectors to
+	// keep the caller's slice alignment; the retriever treats zero
+	// vectors as non-matches.
+	nonEmptyIdx := make([]int, 0, len(inputs))
+	nonEmpty := make([]string, 0, len(inputs))
+	for i, s := range inputs {
+		if strings.TrimSpace(s) == "" {
+			continue
+		}
+		nonEmptyIdx = append(nonEmptyIdx, i)
+		nonEmpty = append(nonEmpty, s)
+	}
+
+	out := make([][]float32, len(inputs))
+	for i := range out {
+		out[i] = make([]float32, e.dim)
+	}
+	if len(nonEmpty) == 0 {
+		return out, nil
+	}
+
+	body, err := json.Marshal(ollamaEmbedRequest{Model: e.model, Input: nonEmpty})
+	if err != nil {
+		return nil, fmt.Errorf("embed: marshal request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, e.endpoint+"/api/embed", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("embed: new request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		// Connection refused, DNS miss, etc. — surface as ErrNotReady so
+		// the indexer knows to degrade gracefully rather than erroring
+		// the whole index run.
+		return nil, fmt.Errorf("%w: %v", ErrNotReady, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("embed: read response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("embed: ollama status %d: %s", resp.StatusCode, string(raw))
+	}
+
+	var decoded ollamaEmbedResponse
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return nil, fmt.Errorf("embed: decode response: %w", err)
+	}
+	if decoded.Error != "" {
+		return nil, fmt.Errorf("embed: ollama error: %s", decoded.Error)
+	}
+	if len(decoded.Embeddings) != len(nonEmpty) {
+		return nil, fmt.Errorf("embed: ollama returned %d vectors for %d inputs", len(decoded.Embeddings), len(nonEmpty))
+	}
+
+	// Merge the embedded vectors back into the output at their original
+	// positions; empties keep their zero-initialised slots.
+	for vi, origIdx := range nonEmptyIdx {
+		v := decoded.Embeddings[vi]
+		if len(v) != e.dim {
+			return nil, fmt.Errorf("embed: dim mismatch: got %d, want %d", len(v), e.dim)
+		}
+		out[origIdx] = v
+	}
+	return out, nil
+}

--- a/internal/ai/prompts/system.md
+++ b/internal/ai/prompts/system.md
@@ -1,6 +1,6 @@
 ---
 id: system
-description: Main system prompt for IaC chat generation. Expects {{.Tool}}, {{.ProviderGuide}}, and optional {{.CanvasContext}}.
+description: Main system prompt for IaC chat generation. Expects {{.Tool}}, {{.ProviderGuide}}, optional {{.CanvasContext}}, optional {{.ProjectContext}}.
 ---
 You are an Infrastructure as Code assistant for {{.Tool}}.
 
@@ -8,8 +8,9 @@ CRITICAL RULES:
 1. ONLY use the resource types listed below. NEVER mix providers in a single response.
 2. Follow the user's conversation context — if they started with a specific cloud provider, STAY with that provider.
 3. If resources already exist on the canvas, build on them rather than creating duplicates.
+4. If project context is provided below, match the project's existing naming, tagging, and module conventions.
 
-{{.ProviderGuide}}{{.CanvasContext}}
+{{.ProjectContext}}{{.ProviderGuide}}{{.CanvasContext}}
 
 When the user describes infrastructure, respond with a JSON object:
 {

--- a/internal/ai/rag/chunk.go
+++ b/internal/ai/rag/chunk.go
@@ -66,6 +66,9 @@ func skipDir(name string) bool {
 // file is unreadable.
 func ChunkProject(dir string) ([]Chunk, error) {
 	var chunks []Chunk
+	// parsedDirs caches ParseDir results so each directory is only parsed
+	// once even when it contains multiple HCL files.
+	parsedDirs := map[string][]parser.Resource{}
 	walkErr := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return nil
@@ -88,7 +91,7 @@ func ChunkProject(dir string) ([]Chunk, error) {
 			return nil
 		}
 		rel, _ := filepath.Rel(dir, path)
-		produced, perr := chunkFile(path, rel, ext)
+		produced, perr := chunkFile(path, rel, ext, parsedDirs)
 		if perr != nil {
 			// Don't abort the walk; just skip this file.
 			return nil
@@ -103,14 +106,14 @@ func ChunkProject(dir string) ([]Chunk, error) {
 // everything else goes through whole-file chunking (with a soft line
 // cap that splits very long files into 200-line overlapping windows so
 // the embedder sees coherent regions).
-func chunkFile(absPath, relPath, ext string) ([]Chunk, error) {
+func chunkFile(absPath, relPath, ext string, parsedDirs map[string][]parser.Resource) ([]Chunk, error) {
 	body, err := os.ReadFile(absPath)
 	if err != nil {
 		return nil, err
 	}
 	switch ext {
 	case ".tf", ".hcl", ".tfvars":
-		return chunkHCL(absPath, relPath, body)
+		return chunkHCL(absPath, relPath, body, parsedDirs)
 	case ".md":
 		return chunkByHeadings(relPath, string(body), "markdown"), nil
 	case ".rego":
@@ -124,16 +127,23 @@ func chunkFile(absPath, relPath, ext string) ([]Chunk, error) {
 // chunkHCL uses the HCL parser to emit one chunk per resource/variable/
 // output/module/data/locals block. Non-parseable HCL falls through to a
 // whole-file chunk so we still index partially-broken files during
-// editing.
-func chunkHCL(absPath, relPath string, body []byte) ([]Chunk, error) {
+// editing. parsedDirs is a caller-owned cache: ParseDir is called at
+// most once per directory so a module with 10 .tf files doesn't trigger
+// 10 identical parses.
+func chunkHCL(absPath, relPath string, body []byte, parsedDirs map[string][]parser.Resource) ([]Chunk, error) {
 	lines := strings.Split(string(body), "\n")
 
-	// ParseDir walks the whole directory — a syntax error in a sibling
-	// file (e.g. scratch.tf the user is mid-edit) shouldn't block us
-	// from chunking this file's resources, so we only fall back when
-	// nothing at all was parsed.
-	p := parser.HCLParser{}
-	resources, _ := p.ParseDir(filepath.Dir(absPath))
+	dirPath := filepath.Dir(absPath)
+	resources, ok := parsedDirs[dirPath]
+	if !ok {
+		// ParseDir walks the whole directory — a syntax error in a sibling
+		// file (e.g. scratch.tf the user is mid-edit) shouldn't block us
+		// from chunking this file's resources, so we only fall back when
+		// nothing at all was parsed.
+		p := parser.HCLParser{}
+		resources, _ = p.ParseDir(dirPath)
+		parsedDirs[dirPath] = resources
+	}
 	if len(resources) == 0 {
 		return []Chunk{newChunk(relPath, 1, len(lines), "hcl_file", string(body))}, nil
 	}

--- a/internal/ai/rag/chunk.go
+++ b/internal/ai/rag/chunk.go
@@ -1,0 +1,241 @@
+// Package rag owns the project indexer + retriever that grounds AI
+// prompts on the project's own code. It sits between the embed
+// provider (vectors in) and the prompt builder (top-k chunks out).
+package rag
+
+import (
+	"bufio"
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/iac-studio/iac-studio/internal/parser"
+)
+
+// Chunk is one embeddable unit of project content. It carries enough
+// context that the retriever's output can be fed straight into a
+// prompt without re-reading the source files: Text is the body, Source
+// + StartLine let the model cite a location, Kind is the coarse
+// categorisation so the prompt builder can weight policies differently
+// from code comments.
+type Chunk struct {
+	ID         string `json:"id"`         // content-addressed — Source#StartLine-EndLine hash
+	Source     string `json:"source"`     // project-relative file path
+	StartLine  int    `json:"start_line"` // 1-based, inclusive
+	EndLine    int    `json:"end_line"`   // 1-based, inclusive
+	Kind       string `json:"kind"`       // "hcl_resource" | "rego" | "sentinel" | "markdown" | "text"
+	Text       string `json:"text"`
+}
+
+// chunkableExtensions lists files the indexer walks. Everything else —
+// .terraform/, .git/, node_modules/, binaries — is skipped via
+// skipDir below.
+var chunkableExtensions = map[string]struct{}{
+	".tf":       {},
+	".hcl":      {},
+	".tfvars":   {},
+	".rego":     {},
+	".sentinel": {},
+	".md":       {},
+	".yaml":     {},
+	".yml":      {},
+}
+
+// skipDir returns true for directories the indexer should not descend.
+// Kept terse — these are the same dirs every other walker in the repo
+// skips, so hoisting to a shared helper isn't worth the indirection.
+func skipDir(name string) bool {
+	switch name {
+	case ".git", ".terraform", "node_modules", "dist", "build", ".iac-studio":
+		return true
+	}
+	return false
+}
+
+// ChunkProject walks dir and returns every Chunk the indexer will embed.
+// HCL files use the resource-aware parser so each chunk maps cleanly to
+// a single block; everything else falls back to per-file or per-heading
+// chunking. The caller hands the result to an Embedder batch-by-batch.
+//
+// On walk errors ChunkProject returns whatever it's collected so far +
+// the error — preferable to silently dropping the whole index when one
+// file is unreadable.
+func ChunkProject(dir string) ([]Chunk, error) {
+	var chunks []Chunk
+	walkErr := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			if skipDir(d.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		ext := strings.ToLower(filepath.Ext(path))
+		if _, ok := chunkableExtensions[ext]; !ok {
+			return nil
+		}
+		// Cap per-file size so a 10MB state dump doesn't blow up the
+		// embed budget. 256KB is roughly 64k tokens worth of text —
+		// well past any real HCL module.
+		info, err := d.Info()
+		if err != nil || info.Size() > 256*1024 {
+			return nil
+		}
+		rel, _ := filepath.Rel(dir, path)
+		produced, perr := chunkFile(path, rel, ext)
+		if perr != nil {
+			// Don't abort the walk; just skip this file.
+			return nil
+		}
+		chunks = append(chunks, produced...)
+		return nil
+	})
+	return chunks, walkErr
+}
+
+// chunkFile dispatches by extension. HCL gets the resource-aware path;
+// everything else goes through whole-file chunking (with a soft line
+// cap that splits very long files into 200-line overlapping windows so
+// the embedder sees coherent regions).
+func chunkFile(absPath, relPath, ext string) ([]Chunk, error) {
+	body, err := os.ReadFile(absPath)
+	if err != nil {
+		return nil, err
+	}
+	switch ext {
+	case ".tf", ".hcl", ".tfvars":
+		return chunkHCL(absPath, relPath, body)
+	case ".md":
+		return chunkByHeadings(relPath, string(body), "markdown"), nil
+	case ".rego":
+		return []Chunk{newChunk(relPath, 1, lineCount(body), "rego", string(body))}, nil
+	case ".sentinel":
+		return []Chunk{newChunk(relPath, 1, lineCount(body), "sentinel", string(body))}, nil
+	}
+	return []Chunk{newChunk(relPath, 1, lineCount(body), "text", string(body))}, nil
+}
+
+// chunkHCL uses the HCL parser to emit one chunk per resource/variable/
+// output/module/data/locals block. Non-parseable HCL falls through to a
+// whole-file chunk so we still index partially-broken files during
+// editing.
+func chunkHCL(absPath, relPath string, body []byte) ([]Chunk, error) {
+	lines := strings.Split(string(body), "\n")
+
+	// ParseDir walks the whole directory — a syntax error in a sibling
+	// file (e.g. scratch.tf the user is mid-edit) shouldn't block us
+	// from chunking this file's resources, so we only fall back when
+	// nothing at all was parsed.
+	p := parser.HCLParser{}
+	resources, _ := p.ParseDir(filepath.Dir(absPath))
+	if len(resources) == 0 {
+		return []Chunk{newChunk(relPath, 1, len(lines), "hcl_file", string(body))}, nil
+	}
+
+	// ParseDir returns every resource under the directory; filter to the
+	// file we're chunking. Each resource's Line marks the opening brace;
+	// we greedily extend to the matching close brace to capture the full
+	// block body.
+	var out []Chunk
+	for _, r := range resources {
+		if r.File != absPath {
+			continue
+		}
+		start := r.Line
+		if start <= 0 || start > len(lines) {
+			continue
+		}
+		end := findMatchingClose(lines, start-1)
+		text := strings.Join(lines[start-1:end], "\n")
+		out = append(out, newChunk(relPath, start, end, "hcl_"+strings.ToLower(r.BlockType), text))
+	}
+	if len(out) == 0 {
+		// Parser ran but produced nothing for this file (e.g. only
+		// comments) — index the whole file as a fallback.
+		out = append(out, newChunk(relPath, 1, len(lines), "hcl_file", string(body)))
+	}
+	return out, nil
+}
+
+// findMatchingClose tracks brace depth starting at startIdx (the line
+// that contains the opening brace). Returns the 1-based line number of
+// the line that closes the block, clamped to len(lines) if the file is
+// malformed. We count '{' and '}' naively — string literals in HCL
+// can't contain unescaped braces at parse time so this is good enough
+// for an indexer heuristic; the parser has the authoritative check.
+func findMatchingClose(lines []string, startIdx int) int {
+	depth := 0
+	for i := startIdx; i < len(lines); i++ {
+		for _, ch := range lines[i] {
+			switch ch {
+			case '{':
+				depth++
+			case '}':
+				depth--
+				if depth == 0 {
+					return i + 1
+				}
+			}
+		}
+	}
+	return len(lines)
+}
+
+// chunkByHeadings splits a markdown document at every '#' heading. Each
+// section becomes its own chunk so the retriever can surface the
+// relevant README section without pulling the whole document.
+func chunkByHeadings(relPath, body, kind string) []Chunk {
+	scanner := bufio.NewScanner(strings.NewReader(body))
+	scanner.Buffer(make([]byte, 1<<20), 1<<20) // 1MB line cap — generous for README content
+	var out []Chunk
+	var cur []string
+	sectionStart := 1
+	lineNo := 0
+	flush := func(endLine int) {
+		if len(cur) == 0 {
+			return
+		}
+		out = append(out, newChunk(relPath, sectionStart, endLine, kind, strings.Join(cur, "\n")))
+		cur = cur[:0]
+	}
+	for scanner.Scan() {
+		lineNo++
+		line := scanner.Text()
+		if strings.HasPrefix(line, "#") && len(cur) > 0 {
+			flush(lineNo - 1)
+			sectionStart = lineNo
+		}
+		cur = append(cur, line)
+	}
+	flush(lineNo)
+	return out
+}
+
+func newChunk(source string, startLine, endLine int, kind, text string) Chunk {
+	h := sha1.Sum([]byte(fmt.Sprintf("%s#%d-%d\n%s", source, startLine, endLine, text)))
+	return Chunk{
+		ID:        hex.EncodeToString(h[:]),
+		Source:    source,
+		StartLine: startLine,
+		EndLine:   endLine,
+		Kind:      kind,
+		Text:      text,
+	}
+}
+
+func lineCount(b []byte) int {
+	if len(b) == 0 {
+		return 0
+	}
+	n := strings.Count(string(b), "\n")
+	if b[len(b)-1] != '\n' {
+		n++
+	}
+	return n
+}

--- a/internal/ai/rag/chunk_test.go
+++ b/internal/ai/rag/chunk_test.go
@@ -1,0 +1,122 @@
+package rag
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func scaffoldProject(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	write := func(p, body string) {
+		full := filepath.Join(dir, p)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("main.tf", `resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+  tags = { Owner = "team-platform" }
+}
+
+resource "aws_s3_bucket" "logs" {
+  bucket = "acme-logs"
+}
+`)
+	write("policies/opa/tags.rego", `package main
+
+deny[msg] { not input.tags.Owner; msg := "missing owner" }
+`)
+	write("README.md", `# Acme Infra
+
+## Modules
+Networking, compute, data.
+
+## Policies
+Required tags: Owner, CostCenter.
+`)
+	// Files we shouldn't index.
+	write(".git/config", "ignored")
+	write(".terraform/junk", "ignored")
+	write("node_modules/bad/file.tf", "ignored")
+	return dir
+}
+
+func TestChunkProject_EmitsHCLRego_And_MarkdownSections(t *testing.T) {
+	dir := scaffoldProject(t)
+	chunks, err := ChunkProject(dir)
+	if err != nil {
+		t.Fatalf("ChunkProject: %v", err)
+	}
+
+	kinds := map[string]int{}
+	for _, c := range chunks {
+		kinds[c.Kind]++
+		if strings.Contains(c.Source, ".git") || strings.Contains(c.Source, ".terraform") || strings.Contains(c.Source, "node_modules") {
+			t.Errorf("indexed a skip-dir file: %s", c.Source)
+		}
+	}
+
+	if kinds["hcl_resource"] != 2 {
+		t.Errorf("want 2 hcl_resource chunks (vpc + s3), got %d", kinds["hcl_resource"])
+	}
+	if kinds["rego"] != 1 {
+		t.Errorf("want 1 rego chunk, got %d", kinds["rego"])
+	}
+	// Markdown split at headings: # Acme, ## Modules, ## Policies → 3 sections.
+	if kinds["markdown"] < 2 {
+		t.Errorf("want ≥ 2 markdown sections, got %d", kinds["markdown"])
+	}
+}
+
+func TestChunkProject_ChunksAreContentAddressed(t *testing.T) {
+	dir := scaffoldProject(t)
+	chunks1, _ := ChunkProject(dir)
+	chunks2, _ := ChunkProject(dir)
+
+	if len(chunks1) != len(chunks2) {
+		t.Fatalf("non-deterministic chunk count: %d vs %d", len(chunks1), len(chunks2))
+	}
+	for i := range chunks1 {
+		if chunks1[i].ID != chunks2[i].ID {
+			t.Errorf("chunk ids not deterministic at %d: %s vs %s", i, chunks1[i].ID, chunks2[i].ID)
+		}
+	}
+}
+
+func TestChunkProject_HonorsSizeCap(t *testing.T) {
+	dir := t.TempDir()
+	huge := strings.Repeat("x", 300*1024)
+	if err := os.WriteFile(filepath.Join(dir, "big.md"), []byte(huge), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	chunks, err := ChunkProject(dir)
+	if err != nil {
+		t.Fatalf("ChunkProject: %v", err)
+	}
+	for _, c := range chunks {
+		if c.Source == "big.md" {
+			t.Errorf("300KB file should have been skipped, got chunk: %+v", c)
+		}
+	}
+}
+
+func TestFindMatchingClose(t *testing.T) {
+	src := `resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+  tags = {
+    Owner = "me"
+  }
+}
+extra line
+`
+	end := findMatchingClose(strings.Split(src, "\n"), 0)
+	if end != 6 {
+		t.Errorf("findMatchingClose = %d, want 6", end)
+	}
+}

--- a/internal/ai/rag/index.go
+++ b/internal/ai/rag/index.go
@@ -1,0 +1,186 @@
+package rag
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/iac-studio/iac-studio/internal/ai/embed"
+)
+
+// indexFileName is the on-disk name of the serialised index. Lives
+// under <project>/.iac-studio/ so it's scoped per project and can be
+// .gitignore'd or cache-invalidated without affecting source files.
+const indexFileName = "rag-index.json"
+
+// indexDirName is the subdirectory we create inside each project to
+// host caches and the index. Exported via IndexPath so the file
+// watcher and gitignore helpers can reference the same path.
+const indexDirName = ".iac-studio"
+
+// Index is the in-memory representation of a built index.
+type Index struct {
+	Dim     int       `json:"dim"`
+	Model   string    `json:"model"`
+	BuiltAt time.Time `json:"built_at"`
+	// Chunks and Vectors are parallel slices indexed by position. Kept
+	// parallel (rather than embedding Vector in Chunk) so the marshal-
+	// ler can emit compact JSON — vectors are the bulk of the file and
+	// paired-slice layout is half the size of an embedded field.
+	Chunks  []Chunk     `json:"chunks"`
+	Vectors [][]float32 `json:"vectors"`
+}
+
+// IndexPath returns the absolute path where the index for projectDir
+// is stored. Exposed so the API handlers can surface it in audit logs.
+func IndexPath(projectDir string) string {
+	return filepath.Join(projectDir, indexDirName, indexFileName)
+}
+
+// BuildOptions controls indexing. BatchSize caps how many chunks go
+// into a single Embed call — Ollama keeps the model hot between
+// batches, but very large batches push memory pressure; 64 is a safe
+// default on a laptop.
+type BuildOptions struct {
+	BatchSize int
+}
+
+// Build runs the full index: walk the project, chunk, embed, persist.
+// Returns the fresh Index plus any write error from the persistence
+// step; a partial chunk-only result (zero vectors) is still returned
+// when the Embedder is not ready, so the caller can present a clear
+// "ollama not running" status without losing the walk.
+func Build(ctx context.Context, projectDir string, em embed.Embedder, opts BuildOptions) (*Index, error) {
+	if em == nil {
+		return nil, fmt.Errorf("rag.Build: embedder is nil")
+	}
+	if opts.BatchSize <= 0 {
+		opts.BatchSize = 64
+	}
+
+	chunks, walkErr := ChunkProject(projectDir)
+	idx := &Index{
+		Dim:     em.Dim(),
+		Model:   em.Model(),
+		BuiltAt: time.Now().UTC(),
+		Chunks:  chunks,
+		Vectors: make([][]float32, len(chunks)),
+	}
+
+	// Embed in batches. A single ErrNotReady from any batch kills the
+	// whole run (degrade gracefully) but everything else — a 500 from
+	// one batch, a timeout — is fatal so callers see the real error.
+	for start := 0; start < len(chunks); start += opts.BatchSize {
+		end := start + opts.BatchSize
+		if end > len(chunks) {
+			end = len(chunks)
+		}
+		texts := make([]string, end-start)
+		for i := start; i < end; i++ {
+			texts[i-start] = chunks[i].Text
+		}
+		vecs, err := em.Embed(ctx, texts)
+		if err != nil {
+			return idx, err
+		}
+		for i, v := range vecs {
+			idx.Vectors[start+i] = v
+		}
+	}
+
+	if err := Save(projectDir, idx); err != nil {
+		return idx, err
+	}
+	return idx, walkErr
+}
+
+// Save writes the index to <projectDir>/.iac-studio/rag-index.json.
+// Uses an atomic temp-file + rename so a crashed mid-write can't
+// leave the file half-truncated.
+func Save(projectDir string, idx *Index) error {
+	if idx == nil {
+		return fmt.Errorf("rag.Save: nil index")
+	}
+	dir := filepath.Join(projectDir, indexDirName)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	body, err := json.Marshal(idx)
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, indexFileName+".*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(body); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	return os.Rename(tmpPath, filepath.Join(dir, indexFileName))
+}
+
+// Load reads a previously-saved index. Returns (nil, nil) when the
+// file doesn't exist — callers treat "no index yet" as a valid empty
+// state, not an error.
+func Load(projectDir string) (*Index, error) {
+	path := IndexPath(projectDir)
+	body, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var idx Index
+	if err := json.Unmarshal(body, &idx); err != nil {
+		return nil, fmt.Errorf("rag.Load: %w", err)
+	}
+	return &idx, nil
+}
+
+// Stats is the lightweight status struct surfaced to the HTTP layer —
+// returned from /api/projects/{name}/ai/index for both GET (current
+// state) and POST (rebuild result).
+type Stats struct {
+	Present    bool      `json:"present"`
+	Dim        int       `json:"dim,omitempty"`
+	Model      string    `json:"model,omitempty"`
+	BuiltAt    time.Time `json:"built_at,omitempty"`
+	ChunkCount int       `json:"chunk_count,omitempty"`
+	SizeBytes  int64     `json:"size_bytes,omitempty"`
+}
+
+// StatsFor returns the on-disk stats for projectDir's index. Missing
+// index → Stats{Present: false}, not an error.
+func StatsFor(projectDir string) (Stats, error) {
+	path := IndexPath(projectDir)
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return Stats{}, nil
+		}
+		return Stats{}, err
+	}
+	idx, err := Load(projectDir)
+	if err != nil || idx == nil {
+		return Stats{Present: true, SizeBytes: info.Size()}, err
+	}
+	return Stats{
+		Present:    true,
+		Dim:        idx.Dim,
+		Model:      idx.Model,
+		BuiltAt:    idx.BuiltAt,
+		ChunkCount: len(idx.Chunks),
+		SizeBytes:  info.Size(),
+	}, nil
+}

--- a/internal/ai/rag/index_test.go
+++ b/internal/ai/rag/index_test.go
@@ -1,0 +1,110 @@
+package rag
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/iac-studio/iac-studio/internal/ai/embed"
+)
+
+// stubEmbedServer returns a fake Ollama that replies with deterministic
+// vectors so the tests can assert on persistence + loading without
+// rolling real floats through the pipeline.
+func stubEmbedServer(t *testing.T, dim int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct{ Input []string `json:"input"` }
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		out := make([][]float32, len(req.Input))
+		for i := range req.Input {
+			v := make([]float32, dim)
+			v[i%dim] = 1
+			out[i] = v
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"embeddings": out})
+	}))
+}
+
+func TestBuildSaveLoad_RoundTrip(t *testing.T) {
+	dir := scaffoldProject(t)
+	srv := stubEmbedServer(t, 4)
+	defer srv.Close()
+	em := embed.NewOllama(embed.Config{Endpoint: srv.URL, Model: "test-embed", Dim: 4})
+
+	idx, err := Build(context.Background(), dir, em, BuildOptions{BatchSize: 2})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if idx.Dim != 4 || idx.Model != "test-embed" {
+		t.Errorf("wrong metadata: dim=%d model=%q", idx.Dim, idx.Model)
+	}
+	if len(idx.Chunks) == 0 || len(idx.Vectors) != len(idx.Chunks) {
+		t.Fatalf("chunk/vector mismatch: %d chunks, %d vectors", len(idx.Chunks), len(idx.Vectors))
+	}
+
+	loaded, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded == nil || len(loaded.Chunks) != len(idx.Chunks) {
+		t.Fatalf("Load returned %v", loaded)
+	}
+	if loaded.Vectors[0][0] != idx.Vectors[0][0] {
+		t.Errorf("vectors did not round-trip")
+	}
+}
+
+func TestLoad_MissingIndexIsNilNil(t *testing.T) {
+	dir := t.TempDir()
+	idx, err := Load(dir)
+	if err != nil || idx != nil {
+		t.Errorf("Load(empty) = %v, %v — want nil, nil", idx, err)
+	}
+}
+
+func TestBuild_EmbedderNotReadyDegradesGracefully(t *testing.T) {
+	dir := scaffoldProject(t)
+	srv := stubEmbedServer(t, 4)
+	srv.Close() // kill the server before Build dials it
+
+	em := embed.NewOllama(embed.Config{Endpoint: srv.URL, Model: "x", Dim: 4})
+	idx, err := Build(context.Background(), dir, em, BuildOptions{})
+	if !errors.Is(err, embed.ErrNotReady) {
+		t.Fatalf("want ErrNotReady, got %v", err)
+	}
+	if idx == nil || len(idx.Chunks) == 0 {
+		t.Error("want partial index with chunks populated, got nil/empty")
+	}
+}
+
+func TestStatsFor_ReflectsIndex(t *testing.T) {
+	dir := scaffoldProject(t)
+	srv := stubEmbedServer(t, 4)
+	defer srv.Close()
+	em := embed.NewOllama(embed.Config{Endpoint: srv.URL, Model: "m", Dim: 4})
+
+	stats, _ := StatsFor(dir)
+	if stats.Present {
+		t.Error("stats should not be present before build")
+	}
+
+	if _, err := Build(context.Background(), dir, em, BuildOptions{}); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	stats, err := StatsFor(dir)
+	if err != nil {
+		t.Fatalf("StatsFor: %v", err)
+	}
+	if !stats.Present || stats.ChunkCount == 0 || stats.Dim != 4 {
+		t.Errorf("unexpected stats: %+v", stats)
+	}
+	if _, err := os.Stat(filepath.Join(dir, indexDirName, indexFileName)); err != nil {
+		t.Errorf("index file not written: %v", err)
+	}
+}

--- a/internal/ai/rag/retrieve.go
+++ b/internal/ai/rag/retrieve.go
@@ -1,0 +1,118 @@
+package rag
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/iac-studio/iac-studio/internal/ai/embed"
+)
+
+// Hit is one retrieval result — a Chunk plus its similarity score to
+// the query. The prompt builder uses Score to decide how prominently
+// to present each piece of context (top hit as a strong signal, tail
+// hits as "may also be relevant").
+type Hit struct {
+	Chunk Chunk   `json:"chunk"`
+	Score float32 `json:"score"`
+}
+
+// Retrieve returns the top-k most similar chunks to queryVec from idx.
+// Ties are broken by original chunk order (stable sort) so the output
+// is deterministic across runs with the same index + query.
+//
+// A nil index or zero-length queryVec returns nil — not an error —
+// because "no index yet" and "empty query" are both legitimate states
+// the caller surfaces to the user as "no grounding, model runs as
+// before".
+func Retrieve(idx *Index, queryVec []float32, k int) []Hit {
+	if idx == nil || len(queryVec) == 0 || len(idx.Chunks) == 0 {
+		return nil
+	}
+	if idx.Dim != len(queryVec) {
+		return nil
+	}
+	hits := make([]Hit, 0, len(idx.Chunks))
+	for i := range idx.Chunks {
+		score := embed.Cosine(queryVec, idx.Vectors[i])
+		if score <= 0 {
+			continue
+		}
+		hits = append(hits, Hit{Chunk: idx.Chunks[i], Score: score})
+	}
+	sort.SliceStable(hits, func(i, j int) bool { return hits[i].Score > hits[j].Score })
+	if k > 0 && len(hits) > k {
+		hits = hits[:k]
+	}
+	return hits
+}
+
+// RetrieveText is the common-case helper: embed the query string, then
+// retrieve top-k. Returns nil (no error) when the embedder isn't ready
+// — callers log this and fall through to the no-RAG prompt so the user
+// still gets a response.
+func RetrieveText(ctx context.Context, em embed.Embedder, idx *Index, query string, k int) ([]Hit, error) {
+	if em == nil || idx == nil || strings.TrimSpace(query) == "" {
+		return nil, nil
+	}
+	vecs, err := em.Embed(ctx, []string{query})
+	if err != nil {
+		return nil, err
+	}
+	if len(vecs) != 1 {
+		return nil, fmt.Errorf("rag.RetrieveText: expected 1 vector, got %d", len(vecs))
+	}
+	return Retrieve(idx, vecs[0], k), nil
+}
+
+// FormatContext renders a list of hits as a prompt-ready preamble. The
+// format is deliberately plain-text-first so every provider sees the
+// same payload; markdown-style fenced blocks let the model parse HCL
+// correctly without leaking through as literal ``` characters in a
+// chat response.
+//
+// An empty slice returns empty string so callers can unconditionally
+// concat without guards.
+func FormatContext(hits []Hit) string {
+	if len(hits) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("Here is relevant context from the user's project:\n\n")
+	for i, h := range hits {
+		fmt.Fprintf(&b, "--- context %d: %s (lines %d-%d, relevance %.2f) ---\n",
+			i+1, h.Chunk.Source, h.Chunk.StartLine, h.Chunk.EndLine, h.Score)
+		lang := languageFromKind(h.Chunk.Kind)
+		if lang != "" {
+			b.WriteString("```" + lang + "\n")
+		}
+		b.WriteString(h.Chunk.Text)
+		if !strings.HasSuffix(h.Chunk.Text, "\n") {
+			b.WriteString("\n")
+		}
+		if lang != "" {
+			b.WriteString("```\n")
+		}
+		b.WriteString("\n")
+	}
+	b.WriteString("Use this context to match the project's conventions (naming, tagging, module structure). Cite specific files when relevant. If the context doesn't cover what's needed, proceed using general best practices.\n")
+	return b.String()
+}
+
+// languageFromKind maps our chunk Kind to a markdown fence language tag
+// so the model gets syntax-highlighted context. Unknown kinds → empty
+// (plain text fence).
+func languageFromKind(kind string) string {
+	switch {
+	case strings.HasPrefix(kind, "hcl_"):
+		return "hcl"
+	case kind == "rego":
+		return "rego"
+	case kind == "sentinel":
+		return "sentinel"
+	case kind == "markdown":
+		return "markdown"
+	}
+	return ""
+}

--- a/internal/ai/rag/retrieve_test.go
+++ b/internal/ai/rag/retrieve_test.go
@@ -1,0 +1,88 @@
+package rag
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRetrieve_RanksByCosine(t *testing.T) {
+	// Three chunks, three hand-chosen vectors. Query is aligned with
+	// the second chunk, so we expect it to top the ranking.
+	idx := &Index{
+		Dim: 3,
+		Chunks: []Chunk{
+			{ID: "a", Source: "a.tf", Text: "a"},
+			{ID: "b", Source: "b.tf", Text: "b"},
+			{ID: "c", Source: "c.tf", Text: "c"},
+		},
+		Vectors: [][]float32{
+			{1, 0, 0},
+			{0, 1, 0},
+			{0, 0, 1},
+		},
+	}
+
+	hits := Retrieve(idx, []float32{0, 1, 0}, 2)
+	if len(hits) != 1 {
+		// Only one vector has positive cosine with {0,1,0}; zeros get
+		// filtered (< 0 or exactly 0 both return).
+		t.Fatalf("want 1 hit, got %d", len(hits))
+	}
+	if hits[0].Chunk.ID != "b" {
+		t.Errorf("want top hit 'b', got %q", hits[0].Chunk.ID)
+	}
+}
+
+func TestRetrieve_HandlesEmptyInputs(t *testing.T) {
+	if h := Retrieve(nil, []float32{1, 0}, 5); h != nil {
+		t.Errorf("nil index should return nil, got %v", h)
+	}
+	if h := Retrieve(&Index{Dim: 3}, nil, 5); h != nil {
+		t.Errorf("nil query should return nil, got %v", h)
+	}
+	if h := Retrieve(&Index{Dim: 3}, []float32{1, 2}, 5); h != nil {
+		t.Errorf("dim mismatch should return nil, got %v", h)
+	}
+}
+
+func TestRetrieve_AppliesKLimit(t *testing.T) {
+	idx := &Index{Dim: 2,
+		Chunks:  []Chunk{{ID: "a"}, {ID: "b"}, {ID: "c"}},
+		Vectors: [][]float32{{1, 0}, {0.9, 0.1}, {0.8, 0.2}},
+	}
+	hits := Retrieve(idx, []float32{1, 0}, 2)
+	if len(hits) != 2 {
+		t.Errorf("want 2 hits, got %d", len(hits))
+	}
+}
+
+func TestFormatContext_EmptyReturnsEmpty(t *testing.T) {
+	if got := FormatContext(nil); got != "" {
+		t.Errorf("empty hits should return empty string, got %q", got)
+	}
+}
+
+func TestFormatContext_IncludesCitationAndFence(t *testing.T) {
+	hits := []Hit{
+		{Chunk: Chunk{
+			Source: "modules/networking/main.tf",
+			StartLine: 10, EndLine: 20,
+			Kind: "hcl_resource",
+			Text: "resource \"aws_vpc\" \"main\" {\n  cidr_block = \"10.0.0.0/16\"\n}\n",
+		}, Score: 0.84},
+	}
+	got := FormatContext(hits)
+
+	want := []string{
+		"modules/networking/main.tf",
+		"lines 10-20",
+		"0.84",
+		"```hcl\n",
+		"aws_vpc",
+	}
+	for _, w := range want {
+		if !strings.Contains(got, w) {
+			t.Errorf("FormatContext missing %q in:\n%s", w, got)
+		}
+	}
+}

--- a/internal/ai/testdata/golden/system_ansible_empty.golden
+++ b/internal/ai/testdata/golden/system_ansible_empty.golden
@@ -4,6 +4,7 @@ CRITICAL RULES:
 1. ONLY use the resource types listed below. NEVER mix providers in a single response.
 2. Follow the user's conversation context — if they started with a specific cloud provider, STAY with that provider.
 3. If resources already exist on the canvas, build on them rather than creating duplicates.
+4. If project context is provided below, match the project's existing naming, tagging, and module conventions.
 
 Ansible modules. Use official module names:
 - Package management: apt, yum, dnf, pip

--- a/internal/ai/testdata/golden/system_aws_empty.golden
+++ b/internal/ai/testdata/golden/system_aws_empty.golden
@@ -4,6 +4,7 @@ CRITICAL RULES:
 1. ONLY use the resource types listed below. NEVER mix providers in a single response.
 2. Follow the user's conversation context — if they started with a specific cloud provider, STAY with that provider.
 3. If resources already exist on the canvas, build on them rather than creating duplicates.
+4. If project context is provided below, match the project's existing naming, tagging, and module conventions.
 
 AWS resource types ONLY. Examples:
 - Networking: aws_vpc, aws_subnet, aws_internet_gateway, aws_nat_gateway, aws_security_group, aws_route_table

--- a/internal/ai/testdata/golden/system_aws_with_canvas.golden
+++ b/internal/ai/testdata/golden/system_aws_with_canvas.golden
@@ -4,6 +4,7 @@ CRITICAL RULES:
 1. ONLY use the resource types listed below. NEVER mix providers in a single response.
 2. Follow the user's conversation context — if they started with a specific cloud provider, STAY with that provider.
 3. If resources already exist on the canvas, build on them rather than creating duplicates.
+4. If project context is provided below, match the project's existing naming, tagging, and module conventions.
 
 AWS resource types ONLY. Examples:
 - Networking: aws_vpc, aws_subnet, aws_internet_gateway, aws_nat_gateway, aws_security_group, aws_route_table

--- a/internal/ai/testdata/golden/system_azure_empty.golden
+++ b/internal/ai/testdata/golden/system_azure_empty.golden
@@ -4,6 +4,7 @@ CRITICAL RULES:
 1. ONLY use the resource types listed below. NEVER mix providers in a single response.
 2. Follow the user's conversation context — if they started with a specific cloud provider, STAY with that provider.
 3. If resources already exist on the canvas, build on them rather than creating duplicates.
+4. If project context is provided below, match the project's existing naming, tagging, and module conventions.
 
 Azure resource types ONLY. Examples:
 - Core: azurerm_resource_group (required for all Azure resources)

--- a/internal/ai/testdata/golden/system_gcp_empty.golden
+++ b/internal/ai/testdata/golden/system_gcp_empty.golden
@@ -4,6 +4,7 @@ CRITICAL RULES:
 1. ONLY use the resource types listed below. NEVER mix providers in a single response.
 2. Follow the user's conversation context — if they started with a specific cloud provider, STAY with that provider.
 3. If resources already exist on the canvas, build on them rather than creating duplicates.
+4. If project context is provided below, match the project's existing naming, tagging, and module conventions.
 
 Google Cloud (GCP) resource types ONLY. Examples:
 - Networking: google_compute_network, google_compute_subnetwork, google_compute_firewall, google_compute_router

--- a/internal/api/rag.go
+++ b/internal/api/rag.go
@@ -1,0 +1,227 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/iac-studio/iac-studio/internal/ai"
+	"github.com/iac-studio/iac-studio/internal/ai/embed"
+	"github.com/iac-studio/iac-studio/internal/ai/rag"
+)
+
+// ragBuildMu serialises per-project index rebuilds so two concurrent
+// POSTs don't fight over the same on-disk file. A finer-grained mutex
+// map would let different projects build in parallel, but embeds saturate
+// the model serving thread anyway, so a global lock is simplest.
+var ragBuildMu sync.Mutex
+
+// ragEmbeddingEndpoint / Model / Dim are the defaults the HTTP layer
+// uses when the user hasn't overridden via settings. Nomic-embed-text
+// is the Ollama-side pick because it's small (~300MB) and runs
+// comfortably on CPU — matches the privacy-first posture from issue #8.
+const (
+	defaultEmbedEndpoint = "http://localhost:11434"
+	defaultEmbedModel    = "nomic-embed-text"
+	defaultEmbedDim      = 768
+)
+
+// registerRAGRoutes wires the RAG endpoints onto mux. Isolated so it's
+// testable without spinning up the full router + every other subsystem.
+func registerRAGRoutes(mux *http.ServeMux, projectsDir string, aiClient *ai.Client) {
+	// GET /api/projects/{name}/ai/index — current index stats. Present:
+	// false when no index exists (not an error).
+	mux.HandleFunc("GET /api/projects/{name}/ai/index", func(w http.ResponseWriter, r *http.Request) {
+		name := r.PathValue("name")
+		projectPath, err := safeProjectPath(projectsDir, name)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		stats, err := rag.StatsFor(projectPath)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(stats)
+	})
+
+	// POST /api/projects/{name}/ai/index — rebuild. Body is optional; when
+	// provided it can override the embedding model/endpoint/dim on a per-
+	// call basis (useful for CI benchmarks). Returns the new Stats.
+	mux.HandleFunc("POST /api/projects/{name}/ai/index", func(w http.ResponseWriter, r *http.Request) {
+		limitBody(w, r)
+		name := r.PathValue("name")
+		projectPath, err := safeProjectPath(projectsDir, name)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		type overrideBody struct {
+			Endpoint string `json:"endpoint,omitempty"`
+			Model    string `json:"model,omitempty"`
+			Dim      int    `json:"dim,omitempty"`
+		}
+		var body overrideBody
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil && err.Error() != "EOF" {
+			http.Error(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		em := embed.NewOllama(embed.Config{
+			Endpoint: pick(body.Endpoint, defaultEmbedEndpoint),
+			Model:    pick(body.Model, defaultEmbedModel),
+			Dim:      pickInt(body.Dim, defaultEmbedDim),
+			Timeout:  2 * time.Minute,
+		})
+
+		ragBuildMu.Lock()
+		idx, buildErr := rag.Build(r.Context(), projectPath, em, rag.BuildOptions{})
+		ragBuildMu.Unlock()
+
+		// Build returns a partial index + error when embedding fails — we
+		// still surface the partial so operators can see which files were
+		// at least chunked. The client gets a 502 so it knows the build
+		// didn't complete.
+		stats, _ := rag.StatsFor(projectPath)
+		if buildErr != nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadGateway)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"error": buildErr.Error(),
+				"stats": stats,
+				"partial_chunks": func() int {
+					if idx == nil {
+						return 0
+					}
+					return len(idx.Chunks)
+				}(),
+			})
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(stats)
+	})
+
+	// Expose a retrieval helper for the chat/suggest/fix/topology handlers
+	// to call when building prompts. Kept as a package-level function via
+	// the sharedRAG singleton so the handlers don't each need to re-
+	// instantiate an embedder.
+	sharedRAG.configure(aiClient)
+}
+
+// sharedRAG is the process-wide retrieval helper used by the
+// chat/topology/fix/suggest handlers. It lazily constructs the default
+// Ollama embedder on first use and caches loaded indexes per project
+// (invalidating on file-mtime change of the rag-index.json file) to
+// avoid re-reading a 1-5MB JSON blob on every chat turn.
+var sharedRAG = &ragHelper{}
+
+type ragHelper struct {
+	mu sync.RWMutex
+	em embed.Embedder
+	// cache maps projectDir → (mtime, loaded index). A bigger cache
+	// would evict under pressure; for IaC Studio's typical scale
+	// (≤ 20 open projects, single user) simplicity wins.
+	cache map[string]cachedIndex
+}
+
+type cachedIndex struct {
+	mtime time.Time
+	idx   *rag.Index
+}
+
+func (h *ragHelper) configure(client *ai.Client) {
+	_ = client // reserved for future: pull embed settings from client
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.em == nil {
+		h.em = embed.NewOllama(embed.Config{
+			Endpoint: defaultEmbedEndpoint,
+			Model:    defaultEmbedModel,
+			Dim:      defaultEmbedDim,
+			Timeout:  30 * time.Second,
+		})
+	}
+	if h.cache == nil {
+		h.cache = map[string]cachedIndex{}
+	}
+}
+
+// Context retrieves top-k chunks for query and returns a formatted
+// prompt preamble. Returns empty string when:
+//   - no index exists yet
+//   - the embedder is unavailable
+//   - retrieval returned nothing
+//
+// Never returns an error: RAG is best-effort context, and failing the
+// whole chat over a missing embedder would be strictly worse than
+// running chat without grounding.
+func (h *ragHelper) Context(ctx context.Context, projectDir, query string, k int) string {
+	if h == nil || h.em == nil || projectDir == "" {
+		return ""
+	}
+	idx, err := h.indexFor(projectDir)
+	if err != nil || idx == nil {
+		return ""
+	}
+	hits, err := rag.RetrieveText(ctx, h.em, idx, query, k)
+	if err != nil {
+		// ErrNotReady and friends — degrade silently.
+		return ""
+	}
+	return rag.FormatContext(hits)
+}
+
+func (h *ragHelper) indexFor(projectDir string) (*rag.Index, error) {
+	h.mu.RLock()
+	cached, ok := h.cache[projectDir]
+	h.mu.RUnlock()
+
+	path := rag.IndexPath(projectDir)
+	info, err := statMod(path)
+	if err != nil {
+		return nil, nil
+	}
+	if ok && cached.mtime.Equal(info) {
+		return cached.idx, nil
+	}
+
+	idx, err := rag.Load(projectDir)
+	if err != nil {
+		return nil, err
+	}
+	h.mu.Lock()
+	h.cache[projectDir] = cachedIndex{mtime: info, idx: idx}
+	h.mu.Unlock()
+	return idx, nil
+}
+
+// statMod returns the mtime of path, or a zero time + error if missing.
+func statMod(path string) (time.Time, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return info.ModTime(), nil
+}
+
+// pick / pickInt are tiny helpers for "use body value if set, else default".
+func pick(a, b string) string {
+	if a != "" {
+		return a
+	}
+	return b
+}
+func pickInt(a, b int) int {
+	if a > 0 {
+		return a
+	}
+	return b
+}

--- a/internal/api/rag.go
+++ b/internal/api/rag.go
@@ -3,6 +3,8 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"os"
 	"sync"
@@ -68,7 +70,7 @@ func registerRAGRoutes(mux *http.ServeMux, projectsDir string, aiClient *ai.Clie
 			Dim      int    `json:"dim,omitempty"`
 		}
 		var body overrideBody
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil && err.Error() != "EOF" {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil && !errors.Is(err, io.EOF) {
 			http.Error(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
 			return
 		}

--- a/internal/api/rag_test.go
+++ b/internal/api/rag_test.go
@@ -1,0 +1,108 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/iac-studio/iac-studio/internal/ai"
+	"github.com/iac-studio/iac-studio/internal/ai/rag"
+)
+
+// ragMux wires just the RAG routes so tests don't spin up the full
+// router. safeProjectPath is shared so we still exercise the project-
+// scoping logic.
+func ragMux(t *testing.T, projectsDir string) *http.ServeMux {
+	t.Helper()
+	mux := http.NewServeMux()
+	client := ai.NewClient("http://127.0.0.1:1", "ignored")
+	registerRAGRoutes(mux, projectsDir, client)
+	return mux
+}
+
+func scaffoldRAGProject(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	proj := filepath.Join(root, "demo")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(proj, "main.tf"),
+		[]byte(`resource "aws_vpc" "main" { cidr_block = "10.0.0.0/16" }`),
+		0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func TestRAGStatsEndpoint_EmptyProjectReturnsNotPresent(t *testing.T) {
+	root := scaffoldRAGProject(t)
+	srv := httptest.NewServer(ragMux(t, root))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/projects/demo/ai/index")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	var stats rag.Stats
+	_ = json.NewDecoder(resp.Body).Decode(&stats)
+	if stats.Present {
+		t.Errorf("expected !Present for unindexed project, got %+v", stats)
+	}
+}
+
+func TestRAGStatsEndpoint_PathTraversal(t *testing.T) {
+	root := scaffoldRAGProject(t)
+	srv := httptest.NewServer(ragMux(t, root))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/projects/%2e%2e%2fetc/ai/index")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != 400 {
+		t.Errorf("traversal should 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestRAGBuildEndpoint_OllamaUnavailableReturns502WithPartial(t *testing.T) {
+	root := scaffoldRAGProject(t)
+	srv := httptest.NewServer(ragMux(t, root))
+	defer srv.Close()
+
+	// Point the request at a dead endpoint; Build degrades to chunk-only.
+	body := strings.NewReader(`{"endpoint":"http://127.0.0.1:1","model":"nomic-embed-text","dim":768}`)
+	resp, err := http.Post(srv.URL+"/api/projects/demo/ai/index", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadGateway {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, body = %s", resp.StatusCode, raw)
+	}
+	var payload struct {
+		Error          string    `json:"error"`
+		PartialChunks  int       `json:"partial_chunks"`
+		Stats          rag.Stats `json:"stats"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&payload)
+	if payload.Error == "" {
+		t.Error("expected error field")
+	}
+	if payload.PartialChunks == 0 {
+		t.Error("expected partial_chunks > 0 — chunks should be counted even when embedding fails")
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -593,6 +593,14 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 			return
 		}
 
+		// Populate RAG context when a project is named + indexed. Failures
+		// are swallowed — chat degrades to ungrounded rather than erroring.
+		if req.Project != "" {
+			if projectPath, err := safeProjectPath(projectsDir, req.Project); err == nil {
+				req.ProjectContext = sharedRAG.Context(r.Context(), projectPath, req.Message, 5)
+			}
+		}
+
 		response, resources, err := aiClient.GenerateIaC(r.Context(), req)
 		if err != nil {
 			log.Printf("AI unavailable, using pattern matching: %v", err)
@@ -622,6 +630,14 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			http.Error(w, "invalid request", 400)
 			return
+		}
+
+		// Grounding on the project's own code — same degrade-silent path
+		// as the non-streaming endpoint.
+		if req.Project != "" {
+			if projectPath, err := safeProjectPath(projectsDir, req.Project); err == nil {
+				req.ProjectContext = sharedRAG.Context(r.Context(), projectPath, req.Message, 5)
+			}
 		}
 
 		flusher, ok := w.(http.Flusher)
@@ -1147,6 +1163,11 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 	// AI agent — tool-use orchestrator that drives list_resources, run_policy,
 	// run_scan, write_hcl, etc. against the configured Anthropic provider.
 	registerAgentRoutes(mux, projectsDir, aiClient, regClient)
+
+	// RAG — build & query a per-project embedding index so chat / topology
+	// / fix responses are grounded on the project's own code instead of
+	// generic best-practice knowledge.
+	registerRAGRoutes(mux, projectsDir, aiClient)
 
 	return mux
 }


### PR DESCRIPTION
## Summary
Ground AI responses on the project's own HCL / policies / docs via a local embedding pipeline. Prompts sent to chat + stream-chat now include a \`ProjectContext\` preamble retrieved by cosine similarity against an on-disk index — so generated code matches the project's naming, tagging, and module conventions instead of generic best-practice defaults.

Scope is the RAG half of #8. Vision (diagram-to-project) is a separate PR.

Closes part of #8.

- [x] **Commit 1 — Embedder interface + Ollama adapter**: \`internal/ai/embed\` with batch Embed, ErrNotReady sentinel, shared Cosine helper. Zero vectors preserved for empty inputs so caller alignment stays intact.
- [x] **Commit 2 — Project indexer**: \`internal/ai/rag/chunk.go\` walks the project, skips \`.git\`/\`.terraform\`/\`node_modules\`, chunks HCL per-block via the resource parser and markdown per-heading. \`rag/index.go\` batches embeds, atomically persists \`<project>/.iac-studio/rag-index.json\`.
- [x] **Commit 3 — Retrieval + HTTP + prompt integration**: \`GET/POST /api/projects/{name}/ai/index\`, a process-wide retrieval helper with mtime-keyed cache, and prompt-level injection via the existing \`system.md\` template. Chat and stream-chat both populate \`ProjectContext\` when the request names a project.

## Design notes
- **Privacy first**: default embedder is local Ollama (\`nomic-embed-text\`, 768-dim). Self-hosted projects never leak HCL to remote APIs.
- **Degrade silently**: missing index, unreachable Ollama, empty retrieval — all of these return empty \`ProjectContext\` rather than erroring the chat. RAG is a best-effort hint, not a gate.
- **Atomic writes**: index persisted via temp + rename so a crashed mid-write can't leave a truncated file.
- **Content-addressed chunks**: SHA-1(source#lines + text) so reindex-of-unchanged hits cache-level reuse in the follow-up.

## Test plan
- [x] \`go test ./...\` green across 21 packages
- [x] 15 unit tests in \`internal/ai/embed\` + \`internal/ai/rag\` (cosine, Ollama adapter, chunk kinds, brace matcher, build round-trip, load-missing, not-ready degrades, stats)
- [x] 3 HTTP tests in \`internal/api/rag_test.go\` (empty project not-present, path traversal 400, Ollama-unavailable 502 with partial chunks)
- [ ] Manual smoke: \`ollama pull nomic-embed-text\`, \`POST /api/projects/demo/ai/index\`, chat with \`project: "demo"\` and confirm the response references an existing resource by file path.