### PR TITLE
feat(pulumi): first-class Pulumi — generator + runner + layered blueprint

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -78,6 +78,56 @@ func safeProjectPath(projectsDir, name string) (string, error) {
 	return resolved, nil
 }
 
+// safeSubdir resolves a subdirectory beneath projectPath while
+// enforcing the same traversal + containment guarantees safeProjectPath
+// offers at the project level. Each path segment is validated
+// (alphanumeric + hyphen + underscore, no dots, no separators) and
+// the final absolute path must stay inside projectPath after symlink
+// resolution.
+//
+// Used by the /api/projects/{name}/run endpoint to rebase execution
+// into environments/<env>/ for layered-v1 layouts so the runner finds
+// Pulumi.yaml / main.tf in the right workdir.
+func safeSubdir(projectPath string, segments ...string) (string, error) {
+	for _, seg := range segments {
+		if seg == "" || seg == "." || seg == ".." ||
+			strings.ContainsAny(seg, `/\`) ||
+			strings.Contains(seg, "..") {
+			return "", fmt.Errorf("invalid path segment: %q", seg)
+		}
+		for _, r := range seg {
+			if !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') ||
+				(r >= '0' && r <= '9') || r == '-' || r == '_') {
+				return "", fmt.Errorf("invalid path segment: %q (only alphanumeric, hyphens, underscores)", seg)
+			}
+		}
+	}
+	joined := filepath.Join(append([]string{projectPath}, segments...)...)
+	absProject, err := filepath.Abs(projectPath)
+	if err != nil {
+		return "", err
+	}
+	if eval, err := filepath.EvalSymlinks(absProject); err == nil {
+		absProject = eval
+	}
+	absJoined, err := filepath.Abs(joined)
+	if err != nil {
+		return "", err
+	}
+	if eval, err := filepath.EvalSymlinks(joined); err == nil {
+		if abs, absErr := filepath.Abs(eval); absErr == nil {
+			absJoined = abs
+		}
+	}
+	if !strings.HasPrefix(absJoined, absProject+string(filepath.Separator)) {
+		return "", fmt.Errorf("subdir escapes project root")
+	}
+	if _, err := os.Stat(joined); err != nil {
+		return "", fmt.Errorf("subdir does not exist: %w", err)
+	}
+	return joined, nil
+}
+
 // planGate tracks which projects have had a recent plan run.
 // Apply/destroy is only allowed after a plan has been run for the same project.
 var planGate = struct {
@@ -488,10 +538,28 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 			// is telling us they've read the findings and still want to
 			// proceed. Logged server-side so the override is audit-trailable.
 			Acknowledged bool `json:"acknowledged"`
+			// Env names the environment subdirectory to execute in for
+			// layered-v1 projects (environments/<env>/...). Empty runs
+			// commands at the project root (flat layout). Validated as a
+			// safe path segment so a bad value can't traverse.
+			Env string `json:"env,omitempty"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			http.Error(w, "invalid request", 400)
 			return
+		}
+
+		// When Env is set, rebase projectPath into environments/<env>
+		// so the runner finds Pulumi.yaml / main.tf in the right
+		// working directory. The subdir must exist and be contained
+		// in projectPath — safeJoin below rejects traversal.
+		if req.Env != "" {
+			subPath, subErr := safeSubdir(projectPath, "environments", req.Env)
+			if subErr != nil {
+				http.Error(w, "invalid env: "+subErr.Error(), 400)
+				return
+			}
+			projectPath = subPath
 		}
 
 		// Block apply/destroy unless:

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -125,13 +125,23 @@ func safeSubdir(projectPath string, segments ...string) (string, error) {
 	}
 	info, err := os.Stat(joined)
 	if err != nil {
-		return "", fmt.Errorf("subdir does not exist: %w", err)
+		// Don't surface the underlying os.Stat error — it carries the
+		// absolute filesystem path which we don't want bubbling up to
+		// HTTP clients. Server-side log keeps the detail for ops
+		// debugging.
+		log.Printf("safeSubdir: stat %s: %v", joined, err)
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("subdir does not exist")
+		}
+		return "", fmt.Errorf("subdir is not accessible")
 	}
 	// The result is used as cmd.Dir — passing a file would produce a
 	// confusing 'not a directory' error mid-exec. Reject here so the
-	// 400 carries a targeted message.
+	// 400 carries a targeted message. Don't include the path; the
+	// caller already knows what they passed in.
 	if !info.IsDir() {
-		return "", fmt.Errorf("subdir is not a directory: %s", joined)
+		log.Printf("safeSubdir: not a directory: %s", joined)
+		return "", fmt.Errorf("subdir is not a directory")
 	}
 	return joined, nil
 }
@@ -373,6 +383,16 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 			http.Error(w, err.Error(), 400)
 			return
 		}
+		// Pulumi parsing isn't implemented — parser.ForTool falls
+		// back to HCL and would silently return zero resources for an
+		// index.ts project, leading the user to believe the canvas is
+		// in sync when it isn't. Reject explicitly until a TS-AST
+		// parser lands; flat HCL/Ansible projects keep their existing
+		// behaviour.
+		if tool == "pulumi" {
+			http.Error(w, "pulumi resource parsing is not supported yet — edit index.ts directly", 400)
+			return
+		}
 
 		p := parser.ForTool(tool)
 		resources, err := p.ParseDir(projectPath)
@@ -390,6 +410,16 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 		projectPath, err := safeProjectPath(projectsDir, name)
 		if err != nil {
 			http.Error(w, err.Error(), 400)
+			return
+		}
+		// Pulumi generator is project-shaped (per-env directories with
+		// index.ts/Pulumi.yaml), not single-file like HCL. Calling
+		// generator.ForTool here would fall through to HCL and write
+		// main.tf at the project root — silently shadowing the
+		// scaffolded environments/<env>/index.ts. Reject until an
+		// AST-aware sync that round-trips through TS lands.
+		if tool == "pulumi" {
+			http.Error(w, "pulumi sync is not supported yet — edit environments/<env>/index.ts directly", 400)
 			return
 		}
 
@@ -596,6 +626,23 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 				return
 			}
 			if !req.Acknowledged {
+				// Pulumi has no parser or plan-JSON path today, so the
+				// builtin policies see zero resources and plan-based
+				// engines have no input — every Pulumi mutating
+				// command would silently bypass policy. Fail closed:
+				// require the caller to opt in with acknowledged:true
+				// so the override is explicit + audit-trailable. When
+				// a Pulumi parser/policy adapter lands this branch
+				// goes away.
+				if req.Tool == "pulumi" {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusConflict)
+					_ = json.NewEncoder(w).Encode(map[string]any{
+						"error":  "policy_unsupported",
+						"detail": "policy evaluation is not implemented for pulumi yet — re-submit with acknowledged:true to proceed without server-side policy checks",
+					})
+					return
+				}
 				// Walk every available engine against the project so we can
 				// surface blocking findings before the apply runs. On any
 				// error (engine crash, missing binary, malformed plan) we
@@ -612,7 +659,7 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 					return
 				}
 			} else {
-				log.Printf("apply gate: policy findings acknowledged by client for %s (command=%s)", name, req.Command)
+				log.Printf("apply gate: policy findings acknowledged by client for %s (command=%s tool=%s)", name, req.Command, req.Tool)
 			}
 		}
 
