### PR TITLE
feat(ai): vision — diagram-to-project via Anthropic multimodal

### DIFF
--- a/internal/ai/bridge.go
+++ b/internal/ai/bridge.go
@@ -441,12 +441,16 @@ func (c *Client) GenerateFromDiagram(ctx context.Context, req TopologyRequest, i
 	if c.providerErr != nil {
 		return "", nil, c.providerErr
 	}
+	// Validate input before checking provider capability. A caller that
+	// forgot to attach images should see "no images provided" regardless
+	// of which provider happens to be configured — the error should be
+	// deterministic on the inputs, not the environment.
+	if len(images) == 0 {
+		return "", nil, fmt.Errorf("no images provided — use GenerateTopology for text-only requests")
+	}
 	vu, ok := c.provider.(providers.VisionUser)
 	if !ok {
 		return "", nil, fmt.Errorf("provider %q does not support vision — switch to Anthropic to enable diagram-to-project", c.provider.Kind())
-	}
-	if len(images) == 0 {
-		return "", nil, fmt.Errorf("no images provided — use GenerateTopology for text-only requests")
 	}
 
 	providerGuide := buildProviderGuide(req.Tool, req.Provider)

--- a/internal/ai/bridge.go
+++ b/internal/ai/bridge.go
@@ -421,13 +421,11 @@ Only respond with valid JSON.`, req.Tool, providerGuide)
 	return parseAIResponse(raw)
 }
 
-// DiagramImage is one image attachment for GenerateFromDiagram. The
-// bridge re-exports the providers.Image shape rather than importing
-// it everywhere the HTTP layer uses this method.
-type DiagramImage struct {
-	MediaType string // "image/png" | "image/jpeg" | "image/webp" | "image/gif"
-	Data      []byte
-}
+// DiagramImage is one image attachment for GenerateFromDiagram.
+// It is a type alias for providers.Image so the HTTP layer doesn't
+// need to import the providers package directly, while the bridge
+// avoids copying the slice before passing it to CompleteWithImages.
+type DiagramImage = providers.Image
 
 // GenerateFromDiagram is the vision counterpart to GenerateTopology: it
 // takes architecture diagrams (whiteboard photos, lucid exports,
@@ -486,18 +484,16 @@ Only respond with valid JSON.`, req.Tool, providerGuide)
 		userText = fmt.Sprintf("Build the infrastructure shown in the uploaded diagram. Additional context: %s", d)
 	}
 
-	provImages := make([]providers.Image, 0, len(images))
-	for _, img := range images {
-		provImages = append(provImages, providers.Image{MediaType: img.MediaType, Data: img.Data})
-	}
-
 	raw, err := vu.CompleteWithImages(ctx, providers.Request{
 		System:      systemPrompt,
 		User:        userText,
 		Temperature: defaultTemperature,
 		MaxTokens:   defaultMaxTokens,
 		JSONMode:    true,
-	}, provImages)
+		// The system prompt is long and stable per tool+provider combo;
+		// caching it on Anthropic saves tokens on repeated diagram uploads.
+		Cacheable: true,
+	}, images)
 	if err != nil {
 		return "", nil, err
 	}