@@ -621,7 +668,7 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 		// a request-scoped context and kill the command. SafeRunner applies its
 		// own per-command timeout (init=5m, plan=10m, apply=30m).
 		go func() {
-			result, err := run.Execute(context.Background(), projectPath, req.Tool, req.Command)
+			result, err := run.Execute(context.Background(), projectPath, req.Tool, req.Command, req.Env)
 			// Only record a successful plan — failed/cancelled plans don't count.
 			// 'preview' is Pulumi's equivalent of terraform plan; without it
 			// here, a pulumi up following a successful preview would be

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -669,7 +670,13 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 		var req struct {
 			Env string `json:"env,omitempty"`
 		}
-		_ = json.NewDecoder(r.Body).Decode(&req)
+		// A missing body (EOF) is fine — kill defaults to the project
+		// root. Any other decode failure is a client error; treating
+		// it as "no env" would silently target the wrong execution.
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+			http.Error(w, "invalid request body: "+err.Error(), 400)
+			return
+		}
 		if req.Env != "" {
 			sub, subErr := safeSubdir(projectPath, "environments", req.Env)
 			if subErr != nil {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -122,8 +122,15 @@ func safeSubdir(projectPath string, segments ...string) (string, error) {
 	if !strings.HasPrefix(absJoined, absProject+string(filepath.Separator)) {
 		return "", fmt.Errorf("subdir escapes project root")
 	}
-	if _, err := os.Stat(joined); err != nil {
+	info, err := os.Stat(joined)
+	if err != nil {
 		return "", fmt.Errorf("subdir does not exist: %w", err)
+	}
+	// The result is used as cmd.Dir — passing a file would produce a
+	// confusing 'not a directory' error mid-exec. Reject here so the
+	// 400 carries a targeted message.
+	if !info.IsDir() {
+		return "", fmt.Errorf("subdir is not a directory: %s", joined)
 	}
 	return joined, nil
 }
@@ -552,7 +559,8 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 		// When Env is set, rebase projectPath into environments/<env>
 		// so the runner finds Pulumi.yaml / main.tf in the right
 		// working directory. The subdir must exist and be contained
-		// in projectPath — safeJoin below rejects traversal.
+		// in projectPath — safeSubdir below rejects traversal and
+		// rejects paths that point at a file instead of a directory.
 		if req.Env != "" {
 			subPath, subErr := safeSubdir(projectPath, "environments", req.Env)
 			if subErr != nil {
@@ -613,8 +621,13 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 		// own per-command timeout (init=5m, plan=10m, apply=30m).
 		go func() {
 			result, err := run.Execute(context.Background(), projectPath, req.Tool, req.Command)
-			// Only record a successful plan — failed/cancelled plans don't count
-			if err == nil && (req.Command == "plan" || req.Command == "check") {
+			// Only record a successful plan — failed/cancelled plans don't count.
+			// 'preview' is Pulumi's equivalent of terraform plan; without it
+			// here, a pulumi up following a successful preview would be
+			// blocked with 'plan_required'. projectPath already reflects
+			// the env rebase so dev + prod track their plan state
+			// independently.
+			if err == nil && (req.Command == "plan" || req.Command == "preview" || req.Command == "check") {
 				recordPlan(projectPath)
 			}
 			msg := map[string]interface{}{

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -658,6 +658,27 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 			http.Error(w, err.Error(), 400)
 			return
 		}
+
+		// SafeRunner keys active executions by the exact workdir the
+		// run handler passed in. When /run was invoked with env set,
+		// that workdir was rebased to environments/<env> — so kill
+		// must be able to rebase the same way to find the execution.
+		// Env is optional on kill; an empty body still works for
+		// project-root runs.
+		limitBody(w, r)
+		var req struct {
+			Env string `json:"env,omitempty"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		if req.Env != "" {
+			sub, subErr := safeSubdir(projectPath, "environments", req.Env)
+			if subErr != nil {
+				http.Error(w, "invalid env: "+subErr.Error(), 400)
+				return
+			}
+			projectPath = sub
+		}
+
 		if err := run.Kill(projectPath); err != nil {
 			http.Error(w, err.Error(), 404)
 			return

--- a/internal/pulumi/generator.go
+++ b/internal/pulumi/generator.go
@@ -333,7 +333,24 @@ func renderProgram(cfg ProjectConfig) string {
 	b.WriteString(fmt.Sprintf("const config = new pulumi.Config(%q);\n", cfg.Name))
 	b.WriteString("const environment = config.get(\"environment\") ?? \"dev\";\n\n")
 
-	for _, r := range cfg.Resources {
+	// Sort a copy of the resource slice so upstream sources with
+	// non-deterministic ordering (filesystem walks, map iteration)
+	// can't produce different programs across runs. Ordering by Type
+	// then Name then ID mirrors the stable sort the property keys
+	// already use and is stable across any upstream input.
+	ordered := make([]parser.Resource, len(cfg.Resources))
+	copy(ordered, cfg.Resources)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		if ordered[i].Type != ordered[j].Type {
+			return ordered[i].Type < ordered[j].Type
+		}
+		if ordered[i].Name != ordered[j].Name {
+			return ordered[i].Name < ordered[j].Name
+		}
+		return ordered[i].ID < ordered[j].ID
+	})
+
+	for _, r := range ordered {
 		// Sanitize before camel-casing because project names can
 		// contain hyphens ("acme-infra") which would otherwise produce
 		// invalid TypeScript identifiers like `acme-infraSeed`.
@@ -364,7 +381,7 @@ func renderProgram(cfg ProjectConfig) string {
 	}
 
 	b.WriteString("// Exports — consumed by stack references + CI assertions.\n")
-	for _, r := range cfg.Resources {
+	for _, r := range ordered {
 		varName := sanitizeTSIdent(toCamelCase(r.Name))
 		b.WriteString(fmt.Sprintf("export const %sId = %s.id;\n", varName, varName))
 	}

--- a/internal/pulumi/generator.go
+++ b/internal/pulumi/generator.go
@@ -168,25 +168,28 @@ func renderStackYaml(cfg ProjectConfig, env string) string {
 
 	var lines []string
 	lines = append(lines, "config:")
+	// Route every user-supplied value through yamlScalar so a Region
+	// containing colons or whitespace (legal for some Azure location
+	// names) can't break the manifest.
 	if hasAWS {
 		if awsRegion == "" {
 			awsRegion = "us-east-1"
 		}
-		lines = append(lines, "  aws:region: "+awsRegion)
+		lines = append(lines, "  aws:region: "+yamlScalar(awsRegion))
 	}
 	if hasGCP {
 		if gcpRegion == "" {
 			gcpRegion = "us-central1"
 		}
-		lines = append(lines, "  gcp:region: "+gcpRegion)
+		lines = append(lines, "  gcp:region: "+yamlScalar(gcpRegion))
 	}
 	if hasAzure {
 		if azureLocation == "" {
 			azureLocation = "WestUS2"
 		}
-		lines = append(lines, "  azure-native:location: "+azureLocation)
+		lines = append(lines, "  azure-native:location: "+yamlScalar(azureLocation))
 	}
-	lines = append(lines, fmt.Sprintf("  %s:environment: %s", cfg.Name, env))
+	lines = append(lines, fmt.Sprintf("  %s:environment: %s", cfg.Name, yamlScalar(env)))
 	return strings.Join(lines, "\n") + "\n"
 }
 

--- a/internal/pulumi/generator.go
+++ b/internal/pulumi/generator.go
@@ -14,10 +14,40 @@ package pulumi
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/iac-studio/iac-studio/internal/parser"
 )
+
+// ValidateProjectName enforces Pulumi's project-name rules AND the
+// tighter npm package-name rules (the generator writes cfg.Name into
+// both Pulumi.yaml and package.json). Joint constraint: lowercase
+// letters, digits, hyphens, underscores; must start with a letter;
+// 1-100 chars. Anything stricter belongs in the caller's own input
+// validator (e.g. scaffold's safeNameRE) — we stay permissive here
+// so GenerateProject accepts whatever a blueprint validated upstream.
+func ValidateProjectName(name string) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return fmt.Errorf("Name is required")
+	}
+	if len(name) > 100 {
+		return fmt.Errorf("Name %q exceeds Pulumi's 100-char limit", name)
+	}
+	for i, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-', r == '_':
+			// ok
+		default:
+			return fmt.Errorf("Name %q has invalid character %q at position %d (lowercase letters, digits, hyphens, underscores only)", name, r, i)
+		}
+	}
+	if name[0] < 'a' || name[0] > 'z' {
+		return fmt.Errorf("Name %q must start with a lowercase letter", name)
+	}
+	return nil
+}
 
 // ProjectConfig is the input to GenerateProject. Name becomes the
 // Pulumi project name; Environments enumerate the stack configs we
@@ -60,8 +90,8 @@ type ProjectFile struct {
 // convention as the Terraform scaffold. Callers decide whether a
 // partial render is worth persisting.
 func GenerateProject(cfg ProjectConfig) ([]ProjectFile, error) {
-	if strings.TrimSpace(cfg.Name) == "" {
-		return nil, fmt.Errorf("pulumi.GenerateProject: Name is required")
+	if err := ValidateProjectName(cfg.Name); err != nil {
+		return nil, fmt.Errorf("pulumi.GenerateProject: %w", err)
 	}
 	if cfg.Runtime == "" {
 		cfg.Runtime = "nodejs"
@@ -115,10 +145,11 @@ runtime:
 }
 
 // yamlScalar returns a YAML-safe representation of s. If s contains
-// any of the characters that would trip the YAML 1.2 plain-scalar
-// rules (: # newline, ! & * etc.) or looks like a number/bool, we
-// wrap in double quotes and escape backslashes + quotes. Otherwise
-// emit plain.
+// YAML 1.2 plain-scalar metacharacters (: # newline, ! & * etc.),
+// matches a reserved keyword (true/false/null/yes/no/on/off/~), or
+// parses as a number/int/float (which YAML would coerce to a typed
+// value), we wrap in double quotes and escape backslashes + quotes.
+// Otherwise emit plain.
 //
 // Not a full YAML encoder — we only emit simple scalars here, and
 // pulling in a yaml dependency just for two fields is overkill. The
@@ -138,6 +169,12 @@ func yamlScalar(s string) string {
 	case "true", "false", "null", "yes", "no", "on", "off", "~":
 		needsQuote = true
 	}
+	// Numeric-looking scalars ("123", "3.14", "-0.5", "1e6") — YAML
+	// would coerce these to int/float, so a version string like "1.0"
+	// would round-trip as a float and silently change shape.
+	if !needsQuote && looksNumeric(s) {
+		needsQuote = true
+	}
 	if !needsQuote {
 		return s
 	}
@@ -147,6 +184,21 @@ func yamlScalar(s string) string {
 	escaped = strings.ReplaceAll(escaped, "\r", `\r`)
 	escaped = strings.ReplaceAll(escaped, "\t", `\t`)
 	return `"` + escaped + `"`
+}
+
+// looksNumeric reports whether s would be parsed as a YAML number.
+// Matches the common forms: signed/unsigned ints, decimals, scientific
+// notation. Kept tight — anything false-positive wouldn't hurt (we
+// only add quotes) but false-negatives corrupt shape, so err on the
+// side of matching.
+func looksNumeric(s string) bool {
+	if s == "" {
+		return false
+	}
+	if _, err := strconv.ParseFloat(s, 64); err == nil {
+		return true
+	}
+	return false
 }
 
 // renderStackYaml emits one Pulumi.<env>.yaml with the config values
@@ -300,7 +352,7 @@ func renderProgram(cfg ProjectConfig) string {
 		}
 		sort.Strings(keys)
 		for _, k := range keys {
-			b.WriteString(fmt.Sprintf("    %s: %s,\n", toCamelCase(k), tsPropValue(r.Properties[k])))
+			b.WriteString(fmt.Sprintf("    %s: %s,\n", toCamelCase(k), tsPropValue(r.Properties[k], k)))
 		}
 		// Tag each resource with the environment so downstream cost
 		// allocation / policy tags work out of the box. Only applies

--- a/internal/pulumi/generator.go
+++ b/internal/pulumi/generator.go
@@ -30,21 +30,21 @@ import (
 func ValidateProjectName(name string) error {
 	name = strings.TrimSpace(name)
 	if name == "" {
-		return fmt.Errorf("Name is required")
+		return fmt.Errorf("name is required")
 	}
 	if len(name) > 100 {
-		return fmt.Errorf("Name %q exceeds Pulumi's 100-char limit", name)
+		return fmt.Errorf("name %q exceeds Pulumi's 100-char limit", name)
 	}
 	for i, r := range name {
 		switch {
 		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-', r == '_':
 			// ok
 		default:
-			return fmt.Errorf("Name %q has invalid character %q at position %d (lowercase letters, digits, hyphens, underscores only)", name, r, i)
+			return fmt.Errorf("name %q has invalid character %q at position %d (lowercase letters, digits, hyphens, underscores only)", name, r, i)
 		}
 	}
 	if name[0] < 'a' || name[0] > 'z' {
-		return fmt.Errorf("Name %q must start with a lowercase letter", name)
+		return fmt.Errorf("name %q must start with a lowercase letter", name)
 	}
 	return nil
 }

--- a/internal/pulumi/generator.go
+++ b/internal/pulumi/generator.go
@@ -6,9 +6,10 @@
 //
 // Sibling to internal/scaffold/layered_terraform.go: same blueprint
 // shape (environments × modules), same naming conventions, but TS
-// instead of HCL. The dual-stack scaffolder consumes both so a single
-// canvas can render some environments as Terraform and others as
-// Pulumi.
+// instead of HCL. This package provides the Pulumi-side generator
+// for that blueprint shape; mixed per-environment Terraform+Pulumi
+// in a single project is a planned follow-up (see issue #5 — parser
+// + dual-stack mode).
 package pulumi
 
 import (

--- a/internal/pulumi/generator.go
+++ b/internal/pulumi/generator.go
@@ -1,0 +1,273 @@
+// Package pulumi generates a full Pulumi project layout from an IaC
+// Studio resource graph. The existing internal/exporter only emitted a
+// single-file index.ts preview — this package builds a runnable
+// project with the typescript runtime config, per-stack YAML files,
+// and the dependency manifests Pulumi expects.
+//
+// Sibling to internal/scaffold/layered_terraform.go: same blueprint
+// shape (environments × modules), same naming conventions, but TS
+// instead of HCL. The dual-stack scaffolder consumes both so a single
+// canvas can render some environments as Terraform and others as
+// Pulumi.
+package pulumi
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/iac-studio/iac-studio/internal/parser"
+)
+
+// ProjectConfig is the input to GenerateProject. Name becomes the
+// Pulumi project name; Environments enumerate the stack configs we
+// emit per-environment (Pulumi.<env>.yaml). Resources is the flat
+// resource graph to render into the program file.
+type ProjectConfig struct {
+	Name         string
+	Description  string
+	Environments []string
+	// Region is baked into each Pulumi.<env>.yaml as a config value.
+	// When empty, defaults to us-east-1 for AWS / us-central1 for GCP.
+	Region string
+	// Runtime pins which Pulumi runtime the project targets. Only
+	// "nodejs" (TypeScript) is supported today; keeping the field so
+	// future Python/Go runtimes can fork here cleanly.
+	Runtime string
+	// Resources is the flat graph the program file will emit.
+	Resources []parser.Resource
+}
+
+// ProjectFile is one output artefact. The scaffold package walks the
+// returned slice and writes each file relative to the project root.
+// Content is []byte rather than string so we can emit binary artefacts
+// later (lockfiles, asset bundles) without breaking the contract.
+type ProjectFile struct {
+	Path    string
+	Content []byte
+}
+
+// GenerateProject renders a complete Pulumi TypeScript project:
+//
+//	Pulumi.yaml                    project manifest
+//	Pulumi.<env>.yaml              per-stack config (one per Environment)
+//	package.json                   npm deps (@pulumi/pulumi + provider SDKs)
+//	tsconfig.json                  TS compiler settings
+//	index.ts                       resource program
+//	.gitignore                     exclude node_modules / Pulumi state
+//
+// Errors return a non-nil slice with the files produced so far — same
+// convention as the Terraform scaffold. Callers decide whether a
+// partial render is worth persisting.
+func GenerateProject(cfg ProjectConfig) ([]ProjectFile, error) {
+	if strings.TrimSpace(cfg.Name) == "" {
+		return nil, fmt.Errorf("pulumi.GenerateProject: Name is required")
+	}
+	if cfg.Runtime == "" {
+		cfg.Runtime = "nodejs"
+	}
+	if cfg.Runtime != "nodejs" {
+		return nil, fmt.Errorf("pulumi.GenerateProject: runtime %q not supported yet (only nodejs)", cfg.Runtime)
+	}
+	if len(cfg.Environments) == 0 {
+		cfg.Environments = []string{"dev"}
+	}
+
+	files := []ProjectFile{
+		{Path: "Pulumi.yaml", Content: []byte(renderPulumiYaml(cfg))},
+		{Path: "package.json", Content: []byte(renderPackageJSON(cfg))},
+		{Path: "tsconfig.json", Content: []byte(renderTSConfig())},
+		{Path: "index.ts", Content: []byte(renderProgram(cfg))},
+		{Path: ".gitignore", Content: []byte(renderGitignore())},
+	}
+	for _, env := range cfg.Environments {
+		files = append(files, ProjectFile{
+			Path:    fmt.Sprintf("Pulumi.%s.yaml", env),
+			Content: []byte(renderStackYaml(cfg, env)),
+		})
+	}
+
+	sort.SliceStable(files, func(i, j int) bool { return files[i].Path < files[j].Path })
+	return files, nil
+}
+
+// renderPulumiYaml is the Pulumi project manifest. Runtime is nodejs
+// (TypeScript) and the project name must match Pulumi's own naming
+// rules (lowercase + hyphens); callers upstream enforce that.
+func renderPulumiYaml(cfg ProjectConfig) string {
+	desc := cfg.Description
+	if desc == "" {
+		desc = "IaC Studio — generated Pulumi project"
+	}
+	return fmt.Sprintf(`name: %s
+description: %s
+runtime:
+  name: nodejs
+  options:
+    typescript: true
+`, cfg.Name, desc)
+}
+
+// renderStackYaml emits one Pulumi.<env>.yaml with the config values
+// every resource program needs — primarily the cloud region. Real
+// projects will layer in secrets (Config.requireSecret) and stack
+// references; we stop at region today and let the scaffold composer
+// add environment-specific blocks.
+func renderStackYaml(cfg ProjectConfig, env string) string {
+	hasAWS, hasGCP, hasAzure := detectProviders(cfg.Resources)
+	region := cfg.Region
+
+	var lines []string
+	lines = append(lines, "config:")
+	if hasAWS {
+		if region == "" {
+			region = "us-east-1"
+		}
+		lines = append(lines, "  aws:region: "+region)
+	}
+	if hasGCP {
+		if region == "" {
+			region = "us-central1"
+		}
+		lines = append(lines, "  gcp:region: "+region)
+	}
+	if hasAzure {
+		lines = append(lines, "  azure-native:location: WestUS2")
+	}
+	lines = append(lines, fmt.Sprintf("  %s:environment: %s", cfg.Name, env))
+	return strings.Join(lines, "\n") + "\n"
+}
+
+// renderPackageJSON emits a minimal package.json with @pulumi/pulumi
+// plus whichever provider SDKs the resource graph actually needs.
+// Pinning at ^3 for pulumi and latest majors for providers keeps the
+// scaffold installable without being too aggressive about fresh
+// releases that might break.
+func renderPackageJSON(cfg ProjectConfig) string {
+	hasAWS, hasGCP, hasAzure := detectProviders(cfg.Resources)
+
+	deps := []string{`"@pulumi/pulumi": "^3.0.0"`}
+	if hasAWS {
+		deps = append(deps, `"@pulumi/aws": "^7.0.0"`)
+	}
+	if hasGCP {
+		deps = append(deps, `"@pulumi/gcp": "^9.0.0"`)
+	}
+	if hasAzure {
+		deps = append(deps, `"@pulumi/azure-native": "^3.0.0"`)
+	}
+
+	return fmt.Sprintf(`{
+  "name": "%s",
+  "private": true,
+  "main": "index.ts",
+  "dependencies": {
+    %s
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.5.0"
+  }
+}
+`, cfg.Name, strings.Join(deps, ",\n    "))
+}
+
+// renderTSConfig is the tsconfig every Pulumi nodejs project ships
+// with. Strict mode is on — catches missing required inputs at compile
+// time. Target ES2022 matches Pulumi's own docs.
+func renderTSConfig() string {
+	return `{
+  "compilerOptions": {
+    "strict": true,
+    "outDir": "bin",
+    "target": "es2022",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "experimentalDecorators": true,
+    "pretty": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+    "index.ts"
+  ]
+}
+`
+}
+
+// renderProgram emits the TypeScript program that creates every
+// resource in cfg.Resources. Provider imports are conditionally added
+// based on resource prefixes. toCamelCase + typeTerraformToPulumi +
+// tsPropValue mirror the helpers already in internal/exporter, copied
+// here to keep the package boundary clean (exporter stays preview-
+// only; pulumi owns the full-project generator).
+func renderProgram(cfg ProjectConfig) string {
+	var b strings.Builder
+
+	b.WriteString(`import * as pulumi from "@pulumi/pulumi";
+`)
+	hasAWS, hasGCP, hasAzure := detectProviders(cfg.Resources)
+	if hasAWS {
+		b.WriteString(`import * as aws from "@pulumi/aws";
+`)
+	}
+	if hasGCP {
+		b.WriteString(`import * as gcp from "@pulumi/gcp";
+`)
+	}
+	if hasAzure {
+		b.WriteString(`import * as azure from "@pulumi/azure-native";
+`)
+	}
+	b.WriteString("\n")
+	b.WriteString("// Config is populated from Pulumi.<stack>.yaml — see `pulumi config set` to modify.\n")
+	b.WriteString(fmt.Sprintf("const config = new pulumi.Config(%q);\n", cfg.Name))
+	b.WriteString("const environment = config.get(\"environment\") ?? \"dev\";\n\n")
+
+	for _, r := range cfg.Resources {
+		varName := toCamelCase(r.Name)
+		pType := terraformToPulumi(r.Type)
+		b.WriteString(fmt.Sprintf("const %s = new %s(%q, {\n", varName, pType, r.Name))
+
+		// Stable property ordering so the generated program is
+		// deterministic across runs with the same input.
+		keys := make([]string, 0, len(r.Properties))
+		for k := range r.Properties {
+			if strings.HasPrefix(k, "__") {
+				continue
+			}
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			b.WriteString(fmt.Sprintf("    %s: %s,\n", toCamelCase(k), tsPropValue(r.Properties[k])))
+		}
+		// Tag each resource with the environment so downstream cost
+		// allocation / policy tags work out of the box. Only applies
+		// when the property isn't already set.
+		if _, ok := r.Properties["tags"]; !ok && isTaggableAWS(r.Type) {
+			b.WriteString("    tags: { Environment: environment, ManagedBy: \"iac-studio\" },\n")
+		}
+		b.WriteString("});\n\n")
+	}
+
+	b.WriteString("// Exports — consumed by stack references + CI assertions.\n")
+	for _, r := range cfg.Resources {
+		varName := toCamelCase(r.Name)
+		b.WriteString(fmt.Sprintf("export const %sId = %s.id;\n", varName, varName))
+	}
+	return b.String()
+}
+
+// renderGitignore mirrors Pulumi's own scaffold template. Keeping
+// node_modules and the local state dir out of VCS is table stakes.
+func renderGitignore() string {
+	return `node_modules/
+bin/
+*.log
+*.tsbuildinfo
+/.pulumi/
+`
+}

--- a/internal/pulumi/generator.go
+++ b/internal/pulumi/generator.go
@@ -87,9 +87,9 @@ type ProjectFile struct {
 //	index.ts                       resource program
 //	.gitignore                     exclude node_modules / Pulumi state
 //
-// Errors return a non-nil slice with the files produced so far — same
-// convention as the Terraform scaffold. Callers decide whether a
-// partial render is worth persisting.
+// Validation and unsupported-runtime errors return (nil, err). On
+// success the returned slice contains the complete rendered file set;
+// there are no partial-return paths today.
 func GenerateProject(cfg ProjectConfig) ([]ProjectFile, error) {
 	if err := ValidateProjectName(cfg.Name); err != nil {
 		return nil, fmt.Errorf("pulumi.GenerateProject: %w", err)

--- a/internal/pulumi/generator.go
+++ b/internal/pulumi/generator.go
@@ -164,6 +164,19 @@ func yamlScalar(s string) string {
 	if !needsQuote && (s[0] == ' ' || s[len(s)-1] == ' ') {
 		needsQuote = true
 	}
+	// YAML plain scalars cannot safely start with the block / mapping
+	// indicator characters (-, ?, :) when the next char is whitespace
+	// — the parser would treat the scalar as a sequence/mapping
+	// element instead of a string. A description like "- note" would
+	// otherwise turn the whole document into an unintended list.
+	if !needsQuote && len(s) >= 2 {
+		switch s[0] {
+		case '-', '?', ':':
+			if s[1] == ' ' || s[1] == '\t' {
+				needsQuote = true
+			}
+		}
+	}
 	// Pure digits / reserved keywords would be parsed as numbers or
 	// booleans if emitted plain.
 	switch strings.ToLower(s) {

--- a/internal/pulumi/generator.go
+++ b/internal/pulumi/generator.go
@@ -350,11 +350,20 @@ func renderProgram(cfg ProjectConfig) string {
 		return ordered[i].ID < ordered[j].ID
 	})
 
-	for _, r := range ordered {
+	// used tracks which TS identifiers have been emitted in this
+	// program so we can suffix a counter when two resources share a
+	// Name (aws_vpc.main + aws_subnet.main would both camelCase to
+	// "main" and produce a redeclaration error). We'd rather emit
+	// slightly ugly `mainVpc` / `mainSubnet` than a program that
+	// doesn't compile.
+	used := make(map[string]int)
+	varNames := make([]string, len(ordered))
+	for i, r := range ordered {
 		// Sanitize before camel-casing because project names can
 		// contain hyphens ("acme-infra") which would otherwise produce
 		// invalid TypeScript identifiers like `acme-infraSeed`.
-		varName := sanitizeTSIdent(toCamelCase(r.Name))
+		varName := uniqueVarName(sanitizeTSIdent(toCamelCase(r.Name)), r.Type, used)
+		varNames[i] = varName
 		pType := terraformToPulumi(r.Type)
 		b.WriteString(fmt.Sprintf("const %s = new %s(%q, {\n", varName, pType, r.Name))
 
@@ -381,8 +390,8 @@ func renderProgram(cfg ProjectConfig) string {
 	}
 
 	b.WriteString("// Exports — consumed by stack references + CI assertions.\n")
-	for _, r := range ordered {
-		varName := sanitizeTSIdent(toCamelCase(r.Name))
+	for i := range ordered {
+		varName := varNames[i]
 		b.WriteString(fmt.Sprintf("export const %sId = %s.id;\n", varName, varName))
 	}
 	return b.String()

--- a/internal/pulumi/generator.go
+++ b/internal/pulumi/generator.go
@@ -113,26 +113,37 @@ runtime:
 // projects will layer in secrets (Config.requireSecret) and stack
 // references; we stop at region today and let the scaffold composer
 // add environment-specific blocks.
+//
+// Region handling keeps a separate default per provider so a project
+// mixing AWS + GCP resources with an empty cfg.Region gets both
+// us-east-1 for AWS and us-central1 for GCP, instead of AWS's value
+// leaking into GCP's config. Azure honours cfg.Region too (treating
+// it as a location name) and falls back to WestUS2.
 func renderStackYaml(cfg ProjectConfig, env string) string {
 	hasAWS, hasGCP, hasAzure := detectProviders(cfg.Resources)
-	region := cfg.Region
+	awsRegion := cfg.Region
+	gcpRegion := cfg.Region
+	azureLocation := cfg.Region
 
 	var lines []string
 	lines = append(lines, "config:")
 	if hasAWS {
-		if region == "" {
-			region = "us-east-1"
+		if awsRegion == "" {
+			awsRegion = "us-east-1"
 		}
-		lines = append(lines, "  aws:region: "+region)
+		lines = append(lines, "  aws:region: "+awsRegion)
 	}
 	if hasGCP {
-		if region == "" {
-			region = "us-central1"
+		if gcpRegion == "" {
+			gcpRegion = "us-central1"
 		}
-		lines = append(lines, "  gcp:region: "+region)
+		lines = append(lines, "  gcp:region: "+gcpRegion)
 	}
 	if hasAzure {
-		lines = append(lines, "  azure-native:location: WestUS2")
+		if azureLocation == "" {
+			azureLocation = "WestUS2"
+		}
+		lines = append(lines, "  azure-native:location: "+azureLocation)
 	}
 	lines = append(lines, fmt.Sprintf("  %s:environment: %s", cfg.Name, env))
 	return strings.Join(lines, "\n") + "\n"
@@ -227,7 +238,10 @@ func renderProgram(cfg ProjectConfig) string {
 	b.WriteString("const environment = config.get(\"environment\") ?? \"dev\";\n\n")
 
 	for _, r := range cfg.Resources {
-		varName := toCamelCase(r.Name)
+		// Sanitize before camel-casing because project names can
+		// contain hyphens ("acme-infra") which would otherwise produce
+		// invalid TypeScript identifiers like `acme-infraSeed`.
+		varName := sanitizeTSIdent(toCamelCase(r.Name))
 		pType := terraformToPulumi(r.Type)
 		b.WriteString(fmt.Sprintf("const %s = new %s(%q, {\n", varName, pType, r.Name))
 
@@ -255,7 +269,7 @@ func renderProgram(cfg ProjectConfig) string {
 
 	b.WriteString("// Exports — consumed by stack references + CI assertions.\n")
 	for _, r := range cfg.Resources {
-		varName := toCamelCase(r.Name)
+		varName := sanitizeTSIdent(toCamelCase(r.Name))
 		b.WriteString(fmt.Sprintf("export const %sId = %s.id;\n", varName, varName))
 	}
 	return b.String()

--- a/internal/pulumi/generator.go
+++ b/internal/pulumi/generator.go
@@ -94,6 +94,12 @@ func GenerateProject(cfg ProjectConfig) ([]ProjectFile, error) {
 // renderPulumiYaml is the Pulumi project manifest. Runtime is nodejs
 // (TypeScript) and the project name must match Pulumi's own naming
 // rules (lowercase + hyphens); callers upstream enforce that.
+//
+// Name + description go through yamlScalar so values containing
+// colons, hashes, leading/trailing spaces, or newlines don't produce
+// invalid YAML. Pulumi's own manifests tend to stay simple so the
+// naive path worked in practice, but user-supplied descriptions are
+// the weak link and worth escaping.
 func renderPulumiYaml(cfg ProjectConfig) string {
 	desc := cfg.Description
 	if desc == "" {
@@ -105,7 +111,42 @@ runtime:
   name: nodejs
   options:
     typescript: true
-`, cfg.Name, desc)
+`, yamlScalar(cfg.Name), yamlScalar(desc))
+}
+
+// yamlScalar returns a YAML-safe representation of s. If s contains
+// any of the characters that would trip the YAML 1.2 plain-scalar
+// rules (: # newline, ! & * etc.) or looks like a number/bool, we
+// wrap in double quotes and escape backslashes + quotes. Otherwise
+// emit plain.
+//
+// Not a full YAML encoder — we only emit simple scalars here, and
+// pulling in a yaml dependency just for two fields is overkill. The
+// check list is conservative: anything the spec treats specially
+// triggers the quoted form.
+func yamlScalar(s string) string {
+	if s == "" {
+		return `""`
+	}
+	needsQuote := strings.ContainsAny(s, ":#\n\r\t!&*%@`\"'[]{},|>\\")
+	if !needsQuote && (s[0] == ' ' || s[len(s)-1] == ' ') {
+		needsQuote = true
+	}
+	// Pure digits / reserved keywords would be parsed as numbers or
+	// booleans if emitted plain.
+	switch strings.ToLower(s) {
+	case "true", "false", "null", "yes", "no", "on", "off", "~":
+		needsQuote = true
+	}
+	if !needsQuote {
+		return s
+	}
+	escaped := strings.ReplaceAll(s, `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, `"`, `\"`)
+	escaped = strings.ReplaceAll(escaped, "\n", `\n`)
+	escaped = strings.ReplaceAll(escaped, "\r", `\r`)
+	escaped = strings.ReplaceAll(escaped, "\t", `\t`)
+	return `"` + escaped + `"`
 }
 
 // renderStackYaml emits one Pulumi.<env>.yaml with the config values

--- a/internal/pulumi/generator_test.go
+++ b/internal/pulumi/generator_test.go
@@ -167,13 +167,19 @@ func TestTerraformToPulumi_Overrides(t *testing.T) {
 }
 
 func TestTerraformToPulumi_FallbackCompiles(t *testing.T) {
-	// Unknown type falls through to a best-effort guess. We don't
-	// enforce an exact string — just that it produces a dotted
-	// identifier that TS will parse (and the user can hand-fix if
-	// needed).
-	got := terraformToPulumi("aws_weirdthing_newservice")
-	if !strings.Contains(got, ".") || !strings.HasPrefix(got, "aws.") {
-		t.Errorf("unexpected fallback shape: %q", got)
+	// Unknown AWS/GCP/Azure types all fall through to the same
+	// (<ns> as any).<pkg>.<Type> shape so the TS compiler accepts
+	// them even when the guessed subpackage is wrong.
+	cases := map[string]string{
+		"aws_weirdthing_newservice":    "(aws as any).",
+		"google_bogus_service":         "(gcp as any).",
+		"azurerm_fictional_thing":      "(azure as any).",
+	}
+	for in, wantPrefix := range cases {
+		got := terraformToPulumi(in)
+		if !strings.HasPrefix(got, wantPrefix) {
+			t.Errorf("terraformToPulumi(%q) = %q, want prefix %q", in, got, wantPrefix)
+		}
 	}
 }
 

--- a/internal/pulumi/generator_test.go
+++ b/internal/pulumi/generator_test.go
@@ -1,0 +1,221 @@
+package pulumi
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/iac-studio/iac-studio/internal/parser"
+)
+
+func sampleResources() []parser.Resource {
+	return []parser.Resource{
+		{
+			ID: "aws_vpc.main", Type: "aws_vpc", Name: "main",
+			Properties: map[string]any{"cidr_block": "10.0.0.0/16"},
+		},
+		{
+			ID: "aws_s3_bucket.logs", Type: "aws_s3_bucket", Name: "logs",
+			Properties: map[string]any{"bucket": "acme-logs", "versioning": map[string]any{"enabled": true}},
+		},
+	}
+}
+
+func TestGenerateProject_ProducesFullLayout(t *testing.T) {
+	files, err := GenerateProject(ProjectConfig{
+		Name:         "acme-infra",
+		Environments: []string{"dev", "prod"},
+		Resources:    sampleResources(),
+	})
+	if err != nil {
+		t.Fatalf("GenerateProject: %v", err)
+	}
+
+	want := map[string]bool{
+		"Pulumi.yaml":     false,
+		"Pulumi.dev.yaml": false,
+		"Pulumi.prod.yaml": false,
+		"package.json":    false,
+		"tsconfig.json":   false,
+		"index.ts":        false,
+		".gitignore":      false,
+	}
+	for _, f := range files {
+		want[f.Path] = true
+	}
+	for path, ok := range want {
+		if !ok {
+			t.Errorf("missing expected file %q", path)
+		}
+	}
+}
+
+func TestGenerateProject_RejectsEmptyName(t *testing.T) {
+	_, err := GenerateProject(ProjectConfig{Environments: []string{"dev"}, Resources: sampleResources()})
+	if err == nil {
+		t.Error("want error for empty Name")
+	}
+}
+
+func TestGenerateProject_RejectsUnknownRuntime(t *testing.T) {
+	_, err := GenerateProject(ProjectConfig{Name: "x", Runtime: "python", Resources: sampleResources()})
+	if err == nil {
+		t.Error("want error for non-nodejs runtime")
+	}
+}
+
+func TestGenerateProject_DefaultsToDevEnvironmentWhenEmpty(t *testing.T) {
+	files, err := GenerateProject(ProjectConfig{Name: "x", Resources: sampleResources()})
+	if err != nil {
+		t.Fatalf("GenerateProject: %v", err)
+	}
+	for _, f := range files {
+		if f.Path == "Pulumi.dev.yaml" {
+			return
+		}
+	}
+	t.Error("expected implicit Pulumi.dev.yaml when Environments is empty")
+}
+
+func TestRenderProgram_ImportsMatchProviders(t *testing.T) {
+	prog := renderProgram(ProjectConfig{
+		Name: "acme", Resources: sampleResources(),
+	})
+
+	mustContain(t, prog, `import * as pulumi from "@pulumi/pulumi"`)
+	mustContain(t, prog, `import * as aws from "@pulumi/aws"`)
+	// No GCP / Azure resources → no corresponding imports.
+	if strings.Contains(prog, `@pulumi/gcp`) {
+		t.Error("program should not import gcp when no google_ resources are present")
+	}
+	if strings.Contains(prog, `@pulumi/azure-native`) {
+		t.Error("program should not import azure-native when no azurerm_ resources are present")
+	}
+}
+
+func TestRenderProgram_EmitsResourceConstructorsAndExports(t *testing.T) {
+	prog := renderProgram(ProjectConfig{
+		Name: "acme", Resources: sampleResources(),
+	})
+	mustContain(t, prog, `new aws.ec2.Vpc("main"`)
+	mustContain(t, prog, `new aws.s3.Bucket("logs"`)
+	mustContain(t, prog, `export const mainId = main.id;`)
+	mustContain(t, prog, `export const logsId = logs.id;`)
+	// Taggable AWS resources get the default Environment / ManagedBy
+	// tags auto-injected so cost + policy enforcement work out of the
+	// box.
+	mustContain(t, prog, `tags: { Environment: environment, ManagedBy: "iac-studio" }`)
+}
+
+func TestRenderProgram_IsDeterministic(t *testing.T) {
+	// Two runs with the same input must produce identical output —
+	// critical for review diffs and CI caching.
+	a := renderProgram(ProjectConfig{Name: "a", Resources: sampleResources()})
+	b := renderProgram(ProjectConfig{Name: "a", Resources: sampleResources()})
+	if a != b {
+		t.Error("renderProgram is non-deterministic across runs")
+	}
+}
+
+func TestRenderStackYaml_IncludesRegionPerProvider(t *testing.T) {
+	// AWS resources → aws:region line.
+	y := renderStackYaml(ProjectConfig{
+		Name: "acme", Region: "eu-west-1", Resources: sampleResources(),
+	}, "stage")
+	mustContain(t, y, "aws:region: eu-west-1")
+	mustContain(t, y, "acme:environment: stage")
+
+	// GCP-only resources → gcp:region, no aws:region.
+	yg := renderStackYaml(ProjectConfig{
+		Name: "gcp-proj",
+		Resources: []parser.Resource{
+			{ID: "google_storage_bucket.x", Type: "google_storage_bucket", Name: "x"},
+		},
+	}, "dev")
+	mustContain(t, yg, "gcp:region: us-central1")
+	if strings.Contains(yg, "aws:region") {
+		t.Errorf("aws:region should not appear in GCP-only stack yaml:\n%s", yg)
+	}
+}
+
+func TestRenderPackageJSON_IncludesProviderSDKsInUse(t *testing.T) {
+	p := renderPackageJSON(ProjectConfig{
+		Name:      "acme",
+		Resources: sampleResources(),
+	})
+	mustContain(t, p, `"@pulumi/pulumi"`)
+	mustContain(t, p, `"@pulumi/aws"`)
+	if strings.Contains(p, "@pulumi/gcp") || strings.Contains(p, "@pulumi/azure-native") {
+		t.Error("package.json should only pull in SDKs we use")
+	}
+}
+
+// ─── Helpers under test ─────────────────────────────────────────
+
+func TestTerraformToPulumi_Overrides(t *testing.T) {
+	cases := map[string]string{
+		"aws_vpc":           "aws.ec2.Vpc",
+		"aws_s3_bucket":     "aws.s3.Bucket",
+		"aws_lambda_function": "aws.lambda.Function",
+		"google_storage_bucket": "gcp.storage.Bucket",
+		"azurerm_virtual_network": "azure.network.VirtualNetwork",
+	}
+	for tf, want := range cases {
+		if got := terraformToPulumi(tf); got != want {
+			t.Errorf("terraformToPulumi(%q) = %q, want %q", tf, got, want)
+		}
+	}
+}
+
+func TestTerraformToPulumi_FallbackCompiles(t *testing.T) {
+	// Unknown type falls through to a best-effort guess. We don't
+	// enforce an exact string — just that it produces a dotted
+	// identifier that TS will parse (and the user can hand-fix if
+	// needed).
+	got := terraformToPulumi("aws_weirdthing_newservice")
+	if !strings.Contains(got, ".") || !strings.HasPrefix(got, "aws.") {
+		t.Errorf("unexpected fallback shape: %q", got)
+	}
+}
+
+func TestTsPropValue_HandlesAllScalarTypes(t *testing.T) {
+	cases := []struct {
+		in   any
+		want string
+	}{
+		{nil, "undefined"},
+		{true, "true"},
+		{42, "42"},
+		{3.14, "3.14"},
+		{"hello", `"hello"`},
+		{[]any{"a", 1, true}, `["a", 1, true]`},
+		{map[string]any{"b": 2, "a": 1}, `{ "a": 1, "b": 2 }`}, // sorted keys
+	}
+	for _, tc := range cases {
+		if got := tsPropValue(tc.in); got != tc.want {
+			t.Errorf("tsPropValue(%v) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestToCamelCase(t *testing.T) {
+	cases := map[string]string{
+		"web_server":      "webServer",
+		"main":            "main",
+		"cidr_block":      "cidrBlock",
+		"multi_word_name": "multiWordName",
+	}
+	for in, want := range cases {
+		if got := toCamelCase(in); got != want {
+			t.Errorf("toCamelCase(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// mustContain fails the test when haystack doesn't contain needle;
+// keeps the test bodies terse.
+func mustContain(t *testing.T, haystack, needle string) {
+	t.Helper()
+	if !strings.Contains(haystack, needle) {
+		t.Errorf("expected %q in:\n%s", needle, haystack)
+	}
+}

--- a/internal/pulumi/generator_test.go
+++ b/internal/pulumi/generator_test.go
@@ -197,6 +197,84 @@ func TestTsPropValue_HandlesAllScalarTypes(t *testing.T) {
 	}
 }
 
+func TestRenderProgram_SanitizesHyphenatedProjectNames(t *testing.T) {
+	// Resource names derived from hyphenated project names used to
+	// produce `const acme-infraSeed = ...` which is a TS parse error.
+	// Every identifier we emit must pass through sanitizeTSIdent.
+	prog := renderProgram(ProjectConfig{
+		Name: "acme-infra",
+		Resources: []parser.Resource{{
+			ID: "aws_s3_bucket.seed", Type: "aws_s3_bucket",
+			Name:       "acme-infra_seed",
+			Properties: map[string]any{"bucket": "x"},
+		}},
+	})
+	// Hyphen replaced with underscore after camelCase; the identifier
+	// is legal TS. We don't pin the exact form, just that no hyphen
+	// appears in a `const` or `export const` identifier.
+	for _, line := range strings.Split(prog, "\n") {
+		if strings.HasPrefix(line, "const ") || strings.HasPrefix(line, "export const ") {
+			// Everything between the keyword and "=" is the identifier
+			// (with any type annotation); strip to that window.
+			trimmed := strings.TrimPrefix(strings.TrimPrefix(line, "export "), "const ")
+			if idx := strings.IndexByte(trimmed, '='); idx > 0 {
+				trimmed = trimmed[:idx]
+			}
+			if strings.Contains(trimmed, "-") {
+				t.Errorf("emitted hyphenated identifier: %q", line)
+			}
+		}
+	}
+}
+
+func TestSanitizeTSIdent(t *testing.T) {
+	cases := map[string]string{
+		"webServer":      "webServer",
+		"acme-infraSeed": "acme_infraSeed",
+		"1_starts_digit": "_1_starts_digit",
+		"name with space": "name_with_space",
+		"":                "_",
+	}
+	for in, want := range cases {
+		if got := sanitizeTSIdent(in); got != want {
+			t.Errorf("sanitizeTSIdent(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestRenderStackYaml_PerProviderDefaults(t *testing.T) {
+	// AWS + GCP resources with empty cfg.Region — each provider must
+	// pick up its own default, not share the first one applied.
+	y := renderStackYaml(ProjectConfig{
+		Name: "mix",
+		Resources: []parser.Resource{
+			{ID: "aws_s3_bucket.a", Type: "aws_s3_bucket", Name: "a"},
+			{ID: "google_storage_bucket.b", Type: "google_storage_bucket", Name: "b"},
+		},
+	}, "dev")
+	mustContain(t, y, "aws:region: us-east-1")
+	mustContain(t, y, "gcp:region: us-central1")
+}
+
+func TestRenderStackYaml_AzureHonorsCfgRegion(t *testing.T) {
+	y := renderStackYaml(ProjectConfig{
+		Name:   "x",
+		Region: "EastUS2",
+		Resources: []parser.Resource{
+			{ID: "azurerm_resource_group.a", Type: "azurerm_resource_group", Name: "a"},
+		},
+	}, "dev")
+	mustContain(t, y, "azure-native:location: EastUS2")
+	// Azure default kicks in only when Region is empty.
+	yDefault := renderStackYaml(ProjectConfig{
+		Name: "x",
+		Resources: []parser.Resource{
+			{ID: "azurerm_resource_group.a", Type: "azurerm_resource_group", Name: "a"},
+		},
+	}, "dev")
+	mustContain(t, yDefault, "azure-native:location: WestUS2")
+}
+
 func TestToCamelCase(t *testing.T) {
 	cases := map[string]string{
 		"web_server":      "webServer",

--- a/internal/pulumi/generator_test.go
+++ b/internal/pulumi/generator_test.go
@@ -191,7 +191,7 @@ func TestTsPropValue_HandlesAllScalarTypes(t *testing.T) {
 		{map[string]any{"b": 2, "a": 1}, `{ "a": 1, "b": 2 }`}, // sorted keys
 	}
 	for _, tc := range cases {
-		if got := tsPropValue(tc.in); got != tc.want {
+		if got := tsPropValue(tc.in, ""); got != tc.want {
 			t.Errorf("tsPropValue(%v) = %q, want %q", tc.in, got, tc.want)
 		}
 	}
@@ -333,6 +333,48 @@ func TestFallbackPulumiType_AzureUsesAsAnyCast(t *testing.T) {
 	got := terraformToPulumi("azurerm_fictional_thing")
 	if !strings.Contains(got, "(azure as any).") {
 		t.Errorf("Azure fallback should use `as any` cast, got %q", got)
+	}
+}
+
+func TestTsPropValue_CamelCasesNestedPropertyKeys(t *testing.T) {
+	// Terraform-style nested block — keys should camelCase so Pulumi
+	// sees 'networkAcl' + 'cidrBlocks' instead of the snake_case
+	// forms (which would be unrecognised SDK properties).
+	got := tsPropValue(map[string]any{
+		"network_acl": map[string]any{
+			"cidr_blocks": []any{"10.0.0.0/24"},
+		},
+	}, "ingress_rule")
+	if !strings.Contains(got, `"networkAcl"`) {
+		t.Errorf("expected camelCased 'networkAcl' in %q", got)
+	}
+	if !strings.Contains(got, `"cidrBlocks"`) {
+		t.Errorf("expected camelCased 'cidrBlocks' in %q", got)
+	}
+}
+
+func TestTsPropValue_PreservesTagAndLabelKeys(t *testing.T) {
+	// tags/labels keys ARE the tag name — a camelCase rewrite would
+	// silently change the infrastructure-level tag identifier.
+	got := tsPropValue(map[string]any{
+		"Owner":      "team_alpha",
+		"ManagedBy":  "iac-studio",
+		"cost_center": "platform",
+	}, "tags")
+	for _, key := range []string{`"Owner"`, `"ManagedBy"`, `"cost_center"`} {
+		if !strings.Contains(got, key) {
+			t.Errorf("tags key should be preserved: %q missing in %q", key, got)
+		}
+	}
+	// And labels get the same treatment.
+	gotLabels := tsPropValue(map[string]any{
+		"k8s-app":    "web",
+		"snake_case": "value",
+	}, "labels")
+	for _, key := range []string{`"k8s-app"`, `"snake_case"`} {
+		if !strings.Contains(gotLabels, key) {
+			t.Errorf("labels key should be preserved: %q missing in %q", key, gotLabels)
+		}
 	}
 }
 

--- a/internal/pulumi/generator_test.go
+++ b/internal/pulumi/generator_test.go
@@ -336,6 +336,31 @@ func TestFallbackPulumiType_AzureUsesAsAnyCast(t *testing.T) {
 	}
 }
 
+func TestRenderProgram_DedupesSharedNamesAcrossTypes(t *testing.T) {
+	// Two resources of different types share the name "main". Without
+	// dedup we'd emit `const main = ...` twice (TS redeclaration
+	// error). Output should carry mainVpc + mainSubnet (Type-derived
+	// suffix) so the program compiles.
+	prog := renderProgram(ProjectConfig{
+		Name: "acme",
+		Resources: []parser.Resource{
+			{ID: "aws_vpc.main", Type: "aws_vpc", Name: "main",
+				Properties: map[string]any{"cidr_block": "10.0.0.0/16"}},
+			{ID: "aws_subnet.main", Type: "aws_subnet", Name: "main",
+				Properties: map[string]any{"cidr_block": "10.0.1.0/24"}},
+		},
+	})
+	mainCount := strings.Count(prog, "const main = ")
+	if mainCount > 1 {
+		t.Errorf("duplicate `const main` redeclaration — want at most 1, got %d\n%s", mainCount, prog)
+	}
+	// Second occurrence gets a type suffix so both resources end up
+	// with distinct identifiers.
+	if !strings.Contains(prog, "const main ") && !strings.Contains(prog, "const mainVpc ") {
+		t.Error("neither main nor mainVpc emitted")
+	}
+}
+
 func TestTsPropValue_CamelCasesNestedPropertyKeys(t *testing.T) {
 	// Terraform-style nested block — keys should camelCase so Pulumi
 	// sees 'networkAcl' + 'cidrBlocks' instead of the snake_case

--- a/internal/pulumi/generator_test.go
+++ b/internal/pulumi/generator_test.go
@@ -275,6 +275,67 @@ func TestRenderStackYaml_AzureHonorsCfgRegion(t *testing.T) {
 	mustContain(t, yDefault, "azure-native:location: WestUS2")
 }
 
+func TestYamlScalar(t *testing.T) {
+	cases := map[string]string{
+		"simple":                  "simple",
+		"":                        `""`,
+		"has:colon":               `"has:colon"`,
+		"has#hash":                `"has#hash"`,
+		"with\nnewline":           `"with\nnewline"`,
+		"true":                    `"true"`,   // reserved bool
+		"null":                    `"null"`,   // reserved null
+		" leadingspace":           `" leadingspace"`,
+		"trailingspace ":          `"trailingspace "`,
+		`has"quote`:               `"has\"quote"`,
+		`back\slash`:              `"back\\slash"`,
+	}
+	for in, want := range cases {
+		if got := yamlScalar(in); got != want {
+			t.Errorf("yamlScalar(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestRenderPulumiYaml_QuotesRiskyValues(t *testing.T) {
+	// A description containing a colon must be quoted — otherwise YAML
+	// would parse "description: note: see docs" as a mapping.
+	y := renderPulumiYaml(ProjectConfig{
+		Name:        "simple-name",
+		Description: "note: see docs",
+	})
+	mustContain(t, y, `description: "note: see docs"`)
+	mustContain(t, y, "name: simple-name") // plain scalar is fine
+}
+
+func TestIsTaggableAWS_IsAllowlist(t *testing.T) {
+	// Unknown AWS types default to false now — previously they
+	// defaulted to true and would auto-inject `tags:` blocks into
+	// resources that don't accept them.
+	if isTaggableAWS("aws_route_table_association") {
+		t.Error("aws_route_table_association should not be taggable (unknown types default false)")
+	}
+	if isTaggableAWS("aws_iam_instance_profile") {
+		t.Error("aws_iam_instance_profile should not be taggable")
+	}
+	// Known taggable types still return true.
+	if !isTaggableAWS("aws_vpc") {
+		t.Error("aws_vpc should be taggable")
+	}
+	if !isTaggableAWS("aws_s3_bucket") {
+		t.Error("aws_s3_bucket should be taggable")
+	}
+}
+
+func TestFallbackPulumiType_AzureUsesAsAnyCast(t *testing.T) {
+	// (azure as any).<pkg>.<Type> parses cleanly in TS even when the
+	// namespace is wrong — better than azure.unknown.<Type> which
+	// hard-fails tsc at compile time.
+	got := terraformToPulumi("azurerm_fictional_thing")
+	if !strings.Contains(got, "(azure as any).") {
+		t.Errorf("Azure fallback should use `as any` cast, got %q", got)
+	}
+}
+
 func TestToCamelCase(t *testing.T) {
 	cases := map[string]string{
 		"web_server":      "webServer",

--- a/internal/pulumi/helpers.go
+++ b/internal/pulumi/helpers.go
@@ -100,26 +100,24 @@ var pulumiTypeOverrides = map[string]string{
 }
 
 // fallbackPulumiType guesses a Pulumi constructor when there's no
-// explicit override. It returns something that compiles even when the
-// package name is a guess — the user sees the TS compiler's missing-
-// module error and knows to either register an override upstream or
-// hand-edit the import.
+// explicit override. Every unknown path goes through an `as any` cast
+// so the generated program parses in TypeScript regardless of whether
+// the guessed subpackage exists. Without the cast, `aws.fictional.
+// Thing` / `gcp.bogus.Thing` would hard-fail tsc at the unknown
+// namespace reference, turning a best-effort guess into a blocker.
+// The user sees undefined-at-runtime errors when they actually wire
+// the resource up, and can register an override in
+// pulumiTypeOverrides or hand-edit the import.
 func fallbackPulumiType(tfType string) string {
 	switch {
 	case strings.HasPrefix(tfType, "aws_"):
 		rest := strings.TrimPrefix(tfType, "aws_")
-		return "aws." + guessAWSPackage(rest) + "." + pascalCaseFromSnake(rest)
+		return "(aws as any)." + guessAWSPackage(rest) + "." + pascalCaseFromSnake(rest)
 	case strings.HasPrefix(tfType, "google_"):
 		rest := strings.TrimPrefix(tfType, "google_")
-		return "gcp." + guessGCPPackage(rest) + "." + pascalCaseFromSnake(rest)
+		return "(gcp as any)." + guessGCPPackage(rest) + "." + pascalCaseFromSnake(rest)
 	case strings.HasPrefix(tfType, "azurerm_"):
 		rest := strings.TrimPrefix(tfType, "azurerm_")
-		// (azure as any) sidesteps the per-package typing for
-		// unknown Azure resources. TS still parses the expression
-		// and the program compiles; the user hand-fixes the import
-		// when they actually wire the resource up. Without the
-		// `as any` cast, `azure.fictional.Thing` would hard-fail
-		// tsc at the unknown namespace reference.
 		return "(azure as any)." + guessAzurePackage(rest) + "." + pascalCaseFromSnake(rest)
 	}
 	return pascalCaseFromSnake(tfType)

--- a/internal/pulumi/helpers.go
+++ b/internal/pulumi/helpers.go
@@ -1,0 +1,245 @@
+package pulumi
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+
+	"github.com/iac-studio/iac-studio/internal/parser"
+)
+
+// Helpers live in their own file so the generator stays readable.
+// Several are near-duplicates of helpers in internal/exporter; we
+// intentionally don't share them — the exporter is a single-file
+// preview surface, pulumi is a full project scaffold, and coupling
+// them would make a change in one break the other's output.
+
+// detectProviders reports which cloud SDKs the resource list requires.
+// Used to gate imports + package.json deps + stack config.
+func detectProviders(resources []parser.Resource) (aws, gcp, azure bool) {
+	for _, r := range resources {
+		switch {
+		case strings.HasPrefix(r.Type, "aws_"):
+			aws = true
+		case strings.HasPrefix(r.Type, "google_"):
+			gcp = true
+		case strings.HasPrefix(r.Type, "azurerm_"):
+			azure = true
+		}
+	}
+	return aws, gcp, azure
+}
+
+// terraformToPulumi maps a Terraform resource type to the Pulumi
+// constructor. The mapping is deterministic:
+//
+//	aws_vpc           → aws.ec2.Vpc
+//	aws_s3_bucket     → aws.s3.Bucket
+//	google_storage_*  → gcp.storage.*
+//
+// When a specific mapping isn't registered we fall back to the
+// convention: drop the provider prefix, split the rest on underscore,
+// PascalCase each segment, and lookup a best-effort package name.
+// Real completeness across all ~800 AWS resource types lives in a
+// future "provider catalog" commit; this covers the subset the
+// scaffold + canvas demo cares about.
+func terraformToPulumi(tfType string) string {
+	if m, ok := pulumiTypeOverrides[tfType]; ok {
+		return m
+	}
+	// Unknown — fall back to a best-effort guess so the scaffold
+	// compiles as long as the user hand-fixes the import path later.
+	return fallbackPulumiType(tfType)
+}
+
+// pulumiTypeOverrides maps the common resources the canvas + fallback
+// palette emit. Keep this list tight — a 500-entry dictionary here
+// would rot faster than the scaffold can benefit.
+var pulumiTypeOverrides = map[string]string{
+	// AWS — networking
+	"aws_vpc":             "aws.ec2.Vpc",
+	"aws_subnet":          "aws.ec2.Subnet",
+	"aws_internet_gateway": "aws.ec2.InternetGateway",
+	"aws_nat_gateway":     "aws.ec2.NatGateway",
+	"aws_route_table":     "aws.ec2.RouteTable",
+	"aws_security_group":  "aws.ec2.SecurityGroup",
+	// AWS — compute
+	"aws_instance":        "aws.ec2.Instance",
+	"aws_lambda_function": "aws.lambda.Function",
+	"aws_ecs_cluster":     "aws.ecs.Cluster",
+	"aws_eks_cluster":     "aws.eks.Cluster",
+	// AWS — storage / data
+	"aws_s3_bucket":        "aws.s3.Bucket",
+	"aws_ebs_volume":       "aws.ebs.Volume",
+	"aws_ecr_repository":   "aws.ecr.Repository",
+	"aws_db_instance":      "aws.rds.Instance",
+	"aws_dynamodb_table":   "aws.dynamodb.Table",
+	"aws_elasticache_cluster": "aws.elasticache.Cluster",
+	// AWS — security / IAM
+	"aws_iam_role":            "aws.iam.Role",
+	"aws_iam_policy":          "aws.iam.Policy",
+	"aws_kms_key":             "aws.kms.Key",
+	"aws_secretsmanager_secret": "aws.secretsmanager.Secret",
+	// AWS — lb
+	"aws_lb":              "aws.lb.LoadBalancer",
+	"aws_lb_target_group": "aws.lb.TargetGroup",
+	// GCP
+	"google_compute_network": "gcp.compute.Network",
+	"google_compute_subnetwork": "gcp.compute.Subnetwork",
+	"google_compute_instance": "gcp.compute.Instance",
+	"google_container_cluster": "gcp.container.Cluster",
+	"google_storage_bucket":   "gcp.storage.Bucket",
+	"google_sql_database_instance": "gcp.sql.DatabaseInstance",
+	// Azure (azure-native uses service.Resource, not PascalCased TF suffix)
+	"azurerm_resource_group":   "azure.resources.ResourceGroup",
+	"azurerm_virtual_network":  "azure.network.VirtualNetwork",
+	"azurerm_subnet":           "azure.network.Subnet",
+	"azurerm_storage_account":  "azure.storage.StorageAccount",
+	"azurerm_linux_virtual_machine": "azure.compute.VirtualMachine",
+}
+
+// fallbackPulumiType guesses a Pulumi constructor when there's no
+// explicit override. It returns something that compiles even when the
+// package name is a guess — the user sees the TS compiler's missing-
+// module error and knows to either register an override upstream or
+// hand-edit the import.
+func fallbackPulumiType(tfType string) string {
+	switch {
+	case strings.HasPrefix(tfType, "aws_"):
+		rest := strings.TrimPrefix(tfType, "aws_")
+		return "aws." + guessAWSPackage(rest) + "." + pascalCaseFromSnake(rest)
+	case strings.HasPrefix(tfType, "google_"):
+		rest := strings.TrimPrefix(tfType, "google_")
+		return "gcp." + guessGCPPackage(rest) + "." + pascalCaseFromSnake(rest)
+	case strings.HasPrefix(tfType, "azurerm_"):
+		return "azure.unknown." + pascalCaseFromSnake(strings.TrimPrefix(tfType, "azurerm_"))
+	}
+	return pascalCaseFromSnake(tfType)
+}
+
+// guessAWSPackage picks a reasonable Pulumi AWS subpackage from the
+// first token of the resource type's suffix. These are the ~30 most-
+// used; unknowns default to "ec2" which at least compiles.
+func guessAWSPackage(rest string) string {
+	head := strings.SplitN(rest, "_", 2)[0]
+	pkgByHead := map[string]string{
+		"s3": "s3", "ec2": "ec2", "vpc": "ec2", "subnet": "ec2",
+		"rds": "rds", "dynamodb": "dynamodb", "lambda": "lambda",
+		"iam": "iam", "kms": "kms", "eks": "eks", "ecs": "ecs",
+		"ecr": "ecr", "lb": "lb", "elb": "elb", "cloudwatch": "cloudwatch",
+		"sns": "sns", "sqs": "sqs", "apigateway": "apigateway",
+	}
+	if p, ok := pkgByHead[head]; ok {
+		return p
+	}
+	return "ec2"
+}
+
+func guessGCPPackage(rest string) string {
+	head := strings.SplitN(rest, "_", 2)[0]
+	pkgByHead := map[string]string{
+		"storage": "storage", "compute": "compute", "container": "container",
+		"sql": "sql", "pubsub": "pubsub", "bigquery": "bigquery",
+	}
+	if p, ok := pkgByHead[head]; ok {
+		return p
+	}
+	return "compute"
+}
+
+// pascalCaseFromSnake: "nat_gateway" → "NatGateway". Pulumi
+// constructors are PascalCase; Terraform types are snake_case. Drops
+// empty segments so double-underscores don't produce an empty camel.
+func pascalCaseFromSnake(s string) string {
+	parts := strings.Split(s, "_")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p == "" {
+			continue
+		}
+		runes := []rune(p)
+		runes[0] = unicode.ToUpper(runes[0])
+		out = append(out, string(runes))
+	}
+	return strings.Join(out, "")
+}
+
+// toCamelCase: "web_server" → "webServer". Used for both variable
+// names and property keys; Pulumi's TypeScript SDK follows JS
+// conventions so camelCase is idiomatic.
+func toCamelCase(s string) string {
+	parts := strings.Split(s, "_")
+	if len(parts) == 0 {
+		return s
+	}
+	out := parts[0]
+	for _, p := range parts[1:] {
+		if p == "" {
+			continue
+		}
+		runes := []rune(p)
+		runes[0] = unicode.ToUpper(runes[0])
+		out += string(runes)
+	}
+	return out
+}
+
+// tsPropValue renders a resource property as TypeScript source. Maps
+// and slices recurse; primitive scalars emit their literal form. The
+// output is deterministic (sorted map keys) so two runs with the same
+// input produce byte-identical programs — important for CI diffing.
+func tsPropValue(v any) string {
+	switch x := v.(type) {
+	case nil:
+		return "undefined"
+	case bool:
+		return fmt.Sprintf("%t", x)
+	case int, int32, int64, float32, float64:
+		return fmt.Sprintf("%v", x)
+	case string:
+		return fmt.Sprintf("%q", x)
+	case []any:
+		items := make([]string, 0, len(x))
+		for _, el := range x {
+			items = append(items, tsPropValue(el))
+		}
+		return "[" + strings.Join(items, ", ") + "]"
+	case map[string]any:
+		keys := make([]string, 0, len(x))
+		for k := range x {
+			keys = append(keys, k)
+		}
+		// Sort for deterministic output (Go maps iterate randomly).
+		for i := 0; i < len(keys); i++ {
+			for j := i + 1; j < len(keys); j++ {
+				if keys[j] < keys[i] {
+					keys[i], keys[j] = keys[j], keys[i]
+				}
+			}
+		}
+		items := make([]string, 0, len(keys))
+		for _, k := range keys {
+			items = append(items, fmt.Sprintf("%q: %s", k, tsPropValue(x[k])))
+		}
+		return "{ " + strings.Join(items, ", ") + " }"
+	}
+	return fmt.Sprintf("%q", fmt.Sprint(v))
+}
+
+// isTaggableAWS reports whether the given AWS resource type accepts
+// tags. Covers the common taggable types; unknowns default to false
+// so we don't generate a `tags:` block on something that rejects it.
+func isTaggableAWS(tfType string) bool {
+	if !strings.HasPrefix(tfType, "aws_") {
+		return false
+	}
+	nonTaggable := map[string]struct{}{
+		"aws_iam_policy":   {},
+		"aws_iam_role":     {}, // can tag but requires tag block shape
+		"aws_route_table":  {},
+	}
+	if _, no := nonTaggable[tfType]; no {
+		return false
+	}
+	return true
+}

--- a/internal/pulumi/helpers.go
+++ b/internal/pulumi/helpers.go
@@ -248,7 +248,16 @@ func sanitizeTSIdent(s string) string {
 // and slices recurse; primitive scalars emit their literal form. The
 // output is deterministic (sorted map keys) so two runs with the same
 // input produce byte-identical programs — important for CI diffing.
-func tsPropValue(v any) string {
+//
+// parentKey lets callers signal the semantic of the map being rendered:
+// map values under "tags" / "labels" / "environment" / similar keep
+// their literal key names (those ARE the tag/label/env-var identifier,
+// not a Pulumi property name). All other nested maps camelCase their
+// keys to match Pulumi TypeScript SDK conventions — a Terraform-style
+// nested block like `{network_acl: {cidr_blocks: […]}}` renders as
+// `{networkAcl: {cidrBlocks: […]}}`. Pass "" (or use tsPropValueTop)
+// at the outermost call site.
+func tsPropValue(v any, parentKey string) string {
 	switch x := v.(type) {
 	case nil:
 		return "undefined"
@@ -261,7 +270,7 @@ func tsPropValue(v any) string {
 	case []any:
 		items := make([]string, 0, len(x))
 		for _, el := range x {
-			items = append(items, tsPropValue(el))
+			items = append(items, tsPropValue(el, parentKey))
 		}
 		return "[" + strings.Join(items, ", ") + "]"
 	case map[string]any:
@@ -271,13 +280,35 @@ func tsPropValue(v any) string {
 		}
 		// Sort for deterministic output (Go maps iterate randomly).
 		sort.Strings(keys)
+		preserve := preservesLiteralKeys(parentKey)
 		items := make([]string, 0, len(keys))
 		for _, k := range keys {
-			items = append(items, fmt.Sprintf("%q: %s", k, tsPropValue(x[k])))
+			renderedKey := k
+			if !preserve {
+				renderedKey = toCamelCase(k)
+			}
+			items = append(items, fmt.Sprintf("%q: %s", renderedKey, tsPropValue(x[k], k)))
 		}
 		return "{ " + strings.Join(items, ", ") + " }"
 	}
 	return fmt.Sprintf("%q", fmt.Sprint(v))
+}
+
+// preservesLiteralKeys reports whether a map value whose parent key
+// matches one of the known literal-keyed wrappers (tags, labels,
+// environment variables, metadata, annotations) should keep its child
+// keys verbatim instead of camelCasing them. These are the places
+// where the child key IS the real-world tag / label / env-var name,
+// not a Pulumi SDK property. Getting this wrong produces subtly
+// incorrect infrastructure — e.g. "Owner" → "owner" silently changes
+// the tag key in the cloud.
+func preservesLiteralKeys(parentKey string) bool {
+	switch parentKey {
+	case "tags", "labels", "metadata", "annotations",
+		"environment", "environment_variables", "env":
+		return true
+	}
+	return false
 }
 
 // isTaggableAWS reports whether the given AWS resource type accepts

--- a/internal/pulumi/helpers.go
+++ b/internal/pulumi/helpers.go
@@ -213,6 +213,43 @@ func toCamelCase(s string) string {
 	return out
 }
 
+// uniqueVarName returns a TS-safe variable name for a resource,
+// suffixing with a type-derived hint when the base camelCased name
+// is already in use. Terraform graphs only enforce Name-uniqueness
+// per-Type, so aws_vpc.main and aws_subnet.main can legitimately
+// coexist; emitting `const main = ...` twice is a TS redeclaration.
+//
+// First collision adopts Type-derived suffix ("mainVpc"); subsequent
+// collisions of the same suffix append a counter ("mainVpc2"). The
+// `used` map is mutated and expected to be caller-scoped to a single
+// program render.
+func uniqueVarName(base, resourceType string, used map[string]int) string {
+	if _, taken := used[base]; !taken {
+		used[base] = 1
+		return base
+	}
+	// Derive a suffix from the TF type's leaf segment: aws_vpc → Vpc.
+	parts := strings.Split(resourceType, "_")
+	suffix := ""
+	if len(parts) > 0 {
+		last := parts[len(parts)-1]
+		if last != "" {
+			runes := []rune(last)
+			runes[0] = unicode.ToUpper(runes[0])
+			suffix = string(runes)
+		}
+	}
+	candidate := base + suffix
+	for {
+		if _, taken := used[candidate]; !taken {
+			used[candidate] = 1
+			return candidate
+		}
+		used[base+suffix]++
+		candidate = fmt.Sprintf("%s%s%d", base, suffix, used[base+suffix])
+	}
+}
+
 // sanitizeTSIdent turns an arbitrary resource name into a valid
 // TypeScript identifier. camelCase on resource names like
 // "<project>_seed" is fine when the project is a valid identifier,

--- a/internal/pulumi/helpers.go
+++ b/internal/pulumi/helpers.go
@@ -113,7 +113,14 @@ func fallbackPulumiType(tfType string) string {
 		rest := strings.TrimPrefix(tfType, "google_")
 		return "gcp." + guessGCPPackage(rest) + "." + pascalCaseFromSnake(rest)
 	case strings.HasPrefix(tfType, "azurerm_"):
-		return "azure.unknown." + pascalCaseFromSnake(strings.TrimPrefix(tfType, "azurerm_"))
+		rest := strings.TrimPrefix(tfType, "azurerm_")
+		// (azure as any) sidesteps the per-package typing for
+		// unknown Azure resources. TS still parses the expression
+		// and the program compiles; the user hand-fixes the import
+		// when they actually wire the resource up. Without the
+		// `as any` cast, `azure.fictional.Thing` would hard-fail
+		// tsc at the unknown namespace reference.
+		return "(azure as any)." + guessAzurePackage(rest) + "." + pascalCaseFromSnake(rest)
 	}
 	return pascalCaseFromSnake(tfType)
 }
@@ -146,6 +153,27 @@ func guessGCPPackage(rest string) string {
 		return p
 	}
 	return "compute"
+}
+
+// guessAzurePackage maps the first token after "azurerm_" to an
+// azure-native subpackage guess. Azure's namespacing doesn't line up
+// as cleanly as AWS/GCP — many TF types collapse unrelated services
+// (azurerm_key_vault vs. azurerm_storage_account) — so the fallback
+// defaults to "resources" which at least parses in TS with the
+// `(azure as any)` cast.
+func guessAzurePackage(rest string) string {
+	head := strings.SplitN(rest, "_", 2)[0]
+	pkgByHead := map[string]string{
+		"resource": "resources", "storage": "storage", "virtual": "network",
+		"subnet": "network", "network": "network", "key": "keyvault",
+		"linux": "compute", "windows": "compute", "container": "containerservice",
+		"managed": "containerservice", "postgresql": "dbforpostgresql",
+		"mysql": "dbformysql", "redis": "cache", "app": "web",
+	}
+	if p, ok := pkgByHead[head]; ok {
+		return p
+	}
+	return "resources"
 }
 
 // pascalCaseFromSnake: "nat_gateway" → "NatGateway". Pulumi
@@ -249,19 +277,43 @@ func tsPropValue(v any) string {
 }
 
 // isTaggableAWS reports whether the given AWS resource type accepts
-// tags. Covers the common taggable types; unknowns default to false
-// so we don't generate a `tags:` block on something that rejects it.
+// a flat map[string]string `tags` property. Allowlist rather than
+// denylist: many AWS resources don't accept tags at all
+// (aws_route_table_association, aws_iam_instance_profile, …) and a
+// previous denylist approach auto-injected tags into them, which
+// then fails tsc or the provider at plan time. Unknown types default
+// to false — safer to drop the convenience tags than to emit
+// resource programs that don't compile.
 func isTaggableAWS(tfType string) bool {
-	if !strings.HasPrefix(tfType, "aws_") {
-		return false
-	}
-	nonTaggable := map[string]struct{}{
-		"aws_iam_policy":   {},
-		"aws_iam_role":     {}, // can tag but requires tag block shape
-		"aws_route_table":  {},
-	}
-	if _, no := nonTaggable[tfType]; no {
-		return false
-	}
-	return true
+	_, ok := taggableAWSResources[tfType]
+	return ok
+}
+
+// taggableAWSResources lists AWS resource types that accept the flat
+// tags = { K: V, ... } shape. Covers the common set the canvas + fall-
+// back palette emit — not exhaustive across AWS's ~800 types, but
+// extending is a one-line addition as new resources are added to the
+// catalog.
+var taggableAWSResources = map[string]struct{}{
+	"aws_vpc":                   {},
+	"aws_subnet":                {},
+	"aws_internet_gateway":      {},
+	"aws_nat_gateway":           {},
+	"aws_security_group":        {},
+	"aws_instance":              {},
+	"aws_lambda_function":       {},
+	"aws_ecs_cluster":           {},
+	"aws_eks_cluster":           {},
+	"aws_s3_bucket":             {},
+	"aws_ebs_volume":            {},
+	"aws_ecr_repository":        {},
+	"aws_db_instance":           {},
+	"aws_dynamodb_table":        {},
+	"aws_elasticache_cluster":   {},
+	"aws_kms_key":               {},
+	"aws_secretsmanager_secret": {},
+	"aws_lb":                    {},
+	"aws_lb_target_group":       {},
+	"aws_autoscaling_group":     {},
+	"aws_cloudwatch_log_group":  {},
 }

--- a/internal/pulumi/helpers.go
+++ b/internal/pulumi/helpers.go
@@ -2,6 +2,7 @@ package pulumi
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"unicode"
 
@@ -184,6 +185,33 @@ func toCamelCase(s string) string {
 	return out
 }
 
+// sanitizeTSIdent turns an arbitrary resource name into a valid
+// TypeScript identifier. camelCase on resource names like
+// "<project>_seed" is fine when the project is a valid identifier,
+// but project names are allowed to contain hyphens ("acme-infra"),
+// which would produce `const acme-infraSeed = …` — parse error. We
+// replace any non-[A-Za-z0-9_] with "_" and prefix a "_" when the
+// first rune is a digit so the result is always a legal identifier.
+func sanitizeTSIdent(s string) string {
+	if s == "" {
+		return "_"
+	}
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case unicode.IsLetter(r), unicode.IsDigit(r), r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('_')
+		}
+	}
+	out := b.String()
+	if unicode.IsDigit(rune(out[0])) {
+		out = "_" + out
+	}
+	return out
+}
+
 // tsPropValue renders a resource property as TypeScript source. Maps
 // and slices recurse; primitive scalars emit their literal form. The
 // output is deterministic (sorted map keys) so two runs with the same
@@ -210,13 +238,7 @@ func tsPropValue(v any) string {
 			keys = append(keys, k)
 		}
 		// Sort for deterministic output (Go maps iterate randomly).
-		for i := 0; i < len(keys); i++ {
-			for j := i + 1; j < len(keys); j++ {
-				if keys[j] < keys[i] {
-					keys[i], keys[j] = keys[j], keys[i]
-				}
-			}
-		}
+		sort.Strings(keys)
 		items := make([]string, 0, len(keys))
 		for _, k := range keys {
 			items = append(items, fmt.Sprintf("%q: %s", k, tsPropValue(x[k])))

--- a/internal/pulumi/helpers.go
+++ b/internal/pulumi/helpers.go
@@ -234,7 +234,11 @@ func sanitizeTSIdent(s string) string {
 		}
 	}
 	out := b.String()
-	if unicode.IsDigit(rune(out[0])) {
+	// Use []rune so a multibyte UTF-8 leading character isn't
+	// misidentified by a naive byte check. IsDigit on the first rune
+	// decides the underscore prefix.
+	runes := []rune(out)
+	if len(runes) > 0 && unicode.IsDigit(runes[0]) {
 		out = "_" + out
 	}
 	return out

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -32,6 +32,7 @@ func (r *Runner) DetectTools() []ToolInfo {
 		{"Terraform", "terraform", []string{"version"}},
 		{"OpenTofu", "tofu", []string{"version"}},
 		{"Ansible", "ansible", []string{"--version"}},
+		{"Pulumi", "pulumi", []string{"version"}},
 	}
 
 	var results []ToolInfo
@@ -88,6 +89,8 @@ func (r *Runner) buildArgs(tool, command string) []string {
 		return r.terraformArgs(command, "tofu")
 	case "ansible":
 		return r.ansibleArgs(command)
+	case "pulumi":
+		return r.pulumiArgs(command)
 	}
 	return nil
 }
@@ -106,6 +109,47 @@ func (r *Runner) terraformArgs(command, binary string) []string {
 		return []string{binary, "validate", "-no-color"}
 	case "fmt":
 		return []string{binary, "fmt"}
+	}
+	return nil
+}
+
+// pulumiArgs maps the canvas's logical command names ("plan" / "apply"
+// / "destroy") onto the Pulumi CLI's native verbs. We keep the same
+// vocabulary the Terraform path uses so the UI doesn't need a per-tool
+// branch — the translation happens here.
+//
+// "init" resolves to `npm install` rather than `pulumi stack init`
+// because the scaffolded project has no stack state yet and stack
+// creation requires an auth backend selection (local vs. Pulumi
+// Cloud) that's outside the runner's scope. Users still run
+// `pulumi login` + `pulumi stack init <env>` once per machine; the
+// safe-runner path below only drives preview/up/destroy/refresh
+// after that bootstrap is done.
+//
+// Every destructive verb carries --yes because the SafeRunner's
+// approval gate fronts them — we rely on the server-side plan review
+// rather than Pulumi's own interactive confirmation.
+func (r *Runner) pulumiArgs(command string) []string {
+	switch command {
+	case "init":
+		// Prime the project: install node_modules so the TS program
+		// compiles. Pulumi itself doesn't need this step, but without
+		// it `pulumi preview` fails immediately on the missing
+		// @pulumi/* SDKs.
+		return []string{"npm", "install"}
+	case "plan", "preview":
+		return []string{"pulumi", "preview", "--non-interactive", "--color=never"}
+	case "apply", "up":
+		return []string{"pulumi", "up", "--yes", "--non-interactive", "--color=never"}
+	case "destroy":
+		return []string{"pulumi", "destroy", "--yes", "--non-interactive", "--color=never"}
+	case "refresh":
+		return []string{"pulumi", "refresh", "--yes", "--non-interactive", "--color=never"}
+	case "validate":
+		// The closest Pulumi equivalent of `terraform validate` is a
+		// TypeScript compile with no emit — catches type errors
+		// without invoking the engine.
+		return []string{"npx", "tsc", "--noEmit"}
 	}
 	return nil
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -55,8 +55,14 @@ func (r *Runner) DetectTools() []ToolInfo {
 }
 
 // Execute runs an IaC command in the given project directory.
-func (r *Runner) Execute(projectDir, tool, command string) (string, error) {
-	args := r.buildArgs(tool, command)
+//
+// env names the layered-v1 environment to target. For pulumi, env is
+// passed through as `--stack <env>` so a request bound to dev cannot
+// silently mutate the workspace-selected stack (which Pulumi resolves
+// from local state and could be anything). Empty env runs in the
+// project root with no explicit stack — fine for flat layouts.
+func (r *Runner) Execute(projectDir, tool, command, env string) (string, error) {
+	args := r.buildArgs(tool, command, env)
 	if len(args) == 0 {
 		return "", fmt.Errorf("unknown tool/command: %s %s", tool, command)
 	}
@@ -81,7 +87,7 @@ func (r *Runner) Execute(projectDir, tool, command string) (string, error) {
 	return output, err
 }
 
-func (r *Runner) buildArgs(tool, command string) []string {
+func (r *Runner) buildArgs(tool, command, env string) []string {
 	switch tool {
 	case "terraform":
 		return r.terraformArgs(command, "terraform")
@@ -90,7 +96,7 @@ func (r *Runner) buildArgs(tool, command string) []string {
 	case "ansible":
 		return r.ansibleArgs(command)
 	case "pulumi":
-		return r.pulumiArgs(command)
+		return r.pulumiArgs(command, env)
 	}
 	return nil
 }
@@ -137,7 +143,20 @@ func (r *Runner) terraformArgs(command, binary string) []string {
 // follow-up; for now, layered-pulumi users run through the scaffold's
 // scripts/{init,plan,apply,destroy}.sh wrappers which handle the cd
 // per-env themselves.
-func (r *Runner) pulumiArgs(command string) []string {
+func (r *Runner) pulumiArgs(command, env string) []string {
+	// withStack appends --stack <env> when env is provided. Pulumi
+	// otherwise resolves the stack from local workspace state, so a
+	// request bound to dev could silently mutate whatever stack
+	// happens to be selected. Pinning explicitly removes that
+	// ambiguity AND ensures the plan-gate (keyed by env-rebased
+	// projectPath) actually corresponds to the stack apply will run
+	// against.
+	withStack := func(args []string) []string {
+		if env == "" {
+			return args
+		}
+		return append(args, "--stack", env)
+	}
 	switch command {
 	case "init":
 		// Prime the project: install node_modules so the TS program
@@ -146,13 +165,13 @@ func (r *Runner) pulumiArgs(command string) []string {
 		// @pulumi/* SDKs.
 		return []string{"npm", "install"}
 	case "plan", "preview":
-		return []string{"pulumi", "preview", "--non-interactive", "--color=never"}
+		return withStack([]string{"pulumi", "preview", "--non-interactive", "--color=never"})
 	case "apply", "up":
-		return []string{"pulumi", "up", "--yes", "--non-interactive", "--color=never"}
+		return withStack([]string{"pulumi", "up", "--yes", "--non-interactive", "--color=never"})
 	case "destroy":
-		return []string{"pulumi", "destroy", "--yes", "--non-interactive", "--color=never"}
+		return withStack([]string{"pulumi", "destroy", "--yes", "--non-interactive", "--color=never"})
 	case "refresh":
-		return []string{"pulumi", "refresh", "--yes", "--non-interactive", "--color=never"}
+		return withStack([]string{"pulumi", "refresh", "--yes", "--non-interactive", "--color=never"})
 	case "validate":
 		// The closest Pulumi equivalent of `terraform validate` is a
 		// TypeScript compile with no emit — catches type errors

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -129,6 +129,14 @@ func (r *Runner) terraformArgs(command, binary string) []string {
 // Every destructive verb carries --yes because the SafeRunner's
 // approval gate fronts them — we rely on the server-side plan review
 // rather than Pulumi's own interactive confirmation.
+//
+// Layout note: these args run in the caller's workdir. A single-env
+// Pulumi project (Pulumi.yaml at the root) works as-is. Layered-
+// pulumi projects (Pulumi.yaml under environments/<env>/) need the
+// runner to cd into the env subdir first — that plumbing is a
+// follow-up; for now, layered-pulumi users run through the scaffold's
+// scripts/{init,plan,apply,destroy}.sh wrappers which handle the cd
+// per-env themselves.
 func (r *Runner) pulumiArgs(command string) []string {
 	switch command {
 	case "init":

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -8,8 +8,8 @@ func TestDetectTools(t *testing.T) {
 	r := New()
 	tools := r.DetectTools()
 
-	if len(tools) != 3 {
-		t.Errorf("DetectTools returned %d tools, want 3", len(tools))
+	if len(tools) != 4 {
+		t.Errorf("DetectTools returned %d tools, want 4", len(tools))
 	}
 
 	names := map[string]bool{}
@@ -23,7 +23,7 @@ func TestDetectTools(t *testing.T) {
 		}
 	}
 
-	for _, expected := range []string{"Terraform", "OpenTofu", "Ansible"} {
+	for _, expected := range []string{"Terraform", "OpenTofu", "Ansible", "Pulumi"} {
 		if !names[expected] {
 			t.Errorf("Missing tool: %s", expected)
 		}
@@ -87,6 +87,50 @@ func TestBuildArgs_Ansible(t *testing.T) {
 	}
 }
 
+func TestBuildArgs_Pulumi(t *testing.T) {
+	r := New()
+
+	cases := []struct {
+		command    string
+		wantBinary string
+		// wantHasYes asserts destructive commands carry --yes so the
+		// CLI doesn't hang on its own interactive confirmation (the
+		// server-side approval gate handles that instead).
+		wantHasYes bool
+	}{
+		{"init", "npm", false},     // npm install, not pulumi stack init
+		{"plan", "pulumi", false},  // preview
+		{"preview", "pulumi", false},
+		{"apply", "pulumi", true},
+		{"up", "pulumi", true},
+		{"destroy", "pulumi", true},
+		{"refresh", "pulumi", true},
+		{"validate", "npx", false}, // tsc --noEmit
+	}
+	for _, tc := range cases {
+		args := r.buildArgs("pulumi", tc.command)
+		if len(args) == 0 {
+			t.Errorf("buildArgs(pulumi, %s) returned empty", tc.command)
+			continue
+		}
+		if args[0] != tc.wantBinary {
+			t.Errorf("buildArgs(pulumi, %s)[0] = %s, want %s", tc.command, args[0], tc.wantBinary)
+		}
+		if tc.wantHasYes {
+			found := false
+			for _, a := range args {
+				if a == "--yes" {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("buildArgs(pulumi, %s) missing --yes flag: %v", tc.command, args)
+			}
+		}
+	}
+}
+
 func TestBuildArgs_Unknown(t *testing.T) {
 	r := New()
 	args := r.buildArgs("unknown_tool", "init")
@@ -100,5 +144,25 @@ func TestBuildArgs_UnknownCommand(t *testing.T) {
 	args := r.buildArgs("terraform", "unknown_command")
 	if args != nil {
 		t.Errorf("Unknown command should return nil, got %v", args)
+	}
+}
+
+// TestRequiresApproval_CoversPulumiUp ensures Pulumi's native 'up'
+// verb lands on the approval gate just like terraform/ansible's
+// 'apply'. A regression here would let pulumi up skip plan review.
+func TestRequiresApproval_CoversPulumiUp(t *testing.T) {
+	sr := NewSafeRunner(DefaultSafetyConfig())
+	cases := map[string]bool{
+		"plan":    false,
+		"preview": false,
+		"apply":   true,
+		"up":      true,
+		"destroy": true,
+		"refresh": false,
+	}
+	for cmd, want := range cases {
+		if got := sr.RequiresApproval(cmd); got != want {
+			t.Errorf("RequiresApproval(%q) = %v, want %v", cmd, got, want)
+		}
 	}
 }

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -44,7 +44,7 @@ func TestBuildArgs_Terraform(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		args := r.buildArgs("terraform", tt.command)
+		args := r.buildArgs("terraform", tt.command, "")
 		if len(args) == 0 {
 			t.Errorf("buildArgs(terraform, %s) returned empty", tt.command)
 			continue
@@ -57,7 +57,7 @@ func TestBuildArgs_Terraform(t *testing.T) {
 
 func TestBuildArgs_OpenTofu(t *testing.T) {
 	r := New()
-	args := r.buildArgs("opentofu", "plan")
+	args := r.buildArgs("opentofu", "plan", "")
 	if len(args) == 0 || args[0] != "tofu" {
 		t.Errorf("OpenTofu should use 'tofu' binary, got %v", args)
 	}
@@ -76,7 +76,7 @@ func TestBuildArgs_Ansible(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		args := r.buildArgs("ansible", tt.command)
+		args := r.buildArgs("ansible", tt.command, "")
 		if len(args) == 0 {
 			t.Errorf("buildArgs(ansible, %s) returned empty", tt.command)
 			continue
@@ -108,7 +108,7 @@ func TestBuildArgs_Pulumi(t *testing.T) {
 		{"validate", "npx", false}, // tsc --noEmit
 	}
 	for _, tc := range cases {
-		args := r.buildArgs("pulumi", tc.command)
+		args := r.buildArgs("pulumi", tc.command, "")
 		if len(args) == 0 {
 			t.Errorf("buildArgs(pulumi, %s) returned empty", tc.command)
 			continue
@@ -133,7 +133,7 @@ func TestBuildArgs_Pulumi(t *testing.T) {
 
 func TestBuildArgs_Unknown(t *testing.T) {
 	r := New()
-	args := r.buildArgs("unknown_tool", "init")
+	args := r.buildArgs("unknown_tool", "init", "")
 	if args != nil {
 		t.Errorf("Unknown tool should return nil, got %v", args)
 	}
@@ -141,9 +141,46 @@ func TestBuildArgs_Unknown(t *testing.T) {
 
 func TestBuildArgs_UnknownCommand(t *testing.T) {
 	r := New()
-	args := r.buildArgs("terraform", "unknown_command")
+	args := r.buildArgs("terraform", "unknown_command", "")
 	if args != nil {
 		t.Errorf("Unknown command should return nil, got %v", args)
+	}
+}
+
+// TestBuildArgs_PulumiPassesStack pins the env→--stack plumbing.
+// Without this, an env-rebased Pulumi run would inherit whichever
+// stack is workspace-selected in environments/<env>/, which lets a
+// preview against dev hand-off to an apply against whatever was last
+// `pulumi stack select`'d — wrong-environment mutation risk.
+func TestBuildArgs_PulumiPassesStack(t *testing.T) {
+	r := New()
+	cases := []string{"plan", "preview", "apply", "up", "destroy", "refresh"}
+	for _, cmd := range cases {
+		args := r.buildArgs("pulumi", cmd, "dev")
+		hasStack := false
+		for i, a := range args {
+			if a == "--stack" && i+1 < len(args) && args[i+1] == "dev" {
+				hasStack = true
+				break
+			}
+		}
+		if !hasStack {
+			t.Errorf("buildArgs(pulumi, %s, env=dev) missing --stack dev: %v", cmd, args)
+		}
+	}
+	// Empty env → no --stack flag (flat layout).
+	args := r.buildArgs("pulumi", "preview", "")
+	for _, a := range args {
+		if a == "--stack" {
+			t.Errorf("empty env should not emit --stack: %v", args)
+		}
+	}
+	// init uses npm, no --stack regardless of env.
+	args = r.buildArgs("pulumi", "init", "dev")
+	for _, a := range args {
+		if a == "--stack" {
+			t.Errorf("init should not carry --stack: %v", args)
+		}
 	}
 }
 

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -158,7 +158,7 @@ func TestRequiresApproval_CoversPulumiUp(t *testing.T) {
 		"apply":   true,
 		"up":      true,
 		"destroy": true,
-		"refresh": false,
+		"refresh": true, // state-mutating — gated alongside apply/destroy
 	}
 	for cmd, want := range cases {
 		if got := sr.RequiresApproval(cmd); got != want {

--- a/internal/runner/safe_runner.go
+++ b/internal/runner/safe_runner.go
@@ -279,11 +279,18 @@ func (sr *SafeRunner) ExecutePlanJSON(ctx context.Context, projectDir, tool stri
 }
 
 // RequiresApproval returns true if the command needs plan review first.
+// Covers both the Terraform/Ansible vocabulary ("apply", "destroy")
+// and Pulumi's native verbs ("up") so every destructive action lands
+// on the approval gate regardless of which tool the user picked.
 func (sr *SafeRunner) RequiresApproval(command string) bool {
 	if !sr.defaults.RequireApproval {
 		return false
 	}
-	return command == "apply" || command == "destroy"
+	switch command {
+	case "apply", "up", "destroy":
+		return true
+	}
+	return false
 }
 
 // ParsePlanSummary extracts the summary line from terraform plan output.

--- a/internal/runner/safe_runner.go
+++ b/internal/runner/safe_runner.go
@@ -314,9 +314,13 @@ func (sr *SafeRunner) timeoutFor(command string) time.Duration {
 	switch command {
 	case "init":
 		return sr.defaults.InitTimeout
-	case "plan":
+	case "plan", "preview":
 		return sr.defaults.PlanTimeout
-	case "apply", "destroy":
+	case "apply", "up", "destroy", "refresh":
+		// Pulumi's "up" and "refresh" mutate state the same way
+		// terraform's "apply" / "destroy" do — give them the long
+		// apply-timeout bucket so real stacks don't hit the 5-minute
+		// DefaultTimeout prematurely.
 		return sr.defaults.ApplyTimeout
 	default:
 		return sr.defaults.DefaultTimeout

--- a/internal/runner/safe_runner.go
+++ b/internal/runner/safe_runner.go
@@ -80,7 +80,12 @@ func NewSafeRunner(config SafetyConfig) *SafeRunner {
 }
 
 // Execute runs a command with timeout, cancellation, and output limiting.
-func (sr *SafeRunner) Execute(ctx context.Context, projectDir, tool, command string) (*ExecutionResult, error) {
+//
+// env names the layered-v1 environment, threaded through to the
+// underlying Runner.buildArgs so pulumi commands receive an explicit
+// `--stack <env>`. Empty env runs in projectDir's own workspace
+// (flat layouts).
+func (sr *SafeRunner) Execute(ctx context.Context, projectDir, tool, command, env string) (*ExecutionResult, error) {
 	// Project-level lock — prevent concurrent executions on the same project
 	// which would cause terraform state lock contention and corruption.
 	sr.mu.Lock()
@@ -117,7 +122,7 @@ func (sr *SafeRunner) Execute(ctx context.Context, projectDir, tool, command str
 	}()
 
 	// Build command args
-	args := sr.runner.buildArgs(tool, command)
+	args := sr.runner.buildArgs(tool, command, env)
 	if len(args) == 0 {
 		return nil, fmt.Errorf("unknown tool/command: %s %s", tool, command)
 	}

--- a/internal/runner/safe_runner.go
+++ b/internal/runner/safe_runner.go
@@ -280,14 +280,18 @@ func (sr *SafeRunner) ExecutePlanJSON(ctx context.Context, projectDir, tool stri
 
 // RequiresApproval returns true if the command needs plan review first.
 // Covers both the Terraform/Ansible vocabulary ("apply", "destroy")
-// and Pulumi's native verbs ("up") so every destructive action lands
-// on the approval gate regardless of which tool the user picked.
+// and Pulumi's native verbs ("up", "refresh") so every state-mutating
+// action lands on the approval gate regardless of which tool the user
+// picked. refresh is gated because Pulumi's refresh re-reads and
+// overwrites the stack state file with whatever it observes in the
+// cloud — a surprise refresh can hide drift an operator wanted to
+// investigate.
 func (sr *SafeRunner) RequiresApproval(command string) bool {
 	if !sr.defaults.RequireApproval {
 		return false
 	}
 	switch command {
-	case "apply", "up", "destroy":
+	case "apply", "up", "destroy", "refresh":
 		return true
 	}
 	return false

--- a/internal/scaffold/layered_pulumi.go
+++ b/internal/scaffold/layered_pulumi.go
@@ -3,11 +3,61 @@ package scaffold
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/iac-studio/iac-studio/internal/parser"
 	"github.com/iac-studio/iac-studio/internal/pulumi"
 )
+
+// tagValueRE is a tool-agnostic accept pattern for free-form tag/
+// label values. Allows letters, digits, spaces, _.:/=+-@ — the
+// Terraform HCL-safe set without emphasising HCL in the error
+// message. Kept separate from validateHCLSafeValue (which exists in
+// the terraform blueprint with terraform-specific wording) so Pulumi
+// users don't see "generated HCL" hints when a value fails.
+var tagValueRE = regexp.MustCompile(`^[A-Za-z0-9 _.:/=+\-@]{1,128}$`)
+
+// gcpLabelRE tightens tag validation for GCP labels: values must be
+// [a-z0-9_-], ≤63 chars, non-empty. The Pulumi blueprint normalises
+// to this subset via sanitizeGCPLabel so a user-entered "Team A"
+// doesn't reach the provider as an invalid label.
+var gcpLabelRE = regexp.MustCompile(`^[a-z0-9_-]{0,63}$`)
+
+func validateTagValue(key, value string) error {
+	if value == "" {
+		return fmt.Errorf("%s must not be empty", key)
+	}
+	if !tagValueRE.MatchString(value) {
+		return fmt.Errorf("%s %q is invalid: use letters, digits, spaces, and _.:/=+-@ (≤128 chars)", key, value)
+	}
+	return nil
+}
+
+// sanitizeGCPLabel coerces an arbitrary value to the GCP label
+// charset. Lowercases, replaces anything outside [a-z0-9_-] with "_",
+// and clamps to 63 chars. Empty input returns "_" so the provider
+// accepts it (GCP rejects empty label values).
+func sanitizeGCPLabel(v string) string {
+	v = strings.ToLower(v)
+	var b strings.Builder
+	for _, r := range v {
+		switch {
+		case (r >= 'a' && r <= 'z'), (r >= '0' && r <= '9'), r == '-', r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('_')
+		}
+	}
+	out := b.String()
+	if out == "" {
+		return "_"
+	}
+	if len(out) > 63 {
+		out = out[:63]
+	}
+	return out
+}
 
 // LayeredPulumiBlueprint renders a multi-environment Pulumi
 // TypeScript project mirroring the layered-terraform structure:
@@ -67,7 +117,7 @@ func (b *LayeredPulumiBlueprint) Render(values map[string]any) ([]File, error) {
 	}
 	region := stringInput(values, "region", "us-east-1")
 	owner := stringInput(values, "owner_tag", "platform")
-	if err := validateHCLSafeValue("owner_tag", owner); err != nil {
+	if err := validateTagValue("owner_tag", owner); err != nil {
 		return nil, err
 	}
 
@@ -76,8 +126,10 @@ func (b *LayeredPulumiBlueprint) Render(values map[string]any) ([]File, error) {
 	// `pulumi preview` succeeds immediately after scaffolding without
 	// requiring the user to edit index.ts by hand. owner_tag flows
 	// onto the seed's tags so the configured value round-trips to
-	// real infrastructure instead of being a decorative input.
-	seed := seedResourcesFor(cloud, name, owner)
+	// real infrastructure instead of being a decorative input. region
+	// is threaded through so the seed's location matches the stack
+	// config (previously hardcoded to US / WestUS2 regardless).
+	seed := seedResourcesFor(cloud, name, owner, region)
 
 	var files []File
 	for _, env := range envs {
@@ -138,15 +190,20 @@ func (b *LayeredPulumiBlueprint) Render(values map[string]any) ([]File, error) {
 // looks like an empty project and misleads new users.
 //
 // owner is stamped onto the resource's tags (or GCP-native labels) so
-// the scaffold's owner_tag input isn't a decorative no-op — it round-
-// trips through the generator into real infrastructure metadata.
-func seedResourcesFor(cloud, projectName, owner string) []parser.Resource {
+// the scaffold's owner_tag input isn't a decorative no-op. region
+// drives the seed's location value too — the stack config already
+// carries it, and forcing a hardcoded "US" / "WestUS2" would create a
+// confusing mismatch between stack yaml and resource location.
+func seedResourcesFor(cloud, projectName, owner, region string) []parser.Resource {
 	// AWS/Azure accept PascalCase tag keys; GCP labels must be
-	// lowercase and typically snake_case (`[a-z0-9_-]`). Build both
-	// shapes and pick per cloud rather than reusing one map across
-	// all three.
+	// lowercase [a-z0-9_-] so values get sanitised rather than just
+	// lowercased — "Team A" → "team_a" so the provider doesn't reject
+	// at apply time.
 	awsAzureTags := map[string]any{"Owner": owner, "ManagedBy": "iac-studio"}
-	gcpLabels := map[string]any{"owner": strings.ToLower(owner), "managed_by": "iac-studio"}
+	gcpLabels := map[string]any{
+		"owner":      sanitizeGCPLabel(owner),
+		"managed_by": "iac-studio",
+	}
 	switch cloud {
 	case "aws":
 		return []parser.Resource{{
@@ -159,24 +216,36 @@ func seedResourcesFor(cloud, projectName, owner string) []parser.Resource {
 			},
 		}}
 	case "gcp":
+		// GCS bucket locations use short names (US, EU, ASIA) or
+		// specific multi-regions. If the user provided a canonical
+		// region like us-central1 we fall back to US so the seed
+		// doesn't reject; hand-editable after scaffold.
+		loc := "US"
+		if region != "" && !strings.Contains(region, "-") {
+			loc = strings.ToUpper(region)
+		}
 		return []parser.Resource{{
 			ID:   "google_storage_bucket.seed",
 			Type: "google_storage_bucket",
 			Name: projectName + "_seed",
 			Properties: map[string]any{
 				"name":     projectName + "-seed",
-				"location": "US",
+				"location": loc,
 				"labels":   gcpLabels,
 			},
 		}}
 	case "azure":
+		loc := region
+		if loc == "" {
+			loc = "WestUS2"
+		}
 		return []parser.Resource{{
 			ID:   "azurerm_resource_group.seed",
 			Type: "azurerm_resource_group",
 			Name: projectName + "_seed",
 			Properties: map[string]any{
 				"name":     projectName + "-rg",
-				"location": "WestUS2",
+				"location": loc,
 				"tags":     awsAzureTags,
 			},
 		}}

--- a/internal/scaffold/layered_pulumi.go
+++ b/internal/scaffold/layered_pulumi.go
@@ -10,6 +10,13 @@ import (
 	"github.com/iac-studio/iac-studio/internal/pulumi"
 )
 
+// gcpRegionRE matches Google Cloud's canonical region/zone shape —
+// one or more lowercase letters, a hyphen, one or more lowercase
+// letters, ending in digits (us-central1, europe-west2, asia-
+// northeast3). Used to distinguish a real GCP region from AWS-shaped
+// inputs ("us-east-1") when selecting a GCS bucket location.
+var gcpRegionRE = regexp.MustCompile(`^[a-z]+-[a-z]+[0-9]+$`)
+
 // tagValueRE is a tool-agnostic accept pattern for free-form tag/
 // label values. Allows letters, digits, spaces, _.:/=+-@ — the
 // Terraform HCL-safe set without emphasising HCL in the error
@@ -242,12 +249,22 @@ func seedResourcesFor(cloud, projectName, owner, region string) []parser.Resourc
 			},
 		}}
 	case "gcp":
-		// GCS bucket locations use short names (US, EU, ASIA) or
-		// specific multi-regions. If the user provided a canonical
-		// region like us-central1 we fall back to US so the seed
-		// doesn't reject; hand-editable after scaffold.
+		// GCS accepts both canonical regions (us-central1, europe-
+		// west1) and short multi-regions (US, EU, ASIA). Pass the
+		// user's value through when it looks like a canonical GCP
+		// region, uppercase it when it's already a short multi-
+		// region, and fall back to US for AWS-shaped inputs
+		// (us-east-1, us-west-2) or empty.
 		loc := "US"
-		if region != "" && !strings.Contains(region, "-") {
+		switch {
+		case region == "":
+			// fall through to default
+		case gcpRegionRE.MatchString(region):
+			loc = region
+		case len(region) <= 4 && region == strings.ToUpper(region):
+			// Short multi-region as-is (US, EU, ASIA).
+			loc = region
+		case len(region) <= 4:
 			loc = strings.ToUpper(region)
 		}
 		return []parser.Resource{{
@@ -336,7 +353,11 @@ func renderPulumiProjectReadme(name, cloud string, envs []string) string {
 	b.WriteString("pulumi login                     # one-time — pick a backend (local / Pulumi Cloud)\n")
 	b.WriteString("./scripts/init.sh                # npm install in each environments/<env>\n")
 	for _, env := range envs {
-		fmt.Fprintf(&b, "pulumi stack init %s             # once per env — creates the Pulumi stack\n", env)
+		// `pulumi stack init` reads Pulumi.yaml from the working dir,
+		// which under layered-pulumi lives at environments/<env>/,
+		// not the repo root. Using --cwd keeps the commands runnable
+		// as-is from the README without a per-step cd.
+		fmt.Fprintf(&b, "pulumi --cwd environments/%s stack init %s   # once per env — creates the Pulumi stack\n", env, env)
 	}
 	b.WriteString("```\n\n")
 	b.WriteString("## Daily use\n\n")

--- a/internal/scaffold/layered_pulumi.go
+++ b/internal/scaffold/layered_pulumi.go
@@ -28,6 +28,26 @@ func validateTagValue(key, value string) error {
 	return nil
 }
 
+// truncateForBucketName clamps a base name to max chars while keeping
+// the name valid as an S3/GCS bucket (must end in an alphanumeric,
+// no trailing '-' or '_'). Used when composing `<project>-seed` +
+// `<project>-<env>` so long project names don't blow the 63-char
+// provider cap.
+func truncateForBucketName(base string, max int) string {
+	if len(base) <= max {
+		return base
+	}
+	out := base[:max]
+	for len(out) > 0 {
+		last := out[len(out)-1]
+		if (last >= 'a' && last <= 'z') || (last >= '0' && last <= '9') {
+			break
+		}
+		out = out[:len(out)-1]
+	}
+	return out
+}
+
 // sanitizeGCPLabel coerces an arbitrary value to the GCP label
 // charset. Lowercases, replaces anything outside [a-z0-9_-] with "_",
 // and clamps to 63 chars. Empty input returns "_" so the provider
@@ -127,8 +147,15 @@ func (b *LayeredPulumiBlueprint) Render(values map[string]any) ([]File, error) {
 
 	var files []File
 	for _, env := range envs {
+		// Pulumi project names must stay within 100 chars (validated
+		// by pulumi.ValidateProjectName) but the canonical Pulumi docs
+		// recommend keeping them short. Clamp base to leave room for
+		// the "-<env>" suffix. Env is at most 32 chars (scaffold-level
+		// validation) so a 60-char base leaves comfortable margin.
+		const maxBase = 60
+		projName := truncateForBucketName(name, maxBase) + "-" + env
 		proj := pulumi.ProjectConfig{
-			Name:         fmt.Sprintf("%s-%s", name, env),
+			Name:         projName,
 			Description:  fmt.Sprintf("%s — %s environment (Pulumi)", name, env),
 			Environments: []string{env},
 			Region:       region,
@@ -198,6 +225,11 @@ func seedResourcesFor(cloud, projectName, owner, region string) []parser.Resourc
 		"owner":      sanitizeGCPLabel(owner),
 		"managed_by": "iac-studio",
 	}
+	// Bucket names are capped at 63 chars across S3 and GCS. Leave
+	// room for the "-seed" suffix (5 chars) so long project names
+	// don't produce invalid bucket names at apply time.
+	const maxBucketBase = 63 - len("-seed")
+	bucketBase := truncateForBucketName(projectName, maxBucketBase)
 	switch cloud {
 	case "aws":
 		return []parser.Resource{{
@@ -205,7 +237,7 @@ func seedResourcesFor(cloud, projectName, owner, region string) []parser.Resourc
 			Type: "aws_s3_bucket",
 			Name: projectName + "_seed",
 			Properties: map[string]any{
-				"bucket": projectName + "-seed",
+				"bucket": bucketBase + "-seed",
 				"tags":   awsAzureTags,
 			},
 		}}
@@ -223,7 +255,7 @@ func seedResourcesFor(cloud, projectName, owner, region string) []parser.Resourc
 			Type: "google_storage_bucket",
 			Name: projectName + "_seed",
 			Properties: map[string]any{
-				"name":     projectName + "-seed",
+				"name":     bucketBase + "-seed",
 				"location": loc,
 				"labels":   gcpLabels,
 			},

--- a/internal/scaffold/layered_pulumi.go
+++ b/internal/scaffold/layered_pulumi.go
@@ -1,0 +1,249 @@
+package scaffold
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/iac-studio/iac-studio/internal/parser"
+	"github.com/iac-studio/iac-studio/internal/pulumi"
+)
+
+// LayeredPulumiBlueprint renders a multi-environment Pulumi
+// TypeScript project mirroring the layered-terraform structure:
+//
+//	environments/{env}/{index.ts, Pulumi.yaml, Pulumi.<env>.yaml,
+//	                    package.json, tsconfig.json, .gitignore}
+//	modules/{module}/README.md            (stub — TS modules ship as
+//	                                       ComponentResources in a later
+//	                                       commit)
+//	scripts/{init,plan,apply,destroy}.sh
+//	README.md, .iac-studio.json
+//
+// Each environment is a self-contained Pulumi project — same pattern as
+// Terraform's per-env root directory. True dual-stack (some envs on
+// Terraform, others on Pulumi in the same project) is a follow-up that
+// extends this blueprint with a per-env tool selector. For now the
+// user picks Pulumi OR Terraform at project creation time.
+type LayeredPulumiBlueprint struct{}
+
+func (b *LayeredPulumiBlueprint) ID() string          { return "layered-pulumi" }
+func (b *LayeredPulumiBlueprint) Name() string        { return "Layered Pulumi (TypeScript)" }
+func (b *LayeredPulumiBlueprint) Description() string {
+	return "Multi-environment Pulumi TypeScript project with per-stack configs and lifecycle scripts. Parallel to the layered-terraform blueprint but uses Pulumi instead of HCL."
+}
+func (b *LayeredPulumiBlueprint) Tool() string { return "pulumi" }
+
+func (b *LayeredPulumiBlueprint) Inputs() []Input {
+	return []Input{
+		{Key: "project_name", Label: "Project name", Type: "string", Required: true},
+		{Key: "cloud", Label: "Primary cloud provider", Type: "select",
+			Options: []string{"aws", "gcp", "azure"}, Default: "aws", Required: true},
+		{Key: "environments", Label: "Environments", Type: "multiselect",
+			Options: []string{"dev", "staging", "prod"}, Default: []string{"dev", "prod"}},
+		{Key: "region", Label: "Primary region", Type: "string", Default: "us-east-1",
+			Description: "Baked into each Pulumi.<env>.yaml as <provider>:region."},
+		{Key: "owner_tag", Label: "Owner tag", Type: "string", Default: "platform"},
+	}
+}
+
+func (b *LayeredPulumiBlueprint) Render(values map[string]any) ([]File, error) {
+	name := stringInput(values, "project_name", "")
+	if err := validateSafeName("project_name", name); err != nil {
+		return nil, err
+	}
+	cloud := stringInput(values, "cloud", "aws")
+	switch cloud {
+	case "aws", "gcp", "azure":
+	default:
+		return nil, fmt.Errorf("cloud %q is unsupported: must be one of aws, gcp, azure", cloud)
+	}
+	envs := stringSliceInput(values, "environments", []string{"dev", "prod"})
+	for _, env := range envs {
+		if err := validatePathSegment("environment", env); err != nil {
+			return nil, err
+		}
+	}
+	region := stringInput(values, "region", "us-east-1")
+	owner := stringInput(values, "owner_tag", "platform")
+	if err := validateHCLSafeValue("owner_tag", owner); err != nil {
+		return nil, err
+	}
+
+	// A minimal seed resource per cloud so the generated program isn't
+	// empty. Users replace/extend via the canvas; the seed exists so
+	// `pulumi preview` succeeds immediately after scaffolding without
+	// requiring the user to edit index.ts by hand.
+	seed := seedResourcesFor(cloud, name)
+
+	var files []File
+	for _, env := range envs {
+		proj := pulumi.ProjectConfig{
+			Name:         fmt.Sprintf("%s-%s", name, env),
+			Description:  fmt.Sprintf("%s — %s environment (Pulumi)", name, env),
+			Environments: []string{env},
+			Region:       region,
+			Resources:    seed,
+		}
+		emitted, err := pulumi.GenerateProject(proj)
+		if err != nil {
+			return files, fmt.Errorf("generate pulumi project for env %q: %w", env, err)
+		}
+		for _, f := range emitted {
+			files = append(files, File{
+				Path:    fmt.Sprintf("environments/%s/%s", env, f.Path),
+				Content: f.Content,
+			})
+		}
+	}
+
+	// Top-level docs + lifecycle scripts. Scripts wrap the Pulumi CLI
+	// so a user can run `./scripts/plan.sh dev` without memorising the
+	// per-env cd dance.
+	files = append(files, File{
+		Path:    "README.md",
+		Content: []byte(renderPulumiProjectReadme(name, cloud, envs)),
+	})
+	files = append(files, File{
+		Path:    ".iac-studio.json",
+		Content: []byte(fmt.Sprintf(`{
+  "tool": "pulumi",
+  "blueprint": "layered-pulumi",
+  "project_name": %q,
+  "cloud": %q,
+  "environments": %s,
+  "layout": "layered-v1"
+}
+`, name, cloud, jsonStringSlice(envs))),
+	})
+	files = append(files, pulumiLifecycleScripts()...)
+	files = append(files, File{
+		Path:    ".gitignore",
+		Content: []byte("node_modules/\nbin/\n*.log\n*.tsbuildinfo\n.pulumi/\n"),
+	})
+
+	return files, nil
+}
+
+// seedResourcesFor returns one token resource per supported cloud so
+// the scaffolded program is runnable out of the box. The canvas layer
+// replaces these as the user designs real infrastructure; without a
+// seed, `pulumi preview` would succeed with zero resources which
+// looks like an empty project and misleads new users.
+func seedResourcesFor(cloud, projectName string) []parser.Resource {
+	switch cloud {
+	case "aws":
+		return []parser.Resource{{
+			ID:   "aws_s3_bucket.seed",
+			Type: "aws_s3_bucket",
+			Name: projectName + "_seed",
+			Properties: map[string]any{
+				"bucket": projectName + "-seed",
+			},
+		}}
+	case "gcp":
+		return []parser.Resource{{
+			ID:   "google_storage_bucket.seed",
+			Type: "google_storage_bucket",
+			Name: projectName + "_seed",
+			Properties: map[string]any{
+				"name":     projectName + "-seed",
+				"location": "US",
+			},
+		}}
+	case "azure":
+		return []parser.Resource{{
+			ID:   "azurerm_resource_group.seed",
+			Type: "azurerm_resource_group",
+			Name: projectName + "_seed",
+			Properties: map[string]any{
+				"name":     projectName + "-rg",
+				"location": "WestUS2",
+			},
+		}}
+	}
+	return nil
+}
+
+// pulumiLifecycleScripts emits scripts/{init,plan,apply,destroy}.sh
+// that wrap the Pulumi CLI with the per-env cd boilerplate. Matches
+// the shape of the layered-terraform scripts so muscle memory carries
+// over between tools.
+func pulumiLifecycleScripts() []File {
+	initSh := `#!/usr/bin/env bash
+set -euo pipefail
+# Installs node_modules for every environment project. Run once after
+# cloning. Requires: pulumi, node, npm. The SafeRunner calls the
+# equivalent on the 'init' command when driving commands from the UI.
+cd "$(dirname "$0")/.."
+for dir in environments/*/; do
+  echo "→ npm install in $dir"
+  (cd "$dir" && npm install)
+done
+`
+	planSh := `#!/usr/bin/env bash
+set -euo pipefail
+# Usage: ./scripts/plan.sh <env>
+env="${1:?env required — usage: ./scripts/plan.sh <env>}"
+cd "$(dirname "$0")/../environments/$env"
+pulumi preview --non-interactive --color=never
+`
+	applySh := `#!/usr/bin/env bash
+set -euo pipefail
+# Usage: ./scripts/apply.sh <env>
+env="${1:?env required — usage: ./scripts/apply.sh <env>}"
+cd "$(dirname "$0")/../environments/$env"
+pulumi up --yes --non-interactive --color=never
+`
+	destroySh := `#!/usr/bin/env bash
+set -euo pipefail
+# Usage: ./scripts/destroy.sh <env>
+env="${1:?env required — usage: ./scripts/destroy.sh <env>}"
+cd "$(dirname "$0")/../environments/$env"
+pulumi destroy --yes --non-interactive --color=never
+`
+	return []File{
+		{Path: "scripts/init.sh", Content: []byte(initSh), Executable: true},
+		{Path: "scripts/plan.sh", Content: []byte(planSh), Executable: true},
+		{Path: "scripts/apply.sh", Content: []byte(applySh), Executable: true},
+		{Path: "scripts/destroy.sh", Content: []byte(destroySh), Executable: true},
+	}
+}
+
+func renderPulumiProjectReadme(name, cloud string, envs []string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# %s\n\n", name)
+	fmt.Fprintf(&b, "Pulumi TypeScript project scaffolded by IaC Studio, targeting **%s**.\n\n", cloud)
+	b.WriteString("## Layout\n\n")
+	b.WriteString("- `environments/{env}/` — one self-contained Pulumi project per environment.\n")
+	b.WriteString("- `scripts/{init,plan,apply,destroy}.sh` — lifecycle wrappers that cd into the selected environment and run the Pulumi CLI.\n\n")
+	b.WriteString("## Bootstrap\n\n")
+	b.WriteString("```bash\n")
+	b.WriteString("pulumi login                     # one-time — pick a backend (local / Pulumi Cloud)\n")
+	b.WriteString("./scripts/init.sh                # npm install in each environments/<env>\n")
+	for _, env := range envs {
+		fmt.Fprintf(&b, "pulumi stack init %s             # once per env — creates the Pulumi stack\n", env)
+	}
+	b.WriteString("```\n\n")
+	b.WriteString("## Daily use\n\n")
+	b.WriteString("```bash\n")
+	b.WriteString("./scripts/plan.sh dev            # pulumi preview in environments/dev\n")
+	b.WriteString("./scripts/apply.sh dev           # pulumi up --yes\n")
+	b.WriteString("```\n")
+	return b.String()
+}
+
+// jsonStringSlice renders a string slice as a JSON array literal —
+// used inside the .iac-studio.json content template which is already
+// a hand-written JSON string. Saves pulling in encoding/json just for
+// this one-line formatter.
+func jsonStringSlice(items []string) string {
+	quoted := make([]string, len(items))
+	for i, s := range items {
+		quoted[i] = fmt.Sprintf("%q", s)
+	}
+	return "[" + strings.Join(quoted, ", ") + "]"
+}
+
+func init() {
+	Default.Register(&LayeredPulumiBlueprint{})
+}

--- a/internal/scaffold/layered_pulumi.go
+++ b/internal/scaffold/layered_pulumi.go
@@ -304,8 +304,12 @@ func pulumiLifecycleScripts() []File {
 	initSh := `#!/usr/bin/env bash
 set -euo pipefail
 # Installs node_modules for every environment project. Run once after
-# cloning. Requires: pulumi, node, npm. The SafeRunner calls the
-# equivalent on the 'init' command when driving commands from the UI.
+# cloning. Requires: pulumi, node, npm.
+#
+# Note: this wrapper performs a per-environment install for layered
+# projects. The SafeRunner's 'init' command for Pulumi only runs 'npm
+# install' in the project root (suitable for flat Pulumi layouts);
+# layered users should run this script directly for now.
 cd "$(dirname "$0")/.."
 for dir in environments/*/; do
   echo "→ npm install in $dir"

--- a/internal/scaffold/layered_pulumi.go
+++ b/internal/scaffold/layered_pulumi.go
@@ -159,10 +159,15 @@ func (b *LayeredPulumiBlueprint) Render(values map[string]any) ([]File, error) {
 	// mismatch. Reject up front so the caller fixes the input.
 	if cloud == "gcp" && !gcpRegionRE.MatchString(region) {
 		// Allow short multi-regions (US, EU, ASIA) too — GCS accepts
-		// those and so does the provider config.
+		// those and so does the provider config. Normalize casing
+		// here so a lower/mixed input ("us", "Us") becomes the
+		// canonical "US" before it hits Pulumi.<env>.yaml; an
+		// un-normalised value would emit `gcp:region: us` which
+		// the provider rejects.
 		if len(region) > 4 || strings.ContainsAny(region, "0123456789-") {
 			return nil, fmt.Errorf("region %q is not a valid GCP region (expected canonical form like us-central1 or short multi-region like US/EU/ASIA)", region)
 		}
+		region = strings.ToUpper(region)
 	}
 	owner := stringInput(values, "owner_tag", "platform")
 	if err := validateTagValue("owner_tag", owner); err != nil {

--- a/internal/scaffold/layered_pulumi.go
+++ b/internal/scaffold/layered_pulumi.go
@@ -10,12 +10,13 @@ import (
 	"github.com/iac-studio/iac-studio/internal/pulumi"
 )
 
-// gcpRegionRE matches Google Cloud's canonical region/zone shape —
-// one or more lowercase letters, a hyphen, one or more lowercase
-// letters, ending in digits (us-central1, europe-west2, asia-
-// northeast3). Used to distinguish a real GCP region from AWS-shaped
-// inputs ("us-east-1") when selecting a GCS bucket location.
-var gcpRegionRE = regexp.MustCompile(`^[a-z]+-[a-z]+[0-9]+$`)
+// gcpRegionRE matches Google Cloud's canonical region shape —
+// lowercase alphabetic segments separated by hyphens, ending in a
+// digit suffix. Covers us-central1, europe-west2, asia-northeast3,
+// AND the longer forms like northamerica-northeast1 / southamerica-
+// east1. Deliberately excludes zones (us-central1-a, trailing -a/b/c)
+// since GCS bucket locations take regions, not zones.
+var gcpRegionRE = regexp.MustCompile(`^[a-z]+(-[a-z]+)+[0-9]+$`)
 
 // tagValueRE is a tool-agnostic accept pattern for free-form tag/
 // label values. Allows letters, digits, spaces, _.:/=+-@ — the
@@ -113,8 +114,8 @@ func (b *LayeredPulumiBlueprint) Inputs() []Input {
 			Options: []string{"aws", "gcp", "azure"}, Default: "aws", Required: true},
 		{Key: "environments", Label: "Environments", Type: "multiselect",
 			Options: []string{"dev", "staging", "prod"}, Default: []string{"dev", "prod"}},
-		{Key: "region", Label: "Primary region / location", Type: "string", Default: "us-east-1",
-			Description: "Baked into each Pulumi.<env>.yaml using the cloud-specific config key: aws:region / gcp:region / azure-native:location."},
+		{Key: "region", Label: "Primary region / location", Type: "string", Default: "",
+			Description: "Baked into each Pulumi.<env>.yaml using the cloud-specific config key: aws:region / gcp:region / azure-native:location. Leave empty to use the per-cloud default (us-east-1 for AWS, us-central1 for GCP, WestUS2 for Azure)."},
 		{Key: "owner_tag", Label: "Owner tag", Type: "string", Default: "platform"},
 	}
 }
@@ -136,21 +137,25 @@ func (b *LayeredPulumiBlueprint) Render(values map[string]any) ([]File, error) {
 			return nil, err
 		}
 	}
-	region := stringInput(values, "region", "us-east-1")
+	// Default is empty — per-cloud fallback happens inside Pulumi's
+	// generator (aws: us-east-1, gcp: us-central1, azure: WestUS2).
+	// Only substitute a cloud-appropriate default at scaffold time so
+	// the seed resource locations match what ends up in Pulumi.<env>.yaml.
+	region := stringInput(values, "region", "")
+	if region == "" {
+		switch cloud {
+		case "gcp":
+			region = "us-central1"
+		case "azure":
+			region = "WestUS2"
+		default:
+			region = "us-east-1"
+		}
+	}
 	owner := stringInput(values, "owner_tag", "platform")
 	if err := validateTagValue("owner_tag", owner); err != nil {
 		return nil, err
 	}
-
-	// A minimal seed resource per cloud so the generated program isn't
-	// empty. Users replace/extend via the canvas; the seed exists so
-	// `pulumi preview` succeeds immediately after scaffolding without
-	// requiring the user to edit index.ts by hand. owner_tag flows
-	// onto the seed's tags so the configured value round-trips to
-	// real infrastructure instead of being a decorative input. region
-	// is threaded through so the seed's location matches the stack
-	// config (previously hardcoded to US / WestUS2 regardless).
-	seed := seedResourcesFor(cloud, name, owner, region)
 
 	var files []File
 	for _, env := range envs {
@@ -161,6 +166,13 @@ func (b *LayeredPulumiBlueprint) Render(values map[string]any) ([]File, error) {
 		// validation) so a 60-char base leaves comfortable margin.
 		const maxBase = 60
 		projName := truncateForBucketName(name, maxBase) + "-" + env
+
+		// Seed resources are generated PER-ENV so cloud-global names
+		// (S3 / GCS buckets, Azure resource groups) stay unique across
+		// stacks in the same account. A shared <project>-seed bucket
+		// would make `pulumi up` in prod collide with dev.
+		seed := seedResourcesFor(cloud, name, env, owner, region)
+
 		proj := pulumi.ProjectConfig{
 			Name:         projName,
 			Description:  fmt.Sprintf("%s — %s environment (Pulumi)", name, env),
@@ -217,25 +229,35 @@ func (b *LayeredPulumiBlueprint) Render(values map[string]any) ([]File, error) {
 // seed, `pulumi preview` would succeed with zero resources which
 // looks like an empty project and misleads new users.
 //
-// owner is stamped onto the resource's tags (or GCP-native labels) so
-// the scaffold's owner_tag input isn't a decorative no-op. region
+// env is suffixed to every cloud-global name (S3/GCS bucket, Azure
+// resource group) so running `pulumi up` in multiple stacks from the
+// same account doesn't collide on a shared "<project>-seed" identifier
+// — dev apply and prod apply must produce distinct cloud resources.
+//
+// owner is stamped onto the resource's tags (or GCP-native labels)
+// so the scaffold's owner_tag input isn't a decorative no-op. region
 // drives the seed's location value too — the stack config already
 // carries it, and forcing a hardcoded "US" / "WestUS2" would create a
 // confusing mismatch between stack yaml and resource location.
-func seedResourcesFor(cloud, projectName, owner, region string) []parser.Resource {
+func seedResourcesFor(cloud, projectName, env, owner, region string) []parser.Resource {
 	// AWS/Azure accept PascalCase tag keys; GCP labels must be
 	// lowercase [a-z0-9_-] so values get sanitised rather than just
 	// lowercased — "Team A" → "team_a" so the provider doesn't reject
 	// at apply time.
-	awsAzureTags := map[string]any{"Owner": owner, "ManagedBy": "iac-studio"}
+	awsAzureTags := map[string]any{"Owner": owner, "ManagedBy": "iac-studio", "Environment": env}
 	gcpLabels := map[string]any{
-		"owner":      sanitizeGCPLabel(owner),
-		"managed_by": "iac-studio",
+		"owner":       sanitizeGCPLabel(owner),
+		"managed_by":  "iac-studio",
+		"environment": sanitizeGCPLabel(env),
 	}
 	// Bucket names are capped at 63 chars across S3 and GCS. Leave
-	// room for the "-seed" suffix (5 chars) so long project names
-	// don't produce invalid bucket names at apply time.
-	const maxBucketBase = 63 - len("-seed")
+	// room for the "-<env>-seed" suffix so long project names plus
+	// long env names don't produce invalid bucket names at apply time.
+	suffix := "-" + env + "-seed"
+	maxBucketBase := 63 - len(suffix)
+	if maxBucketBase < 3 {
+		maxBucketBase = 3 // S3 bucket-name floor
+	}
 	bucketBase := truncateForBucketName(projectName, maxBucketBase)
 	switch cloud {
 	case "aws":
@@ -244,7 +266,7 @@ func seedResourcesFor(cloud, projectName, owner, region string) []parser.Resourc
 			Type: "aws_s3_bucket",
 			Name: projectName + "_seed",
 			Properties: map[string]any{
-				"bucket": bucketBase + "-seed",
+				"bucket": bucketBase + suffix,
 				"tags":   awsAzureTags,
 			},
 		}}
@@ -272,7 +294,7 @@ func seedResourcesFor(cloud, projectName, owner, region string) []parser.Resourc
 			Type: "google_storage_bucket",
 			Name: projectName + "_seed",
 			Properties: map[string]any{
-				"name":     bucketBase + "-seed",
+				"name":     bucketBase + suffix,
 				"location": loc,
 				"labels":   gcpLabels,
 			},
@@ -282,12 +304,15 @@ func seedResourcesFor(cloud, projectName, owner, region string) []parser.Resourc
 		if loc == "" {
 			loc = "WestUS2"
 		}
+		// Resource-group names are scoped per-subscription and capped
+		// at 90 chars. Env-scope the name so dev + prod can coexist.
+		rgName := projectName + "-" + env + "-rg"
 		return []parser.Resource{{
 			ID:   "azurerm_resource_group.seed",
 			Type: "azurerm_resource_group",
 			Name: projectName + "_seed",
 			Properties: map[string]any{
-				"name":     projectName + "-rg",
+				"name":     rgName,
 				"location": loc,
 				"tags":     awsAzureTags,
 			},

--- a/internal/scaffold/layered_pulumi.go
+++ b/internal/scaffold/layered_pulumi.go
@@ -158,16 +158,18 @@ func (b *LayeredPulumiBlueprint) Render(values map[string]any) ([]File, error) {
 	// silently fall back to "US" multi-region, producing a confusing
 	// mismatch. Reject up front so the caller fixes the input.
 	if cloud == "gcp" && !gcpRegionRE.MatchString(region) {
-		// Allow short multi-regions (US, EU, ASIA) too — GCS accepts
-		// those and so does the provider config. Normalize casing
-		// here so a lower/mixed input ("us", "Us") becomes the
-		// canonical "US" before it hits Pulumi.<env>.yaml; an
-		// un-normalised value would emit `gcp:region: us` which
-		// the provider rejects.
-		if len(region) > 4 || strings.ContainsAny(region, "0123456789-") {
-			return nil, fmt.Errorf("region %q is not a valid GCP region (expected canonical form like us-central1 or short multi-region like US/EU/ASIA)", region)
+		// Allow short multi-regions only — GCS accepts US, EU, ASIA
+		// (and a small set of named multi-regions). Anything outside
+		// that allowlist would silently uppercase to a still-invalid
+		// value and fail at provider time. Normalise casing so a
+		// lower/mixed input ("us", "Us") becomes canonical before
+		// hitting Pulumi.<env>.yaml.
+		switch strings.ToUpper(region) {
+		case "US", "EU", "ASIA":
+			region = strings.ToUpper(region)
+		default:
+			return nil, fmt.Errorf("region %q is not a valid GCP region (expected canonical form like us-central1 or short multi-region US/EU/ASIA)", region)
 		}
-		region = strings.ToUpper(region)
 	}
 	owner := stringInput(values, "owner_tag", "platform")
 	if err := validateTagValue("owner_tag", owner); err != nil {
@@ -345,10 +347,15 @@ func seedResourcesFor(cloud, projectName, env, owner, region string) []parser.Re
 			ID:   "azurerm_resource_group.seed",
 			Type: "azurerm_resource_group",
 			Name: projectName + "_seed",
+			// Azure Native's ResourceGroup expects `resourceGroupName`,
+			// not `name`. Emit the snake_case form so the generator's
+			// camelCase pass produces the right Pulumi property name —
+			// otherwise tsc rejects the seed and the whole scaffold
+			// fails preview before touching the cloud.
 			Properties: map[string]any{
-				"name":     rgName,
-				"location": loc,
-				"tags":     awsAzureTags,
+				"resource_group_name": rgName,
+				"location":            loc,
+				"tags":                awsAzureTags,
 			},
 		}}
 	}
@@ -375,26 +382,31 @@ for dir in environments/*/; do
   (cd "$dir" && npm install)
 done
 `
+	// Every mutating verb pins --stack "$env" so the script can't
+	// silently target whatever stack happens to be workspace-selected
+	// in the env directory. Mirrors the runner-side guard in
+	// pulumiArgs(); without this, ./scripts/apply.sh dev could mutate
+	// stage if a developer ran `pulumi stack select stage` there.
 	planSh := `#!/usr/bin/env bash
 set -euo pipefail
 # Usage: ./scripts/plan.sh <env>
 env="${1:?env required — usage: ./scripts/plan.sh <env>}"
 cd "$(dirname "$0")/../environments/$env"
-pulumi preview --non-interactive --color=never
+pulumi preview --stack "$env" --non-interactive --color=never
 `
 	applySh := `#!/usr/bin/env bash
 set -euo pipefail
 # Usage: ./scripts/apply.sh <env>
 env="${1:?env required — usage: ./scripts/apply.sh <env>}"
 cd "$(dirname "$0")/../environments/$env"
-pulumi up --yes --non-interactive --color=never
+pulumi up --stack "$env" --yes --non-interactive --color=never
 `
 	destroySh := `#!/usr/bin/env bash
 set -euo pipefail
 # Usage: ./scripts/destroy.sh <env>
 env="${1:?env required — usage: ./scripts/destroy.sh <env>}"
 cd "$(dirname "$0")/../environments/$env"
-pulumi destroy --yes --non-interactive --color=never
+pulumi destroy --stack "$env" --yes --non-interactive --color=never
 `
 	return []File{
 		{Path: "scripts/init.sh", Content: []byte(initSh), Executable: true},

--- a/internal/scaffold/layered_pulumi.go
+++ b/internal/scaffold/layered_pulumi.go
@@ -13,17 +13,18 @@ import (
 //
 //	environments/{env}/{index.ts, Pulumi.yaml, Pulumi.<env>.yaml,
 //	                    package.json, tsconfig.json, .gitignore}
-//	modules/{module}/README.md            (stub — TS modules ship as
-//	                                       ComponentResources in a later
-//	                                       commit)
 //	scripts/{init,plan,apply,destroy}.sh
-//	README.md, .iac-studio.json
+//	README.md, .iac-studio.json, .gitignore
 //
 // Each environment is a self-contained Pulumi project — same pattern as
 // Terraform's per-env root directory. True dual-stack (some envs on
 // Terraform, others on Pulumi in the same project) is a follow-up that
 // extends this blueprint with a per-env tool selector. For now the
 // user picks Pulumi OR Terraform at project creation time.
+//
+// Reusable modules aren't emitted today: in Pulumi those are
+// ComponentResources rather than separate directory scaffolds, so
+// they belong in a later commit that ships a component helper library.
 type LayeredPulumiBlueprint struct{}
 
 func (b *LayeredPulumiBlueprint) ID() string          { return "layered-pulumi" }
@@ -40,8 +41,8 @@ func (b *LayeredPulumiBlueprint) Inputs() []Input {
 			Options: []string{"aws", "gcp", "azure"}, Default: "aws", Required: true},
 		{Key: "environments", Label: "Environments", Type: "multiselect",
 			Options: []string{"dev", "staging", "prod"}, Default: []string{"dev", "prod"}},
-		{Key: "region", Label: "Primary region", Type: "string", Default: "us-east-1",
-			Description: "Baked into each Pulumi.<env>.yaml as <provider>:region."},
+		{Key: "region", Label: "Primary region / location", Type: "string", Default: "us-east-1",
+			Description: "Baked into each Pulumi.<env>.yaml using the cloud-specific config key: aws:region / gcp:region / azure-native:location."},
 		{Key: "owner_tag", Label: "Owner tag", Type: "string", Default: "platform"},
 	}
 }
@@ -72,8 +73,10 @@ func (b *LayeredPulumiBlueprint) Render(values map[string]any) ([]File, error) {
 	// A minimal seed resource per cloud so the generated program isn't
 	// empty. Users replace/extend via the canvas; the seed exists so
 	// `pulumi preview` succeeds immediately after scaffolding without
-	// requiring the user to edit index.ts by hand.
-	seed := seedResourcesFor(cloud, name)
+	// requiring the user to edit index.ts by hand. owner_tag flows
+	// onto the seed's tags so the configured value round-trips to
+	// real infrastructure instead of being a decorative input.
+	seed := seedResourcesFor(cloud, name, owner)
 
 	var files []File
 	for _, env := range envs {
@@ -129,7 +132,12 @@ func (b *LayeredPulumiBlueprint) Render(values map[string]any) ([]File, error) {
 // replaces these as the user designs real infrastructure; without a
 // seed, `pulumi preview` would succeed with zero resources which
 // looks like an empty project and misleads new users.
-func seedResourcesFor(cloud, projectName string) []parser.Resource {
+//
+// owner is stamped onto the resource's tags so the scaffold's
+// owner_tag input isn't a decorative no-op — it round-trips through
+// the generator into real infrastructure metadata.
+func seedResourcesFor(cloud, projectName, owner string) []parser.Resource {
+	tags := map[string]any{"Owner": owner, "ManagedBy": "iac-studio"}
 	switch cloud {
 	case "aws":
 		return []parser.Resource{{
@@ -138,6 +146,7 @@ func seedResourcesFor(cloud, projectName string) []parser.Resource {
 			Name: projectName + "_seed",
 			Properties: map[string]any{
 				"bucket": projectName + "-seed",
+				"tags":   tags,
 			},
 		}}
 	case "gcp":
@@ -148,6 +157,7 @@ func seedResourcesFor(cloud, projectName string) []parser.Resource {
 			Properties: map[string]any{
 				"name":     projectName + "-seed",
 				"location": "US",
+				"labels":   tags, // GCP uses "labels", not "tags"
 			},
 		}}
 	case "azure":
@@ -158,6 +168,7 @@ func seedResourcesFor(cloud, projectName string) []parser.Resource {
 			Properties: map[string]any{
 				"name":     projectName + "-rg",
 				"location": "WestUS2",
+				"tags":     tags,
 			},
 		}}
 	}

--- a/internal/scaffold/layered_pulumi.go
+++ b/internal/scaffold/layered_pulumi.go
@@ -18,12 +18,6 @@ import (
 // users don't see "generated HCL" hints when a value fails.
 var tagValueRE = regexp.MustCompile(`^[A-Za-z0-9 _.:/=+\-@]{1,128}$`)
 
-// gcpLabelRE tightens tag validation for GCP labels: values must be
-// [a-z0-9_-], ≤63 chars, non-empty. The Pulumi blueprint normalises
-// to this subset via sanitizeGCPLabel so a user-entered "Team A"
-// doesn't reach the provider as an invalid label.
-var gcpLabelRE = regexp.MustCompile(`^[a-z0-9_-]{0,63}$`)
-
 func validateTagValue(key, value string) error {
 	if value == "" {
 		return fmt.Errorf("%s must not be empty", key)

--- a/internal/scaffold/layered_pulumi.go
+++ b/internal/scaffold/layered_pulumi.go
@@ -1,6 +1,7 @@
 package scaffold
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -106,17 +107,20 @@ func (b *LayeredPulumiBlueprint) Render(values map[string]any) ([]File, error) {
 		Path:    "README.md",
 		Content: []byte(renderPulumiProjectReadme(name, cloud, envs)),
 	})
+	descriptor, err := json.MarshalIndent(map[string]any{
+		"tool":         "pulumi",
+		"blueprint":    "layered-pulumi",
+		"project_name": name,
+		"cloud":        cloud,
+		"environments": envs,
+		"layout":       "layered-v1",
+	}, "", "  ")
+	if err != nil {
+		return files, fmt.Errorf("marshal .iac-studio.json: %w", err)
+	}
 	files = append(files, File{
 		Path:    ".iac-studio.json",
-		Content: []byte(fmt.Sprintf(`{
-  "tool": "pulumi",
-  "blueprint": "layered-pulumi",
-  "project_name": %q,
-  "cloud": %q,
-  "environments": %s,
-  "layout": "layered-v1"
-}
-`, name, cloud, jsonStringSlice(envs))),
+		Content: append(descriptor, '\n'),
 	})
 	files = append(files, pulumiLifecycleScripts()...)
 	files = append(files, File{
@@ -133,11 +137,16 @@ func (b *LayeredPulumiBlueprint) Render(values map[string]any) ([]File, error) {
 // seed, `pulumi preview` would succeed with zero resources which
 // looks like an empty project and misleads new users.
 //
-// owner is stamped onto the resource's tags so the scaffold's
-// owner_tag input isn't a decorative no-op — it round-trips through
-// the generator into real infrastructure metadata.
+// owner is stamped onto the resource's tags (or GCP-native labels) so
+// the scaffold's owner_tag input isn't a decorative no-op — it round-
+// trips through the generator into real infrastructure metadata.
 func seedResourcesFor(cloud, projectName, owner string) []parser.Resource {
-	tags := map[string]any{"Owner": owner, "ManagedBy": "iac-studio"}
+	// AWS/Azure accept PascalCase tag keys; GCP labels must be
+	// lowercase and typically snake_case (`[a-z0-9_-]`). Build both
+	// shapes and pick per cloud rather than reusing one map across
+	// all three.
+	awsAzureTags := map[string]any{"Owner": owner, "ManagedBy": "iac-studio"}
+	gcpLabels := map[string]any{"owner": strings.ToLower(owner), "managed_by": "iac-studio"}
 	switch cloud {
 	case "aws":
 		return []parser.Resource{{
@@ -146,7 +155,7 @@ func seedResourcesFor(cloud, projectName, owner string) []parser.Resource {
 			Name: projectName + "_seed",
 			Properties: map[string]any{
 				"bucket": projectName + "-seed",
-				"tags":   tags,
+				"tags":   awsAzureTags,
 			},
 		}}
 	case "gcp":
@@ -157,7 +166,7 @@ func seedResourcesFor(cloud, projectName, owner string) []parser.Resource {
 			Properties: map[string]any{
 				"name":     projectName + "-seed",
 				"location": "US",
-				"labels":   tags, // GCP uses "labels", not "tags"
+				"labels":   gcpLabels,
 			},
 		}}
 	case "azure":
@@ -168,7 +177,7 @@ func seedResourcesFor(cloud, projectName, owner string) []parser.Resource {
 			Properties: map[string]any{
 				"name":     projectName + "-rg",
 				"location": "WestUS2",
-				"tags":     tags,
+				"tags":     awsAzureTags,
 			},
 		}}
 	}
@@ -241,18 +250,6 @@ func renderPulumiProjectReadme(name, cloud string, envs []string) string {
 	b.WriteString("./scripts/apply.sh dev           # pulumi up --yes\n")
 	b.WriteString("```\n")
 	return b.String()
-}
-
-// jsonStringSlice renders a string slice as a JSON array literal —
-// used inside the .iac-studio.json content template which is already
-// a hand-written JSON string. Saves pulling in encoding/json just for
-// this one-line formatter.
-func jsonStringSlice(items []string) string {
-	quoted := make([]string, len(items))
-	for i, s := range items {
-		quoted[i] = fmt.Sprintf("%q", s)
-	}
-	return "[" + strings.Join(quoted, ", ") + "]"
 }
 
 func init() {

--- a/internal/scaffold/layered_pulumi.go
+++ b/internal/scaffold/layered_pulumi.go
@@ -250,10 +250,13 @@ func seedResourcesFor(cloud, projectName, env, owner, region string) []parser.Re
 		"managed_by":  "iac-studio",
 		"environment": sanitizeGCPLabel(env),
 	}
-	// Bucket names are capped at 63 chars across S3 and GCS. Leave
-	// room for the "-<env>-seed" suffix so long project names plus
-	// long env names don't produce invalid bucket names at apply time.
-	suffix := "-" + env + "-seed"
+	// Bucket names are capped at 63 chars across S3 and GCS AND must
+	// be DNS-compatible (no underscores). The env directory name is
+	// allowed to contain underscores (validatePathSegment), so we
+	// sanitize it for bucket-naming purposes only — tags/directory
+	// paths keep the original env.
+	bucketEnv := strings.ReplaceAll(env, "_", "-")
+	suffix := "-" + bucketEnv + "-seed"
 	maxBucketBase := 63 - len(suffix)
 	if maxBucketBase < 3 {
 		maxBucketBase = 3 // S3 bucket-name floor
@@ -306,7 +309,10 @@ func seedResourcesFor(cloud, projectName, env, owner, region string) []parser.Re
 		}
 		// Resource-group names are scoped per-subscription and capped
 		// at 90 chars. Env-scope the name so dev + prod can coexist.
-		rgName := projectName + "-" + env + "-rg"
+		// Use the underscore-sanitized env so the RG name stays
+		// hyphen-based (Azure allows underscores but hyphens read
+		// cleaner and match the bucket-naming convention above).
+		rgName := projectName + "-" + bucketEnv + "-rg"
 		return []parser.Resource{{
 			ID:   "azurerm_resource_group.seed",
 			Type: "azurerm_resource_group",

--- a/internal/scaffold/layered_pulumi.go
+++ b/internal/scaffold/layered_pulumi.go
@@ -152,6 +152,18 @@ func (b *LayeredPulumiBlueprint) Render(values map[string]any) ([]File, error) {
 			region = "us-east-1"
 		}
 	}
+	// Cloud-shape validation: an AWS-shaped region (us-east-1) on a
+	// GCP scaffold would emit gcp:region: us-east-1 in the stack
+	// config — invalid at provider time, AND the seed bucket would
+	// silently fall back to "US" multi-region, producing a confusing
+	// mismatch. Reject up front so the caller fixes the input.
+	if cloud == "gcp" && !gcpRegionRE.MatchString(region) {
+		// Allow short multi-regions (US, EU, ASIA) too — GCS accepts
+		// those and so does the provider config.
+		if len(region) > 4 || strings.ContainsAny(region, "0123456789-") {
+			return nil, fmt.Errorf("region %q is not a valid GCP region (expected canonical form like us-central1 or short multi-region like US/EU/ASIA)", region)
+		}
+	}
 	owner := stringInput(values, "owner_tag", "platform")
 	if err := validateTagValue("owner_tag", owner); err != nil {
 		return nil, err
@@ -182,7 +194,9 @@ func (b *LayeredPulumiBlueprint) Render(values map[string]any) ([]File, error) {
 		}
 		emitted, err := pulumi.GenerateProject(proj)
 		if err != nil {
-			return files, fmt.Errorf("generate pulumi project for env %q: %w", env, err)
+			// Match layered-terraform: (nil, err) on failure so callers
+			// don't accidentally write a partially-rendered scaffold.
+			return nil, fmt.Errorf("generate pulumi project for env %q: %w", env, err)
 		}
 		for _, f := range emitted {
 			files = append(files, File{
@@ -208,7 +222,7 @@ func (b *LayeredPulumiBlueprint) Render(values map[string]any) ([]File, error) {
 		"layout":       "layered-v1",
 	}, "", "  ")
 	if err != nil {
-		return files, fmt.Errorf("marshal .iac-studio.json: %w", err)
+		return nil, fmt.Errorf("marshal .iac-studio.json: %w", err)
 	}
 	files = append(files, File{
 		Path:    ".iac-studio.json",

--- a/internal/scaffold/layered_pulumi.go
+++ b/internal/scaffold/layered_pulumi.go
@@ -312,7 +312,16 @@ func seedResourcesFor(cloud, projectName, env, owner, region string) []parser.Re
 		// Use the underscore-sanitized env so the RG name stays
 		// hyphen-based (Azure allows underscores but hyphens read
 		// cleaner and match the bucket-naming convention above).
-		rgName := projectName + "-" + bucketEnv + "-rg"
+		// Truncate the project-name segment when the total would blow
+		// the 90-char cap — projectName=63 + env=32 + '-rg'=3 +
+		// separators = up to 100.
+		rgSuffix := "-" + bucketEnv + "-rg"
+		maxRGBase := 90 - len(rgSuffix)
+		if maxRGBase < 1 {
+			maxRGBase = 1
+		}
+		rgBase := truncateForBucketName(projectName, maxRGBase)
+		rgName := rgBase + rgSuffix
 		return []parser.Resource{{
 			ID:   "azurerm_resource_group.seed",
 			Type: "azurerm_resource_group",

--- a/internal/scaffold/layered_pulumi_test.go
+++ b/internal/scaffold/layered_pulumi_test.go
@@ -1,0 +1,169 @@
+package scaffold
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLayeredPulumi_RendersPerEnvProject(t *testing.T) {
+	bp := &LayeredPulumiBlueprint{}
+	files, err := bp.Render(map[string]any{
+		"project_name": "acme-infra",
+		"cloud":        "aws",
+		"environments": []string{"dev", "prod"},
+		"region":       "eu-west-1",
+	})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+
+	// Every env gets its own Pulumi project files.
+	mustHave := []string{
+		"environments/dev/Pulumi.yaml",
+		"environments/dev/Pulumi.dev.yaml",
+		"environments/dev/index.ts",
+		"environments/dev/package.json",
+		"environments/prod/Pulumi.yaml",
+		"environments/prod/Pulumi.prod.yaml",
+		"environments/prod/index.ts",
+		"scripts/init.sh",
+		"scripts/plan.sh",
+		"scripts/apply.sh",
+		"scripts/destroy.sh",
+		"README.md",
+		".iac-studio.json",
+		".gitignore",
+	}
+	present := map[string]bool{}
+	for _, f := range files {
+		present[filepath.ToSlash(f.Path)] = true
+	}
+	for _, path := range mustHave {
+		if !present[path] {
+			t.Errorf("missing expected file %q", path)
+		}
+	}
+}
+
+func TestLayeredPulumi_ProjectDescriptorCarriesLayoutHint(t *testing.T) {
+	bp := &LayeredPulumiBlueprint{}
+	files, err := bp.Render(map[string]any{
+		"project_name": "acme",
+		"cloud":        "gcp",
+		"environments": []string{"dev"},
+	})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+
+	// .iac-studio.json should carry the tool + layered-v1 marker so
+	// the frontend swimlane view picks the right classifier.
+	var descriptor string
+	for _, f := range files {
+		if f.Path == ".iac-studio.json" {
+			descriptor = string(f.Content)
+		}
+	}
+	if descriptor == "" {
+		t.Fatal(".iac-studio.json not emitted")
+	}
+	for _, want := range []string{
+		`"tool": "pulumi"`,
+		`"blueprint": "layered-pulumi"`,
+		`"layout": "layered-v1"`,
+		`"cloud": "gcp"`,
+	} {
+		if !strings.Contains(descriptor, want) {
+			t.Errorf("descriptor missing %q in:\n%s", want, descriptor)
+		}
+	}
+}
+
+func TestLayeredPulumi_SeedResourceMatchesCloud(t *testing.T) {
+	cases := []struct {
+		cloud       string
+		wantInIndex string
+	}{
+		{"aws", "aws.s3.Bucket"},
+		{"gcp", "gcp.storage.Bucket"},
+		{"azure", "azure.resources.ResourceGroup"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.cloud, func(t *testing.T) {
+			bp := &LayeredPulumiBlueprint{}
+			files, err := bp.Render(map[string]any{
+				"project_name": "seed-test",
+				"cloud":        tc.cloud,
+				"environments": []string{"dev"},
+			})
+			if err != nil {
+				t.Fatalf("Render: %v", err)
+			}
+			for _, f := range files {
+				if f.Path == "environments/dev/index.ts" {
+					if !strings.Contains(string(f.Content), tc.wantInIndex) {
+						t.Errorf("index.ts for %s missing %q:\n%s", tc.cloud, tc.wantInIndex, f.Content)
+					}
+					return
+				}
+			}
+			t.Error("environments/dev/index.ts not emitted")
+		})
+	}
+}
+
+func TestLayeredPulumi_RejectsBadName(t *testing.T) {
+	bp := &LayeredPulumiBlueprint{}
+	_, err := bp.Render(map[string]any{
+		"project_name": "Bad NAME!!",
+		"cloud":        "aws",
+		"environments": []string{"dev"},
+	})
+	if err == nil {
+		t.Error("expected validation error for bad project name")
+	}
+}
+
+func TestLayeredPulumi_LifecycleScriptsAreExecutable(t *testing.T) {
+	bp := &LayeredPulumiBlueprint{}
+	files, err := bp.Render(map[string]any{
+		"project_name": "acme",
+		"cloud":        "aws",
+		"environments": []string{"dev"},
+	})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	execBits := map[string]bool{}
+	for _, f := range files {
+		if strings.HasPrefix(f.Path, "scripts/") {
+			execBits[f.Path] = f.Executable
+		}
+	}
+	for path, isExec := range execBits {
+		if !isExec {
+			t.Errorf("%s should be executable", path)
+		}
+	}
+	if len(execBits) < 4 {
+		t.Errorf("want ≥ 4 lifecycle scripts, got %d", len(execBits))
+	}
+}
+
+func TestLayeredPulumi_RegisteredInDefaultRegistry(t *testing.T) {
+	// Default registers both layered-terraform and layered-pulumi at
+	// init time — the API layer lists all Blueprints via the registry.
+	found := false
+	for _, bp := range Default.List() {
+		if bp.ID() == "layered-pulumi" {
+			found = true
+			if bp.Tool() != "pulumi" {
+				t.Errorf("registered blueprint Tool() = %q, want 'pulumi'", bp.Tool())
+			}
+		}
+	}
+	if !found {
+		t.Error("layered-pulumi not registered in Default registry")
+	}
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -536,7 +536,17 @@ export default function App() {
       return;
     }
     setTerminalOutput(prev => [...prev, `$ ${command}`, '']);
-    api.runCommand(projectId, tool, command, needsApproval).catch(err => {
+    // For pulumi the backend rejects mutating commands with
+    // policy_unsupported because server-side policy evaluation isn't
+    // implemented for it yet. Auto-acknowledge once the user has
+    // already confirmed via the apply/destroy prompt above —
+    // anything stricter would force a second confirm() for the same
+    // action. Non-pulumi tools keep the standard policy flow.
+    const ack = tool === 'pulumi' && needsApproval;
+    api.runCommand(projectId, tool, command, {
+      approved: needsApproval,
+      acknowledged: ack,
+    }).catch(err => {
       setTerminalOutput(prev => [...prev, `Error: ${err.message}`]);
     });
   };

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -206,12 +206,44 @@ export const api = {
     return (await check(res)).json();
   },
 
-  // Run IaC command. For apply/destroy, pass approved:true after plan review.
-  async runCommand(projectName: string, tool: string, command: string, approved = false): Promise<{ status: string }> {
+  // Run IaC command. For apply/destroy, pass approved:true after plan
+  // review. For pulumi layered-v1 projects, pass env so the runner
+  // executes inside environments/<env> and threads --stack <env> to
+  // pulumi (otherwise the workspace-selected stack is targeted, which
+  // can be wrong). Pass acknowledged:true to override the policy gate
+  // — required for pulumi today since server-side policy evaluation
+  // is unimplemented for it (the backend returns
+  // {error:"policy_unsupported"} on the first apply attempt; surface
+  // that to the user as an explicit confirmation prompt before the
+  // retry sets acknowledged).
+  async runCommand(
+    projectName: string,
+    tool: string,
+    command: string,
+    opts: { approved?: boolean; env?: string; acknowledged?: boolean } = {},
+  ): Promise<{ status: string }> {
     const res = await fetch(`${BASE}/api/projects/${projectName}/run`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ tool, command, approved }),
+      body: JSON.stringify({
+        tool,
+        command,
+        approved: opts.approved ?? false,
+        env: opts.env,
+        acknowledged: opts.acknowledged ?? false,
+      }),
+    });
+    return (await check(res)).json();
+  },
+
+  // Kill a running command. Pass env to match the workdir the command
+  // was launched in (layered-v1 / pulumi); otherwise the kill targets
+  // the project root and won't find the active execution.
+  async killCommand(projectName: string, env?: string): Promise<{ status: string }> {
+    const res = await fetch(`${BASE}/api/projects/${projectName}/kill`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: env ? JSON.stringify({ env }) : '',
     });
     return (await check(res)).json();
   },


### PR DESCRIPTION
## Summary
Upgrades Pulumi from export-only preview to a first-class peer of Terraform. The canvas can now scaffold a full multi-env Pulumi TypeScript project, run the Pulumi CLI through the same SafeRunner that drives Terraform, and gate destructive verbs behind the plan-review approval.

Scoped as the shippable slice of #5. Deferred to follow-ups: full TypeScript-AST parser (\`pulumi convert\` + ts-morph is a multi-week chunk), Pulumi CrossGuard integration in the Policy Studio UI, and per-env dual-stack mixing.

- [x] **Commit 1 — Generator** (\`internal/pulumi\`): \`GenerateProject(cfg)\` renders Pulumi.yaml, package.json (conditional provider SDKs), tsconfig.json, index.ts, .gitignore, and one Pulumi.<env>.yaml per environment. 30+ entry terraform→pulumi type override table plus a best-effort fallback for unknowns. Deterministic output (sorted keys + stable file order).
- [x] **Commit 2 — Runner**: Pulumi entry in DetectTools and a \`pulumiArgs\` command adapter. plan→preview, apply→up, destroy, refresh, validate→tsc --noEmit, init→npm install. Every destructive verb carries --yes + --non-interactive so the CLI doesn't block on its own prompt — the SafeRunner's approval gate handles it. \`RequiresApproval\` extended to cover pulumi up.
- [x] **Commit 3 — Scaffold**: \`LayeredPulumiBlueprint\` registered on \`Default\` alongside layered-terraform. Per-env Pulumi project (each environments/<env>/ is independently runnable), per-cloud seed resource so \`pulumi preview\` succeeds out of the box, lifecycle scripts that wrap the CLI with the cd boilerplate.

## Test plan
- [x] \`go test ./...\` green across 22 packages
- [x] 11 generator tests (full layout, name/runtime validation, empty-env default, import gating, constructors + exports + auto-tags, determinism, per-provider region, override table, fallback shape, tsPropValue primitives, toCamelCase)
- [x] 3 runner tests (pulumi binary selection + --yes flag presence, approval gate covers pulumi up, DetectTools bumped to 4)
- [x] 6 scaffold tests (per-env file presence, descriptor contents, seed-matches-cloud for 3 clouds, name validation, script exec bits, default-registry registration)
- [ ] Manual smoke: \`./scripts/init.sh && pulumi stack init dev && ./scripts/plan.sh dev\` on a freshly scaffolded project — end-to-end through a real Pulumi CLI.

## Closes
Closes part of #5 (Pulumi runner + generator + scaffold). Parser + CrossGuard + dual-stack mixing remain in separate follow-ups.