--- a/internal/ai/bridge.go
+++ b/internal/ai/bridge.go
@@ -421,6 +421,89 @@ Only respond with valid JSON.`, req.Tool, providerGuide)
 	return parseAIResponse(raw)
 }
 
+// DiagramImage is one image attachment for GenerateFromDiagram. The
+// bridge re-exports the providers.Image shape rather than importing
+// it everywhere the HTTP layer uses this method.
+type DiagramImage struct {
+	MediaType string // "image/png" | "image/jpeg" | "image/webp" | "image/gif"
+	Data      []byte
+}
+
+// GenerateFromDiagram is the vision counterpart to GenerateTopology: it
+// takes architecture diagrams (whiteboard photos, lucid exports,
+// hand-sketches) + an optional free-text description, sends them to a
+// vision-capable provider, and returns the same (message, resources,
+// err) tuple GenerateTopology produces so every downstream scaffolding
+// path works unchanged.
+//
+// Returns a descriptive error when the configured provider does not
+// implement VisionUser — the HTTP handler surfaces that as a 400 with
+// a "switch to Anthropic" hint, mirroring the agent endpoint's pattern.
+func (c *Client) GenerateFromDiagram(ctx context.Context, req TopologyRequest, images []DiagramImage) (string, []parser.Resource, error) {
+	if c.providerErr != nil {
+		return "", nil, c.providerErr
+	}
+	vu, ok := c.provider.(providers.VisionUser)
+	if !ok {
+		return "", nil, fmt.Errorf("provider %q does not support vision — switch to Anthropic to enable diagram-to-project", c.provider.Kind())
+	}
+	if len(images) == 0 {
+		return "", nil, fmt.Errorf("no images provided — use GenerateTopology for text-only requests")
+	}
+
+	providerGuide := buildProviderGuide(req.Tool, req.Provider)
+	systemPrompt := fmt.Sprintf(`You are an expert Infrastructure as Code architect for %s.
+The user has uploaded one or more architecture diagrams. Read every diagram
+carefully: identify resources, relationships, and inferred constraints
+(environments, subnets, public/private tiers, load balancers, data stores).
+
+RULES:
+1. %s
+2. Translate every component visible in the diagram into a concrete
+   resource type. Common diagram shapes: a "VPC" cloud → aws_vpc; subnet
+   rectangles → aws_subnet; an EC2/VM icon → aws_instance; a database
+   cylinder → aws_db_instance or aws_rds_cluster depending on scale;
+   an "ALB"/"ELB" label → aws_lb; anything marked "S3" or a bucket icon
+   → aws_s3_bucket.
+3. Fill in supporting resources the diagram implies but doesn't draw —
+   IAM roles, security groups, route tables, NAT gateways.
+4. Preserve any labels from the diagram as names when they're descriptive
+   (snake_case'd); otherwise pick purposeful names.
+5. Follow dependency order: networking → security → compute → data →
+   monitoring.
+
+Respond with a JSON object:
+{
+  "message": "What you saw in the diagram and how you translated it",
+  "resources": [
+    {"type": "...", "name": "...", "properties": {...}}
+  ]
+}
+Only respond with valid JSON.`, req.Tool, providerGuide)
+
+	userText := "Build the infrastructure shown in the uploaded diagram."
+	if d := strings.TrimSpace(req.Description); d != "" {
+		userText = fmt.Sprintf("Build the infrastructure shown in the uploaded diagram. Additional context: %s", d)
+	}
+
+	provImages := make([]providers.Image, 0, len(images))
+	for _, img := range images {
+		provImages = append(provImages, providers.Image{MediaType: img.MediaType, Data: img.Data})
+	}
+
+	raw, err := vu.CompleteWithImages(ctx, providers.Request{
+		System:      systemPrompt,
+		User:        userText,
+		Temperature: defaultTemperature,
+		MaxTokens:   defaultMaxTokens,
+		JSONMode:    true,
+	}, provImages)
+	if err != nil {
+		return "", nil, err
+	}
+	return parseAIResponse(raw)
+}
+
 // GenerateIaCSimple is the legacy single-message interface (used by pattern matching fallback).
 func (c *Client) GenerateIaCSimple(ctx context.Context, message, tool string) (string, []parser.Resource, error) {
 	return c.GenerateIaC(ctx, ChatRequest{

--- a/internal/ai/providers/anthropic.go
+++ b/internal/ai/providers/anthropic.go
@@ -318,7 +318,14 @@ func (p *anthropicProvider) Stream(ctx context.Context, req Request, onDelta Del
 		Temperature: req.Temperature,
 		Stream:      true,
 	}
-	raw, _ := json.Marshal(reqBody)
+	raw, err := json.Marshal(reqBody)
+	if err != nil {
+		// Same defensive handling as postMessagesAndExtractText — known
+		// request shapes marshal cleanly, but a future caller could
+		// embed a non-marshalable value. Surface the encoding failure
+		// instead of silently POSTing an empty body.
+		return "", fmt.Errorf("marshal anthropic stream request: %w", err)
+	}
 	httpReq, err := http.NewRequestWithContext(ctx, "POST", p.endpoint, bytes.NewReader(raw))
 	if err != nil {
 		return "", err

--- a/internal/ai/providers/anthropic.go
+++ b/internal/ai/providers/anthropic.go
@@ -210,7 +210,14 @@ func clampMaxTokens(n int) int {
 // extracted text. Keeping both paths on one code path means future
 // header tweaks (e.g. a new anthropic-beta flag) land once.
 func (p *anthropicProvider) postMessagesAndExtractText(ctx context.Context, reqBody any) (string, error) {
-	raw, _ := json.Marshal(reqBody)
+	raw, err := json.Marshal(reqBody)
+	if err != nil {
+		// Defensive — the known request shapes are all marshalable, but
+		// a future caller could accidentally embed a non-marshalable
+		// value. Returning the marshal error up front beats silently
+		// issuing an empty POST and masking the real cause.
+		return "", fmt.Errorf("marshal anthropic request: %w", err)
+	}
 
 	httpReq, err := http.NewRequestWithContext(ctx, "POST", p.endpoint, bytes.NewReader(raw))
 	if err != nil {

--- a/internal/ai/providers/anthropic.go
+++ b/internal/ai/providers/anthropic.go
@@ -179,21 +179,37 @@ type anthropicResponse struct {
 }
 
 func (p *anthropicProvider) Complete(ctx context.Context, req Request) (string, error) {
-	maxTokens := req.MaxTokens
-	if maxTokens <= 0 {
-		// The Messages API requires max_tokens; pick a sensible ceiling that
-		// matches the other providers' default.
-		maxTokens = 4096
-	}
 	reqBody := anthropicRequest{
 		Model:  p.model,
 		System: buildSystemField(req.System, req.Cacheable),
 		Messages: []anthropicMessage{
 			{Role: "user", Content: req.User},
 		},
-		MaxTokens:   maxTokens,
+		MaxTokens:   clampMaxTokens(req.MaxTokens),
 		Temperature: req.Temperature,
 	}
+	return p.postMessagesAndExtractText(ctx, reqBody)
+}
+
+// clampMaxTokens enforces the Messages API requirement that max_tokens
+// is set, picking a sensible ceiling when the caller left it at zero.
+// Factored out of Complete so the vision path picks up the same
+// default without re-deriving the magic number.
+func clampMaxTokens(n int) int {
+	if n <= 0 {
+		return 4096
+	}
+	return n
+}
+
+// postMessagesAndExtractText is the shared HTTP round-trip used by
+// both Complete and CompleteWithImages. Accepts any JSON-marshalable
+// request body (the two methods diverge on Messages shape but agree
+// on everything else — headers, error handling, response decode,
+// usage bookkeeping, content-block concatenation) and returns the
+// extracted text. Keeping both paths on one code path means future
+// header tweaks (e.g. a new anthropic-beta flag) land once.
+func (p *anthropicProvider) postMessagesAndExtractText(ctx context.Context, reqBody any) (string, error) {
 	raw, _ := json.Marshal(reqBody)
 
 	httpReq, err := http.NewRequestWithContext(ctx, "POST", p.endpoint, bytes.NewReader(raw))

--- a/internal/ai/providers/anthropic.go
+++ b/internal/ai/providers/anthropic.go
@@ -301,17 +301,13 @@ type anthropicStreamEvent struct {
 // Stream consumes Anthropic's Messages SSE stream. Each token arrives as a
 // content_block_delta event whose delta.text carries the increment.
 func (p *anthropicProvider) Stream(ctx context.Context, req Request, onDelta DeltaFunc) (string, error) {
-	maxTokens := req.MaxTokens
-	if maxTokens <= 0 {
-		maxTokens = 4096
-	}
 	reqBody := anthropicRequest{
 		Model:  p.model,
 		System: buildSystemField(req.System, req.Cacheable),
 		Messages: []anthropicMessage{
 			{Role: "user", Content: req.User},
 		},
-		MaxTokens:   maxTokens,
+		MaxTokens:   clampMaxTokens(req.MaxTokens),
 		Temperature: req.Temperature,
 		Stream:      true,
 	}

--- a/internal/ai/providers/anthropic_vision.go
+++ b/internal/ai/providers/anthropic_vision.go
@@ -1,13 +1,9 @@
 package providers
 
 import (
-	"bytes"
 	"context"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
 	"strings"
 )
 
@@ -23,11 +19,6 @@ import (
 func (p *anthropicProvider) CompleteWithImages(ctx context.Context, req Request, images []Image) (string, error) {
 	if len(images) == 0 {
 		return p.Complete(ctx, req)
-	}
-
-	maxTokens := req.MaxTokens
-	if maxTokens <= 0 {
-		maxTokens = 4096
 	}
 
 	// Build a content-block array: images first (the model attends more
@@ -59,62 +50,12 @@ func (p *anthropicProvider) CompleteWithImages(ctx context.Context, req Request,
 		Model:       p.model,
 		System:      buildSystemField(req.System, req.Cacheable),
 		Messages:    []anthropicVisionMessage{{Role: "user", Content: content}},
-		MaxTokens:   maxTokens,
+		MaxTokens:   clampMaxTokens(req.MaxTokens),
 		Temperature: req.Temperature,
 	}
-	raw, _ := json.Marshal(reqBody)
-
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", p.endpoint, bytes.NewReader(raw))
-	if err != nil {
-		return "", err
-	}
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("x-api-key", p.apiKey)
-	httpReq.Header.Set("anthropic-version", p.apiVersion)
-
-	resp, err := p.client.Do(httpReq)
-	if err != nil {
-		return "", fmt.Errorf("anthropic API unavailable: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", fmt.Errorf("read anthropic response: %w", err)
-	}
-
-	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		var apiErr anthropicResponse
-		if err := json.Unmarshal(body, &apiErr); err == nil && apiErr.Error != nil && apiErr.Error.Message != "" {
-			return "", fmt.Errorf("anthropic API error (status %d): %s", resp.StatusCode, apiErr.Error.Message)
-		}
-		if msg := strings.TrimSpace(string(body)); msg != "" {
-			return "", fmt.Errorf("anthropic API error (status %d): %s", resp.StatusCode, msg)
-		}
-		return "", fmt.Errorf("anthropic API error (status %d)", resp.StatusCode)
-	}
-
-	var decoded anthropicResponse
-	if err := json.Unmarshal(body, &decoded); err != nil {
-		return "", fmt.Errorf("decode anthropic response: %w", err)
-	}
-	if decoded.Error != nil {
-		return "", fmt.Errorf("anthropic API error: %s", decoded.Error.Message)
-	}
-	p.recordUsage(decoded.Usage)
-	if len(decoded.Content) == 0 {
-		return "", ErrEmptyResponse
-	}
-	var out strings.Builder
-	for _, block := range decoded.Content {
-		if block.Type == "text" {
-			out.WriteString(block.Text)
-		}
-	}
-	if out.Len() == 0 {
-		return "", ErrEmptyResponse
-	}
-	return out.String(), nil
+	// Shared round-trip: same headers, error handling, usage
+	// bookkeeping, and content-block concatenation as Complete.
+	return p.postMessagesAndExtractText(ctx, reqBody)
 }
 
 // ─── Vision wire structs ─────────────────────────────────────────

--- a/internal/ai/providers/anthropic_vision.go
+++ b/internal/ai/providers/anthropic_vision.go
@@ -3,7 +3,6 @@ package providers
 import (
 	"context"
 	"encoding/base64"
-	"fmt"
 	"strings"
 )
 
@@ -26,6 +25,7 @@ func (p *anthropicProvider) CompleteWithImages(ctx context.Context, req Request,
 	// prompt text. Anthropic's docs explicitly recommend this ordering
 	// for diagram-to-structure tasks.
 	content := make([]any, 0, len(images)+1)
+	usableImages := 0
 	for _, img := range images {
 		if img.MediaType == "" || len(img.Data) == 0 {
 			continue
@@ -38,12 +38,19 @@ func (p *anthropicProvider) CompleteWithImages(ctx context.Context, req Request,
 				Data:      base64.StdEncoding.EncodeToString(img.Data),
 			},
 		})
+		usableImages++
+	}
+	// If every attachment was filtered out (all had empty MediaType or
+	// zero-length Data) the request effectively has no vision payload —
+	// fall back to Complete so the wire shape matches the interface
+	// doc ("empty images slice falls through to Complete"). The text-
+	// only Request would otherwise be sent as a block array which
+	// diverges needlessly.
+	if usableImages == 0 {
+		return p.Complete(ctx, req)
 	}
 	if strings.TrimSpace(req.User) != "" {
 		content = append(content, anthropicTextBlock{Type: "text", Text: req.User})
-	}
-	if len(content) == 0 {
-		return "", fmt.Errorf("anthropic vision: no usable image or text in request")
 	}
 
 	reqBody := anthropicVisionRequest{

--- a/internal/ai/providers/anthropic_vision.go
+++ b/internal/ai/providers/anthropic_vision.go
@@ -1,0 +1,153 @@
+package providers
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// CompleteWithImages is the VisionUser implementation for Anthropic.
+// Each Image becomes a content block inside the user message, ahead of
+// the text prompt. An empty images slice falls through to Complete so
+// callers don't have to branch.
+//
+// Anthropic encodes image bytes as base64 in a content block of type
+// "image". We do the encoding here (not at the caller) so multipart
+// uploads can stream raw bytes straight through. Media types supported
+// by the API: image/png, image/jpeg, image/webp, image/gif.
+func (p *anthropicProvider) CompleteWithImages(ctx context.Context, req Request, images []Image) (string, error) {
+	if len(images) == 0 {
+		return p.Complete(ctx, req)
+	}
+
+	maxTokens := req.MaxTokens
+	if maxTokens <= 0 {
+		maxTokens = 4096
+	}
+
+	// Build a content-block array: images first (the model attends more
+	// consistently when attachments precede the text), then the user
+	// prompt text. Anthropic's docs explicitly recommend this ordering
+	// for diagram-to-structure tasks.
+	content := make([]any, 0, len(images)+1)
+	for _, img := range images {
+		if img.MediaType == "" || len(img.Data) == 0 {
+			continue
+		}
+		content = append(content, anthropicImageBlock{
+			Type: "image",
+			Source: anthropicImageSource{
+				Type:      "base64",
+				MediaType: img.MediaType,
+				Data:      base64.StdEncoding.EncodeToString(img.Data),
+			},
+		})
+	}
+	if strings.TrimSpace(req.User) != "" {
+		content = append(content, anthropicTextBlock{Type: "text", Text: req.User})
+	}
+	if len(content) == 0 {
+		return "", fmt.Errorf("anthropic vision: no usable image or text in request")
+	}
+
+	reqBody := anthropicVisionRequest{
+		Model:       p.model,
+		System:      buildSystemField(req.System, req.Cacheable),
+		Messages:    []anthropicVisionMessage{{Role: "user", Content: content}},
+		MaxTokens:   maxTokens,
+		Temperature: req.Temperature,
+	}
+	raw, _ := json.Marshal(reqBody)
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", p.endpoint, bytes.NewReader(raw))
+	if err != nil {
+		return "", err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("x-api-key", p.apiKey)
+	httpReq.Header.Set("anthropic-version", p.apiVersion)
+
+	resp, err := p.client.Do(httpReq)
+	if err != nil {
+		return "", fmt.Errorf("anthropic API unavailable: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read anthropic response: %w", err)
+	}
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		var apiErr anthropicResponse
+		if err := json.Unmarshal(body, &apiErr); err == nil && apiErr.Error != nil && apiErr.Error.Message != "" {
+			return "", fmt.Errorf("anthropic API error (status %d): %s", resp.StatusCode, apiErr.Error.Message)
+		}
+		if msg := strings.TrimSpace(string(body)); msg != "" {
+			return "", fmt.Errorf("anthropic API error (status %d): %s", resp.StatusCode, msg)
+		}
+		return "", fmt.Errorf("anthropic API error (status %d)", resp.StatusCode)
+	}
+
+	var decoded anthropicResponse
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		return "", fmt.Errorf("decode anthropic response: %w", err)
+	}
+	if decoded.Error != nil {
+		return "", fmt.Errorf("anthropic API error: %s", decoded.Error.Message)
+	}
+	p.recordUsage(decoded.Usage)
+	if len(decoded.Content) == 0 {
+		return "", ErrEmptyResponse
+	}
+	var out strings.Builder
+	for _, block := range decoded.Content {
+		if block.Type == "text" {
+			out.WriteString(block.Text)
+		}
+	}
+	if out.Len() == 0 {
+		return "", ErrEmptyResponse
+	}
+	return out.String(), nil
+}
+
+// ─── Vision wire structs ─────────────────────────────────────────
+
+// anthropicVisionMessage differs from anthropicMessage only in Content:
+// the vision path needs a content-block array (image + text), the
+// existing Complete path keeps the simpler string shape to minimise
+// diff from the established wire format.
+type anthropicVisionMessage struct {
+	Role    string `json:"role"`
+	Content any    `json:"content"`
+}
+
+type anthropicVisionRequest struct {
+	Model       string                   `json:"model"`
+	System      any                      `json:"system,omitempty"`
+	Messages    []anthropicVisionMessage `json:"messages"`
+	MaxTokens   int                      `json:"max_tokens"`
+	Temperature float64                  `json:"temperature,omitempty"`
+}
+
+type anthropicImageBlock struct {
+	Type   string               `json:"type"` // always "image"
+	Source anthropicImageSource `json:"source"`
+}
+
+type anthropicImageSource struct {
+	Type      string `json:"type"`       // always "base64" today
+	MediaType string `json:"media_type"` // "image/png" | "image/jpeg" | "image/webp" | "image/gif"
+	Data      string `json:"data"`       // base64-encoded image bytes
+}
+
+type anthropicTextBlock struct {
+	Type string `json:"type"` // always "text"
+	Text string `json:"text"`
+}

--- a/internal/ai/providers/anthropic_vision_test.go
+++ b/internal/ai/providers/anthropic_vision_test.go
@@ -1,0 +1,146 @@
+package providers
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestAnthropicVision_ImageContentBlockShape — the canonical wire check:
+// a single PNG attachment + text prompt produces a user message whose
+// content array has the image block first (per Anthropic's diagram-to-
+// structure guidance) and the text block second.
+func TestAnthropicVision_ImageContentBlockShape(t *testing.T) {
+	var received anthropicVisionRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(raw, &received); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"content": []map[string]any{{"type": "text", "text": "ok"}},
+		})
+	}))
+	defer srv.Close()
+
+	p := &anthropicProvider{
+		endpoint:   srv.URL,
+		model:      "claude-opus-4-7",
+		apiKey:     "test-key",
+		apiVersion: DefaultAnthropicVersion,
+		client:     &http.Client{},
+	}
+
+	png := []byte{0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a}
+	out, err := p.CompleteWithImages(context.Background(), Request{
+		System: "you analyse diagrams",
+		User:   "describe this",
+	}, []Image{{MediaType: "image/png", Data: png}})
+	if err != nil {
+		t.Fatalf("CompleteWithImages: %v", err)
+	}
+	if out != "ok" {
+		t.Errorf("want 'ok', got %q", out)
+	}
+
+	if len(received.Messages) != 1 || received.Messages[0].Role != "user" {
+		t.Fatalf("want single user message, got %+v", received.Messages)
+	}
+	blocks, ok := received.Messages[0].Content.([]any)
+	if !ok {
+		t.Fatalf("Content should be an array of blocks, got %T", received.Messages[0].Content)
+	}
+	if len(blocks) != 2 {
+		t.Fatalf("want 2 blocks (image + text), got %d", len(blocks))
+	}
+
+	first, _ := blocks[0].(map[string]any)
+	if first["type"] != "image" {
+		t.Errorf("first block should be image, got %v", first["type"])
+	}
+	src, _ := first["source"].(map[string]any)
+	if src["media_type"] != "image/png" {
+		t.Errorf("wrong media_type: %v", src["media_type"])
+	}
+	decoded, err := base64.StdEncoding.DecodeString(src["data"].(string))
+	if err != nil || string(decoded) != string(png) {
+		t.Errorf("image bytes did not round-trip base64")
+	}
+
+	second, _ := blocks[1].(map[string]any)
+	if second["type"] != "text" || second["text"] != "describe this" {
+		t.Errorf("second block wrong: %+v", second)
+	}
+}
+
+func TestAnthropicVision_EmptyImagesFallsBackToComplete(t *testing.T) {
+	// When images is empty, we expect a plain Complete — the wire shape
+	// has string Content on the user message, not a block array.
+	var raw []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ = io.ReadAll(r.Body)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"content": []map[string]any{{"type": "text", "text": "ok"}},
+		})
+	}))
+	defer srv.Close()
+
+	p := &anthropicProvider{
+		endpoint:   srv.URL,
+		model:      "claude-opus-4-7",
+		apiKey:     "test-key",
+		apiVersion: DefaultAnthropicVersion,
+		client:     &http.Client{},
+	}
+	if _, err := p.CompleteWithImages(context.Background(), Request{User: "hi"}, nil); err != nil {
+		t.Fatalf("CompleteWithImages: %v", err)
+	}
+
+	// The fallback goes through Complete → plain anthropicRequest with
+	// Content as string. Verify the body doesn't carry the vision shape.
+	if !strings.Contains(string(raw), `"content":"hi"`) {
+		t.Errorf("expected Complete string-form body, got %s", string(raw))
+	}
+}
+
+func TestAnthropicVision_DropsEmptyImages(t *testing.T) {
+	var received anthropicVisionRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &received)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"content": []map[string]any{{"type": "text", "text": "ok"}},
+		})
+	}))
+	defer srv.Close()
+
+	p := &anthropicProvider{
+		endpoint:   srv.URL,
+		model:      "m",
+		apiKey:     "k",
+		apiVersion: DefaultAnthropicVersion,
+		client:     &http.Client{},
+	}
+	_, err := p.CompleteWithImages(context.Background(), Request{User: "hi"}, []Image{
+		{MediaType: "", Data: []byte("x")}, // no media type
+		{MediaType: "image/png", Data: nil}, // empty data
+		{MediaType: "image/png", Data: []byte("real")},
+	})
+	if err != nil {
+		t.Fatalf("CompleteWithImages: %v", err)
+	}
+	blocks, _ := received.Messages[0].Content.([]any)
+	if len(blocks) != 2 {
+		t.Errorf("want 1 image + 1 text block, got %d", len(blocks))
+	}
+}
+
+func TestAnthropicVision_SatisfiesVisionUserInterface(t *testing.T) {
+	// Compile-time assertion: anthropicProvider implements VisionUser.
+	var _ VisionUser = &anthropicProvider{}
+}

--- a/internal/ai/providers/provider.go
+++ b/internal/ai/providers/provider.go
@@ -60,6 +60,32 @@ type Request struct {
 	Cacheable bool
 }
 
+// Image is one visual attachment appended to a Request when the caller
+// wants the model to reason over a diagram. Providers that support
+// vision (Anthropic Opus/Sonnet, OpenAI GPT-4o, Google Gemini)
+// base64-encode Data and include MediaType in the API call; providers
+// without vision ignore the field.
+//
+// MediaType follows the MIME form ("image/png", "image/jpeg",
+// "image/webp", "image/gif"). Validation happens at the HTTP boundary
+// — a caller that hands a Request with an unsupported MediaType to a
+// vision-capable provider gets a provider-specific error back.
+type Image struct {
+	MediaType string
+	Data      []byte
+}
+
+// VisionUser is the optional interface for providers that accept image
+// inputs. Callers type-assert on it the same way ToolUser works; non-
+// vision providers simply lack it.
+type VisionUser interface {
+	// CompleteWithImages is Complete + a slice of attachments. The
+	// implementation packs images alongside the user prompt into a
+	// multimodal message. Empty images slice degrades to Complete
+	// semantics (so callers don't need a separate branch).
+	CompleteWithImages(ctx context.Context, req Request, images []Image) (string, error)
+}
+
 // DeltaFunc receives incremental text chunks as they arrive from the LLM.
 // It MUST NOT block on the caller's UI — implementations of Provider.Stream
 // call this inline during the SSE/NDJSON read loop, so slow callbacks back

--- a/internal/ai/providers/provider.go
+++ b/internal/ai/providers/provider.go
@@ -60,16 +60,18 @@ type Request struct {
 	Cacheable bool
 }
 
-// Image is one visual attachment appended to a Request when the caller
-// wants the model to reason over a diagram. Providers that support
-// vision (Anthropic Opus/Sonnet, OpenAI GPT-4o, Google Gemini)
-// base64-encode Data and include MediaType in the API call; providers
-// without vision ignore the field.
+// Image is one visual attachment passed to VisionUser.CompleteWithImages
+// when the caller wants the model to reason over a diagram. Vision-
+// capable providers (Anthropic Opus/Sonnet, OpenAI GPT-4o, Google
+// Gemini) base64-encode Data and include MediaType in the API call.
+// Providers that don't support vision simply don't implement
+// VisionUser — callers type-assert on it before reaching for this
+// type, so there's no branch to take on the Image itself.
 //
 // MediaType follows the MIME form ("image/png", "image/jpeg",
 // "image/webp", "image/gif"). Validation happens at the HTTP boundary
-// — a caller that hands a Request with an unsupported MediaType to a
-// vision-capable provider gets a provider-specific error back.
+// — a caller that hands an unsupported MediaType to a vision-capable
+// provider gets a provider-specific error back.
 type Image struct {
 	MediaType string
 	Data      []byte

--- a/internal/ai/vision_test.go
+++ b/internal/ai/vision_test.go
@@ -1,0 +1,87 @@
+package ai
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/iac-studio/iac-studio/internal/ai/providers"
+)
+
+// TestGenerateFromDiagram_NonVisionProviderErrors — the default Ollama
+// provider doesn't implement VisionUser, so the bridge must refuse
+// before firing a bad request at the wire.
+func TestGenerateFromDiagram_NonVisionProviderErrors(t *testing.T) {
+	c := NewClient("http://127.0.0.1:1", "ignored") // Ollama
+	_, _, err := c.GenerateFromDiagram(context.Background(), TopologyRequest{
+		Description: "x",
+		Tool:        "terraform",
+		Provider:    "aws",
+	}, []DiagramImage{{MediaType: "image/png", Data: []byte("data")}})
+	if err == nil || !strings.Contains(err.Error(), "does not support vision") {
+		t.Errorf("want vision-not-supported error, got %v", err)
+	}
+}
+
+// TestGenerateFromDiagram_RejectsZeroImages — the text-only path lives
+// on GenerateTopology; GenerateFromDiagram without an image is almost
+// certainly a caller bug, so we surface it rather than silently
+// degrading.
+func TestGenerateFromDiagram_RejectsZeroImages(t *testing.T) {
+	// Swap the provider for a stub that would succeed if called.
+	c := NewClient("http://127.0.0.1:1", "ignored")
+	c.provider = &stubVisionProvider{}
+	c.providerErr = nil
+
+	_, _, err := c.GenerateFromDiagram(context.Background(), TopologyRequest{}, nil)
+	if err == nil || !strings.Contains(err.Error(), "no images") {
+		t.Errorf("want no-images error, got %v", err)
+	}
+}
+
+// TestGenerateFromDiagram_SuccessPath — stub VisionUser returns a JSON
+// topology payload; the bridge parses it via parseAIResponse and
+// surfaces resources.
+func TestGenerateFromDiagram_SuccessPath(t *testing.T) {
+	c := NewClient("http://127.0.0.1:1", "ignored")
+	stub := &stubVisionProvider{
+		reply: `{"message":"parsed vpc + subnet","resources":[{"type":"aws_vpc","name":"main","properties":{"cidr_block":"10.0.0.0/16"}}]}`,
+	}
+	c.provider = stub
+	c.providerErr = nil
+
+	msg, resources, err := c.GenerateFromDiagram(context.Background(), TopologyRequest{
+		Tool:     "terraform",
+		Provider: "aws",
+	}, []DiagramImage{{MediaType: "image/png", Data: []byte{0x89, 0x50, 0x4e, 0x47}}})
+	if err != nil {
+		t.Fatalf("GenerateFromDiagram: %v", err)
+	}
+	if !strings.Contains(msg, "parsed") || len(resources) != 1 {
+		t.Errorf("unexpected output: msg=%q resources=%+v", msg, resources)
+	}
+	if len(stub.lastImages) != 1 || stub.lastImages[0].MediaType != "image/png" {
+		t.Errorf("provider didn't receive the image: %+v", stub.lastImages)
+	}
+}
+
+// stubVisionProvider implements providers.Provider + VisionUser so the
+// bridge tests exercise the typed-assertion branch without touching
+// the real Anthropic transport. Minimal surface — only the methods
+// GenerateFromDiagram actually invokes.
+type stubVisionProvider struct {
+	reply      string
+	lastImages []providers.Image
+}
+
+func (s *stubVisionProvider) Kind() providers.Kind { return providers.KindAnthropic }
+func (s *stubVisionProvider) Complete(context.Context, providers.Request) (string, error) {
+	return s.reply, nil
+}
+func (s *stubVisionProvider) Stream(context.Context, providers.Request, providers.DeltaFunc) (string, error) {
+	return s.reply, nil
+}
+func (s *stubVisionProvider) CompleteWithImages(_ context.Context, _ providers.Request, images []providers.Image) (string, error) {
+	s.lastImages = images
+	return s.reply, nil
+}

--- a/internal/api/agent.go
+++ b/internal/api/agent.go
@@ -179,9 +179,11 @@ func registerAgentRoutes(
 	})
 }
 
-// isClientError distinguishes user-caused errors (picked a non-tool-use
-// provider, misconfiguration) from transport/provider errors. The heuristic
-// is good enough for 400-vs-502 routing; we don't need typed errors.
+// isClientError distinguishes user-caused errors (picked an unsupported
+// provider, misconfiguration, bad inputs) from transport/provider
+// errors. The heuristic is good enough for 400-vs-502 routing; we
+// don't need typed errors. Shared across the agent, vision, and any
+// future handler that can fail for mixed reasons.
 func isClientError(err error) bool {
 	if err == nil {
 		return false
@@ -189,8 +191,12 @@ func isClientError(err error) bool {
 	msg := err.Error()
 	for _, needle := range []string{
 		"does not support tool use",
+		"does not support vision",
 		"no provider configured",
 		"no tool registry configured",
+		"provider requires an API key",
+		"unknown provider kind",
+		"no images provided",
 	} {
 		if strings.Contains(msg, needle) {
 			return true

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1169,6 +1169,10 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 	// generic best-practice knowledge.
 	registerRAGRoutes(mux, projectsDir, aiClient)
 
+	// Vision — diagram-to-topology endpoint; multimodal provider call
+	// through Anthropic's image content blocks.
+	registerVisionRoutes(mux, aiClient)
+
 	return mux
 }
 

--- a/internal/api/vision.go
+++ b/internal/api/vision.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -78,16 +79,18 @@ func registerVisionRoutes(mux *http.ServeMux, aiClient *ai.Client) {
 		r.Body = http.MaxBytesReader(w, r.Body, maxVisionReqBytes)
 
 		ct := r.Header.Get("Content-Type")
-		if !strings.HasPrefix(ct, "multipart/form-data") {
+		mediaType, _, parseErr := mime.ParseMediaType(ct)
+		if parseErr != nil || strings.ToLower(mediaType) != "multipart/form-data" {
 			http.Error(w, "expected multipart/form-data", http.StatusUnsupportedMediaType)
 			return
 		}
 		if err := r.ParseMultipartForm(multipartMaxMemory); err != nil {
-			// MaxBytesReader surfaces its cap as "http: request body too
-			// large" — clients should see a 413 so they can distinguish
-			// a malformed body from one that merely blew the size budget.
-			if strings.Contains(err.Error(), "request body too large") {
-				http.Error(w, err.Error(), http.StatusRequestEntityTooLarge)
+			// MaxBytesReader reports the cap via *http.MaxBytesError
+			// (Go 1.19+). errors.As is robust to wrapping so a future
+			// middleware that re-wraps the error still routes to 413.
+			var maxBytes *http.MaxBytesError
+			if errors.As(err, &maxBytes) {
+				http.Error(w, fmt.Sprintf("request body exceeds %dMB limit", maxBytes.Limit/1024/1024), http.StatusRequestEntityTooLarge)
 				return
 			}
 			http.Error(w, "invalid multipart body: "+err.Error(), http.StatusBadRequest)
@@ -158,9 +161,13 @@ func readUploadedImages(r *http.Request) ([]ai.DiagramImage, error) {
 	}
 	out := make([]ai.DiagramImage, 0, len(files))
 	for _, fh := range files {
-		mediaType, err := parseMediaType(fh.Header.Get("Content-Type"))
+		ctHeader := fh.Header.Get("Content-Type")
+		mediaType, err := parseMediaType(ctHeader)
 		if err != nil {
-			return nil, fmt.Errorf("unsupported image type %q — use png, jpeg, webp, or gif", fh.Header.Get("Content-Type"))
+			// Header was missing or malformed — distinct from "well-
+			// formed but not one we support" so clients get the right
+			// hint on what to fix.
+			return nil, fmt.Errorf("image %q has missing or invalid Content-Type header: %w", fh.Filename, err)
 		}
 		if _, ok := allowedImageMediaTypes[mediaType]; !ok {
 			return nil, fmt.Errorf("unsupported image type %q — use png, jpeg, webp, or gif", mediaType)

--- a/internal/api/vision.go
+++ b/internal/api/vision.go
@@ -189,6 +189,14 @@ func readUploadedImages(r *http.Request) ([]ai.DiagramImage, error) {
 		if int64(len(data)) > maxImageBytes {
 			return nil, fmt.Errorf("image %q exceeds %dMB limit", fh.Filename, maxImageBytes/1024/1024)
 		}
+		if len(data) == 0 {
+			// Empty uploads would pass our len(images)>0 gate but get
+			// silently dropped by the provider's MediaType/Data filter,
+			// so the model runs text-only without warning the user.
+			// Reject at the boundary so the endpoint reliably requires
+			// a real image payload.
+			return nil, fmt.Errorf("image %q is empty — upload must contain image data", fh.Filename)
+		}
 		out = append(out, ai.DiagramImage{MediaType: mediaType, Data: data})
 	}
 	return out, nil

--- a/internal/api/vision.go
+++ b/internal/api/vision.go
@@ -83,6 +83,13 @@ func registerVisionRoutes(mux *http.ServeMux, aiClient *ai.Client) {
 			return
 		}
 		if err := r.ParseMultipartForm(multipartMaxMemory); err != nil {
+			// MaxBytesReader surfaces its cap as "http: request body too
+			// large" — clients should see a 413 so they can distinguish
+			// a malformed body from one that merely blew the size budget.
+			if strings.Contains(err.Error(), "request body too large") {
+				http.Error(w, err.Error(), http.StatusRequestEntityTooLarge)
+				return
+			}
 			http.Error(w, "invalid multipart body: "+err.Error(), http.StatusBadRequest)
 			return
 		}
@@ -115,11 +122,12 @@ func registerVisionRoutes(mux *http.ServeMux, aiClient *ai.Client) {
 			Provider:    strings.TrimSpace(r.FormValue("provider")),
 		}, images)
 		if err != nil {
+			// isClientError covers missing-API-key, unknown-provider,
+			// wrong-provider-for-vision, and other config mistakes the
+			// user can fix. Shared with the agent handler so the 400-vs-
+			// 502 decision stays consistent across endpoints.
 			status := http.StatusBadGateway
-			// The bridge surfaces a descriptive error when the provider
-			// isn't vision-capable — that's a 400 (client picked the
-			// wrong provider), not a 502.
-			if strings.Contains(err.Error(), "does not support vision") {
+			if isClientError(err) {
 				status = http.StatusBadRequest
 			}
 			http.Error(w, err.Error(), status)

--- a/internal/api/vision.go
+++ b/internal/api/vision.go
@@ -1,0 +1,141 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/iac-studio/iac-studio/internal/ai"
+)
+
+// maxImageBytes caps a single image at 8MB and the whole multipart
+// payload at 20MB — matches Anthropic's documented limits (8MB per
+// image, 20MB per request) so we reject oversize uploads before
+// burning a round-trip.
+const (
+	maxImageBytes      int64 = 8 * 1024 * 1024
+	maxVisionReqBytes  int64 = 20 * 1024 * 1024
+	maxImagesPerRequest      = 5
+)
+
+// allowedImageMediaTypes mirrors the formats Anthropic's vision
+// models accept. Kept as a set for O(1) membership; expand if/when a
+// new provider adds support for something else.
+var allowedImageMediaTypes = map[string]struct{}{
+	"image/png":  {},
+	"image/jpeg": {},
+	"image/jpg":  {},
+	"image/webp": {},
+	"image/gif":  {},
+}
+
+// registerVisionRoutes wires the diagram-to-topology endpoint. Isolated
+// so it can be mounted by the router and exercised by tests without
+// pulling in the full request graph.
+func registerVisionRoutes(mux *http.ServeMux, aiClient *ai.Client) {
+	// POST /api/ai/topology/image
+	// multipart/form-data with:
+	//   tool        string (required, form field)
+	//   provider    string (optional, default auto)
+	//   description string (optional, extra context for the model)
+	//   image       file(s) (required; repeatable up to maxImagesPerRequest)
+	//
+	// Response: same JSON shape as /api/ai/topology
+	//   { "message": "...", "resources": [...] }
+	mux.HandleFunc("POST /api/ai/topology/image", func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, maxVisionReqBytes)
+
+		ct := r.Header.Get("Content-Type")
+		if !strings.HasPrefix(ct, "multipart/form-data") {
+			http.Error(w, "expected multipart/form-data", http.StatusUnsupportedMediaType)
+			return
+		}
+		if err := r.ParseMultipartForm(maxVisionReqBytes); err != nil {
+			http.Error(w, "invalid multipart body: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		tool := strings.TrimSpace(r.FormValue("tool"))
+		if tool == "" {
+			http.Error(w, "tool field is required", http.StatusBadRequest)
+			return
+		}
+
+		images, err := readUploadedImages(r)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if len(images) == 0 {
+			http.Error(w, "at least one image upload is required", http.StatusBadRequest)
+			return
+		}
+
+		msg, resources, err := aiClient.GenerateFromDiagram(r.Context(), ai.TopologyRequest{
+			Description: strings.TrimSpace(r.FormValue("description")),
+			Tool:        tool,
+			Provider:    strings.TrimSpace(r.FormValue("provider")),
+		}, images)
+		if err != nil {
+			status := http.StatusBadGateway
+			// The bridge surfaces a descriptive error when the provider
+			// isn't vision-capable — that's a 400 (client picked the
+			// wrong provider), not a 502.
+			if strings.Contains(err.Error(), "does not support vision") {
+				status = http.StatusBadRequest
+			}
+			http.Error(w, err.Error(), status)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"message":   msg,
+			"resources": resources,
+		})
+	})
+}
+
+// readUploadedImages walks the multipart "image" fields and returns the
+// DiagramImage slice. Rejects:
+//   - media types outside the allow-list
+//   - individual images over maxImageBytes
+//   - more than maxImagesPerRequest uploads
+//
+// The file reader is bounded with io.LimitReader so a client claiming
+// a small Content-Length can't sneak past by streaming more bytes than
+// declared.
+func readUploadedImages(r *http.Request) ([]ai.DiagramImage, error) {
+	files := r.MultipartForm.File["image"]
+	if len(files) > maxImagesPerRequest {
+		return nil, fmt.Errorf("too many images: %d (max %d)", len(files), maxImagesPerRequest)
+	}
+	out := make([]ai.DiagramImage, 0, len(files))
+	for _, fh := range files {
+		mediaType := fh.Header.Get("Content-Type")
+		if _, ok := allowedImageMediaTypes[mediaType]; !ok {
+			return nil, fmt.Errorf("unsupported image type %q — use png, jpeg, webp, or gif", mediaType)
+		}
+		// Normalise image/jpg → image/jpeg so the provider sees the
+		// canonical MIME string.
+		if mediaType == "image/jpg" {
+			mediaType = "image/jpeg"
+		}
+		f, err := fh.Open()
+		if err != nil {
+			return nil, fmt.Errorf("read uploaded image %q: %w", fh.Filename, err)
+		}
+		data, err := io.ReadAll(io.LimitReader(f, maxImageBytes+1))
+		_ = f.Close()
+		if err != nil {
+			return nil, fmt.Errorf("read uploaded image %q: %w", fh.Filename, err)
+		}
+		if int64(len(data)) > maxImageBytes {
+			return nil, fmt.Errorf("image %q exceeds %dMB limit", fh.Filename, maxImageBytes/1024/1024)
+		}
+		out = append(out, ai.DiagramImage{MediaType: mediaType, Data: data})
+	}
+	return out, nil
+}

--- a/internal/api/vision.go
+++ b/internal/api/vision.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"strings"
 
@@ -14,10 +15,18 @@ import (
 // payload at 20MB — matches Anthropic's documented limits (8MB per
 // image, 20MB per request) so we reject oversize uploads before
 // burning a round-trip.
+//
+// multipartMaxMemory is the small in-memory buffer ParseMultipartForm
+// keeps before spilling to tmp files. 1MB is enough for the form
+// fields (tool / provider / description) + part headers, which is all
+// we want in RAM — uploaded images should spool to disk so we don't
+// double-buffer (once by ParseMultipartForm, once by readUploadedImages
+// into a new []byte per file).
 const (
-	maxImageBytes      int64 = 8 * 1024 * 1024
-	maxVisionReqBytes  int64 = 20 * 1024 * 1024
-	maxImagesPerRequest      = 5
+	maxImageBytes       int64 = 8 * 1024 * 1024
+	maxVisionReqBytes   int64 = 20 * 1024 * 1024
+	multipartMaxMemory  int64 = 1 * 1024 * 1024
+	maxImagesPerRequest       = 5
 )
 
 // allowedImageMediaTypes mirrors the formats Anthropic's vision
@@ -29,6 +38,22 @@ var allowedImageMediaTypes = map[string]struct{}{
 	"image/jpg":  {},
 	"image/webp": {},
 	"image/gif":  {},
+}
+
+// parseMediaType normalises a multipart part's Content-Type header:
+// strips parameters (e.g. "image/jpeg; charset=binary" → "image/jpeg")
+// and lowercases the result so the allow-list check is insensitive to
+// casing and per-client variations. Returns the stripped+lowered
+// media type, or an error when the header can't be parsed at all.
+func parseMediaType(raw string) (string, error) {
+	if raw == "" {
+		return "", fmt.Errorf("missing content-type")
+	}
+	mt, _, err := mime.ParseMediaType(raw)
+	if err != nil {
+		return "", err
+	}
+	return strings.ToLower(mt), nil
 }
 
 // registerVisionRoutes wires the diagram-to-topology endpoint. Isolated
@@ -57,14 +82,15 @@ func registerVisionRoutes(mux *http.ServeMux, aiClient *ai.Client) {
 			http.Error(w, "expected multipart/form-data", http.StatusUnsupportedMediaType)
 			return
 		}
-		if err := r.ParseMultipartForm(maxVisionReqBytes); err != nil {
+		if err := r.ParseMultipartForm(multipartMaxMemory); err != nil {
 			http.Error(w, "invalid multipart body: "+err.Error(), http.StatusBadRequest)
 			return
 		}
-		// ParseMultipartForm spills to tmp files above its 32MB default
-		// in-memory cap. RemoveAll cleans those up when the handler
-		// returns — without it, aborted uploads would leave temp files
-		// behind for the lifetime of the process.
+		// ParseMultipartForm may create temporary files for file parts
+		// that don't fit in multipartMaxMemory (and at 1MB we expect
+		// every image to spool to disk). RemoveAll cleans those up when
+		// the handler returns — without it, temp files would linger
+		// until process exit.
 		defer func() { _ = r.MultipartForm.RemoveAll() }()
 
 		tool := strings.TrimSpace(r.FormValue("tool"))
@@ -114,9 +140,9 @@ func registerVisionRoutes(mux *http.ServeMux, aiClient *ai.Client) {
 //   - individual images over maxImageBytes
 //   - more than maxImagesPerRequest uploads
 //
-// The file reader is bounded with io.LimitReader so a client claiming
-// a small Content-Length can't sneak past by streaming more bytes than
-// declared.
+// Each multipart file is read through io.LimitReader(maxImageBytes+1)
+// so we enforce the per-image size cap while reading and can detect
+// uploads that exceed maxImageBytes.
 func readUploadedImages(r *http.Request) ([]ai.DiagramImage, error) {
 	files := r.MultipartForm.File["image"]
 	if len(files) > maxImagesPerRequest {
@@ -124,7 +150,10 @@ func readUploadedImages(r *http.Request) ([]ai.DiagramImage, error) {
 	}
 	out := make([]ai.DiagramImage, 0, len(files))
 	for _, fh := range files {
-		mediaType := fh.Header.Get("Content-Type")
+		mediaType, err := parseMediaType(fh.Header.Get("Content-Type"))
+		if err != nil {
+			return nil, fmt.Errorf("unsupported image type %q — use png, jpeg, webp, or gif", fh.Header.Get("Content-Type"))
+		}
 		if _, ok := allowedImageMediaTypes[mediaType]; !ok {
 			return nil, fmt.Errorf("unsupported image type %q — use png, jpeg, webp, or gif", mediaType)
 		}

--- a/internal/api/vision.go
+++ b/internal/api/vision.go
@@ -42,7 +42,12 @@ func registerVisionRoutes(mux *http.ServeMux, aiClient *ai.Client) {
 	//   description string (optional, extra context for the model)
 	//   image       file(s) (required; repeatable up to maxImagesPerRequest)
 	//
-	// Response: same JSON shape as /api/ai/topology
+	// Response is synchronous — the model call blocks until the topology
+	// comes back, then the handler writes the same {message, resources}
+	// payload the text-topology WebSocket event carries. (Text topology
+	// runs async with a 202 + WS result; vision runs sync because the
+	// request itself is already a multipart upload and a second round-
+	// trip to deliver the result adds no value.)
 	//   { "message": "...", "resources": [...] }
 	mux.HandleFunc("POST /api/ai/topology/image", func(w http.ResponseWriter, r *http.Request) {
 		r.Body = http.MaxBytesReader(w, r.Body, maxVisionReqBytes)
@@ -56,6 +61,11 @@ func registerVisionRoutes(mux *http.ServeMux, aiClient *ai.Client) {
 			http.Error(w, "invalid multipart body: "+err.Error(), http.StatusBadRequest)
 			return
 		}
+		// ParseMultipartForm spills to tmp files above its 32MB default
+		// in-memory cap. RemoveAll cleans those up when the handler
+		// returns — without it, aborted uploads would leave temp files
+		// behind for the lifetime of the process.
+		defer func() { _ = r.MultipartForm.RemoveAll() }()
 
 		tool := strings.TrimSpace(r.FormValue("tool"))
 		if tool == "" {

--- a/internal/api/vision.go
+++ b/internal/api/vision.go
@@ -30,13 +30,16 @@ const (
 	maxImagesPerRequest       = 5
 )
 
-// allowedImageMediaTypes mirrors the formats Anthropic's vision
-// models accept. Kept as a set for O(1) membership; expand if/when a
-// new provider adds support for something else.
+// allowedImageMediaTypes is the handler-side accept list. Anthropic's
+// wire format only accepts image/{png,jpeg,webp,gif}; image/jpg is a
+// common client-side alias that we accept here and normalize to
+// image/jpeg before calling the provider (see readUploadedImages).
+// Kept as a set for O(1) membership; expand if/when a new provider
+// adds support for something else.
 var allowedImageMediaTypes = map[string]struct{}{
 	"image/png":  {},
 	"image/jpeg": {},
-	"image/jpg":  {},
+	"image/jpg":  {}, // alias — normalized to image/jpeg below
 	"image/webp": {},
 	"image/gif":  {},
 }

--- a/internal/api/vision_test.go
+++ b/internal/api/vision_test.go
@@ -186,9 +186,10 @@ func TestVision_RejectsTooManyImages(t *testing.T) {
 func TestVision_AcceptsContentTypeWithParametersAndCase(t *testing.T) {
 	// "Image/JPEG; charset=binary" must be accepted — parseMediaType
 	// strips the parameter and lowercases the type. The underlying
-	// provider still rejects (non-vision Ollama), so we expect the
-	// 400 to carry the vision-provider hint, not an unsupported-type
-	// error.
+	// provider still rejects (non-vision Ollama), so we assert the
+	// status is 400 AND the body carries the vision-provider hint.
+	// The positive match matters — a "unsupported image type" false
+	// negative would've slipped past a body-only negative assertion.
 	srv := httptest.NewServer(visionMux(t, ai.NewClient("http://127.0.0.1:1", "x")))
 	defer srv.Close()
 
@@ -203,8 +204,12 @@ func TestVision_AcceptsContentTypeWithParametersAndCase(t *testing.T) {
 	}
 	defer func() { _ = resp.Body.Close() }()
 	msg, _ := io.ReadAll(resp.Body)
-	if strings.Contains(string(msg), "unsupported image type") {
-		t.Errorf("Content-Type with parameters/case should be accepted, got: %s", msg)
+	bodyMsg := string(msg)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("want 400 for non-vision provider, got %d with body %q", resp.StatusCode, bodyMsg)
+	}
+	if !strings.Contains(bodyMsg, "does not support vision") {
+		t.Errorf("want 'does not support vision' hint, got %q", bodyMsg)
 	}
 }
 

--- a/internal/api/vision_test.go
+++ b/internal/api/vision_test.go
@@ -182,3 +182,29 @@ func TestVision_RejectsTooManyImages(t *testing.T) {
 		t.Errorf("want 400 for >%d images, got %d", maxImagesPerRequest, resp.StatusCode)
 	}
 }
+
+func TestVision_RejectsOversizedImage(t *testing.T) {
+	srv := httptest.NewServer(visionMux(t, ai.NewClient("http://127.0.0.1:1", "x")))
+	defer srv.Close()
+
+	// Build a payload whose single image is one byte over the per-image limit.
+	oversized := make([]byte, maxImageBytes+1)
+	body, ct := buildVisionBody(t, "terraform", []struct {
+		name      string
+		mediaType string
+		data      []byte
+	}{{"big.png", "image/png", oversized}})
+
+	resp, err := http.Post(srv.URL+"/api/ai/topology/image", ct, body)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("want 400 for oversized image, got %d", resp.StatusCode)
+	}
+	msg, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(msg), "exceeds") {
+		t.Errorf("want 'exceeds' in error message, got %q", string(msg))
+	}
+}

--- a/internal/api/vision_test.go
+++ b/internal/api/vision_test.go
@@ -1,0 +1,184 @@
+package api
+
+import (
+	"bytes"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"net/textproto"
+	"strings"
+	"testing"
+
+	"github.com/iac-studio/iac-studio/internal/ai"
+)
+
+// visionMux wires the vision endpoint (only) so tests stay hermetic —
+// no agent, no RAG, no full router graph.
+func visionMux(t *testing.T, client *ai.Client) *http.ServeMux {
+	t.Helper()
+	mux := http.NewServeMux()
+	registerVisionRoutes(mux, client)
+	return mux
+}
+
+// writeImagePart attaches one "image" file field with a specific
+// Content-Type header so we can test media-type validation. The
+// default multipart writer infers from filename extension which isn't
+// enough for our whitelist check.
+func writeImagePart(t *testing.T, mw *multipart.Writer, filename, mediaType string, data []byte) {
+	t.Helper()
+	h := textproto.MIMEHeader{}
+	h.Set("Content-Disposition", `form-data; name="image"; filename="`+filename+`"`)
+	h.Set("Content-Type", mediaType)
+	part, err := mw.CreatePart(h)
+	if err != nil {
+		t.Fatalf("CreatePart: %v", err)
+	}
+	if _, err := part.Write(data); err != nil {
+		t.Fatalf("part.Write: %v", err)
+	}
+}
+
+func buildVisionBody(t *testing.T, tool string, images []struct {
+	name      string
+	mediaType string
+	data      []byte
+}) (*bytes.Buffer, string) {
+	t.Helper()
+	body := &bytes.Buffer{}
+	mw := multipart.NewWriter(body)
+	_ = mw.WriteField("tool", tool)
+	for _, img := range images {
+		writeImagePart(t, mw, img.name, img.mediaType, img.data)
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatalf("close multipart: %v", err)
+	}
+	return body, mw.FormDataContentType()
+}
+
+func TestVision_RejectsWrongContentType(t *testing.T) {
+	srv := httptest.NewServer(visionMux(t, ai.NewClient("http://127.0.0.1:1", "x")))
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/api/ai/topology/image", "application/json", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusUnsupportedMediaType {
+		t.Errorf("want 415, got %d", resp.StatusCode)
+	}
+}
+
+func TestVision_RejectsMissingTool(t *testing.T) {
+	srv := httptest.NewServer(visionMux(t, ai.NewClient("http://127.0.0.1:1", "x")))
+	defer srv.Close()
+
+	body, ct := buildVisionBody(t, "", []struct {
+		name      string
+		mediaType string
+		data      []byte
+	}{{"a.png", "image/png", []byte{0x89, 0x50}}})
+	resp, err := http.Post(srv.URL+"/api/ai/topology/image", ct, body)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("want 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestVision_RejectsUnknownMediaType(t *testing.T) {
+	srv := httptest.NewServer(visionMux(t, ai.NewClient("http://127.0.0.1:1", "x")))
+	defer srv.Close()
+
+	body, ct := buildVisionBody(t, "terraform", []struct {
+		name      string
+		mediaType string
+		data      []byte
+	}{{"a.svg", "image/svg+xml", []byte("<svg/>")}})
+	resp, err := http.Post(srv.URL+"/api/ai/topology/image", ct, body)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("want 400, got %d", resp.StatusCode)
+	}
+	msg, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(msg), "unsupported image type") {
+		t.Errorf("missing 'unsupported image type' in %q", msg)
+	}
+}
+
+func TestVision_RejectsMissingImage(t *testing.T) {
+	srv := httptest.NewServer(visionMux(t, ai.NewClient("http://127.0.0.1:1", "x")))
+	defer srv.Close()
+
+	body := &bytes.Buffer{}
+	mw := multipart.NewWriter(body)
+	_ = mw.WriteField("tool", "terraform")
+	_ = mw.Close()
+	resp, err := http.Post(srv.URL+"/api/ai/topology/image", mw.FormDataContentType(), body)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("want 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestVision_NonVisionProviderReturns400(t *testing.T) {
+	// Default Ollama client doesn't implement VisionUser.
+	srv := httptest.NewServer(visionMux(t, ai.NewClient("http://127.0.0.1:1", "x")))
+	defer srv.Close()
+
+	body, ct := buildVisionBody(t, "terraform", []struct {
+		name      string
+		mediaType string
+		data      []byte
+	}{{"a.png", "image/png", []byte{0x89, 0x50}}})
+	resp, err := http.Post(srv.URL+"/api/ai/topology/image", ct, body)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("want 400 for non-vision provider, got %d", resp.StatusCode)
+	}
+	msg, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(msg), "does not support vision") {
+		t.Errorf("expected vision hint, got %q", msg)
+	}
+}
+
+func TestVision_RejectsTooManyImages(t *testing.T) {
+	srv := httptest.NewServer(visionMux(t, ai.NewClient("http://127.0.0.1:1", "x")))
+	defer srv.Close()
+
+	var imgs []struct {
+		name      string
+		mediaType string
+		data      []byte
+	}
+	for i := 0; i < maxImagesPerRequest+1; i++ {
+		imgs = append(imgs, struct {
+			name      string
+			mediaType string
+			data      []byte
+		}{"a.png", "image/png", []byte{0x89, 0x50}})
+	}
+	body, ct := buildVisionBody(t, "terraform", imgs)
+	resp, err := http.Post(srv.URL+"/api/ai/topology/image", ct, body)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("want 400 for >%d images, got %d", maxImagesPerRequest, resp.StatusCode)
+	}
+}

--- a/internal/api/vision_test.go
+++ b/internal/api/vision_test.go
@@ -183,6 +183,31 @@ func TestVision_RejectsTooManyImages(t *testing.T) {
 	}
 }
 
+func TestVision_AcceptsContentTypeWithParametersAndCase(t *testing.T) {
+	// "Image/JPEG; charset=binary" must be accepted — parseMediaType
+	// strips the parameter and lowercases the type. The underlying
+	// provider still rejects (non-vision Ollama), so we expect the
+	// 400 to carry the vision-provider hint, not an unsupported-type
+	// error.
+	srv := httptest.NewServer(visionMux(t, ai.NewClient("http://127.0.0.1:1", "x")))
+	defer srv.Close()
+
+	body, ct := buildVisionBody(t, "terraform", []struct {
+		name      string
+		mediaType string
+		data      []byte
+	}{{"diag.jpeg", "Image/JPEG; charset=binary", []byte{0xFF, 0xD8, 0xFF}}})
+	resp, err := http.Post(srv.URL+"/api/ai/topology/image", ct, body)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	msg, _ := io.ReadAll(resp.Body)
+	if strings.Contains(string(msg), "unsupported image type") {
+		t.Errorf("Content-Type with parameters/case should be accepted, got: %s", msg)
+	}
+}
+
 func TestVision_RejectsOversizedImage(t *testing.T) {
 	srv := httptest.NewServer(visionMux(t, ai.NewClient("http://127.0.0.1:1", "x")))
 	defer srv.Close()

--- a/internal/api/vision_test.go
+++ b/internal/api/vision_test.go
@@ -213,6 +213,33 @@ func TestVision_AcceptsContentTypeWithParametersAndCase(t *testing.T) {
 	}
 }
 
+func TestVision_RejectsEmptyImageUpload(t *testing.T) {
+	// A zero-byte image with a valid Content-Type used to pass the
+	// handler's len(images)>0 gate but then get silently dropped by
+	// the provider's MediaType/Data filter, running the model text-
+	// only. The boundary check now rejects empty payloads explicitly.
+	srv := httptest.NewServer(visionMux(t, ai.NewClient("http://127.0.0.1:1", "x")))
+	defer srv.Close()
+
+	body, ct := buildVisionBody(t, "terraform", []struct {
+		name      string
+		mediaType string
+		data      []byte
+	}{{"empty.png", "image/png", []byte{}}})
+	resp, err := http.Post(srv.URL+"/api/ai/topology/image", ct, body)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("want 400 for empty upload, got %d", resp.StatusCode)
+	}
+	msg, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(msg), "empty") {
+		t.Errorf("want 'empty' hint, got %q", msg)
+	}
+}
+
 func TestVision_RejectsOversizedImage(t *testing.T) {
 	srv := httptest.NewServer(visionMux(t, ai.NewClient("http://127.0.0.1:1", "x")))
 	defer srv.Close()


### PR DESCRIPTION
## Summary
Closes the vision half of #8. Users can POST an architecture diagram (screenshot / whiteboard photo / Lucid export / hand sketch) to a new multipart endpoint and get back the same \`{message, resources}\` topology shape \`POST /api/ai/topology\` produces — so every downstream scaffolding path (canvas insert, sync, plan) works unchanged.

Closes #8 (RAG landed in #17; this is the companion).

- [x] **Commit 1 — Provider surface**: \`providers.Image\` attachment struct + \`VisionUser\` optional interface. \`anthropicProvider.CompleteWithImages\` implements the Messages-API multimodal shape (base64 image content blocks first, text block last — Anthropic's recommended diagram-to-structure ordering). Empty images slice transparently falls through to \`Complete\`.
- [x] **Commit 2 — Bridge**: \`Client.GenerateFromDiagram(ctx, TopologyRequest, []DiagramImage)\`. Type-asserts for VisionUser and returns a \"switch to Anthropic\" error when the active provider can't see images, mirroring the agent-endpoint pattern. System prompt teaches the model the common diagram idioms (VPC cloud → aws_vpc, subnet rectangles → aws_subnet, etc.).
- [x] **Commit 3 — HTTP endpoint**: \`POST /api/ai/topology/image\` multipart. Tool required; up to 5 images per request; 8MB per image, 20MB per request (matches Anthropic's caps). Media-type allow-list: png, jpeg, webp, gif.

## Design notes
- **Stays provider-agnostic**: Ollama + OpenAI don't implement VisionUser yet; the bridge degrades with a clear error rather than silently failing. Adding a new vision provider is one interface implementation away.
- **Bounded at the wire**: per-image \`io.LimitReader\` prevents a small Content-Length + large streamed body attack. Oversize uploads reject locally instead of round-tripping to Anthropic for an API error.
- **No frontend yet**: the drop-zone UI lives in a follow-up PR so this stays shipping-focused. \`curl -F tool=terraform -F provider=aws -F image=@diagram.png\` exercises the path end-to-end today.

## Test plan
- [x] \`go test ./...\` clean across 21 packages
- [x] 4 provider tests: content-block ordering + base64 round-trip, empty-images falls back to \`Complete\`, empty image entries filtered, compile-time interface assertion
- [x] 3 bridge tests: non-vision provider refused, zero-images refused, happy-path JSON parse via stub VisionUser
- [x] 6 HTTP tests: wrong content-type 415, missing tool 400, unknown media type 400, missing image 400, non-vision provider 400 with hint, too-many-images 400
- [ ] Manual smoke with Anthropic key: upload a 3-tier-webapp diagram, confirm resources include VPC/subnets/LB/EC2/RDS.