### PR TITLE
[codex] Add layered hybrid dual-stack projects

### DIFF
--- a/internal/api/policy.go
+++ b/internal/api/policy.go
@@ -99,9 +99,10 @@ func registerPolicyRoutes(mux *http.ServeMux, projectsDir string) {
 			return
 		}
 
-		tool := req.Tool
-		if tool == "" {
-			tool = "terraform"
+		tool := effectiveProjectTool(projectPath, req.Tool, req.Env)
+		if tool == "multi" {
+			http.Error(w, "env is required when running policy for hybrid projects", 400)
+			return
 		}
 		if req.Env != "" {
 			subPath, subErr := safeSubdir(projectPath, "environments", req.Env)

--- a/internal/api/policy.go
+++ b/internal/api/policy.go
@@ -14,6 +14,7 @@ import (
 	"github.com/iac-studio/iac-studio/internal/policy/engines/crossguard"
 	"github.com/iac-studio/iac-studio/internal/policy/engines/opa"
 	"github.com/iac-studio/iac-studio/internal/policy/engines/sentinel"
+	pulumigen "github.com/iac-studio/iac-studio/internal/pulumi"
 )
 
 // defaultPolicyEngines is the list of engines registered on startup. Order
@@ -124,12 +125,7 @@ func registerPolicyRoutes(mux *http.ServeMux, projectsDir string) {
 				planJSON = data
 			}
 		}
-		var resources []parser.Resource
-		if p := parser.ForTool(tool); p != nil {
-			if parsed, err := p.ParseDir(workDir); err == nil {
-				resources = parsed
-			}
-		}
+		resources := parsePolicyResources(workDir, tool)
 
 		selected := filterEngines(engs, req.EngineFilter)
 		results := engines.RunAll(r.Context(), selected, engines.EvalInput{
@@ -195,12 +191,7 @@ func evaluateBlockingPolicies(ctx context.Context, projectRoot, workDir, tool st
 	if workDir == "" {
 		workDir = projectRoot
 	}
-	var resources []parser.Resource
-	if p := parser.ForTool(tool); p != nil {
-		if parsed, err := p.ParseDir(workDir); err == nil {
-			resources = parsed
-		}
-	}
+	resources := parsePolicyResources(workDir, tool)
 
 	var planJSON []byte
 	if data, err := os.ReadFile(filepath.Join(workDir, "tfplan.json")); err == nil {
@@ -220,4 +211,20 @@ func evaluateBlockingPolicies(ctx context.Context, projectRoot, workDir, tool st
 		}
 	}
 	return findings, false
+}
+
+func parsePolicyResources(workDir, tool string) []parser.Resource {
+	var (
+		resources []parser.Resource
+		err       error
+	)
+	if tool == "pulumi" {
+		resources, err = (&pulumigen.TSParser{}).ParseDir(workDir)
+	} else if p := parser.ForTool(tool); p != nil {
+		resources, err = p.ParseDir(workDir)
+	}
+	if err != nil {
+		return nil
+	}
+	return resources
 }

--- a/internal/api/policy.go
+++ b/internal/api/policy.go
@@ -102,7 +102,7 @@ func registerPolicyRoutes(mux *http.ServeMux, projectsDir string) {
 
 		tool := effectiveProjectTool(projectPath, req.Tool, req.Env)
 		if tool == "multi" {
-			http.Error(w, "env is required when running policy for hybrid projects", 400)
+			http.Error(w, hybridToolResolutionMessage("env is required when running policy for hybrid projects", req.Env), 400)
 			return
 		}
 		projectRoot := projectPath

--- a/internal/api/policy.go
+++ b/internal/api/policy.go
@@ -31,8 +31,8 @@ func defaultPolicyEngines() []engines.PolicyEngine {
 
 // policyRunRequest is the request shape for POST /api/projects/{name}/policy/run.
 // PlanJSON, when provided, is used directly. When empty, the handler falls
-// back to tfplan.json in the project root (the layered-terraform blueprint's
-// plan.sh writes it there). When neither is available, engines that require
+// back to tfplan.json in the active IaC workdir. In layered projects, that is
+// environments/<env>. When neither is available, engines that require
 // plan JSON surface a clear error on their Result.
 type policyRunRequest struct {
 	PlanJSON json.RawMessage `json:"plan_json,omitempty"`
@@ -42,9 +42,9 @@ type policyRunRequest struct {
 	// Tool selects the parser to use for the resource walk. Defaults to
 	// terraform.
 	Tool string `json:"tool,omitempty"`
-	// Env names a layered-v1 environment. When set, policy evaluation runs in
-	// environments/<env>, which is where layered Pulumi projects keep
-	// Pulumi.yaml and stack config.
+	// Env names a layered-v1 environment. When set, resources and plan JSON
+	// are loaded from environments/<env>, while policy bundles are discovered
+	// from the owning project root.
 	Env string `json:"env,omitempty"`
 }
 
@@ -104,34 +104,37 @@ func registerPolicyRoutes(mux *http.ServeMux, projectsDir string) {
 			http.Error(w, "env is required when running policy for hybrid projects", 400)
 			return
 		}
+		projectRoot := projectPath
+		workDir := projectPath
 		if req.Env != "" {
 			subPath, subErr := safeSubdir(projectPath, "environments", req.Env)
 			if subErr != nil {
 				http.Error(w, "invalid env: "+subErr.Error(), 400)
 				return
 			}
-			projectPath = subPath
+			workDir = subPath
 		}
 
 		planJSON := []byte(req.PlanJSON)
 		if len(planJSON) == 0 {
-			// Fall back to <project>/tfplan.json which the layered-terraform
-			// blueprint's plan.sh writes after `terraform plan`. Missing is
-			// not an error here — plan-less engines (builtin) still run.
-			if data, err := os.ReadFile(filepath.Join(projectPath, "tfplan.json")); err == nil {
+			// Fall back to the active workdir's tfplan.json. Layered
+			// Terraform/hybrid scripts write one under environments/<env>.
+			// Missing is not an error here — plan-less engines still run.
+			if data, err := os.ReadFile(filepath.Join(workDir, "tfplan.json")); err == nil {
 				planJSON = data
 			}
 		}
 		var resources []parser.Resource
 		if p := parser.ForTool(tool); p != nil {
-			if parsed, err := p.ParseDir(projectPath); err == nil {
+			if parsed, err := p.ParseDir(workDir); err == nil {
 				resources = parsed
 			}
 		}
 
 		selected := filterEngines(engs, req.EngineFilter)
 		results := engines.RunAll(r.Context(), selected, engines.EvalInput{
-			ProjectDir: projectPath,
+			ProjectDir: projectRoot,
+			WorkDir:    workDir,
 			Resources:  resources,
 			PlanJSON:   planJSON,
 		})
@@ -177,33 +180,36 @@ func filterEngines(engs []engines.PolicyEngine, filter []string) []engines.Polic
 // finding list (blocking-first) so the caller can surface it verbatim to the
 // user, and a boolean for a quick gate check.
 //
-// Plan JSON is loaded from tfplan.json on disk when present — the layered-
-// terraform blueprint's plan.sh writes it there after every successful
-// terraform plan. When absent, plan-consuming engines (OPA, Conftest,
-// Sentinel) short-circuit quietly; the builtin still runs against parsed
-// resources so resource-walk findings are caught even without a plan.
+// Plan JSON and resources are loaded from workDir, while policy bundles are
+// discovered from projectRoot. That keeps layered/hybrid env plans scoped to
+// environments/<env> without hiding root-level policies from OPA, Conftest,
+// and Sentinel.
 //
 // Any engine error is swallowed here — apply should not be gated by a
 // broken policy engine. The caller can still observe non-blocking findings
 // via POST /api/projects/{name}/policy/run if needed.
-func evaluateBlockingPolicies(ctx context.Context, projectPath, tool string) ([]engines.Finding, bool) {
+func evaluateBlockingPolicies(ctx context.Context, projectRoot, workDir, tool string) ([]engines.Finding, bool) {
 	if tool == "" {
 		tool = "terraform"
 	}
+	if workDir == "" {
+		workDir = projectRoot
+	}
 	var resources []parser.Resource
 	if p := parser.ForTool(tool); p != nil {
-		if parsed, err := p.ParseDir(projectPath); err == nil {
+		if parsed, err := p.ParseDir(workDir); err == nil {
 			resources = parsed
 		}
 	}
 
 	var planJSON []byte
-	if data, err := os.ReadFile(filepath.Join(projectPath, "tfplan.json")); err == nil {
+	if data, err := os.ReadFile(filepath.Join(workDir, "tfplan.json")); err == nil {
 		planJSON = data
 	}
 
 	results := engines.RunAll(ctx, defaultPolicyEngines(), engines.EvalInput{
-		ProjectDir: projectPath,
+		ProjectDir: projectRoot,
+		WorkDir:    workDir,
 		Resources:  resources,
 		PlanJSON:   planJSON,
 	})

--- a/internal/api/policy_test.go
+++ b/internal/api/policy_test.go
@@ -256,6 +256,55 @@ func TestPolicyRunPulumiEnvRunsCrossGuard(t *testing.T) {
 	}
 }
 
+func TestPolicyRunHybridPulumiEnvBuiltinUsesTSParser(t *testing.T) {
+	root := t.TempDir()
+	project := filepath.Join(root, "demo")
+	envDir := filepath.Join(project, "environments", "dev")
+	if err := os.MkdirAll(envDir, 0o755); err != nil {
+		t.Fatalf("mkdir pulumi env: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(project, ".iac-studio.json"), []byte(`{
+  "layout": "layered-v1",
+  "tool": "multi",
+  "environments": ["dev"],
+  "environment_tools": {"dev": "pulumi"}
+}`), 0o644); err != nil {
+		t.Fatalf("write descriptor: %v", err)
+	}
+	writePulumiPolicyProgram(t, envDir)
+
+	srv := httptest.NewServer(policyMux(root))
+	defer srv.Close()
+
+	body, _ := json.Marshal(map[string]any{
+		"engines": []string{"builtin"},
+		"tool":    "multi",
+		"env":     "dev",
+	})
+	resp, err := http.Post(srv.URL+"/api/projects/demo/policy/run", "application/json", strings.NewReader(string(body)))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("policy run should 200, got %d", resp.StatusCode)
+	}
+
+	var got policyRunResponse
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Results) != 1 || got.Results[0].Engine != "builtin" {
+		t.Fatalf("expected a single builtin result, got %+v", got.Results)
+	}
+	if len(got.Findings) == 0 {
+		t.Fatalf("builtin engine should evaluate Pulumi TS resources, got %+v", got)
+	}
+	if !got.Blocking {
+		t.Fatal("Pulumi TS builtin findings should be blocking")
+	}
+}
+
 func TestPolicyRunHybridTerraformEnvUsesRootPolicies(t *testing.T) {
 	root := t.TempDir()
 	project := filepath.Join(root, "demo")
@@ -361,6 +410,26 @@ deny[msg] {
 	}
 }
 
+func TestEvaluateBlockingPoliciesPulumiUsesTSParser(t *testing.T) {
+	project := t.TempDir()
+	writePulumiPolicyProgram(t, project)
+
+	findings, blocking := evaluateBlockingPolicies(context.Background(), project, project, "pulumi")
+	if !blocking {
+		t.Fatalf("expected Pulumi TS resource policy finding to block apply, findings=%+v", findings)
+	}
+	hasBuiltin := false
+	for _, finding := range findings {
+		if finding.Engine == "builtin" && finding.Resource == "aws_s3_bucket.logs" {
+			hasBuiltin = true
+			break
+		}
+	}
+	if !hasBuiltin {
+		t.Fatalf("expected builtin finding for parsed Pulumi S3 bucket, got %+v", findings)
+	}
+}
+
 func fakePolicyPulumi(t *testing.T, stdout string, exitCode int) string {
 	t.Helper()
 	if runtime.GOOS == "windows" {
@@ -373,4 +442,16 @@ func fakePolicyPulumi(t *testing.T, stdout string, exitCode int) string {
 		t.Fatalf("write fake pulumi: %v", err)
 	}
 	return path
+}
+
+func writePulumiPolicyProgram(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "index.ts"), []byte(`import * as aws from "@pulumi/aws";
+
+const logs = new aws.s3.Bucket("logs", {
+  bucket: "demo-logs",
+});
+`), 0o644); err != nil {
+		t.Fatalf("write index.ts: %v", err)
+	}
 }

--- a/internal/api/policy_test.go
+++ b/internal/api/policy_test.go
@@ -305,6 +305,39 @@ func TestPolicyRunHybridPulumiEnvBuiltinUsesTSParser(t *testing.T) {
 	}
 }
 
+func TestPolicyRunRejectsUnresolvedHybridEnvironmentTool(t *testing.T) {
+	root := t.TempDir()
+	project := filepath.Join(root, "demo")
+	if err := os.MkdirAll(filepath.Join(project, "environments", "dev"), 0o755); err != nil {
+		t.Fatalf("mkdir dev env: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(project, ".iac-studio.json"), []byte(`{
+  "layout": "layered-v1",
+  "tool": "multi",
+  "environments": ["dev"],
+  "environment_tools": {"prod": "terraform"}
+}`), 0o644); err != nil {
+		t.Fatalf("write descriptor: %v", err)
+	}
+
+	srv := httptest.NewServer(policyMux(root))
+	defer srv.Close()
+
+	body, _ := json.Marshal(map[string]any{
+		"tool": "multi",
+		"env":  "dev",
+	})
+	resp, err := http.Post(srv.URL+"/api/projects/demo/policy/run", "application/json", strings.NewReader(string(body)))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("policy run should reject unresolved hybrid env with 400, got %d", resp.StatusCode)
+	}
+	assertResponseBodyContains(t, resp, `unresolved hybrid tool for env "dev"`, ".iac-studio.json environment_tools")
+}
+
 func TestPolicyRunHybridTerraformEnvUsesRootPolicies(t *testing.T) {
 	root := t.TempDir()
 	project := filepath.Join(root, "demo")

--- a/internal/api/policy_test.go
+++ b/internal/api/policy_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -107,6 +108,9 @@ func TestPolicyRunBuiltinOnly(t *testing.T) {
 		t.Fatalf("POST: %v", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("policy run should 200, got %d", resp.StatusCode)
+	}
 
 	var got policyRunResponse
 	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
@@ -249,6 +253,111 @@ func TestPolicyRunPulumiEnvRunsCrossGuard(t *testing.T) {
 	}
 	if !got.Blocking {
 		t.Fatal("mandatory CrossGuard finding should be blocking")
+	}
+}
+
+func TestPolicyRunHybridTerraformEnvUsesRootPolicies(t *testing.T) {
+	root := t.TempDir()
+	project := filepath.Join(root, "demo")
+	envDir := filepath.Join(project, "environments", "prod")
+	policyDir := filepath.Join(project, "policies", "opa")
+	for _, dir := range []string{envDir, policyDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(project, ".iac-studio.json"), []byte(`{
+  "layout": "layered-v1",
+  "tool": "multi",
+  "environments": ["prod"],
+  "environment_tools": {"prod": "terraform"}
+}`), 0o644); err != nil {
+		t.Fatalf("write descriptor: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(envDir, "main.tf"), []byte(`# env-scoped terraform
+`), 0o644); err != nil {
+		t.Fatalf("write env main.tf: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(envDir, "tfplan.json"), []byte(`{"resource_changes":[]}`), 0o644); err != nil {
+		t.Fatalf("write env tfplan: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(policyDir, "policy.rego"), []byte(`package iacstudio.test
+
+deny[msg] {
+  msg := "root policy denied env plan"
+}
+`), 0o644); err != nil {
+		t.Fatalf("write root rego: %v", err)
+	}
+
+	srv := httptest.NewServer(policyMux(root))
+	defer srv.Close()
+
+	body, _ := json.Marshal(map[string]any{
+		"engines": []string{"opa"},
+		"tool":    "multi",
+		"env":     "prod",
+	})
+	resp, err := http.Post(srv.URL+"/api/projects/demo/policy/run", "application/json", strings.NewReader(string(body)))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var got policyRunResponse
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Results) != 1 || got.Results[0].Engine != "opa" {
+		t.Fatalf("expected a single opa result, got %+v", got.Results)
+	}
+	if len(got.Findings) != 1 {
+		t.Fatalf("expected root OPA policy finding for env plan, got %+v", got)
+	}
+	if !got.Blocking {
+		t.Fatal("root OPA deny finding should be blocking")
+	}
+}
+
+func TestEvaluateBlockingPoliciesUsesRootPoliciesAndEnvPlan(t *testing.T) {
+	root := t.TempDir()
+	project := filepath.Join(root, "demo")
+	envDir := filepath.Join(project, "environments", "prod")
+	policyDir := filepath.Join(project, "policies", "opa")
+	for _, dir := range []string{envDir, policyDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(envDir, "main.tf"), []byte(`# env-scoped terraform
+`), 0o644); err != nil {
+		t.Fatalf("write env main.tf: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(envDir, "tfplan.json"), []byte(`{"resource_changes":[]}`), 0o644); err != nil {
+		t.Fatalf("write env tfplan: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(policyDir, "policy.rego"), []byte(`package iacstudio.test
+
+deny[msg] {
+  msg := "root policy denied env apply"
+}
+`), 0o644); err != nil {
+		t.Fatalf("write root rego: %v", err)
+	}
+
+	findings, blocking := evaluateBlockingPolicies(context.Background(), project, envDir, "terraform")
+	if !blocking {
+		t.Fatalf("expected root policy to block env apply, findings=%+v", findings)
+	}
+	hasOPA := false
+	for _, finding := range findings {
+		if finding.Engine == "opa" && strings.Contains(finding.Message, "root policy denied env apply") {
+			hasOPA = true
+			break
+		}
+	}
+	if !hasOPA {
+		t.Fatalf("expected OPA finding from root policy, got %+v", findings)
 	}
 }
 

--- a/internal/api/pulumi_sync_test.go
+++ b/internal/api/pulumi_sync_test.go
@@ -65,6 +65,96 @@ func TestPulumiResourcesParsesLayeredEnv(t *testing.T) {
 	}
 }
 
+func TestHybridResourcesParseEveryEnvironmentWithItsTool(t *testing.T) {
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "demo")
+	if err := os.MkdirAll(filepath.Join(projectDir, "environments", "prod"), 0o755); err != nil {
+		t.Fatalf("mkdir prod env: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, ".iac-studio.json"), []byte(`{
+  "layout": "layered-v1",
+  "tool": "multi",
+  "environments": ["dev", "prod"],
+  "environment_tools": {"dev": "pulumi", "prod": "terraform"}
+}`), 0o644); err != nil {
+		t.Fatalf("write descriptor: %v", err)
+	}
+	writePulumiEnv(t, projectDir, "dev", []parser.Resource{{
+		ID: "aws_s3_bucket.logs", Type: "aws_s3_bucket", Name: "logs",
+		Properties: map[string]any{"bucket": "demo-dev-logs"},
+	}})
+	if err := os.WriteFile(filepath.Join(projectDir, "environments", "prod", "main.tf"), []byte(`resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+}
+`), 0o644); err != nil {
+		t.Fatalf("write prod main.tf: %v", err)
+	}
+
+	srv := httptest.NewServer(fullRouterForTest(t, root))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/projects/demo/resources?tool=multi")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("resources should 200, got %d", resp.StatusCode)
+	}
+	var resources []parser.Resource
+	if err := json.NewDecoder(resp.Body).Decode(&resources); err != nil {
+		t.Fatalf("decode resources: %v", err)
+	}
+	seen := map[string]bool{}
+	for _, resource := range resources {
+		seen[resource.Type+"."+resource.Name] = true
+	}
+	if !seen["aws_s3_bucket.logs"] || !seen["aws_vpc.main"] {
+		t.Fatalf("hybrid resources did not include both tools: %+v", resources)
+	}
+}
+
+func TestHybridSyncResolvesEnvironmentTool(t *testing.T) {
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "demo")
+	envDir := filepath.Join(projectDir, "environments", "prod")
+	if err := os.MkdirAll(envDir, 0o755); err != nil {
+		t.Fatalf("mkdir prod env: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, ".iac-studio.json"), []byte(`{
+  "layout": "layered-v1",
+  "tool": "multi",
+  "environments": ["prod"],
+  "environment_tools": {"prod": "terraform"}
+}`), 0o644); err != nil {
+		t.Fatalf("write descriptor: %v", err)
+	}
+
+	srv := httptest.NewServer(fullRouterForTest(t, root))
+	defer srv.Close()
+
+	body := `{"file":"main.tf","code":"resource \"aws_vpc\" \"main\" {}\n"}`
+	resp, err := http.Post(
+		srv.URL+"/api/projects/demo/sync?tool=multi&env=prod",
+		"application/json",
+		strings.NewReader(body),
+	)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("sync should 200, got %d", resp.StatusCode)
+	}
+	data, err := os.ReadFile(filepath.Join(envDir, "main.tf"))
+	if err != nil {
+		t.Fatalf("read env main.tf: %v", err)
+	}
+	if !strings.Contains(string(data), `resource "aws_vpc" "main"`) {
+		t.Fatalf("sync did not write terraform env file:\n%s", string(data))
+	}
+}
+
 func TestPulumiSyncWritesEnvIndexAndPreservesHelpers(t *testing.T) {
 	root := t.TempDir()
 	projectDir := filepath.Join(root, "demo")

--- a/internal/api/pulumi_sync_test.go
+++ b/internal/api/pulumi_sync_test.go
@@ -227,6 +227,16 @@ func TestHybridResourceSyncResolvesSimpleRelativeFileUnderEnv(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("sync should 200, got %d", resp.StatusCode)
 	}
+	var got struct {
+		File string `json:"file"`
+		Code string `json:"code"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode sync response: %v", err)
+	}
+	if filepath.ToSlash(got.File) != "environments/prod/main.tf" {
+		t.Fatalf("sync response file = %q, want environments/prod/main.tf", got.File)
+	}
 	if _, err := os.Stat(filepath.Join(projectDir, "main.tf")); !os.IsNotExist(err) {
 		t.Fatalf("simple relative resource file should not write root main.tf, stat err=%v", err)
 	}

--- a/internal/api/pulumi_sync_test.go
+++ b/internal/api/pulumi_sync_test.go
@@ -125,6 +125,21 @@ func TestEffectiveProjectToolIgnoresUnknownDescriptorTool(t *testing.T) {
 	}
 }
 
+func TestParseProjectResourcesRejectsUnresolvedHybridEnv(t *testing.T) {
+	projectDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(projectDir, "environments", "dev"), 0o755); err != nil {
+		t.Fatalf("mkdir env: %v", err)
+	}
+
+	_, err := parseProjectResources(projectDir, "multi", "dev")
+	if err == nil {
+		t.Fatal("expected unresolved hybrid tool error, got nil")
+	}
+	if status := resourceParseErrorStatus(err); status != http.StatusBadRequest {
+		t.Fatalf("unresolved hybrid tool status = %d, want 400", status)
+	}
+}
+
 func TestHybridResourcesSortsDescriptorMapEnvironments(t *testing.T) {
 	root := t.TempDir()
 	projectDir := filepath.Join(root, "demo")

--- a/internal/api/pulumi_sync_test.go
+++ b/internal/api/pulumi_sync_test.go
@@ -114,6 +114,52 @@ func TestHybridResourcesParseEveryEnvironmentWithItsTool(t *testing.T) {
 	}
 }
 
+func TestEffectiveProjectToolIgnoresUnknownDescriptorTool(t *testing.T) {
+	projectDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectDir, ".iac-studio.json"), []byte(`{"tool":"definitely-not-a-tool"}`), 0o644); err != nil {
+		t.Fatalf("write descriptor: %v", err)
+	}
+
+	if got := effectiveProjectTool(projectDir, "", ""); got != "terraform" {
+		t.Fatalf("effectiveProjectTool with unknown descriptor tool = %q, want terraform", got)
+	}
+}
+
+func TestHybridResourcesSortsDescriptorMapEnvironments(t *testing.T) {
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "demo")
+	for _, env := range []string{"prod", "dev"} {
+		envDir := filepath.Join(projectDir, "environments", env)
+		if err := os.MkdirAll(envDir, 0o755); err != nil {
+			t.Fatalf("mkdir %s env: %v", env, err)
+		}
+		if err := os.WriteFile(filepath.Join(envDir, "main.tf"), []byte(`resource "aws_vpc" "`+env+`" {
+  cidr_block = "10.0.0.0/16"
+}
+`), 0o644); err != nil {
+			t.Fatalf("write %s main.tf: %v", env, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, ".iac-studio.json"), []byte(`{
+  "layout": "layered-v1",
+  "tool": "multi",
+  "environment_tools": {"prod": "terraform", "dev": "terraform"}
+}`), 0o644); err != nil {
+		t.Fatalf("write descriptor: %v", err)
+	}
+
+	resources, err := parseHybridProjectResources(projectDir)
+	if err != nil {
+		t.Fatalf("parse hybrid resources: %v", err)
+	}
+	if len(resources) != 2 {
+		t.Fatalf("resources length = %d, want 2: %+v", len(resources), resources)
+	}
+	if resources[0].Name != "dev" || resources[1].Name != "prod" {
+		t.Fatalf("resources should be sorted by env name, got %+v", resources)
+	}
+}
+
 func TestResourcesRejectInvalidEnvAsBadRequest(t *testing.T) {
 	root := t.TempDir()
 	projectDir := filepath.Join(root, "demo")
@@ -131,6 +177,50 @@ func TestResourcesRejectInvalidEnvAsBadRequest(t *testing.T) {
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("invalid env should 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestHybridResourceSyncResolvesSimpleRelativeFileUnderEnv(t *testing.T) {
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "demo")
+	envDir := filepath.Join(projectDir, "environments", "prod")
+	if err := os.MkdirAll(envDir, 0o755); err != nil {
+		t.Fatalf("mkdir prod env: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, ".iac-studio.json"), []byte(`{
+  "layout": "layered-v1",
+  "tool": "multi",
+  "environments": ["prod"],
+  "environment_tools": {"prod": "terraform"}
+}`), 0o644); err != nil {
+		t.Fatalf("write descriptor: %v", err)
+	}
+
+	srv := httptest.NewServer(fullRouterForTest(t, root))
+	defer srv.Close()
+
+	body := `{"resources":[{"id":"aws_vpc.main","type":"aws_vpc","name":"main","file":"main.tf","properties":{"cidr_block":"10.0.0.0/16"}}]}`
+	resp, err := http.Post(
+		srv.URL+"/api/projects/demo/sync?tool=multi&env=prod",
+		"application/json",
+		strings.NewReader(body),
+	)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("sync should 200, got %d", resp.StatusCode)
+	}
+	if _, err := os.Stat(filepath.Join(projectDir, "main.tf")); !os.IsNotExist(err) {
+		t.Fatalf("simple relative resource file should not write root main.tf, stat err=%v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(envDir, "main.tf"))
+	if err != nil {
+		t.Fatalf("read env main.tf: %v", err)
+	}
+	if !strings.Contains(string(data), `resource "aws_vpc" "main"`) {
+		t.Fatalf("sync did not write terraform env file:\n%s", string(data))
 	}
 }
 

--- a/internal/api/pulumi_sync_test.go
+++ b/internal/api/pulumi_sync_test.go
@@ -114,6 +114,26 @@ func TestHybridResourcesParseEveryEnvironmentWithItsTool(t *testing.T) {
 	}
 }
 
+func TestResourcesRejectInvalidEnvAsBadRequest(t *testing.T) {
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "demo")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+
+	srv := httptest.NewServer(fullRouterForTest(t, root))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/projects/demo/resources?tool=terraform&env=..")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("invalid env should 400, got %d", resp.StatusCode)
+	}
+}
+
 func TestHybridSyncResolvesEnvironmentTool(t *testing.T) {
 	root := t.TempDir()
 	projectDir := filepath.Join(root, "demo")

--- a/internal/api/pulumi_sync_test.go
+++ b/internal/api/pulumi_sync_test.go
@@ -290,6 +290,73 @@ func TestHybridSyncResolvesEnvironmentTool(t *testing.T) {
 	}
 }
 
+func TestHybridSyncRejectsUnresolvedEnvironmentTool(t *testing.T) {
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "demo")
+	if err := os.MkdirAll(filepath.Join(projectDir, "environments", "dev"), 0o755); err != nil {
+		t.Fatalf("mkdir dev env: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, ".iac-studio.json"), []byte(`{
+  "layout": "layered-v1",
+  "tool": "multi",
+  "environments": ["dev"],
+  "environment_tools": {"prod": "terraform"}
+}`), 0o644); err != nil {
+		t.Fatalf("write descriptor: %v", err)
+	}
+
+	srv := httptest.NewServer(fullRouterForTest(t, root))
+	defer srv.Close()
+
+	resp, err := http.Post(
+		srv.URL+"/api/projects/demo/sync?tool=multi&env=dev",
+		"application/json",
+		strings.NewReader(`{"resources":[]}`),
+	)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("sync should reject unresolved hybrid env with 400, got %d", resp.StatusCode)
+	}
+	assertResponseBodyContains(t, resp, `unresolved hybrid tool for env "dev"`, ".iac-studio.json environment_tools")
+}
+
+func TestHybridRunRejectsUnresolvedEnvironmentTool(t *testing.T) {
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "demo")
+	if err := os.MkdirAll(filepath.Join(projectDir, "environments", "dev"), 0o755); err != nil {
+		t.Fatalf("mkdir dev env: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, ".iac-studio.json"), []byte(`{
+  "layout": "layered-v1",
+  "tool": "multi",
+  "environments": ["dev"],
+  "environment_tools": {"dev": "not-a-tool"}
+}`), 0o644); err != nil {
+		t.Fatalf("write descriptor: %v", err)
+	}
+
+	srv := httptest.NewServer(fullRouterForTest(t, root))
+	defer srv.Close()
+
+	body := `{"tool":"multi","command":"plan","env":"dev"}`
+	resp, err := http.Post(
+		srv.URL+"/api/projects/demo/run",
+		"application/json",
+		strings.NewReader(body),
+	)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("run should reject unresolved hybrid env with 400, got %d", resp.StatusCode)
+	}
+	assertResponseBodyContains(t, resp, `unresolved hybrid tool for env "dev"`, ".iac-studio.json environment_tools")
+}
+
 func TestPulumiSyncWritesEnvIndexAndPreservesHelpers(t *testing.T) {
 	root := t.TempDir()
 	projectDir := filepath.Join(root, "demo")

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -357,6 +358,10 @@ func concreteTool(tool string) bool {
 	}
 }
 
+func descriptorTool(tool string) bool {
+	return tool == "multi" || concreteTool(tool)
+}
+
 func effectiveProjectTool(projectPath, requestedTool, env string) string {
 	requestedDefaulted := false
 	if requestedTool == "" {
@@ -372,7 +377,7 @@ func effectiveProjectTool(projectPath, requestedTool, env string) string {
 			return tool
 		}
 	}
-	if requestedDefaulted && descriptor.Tool != "" {
+	if requestedDefaulted && descriptorTool(descriptor.Tool) {
 		return descriptor.Tool
 	}
 	if requestedTool != "multi" {
@@ -420,6 +425,7 @@ func parseHybridProjectResources(projectPath string) ([]parser.Resource, error) 
 		for env := range descriptor.EnvironmentTools {
 			envs = append(envs, env)
 		}
+		sort.Strings(envs)
 	}
 	var resources []parser.Resource
 	for _, env := range envs {
@@ -456,6 +462,10 @@ func resourceParseErrorStatus(err error) int {
 		return http.StatusBadRequest
 	}
 	return http.StatusInternalServerError
+}
+
+func simpleRelativeFileName(target string) bool {
+	return target != "" && !filepath.IsAbs(target) && !strings.ContainsAny(target, `/\`)
 }
 
 func invalidatePlan(projectPaths ...string) {
@@ -881,7 +891,7 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 			target := body.File
 			if target == "" {
 				target = filepath.Join(syncWorkdir, "main"+ext)
-			} else if env != "" && !filepath.IsAbs(target) && !strings.Contains(filepath.ToSlash(target), "/") {
+			} else if env != "" && simpleRelativeFileName(target) {
 				target = filepath.Join(syncWorkdir, target)
 			}
 			safeTarget, pathErr := safeProjectFile(projectPath, target, allowedExts...)
@@ -941,6 +951,8 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 			target := r.File
 			if target == "" {
 				target = filepath.Join(syncWorkdir, "main"+ext)
+			} else if env != "" && simpleRelativeFileName(target) {
+				target = filepath.Join(syncWorkdir, target)
 			}
 			safeTarget, pathErr := safeProjectFile(projectPath, target, allowedExts...)
 			if pathErr != nil {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -445,6 +445,19 @@ func parseHybridProjectResources(projectPath string) ([]parser.Resource, error) 
 	return resources, nil
 }
 
+func resourceParseErrorStatus(err error) int {
+	if err == nil {
+		return http.StatusOK
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "subdir") ||
+		strings.Contains(msg, "env query parameter") ||
+		strings.Contains(msg, "invalid path segment") {
+		return http.StatusBadRequest
+	}
+	return http.StatusInternalServerError
+}
+
 func invalidatePlan(projectPaths ...string) {
 	planGate.mu.Lock()
 	defer planGate.mu.Unlock()
@@ -819,11 +832,7 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 		tool := effectiveProjectTool(projectPath, requestedTool, env)
 		resources, err := parseProjectResources(projectPath, tool, env)
 		if err != nil {
-			status := http.StatusInternalServerError
-			if strings.Contains(err.Error(), "subdir") || strings.Contains(err.Error(), "env query parameter") {
-				status = http.StatusBadRequest
-			}
-			http.Error(w, err.Error(), status)
+			http.Error(w, err.Error(), resourceParseErrorStatus(err))
 			return
 		}
 		_ = json.NewEncoder(w).Encode(resources)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1053,9 +1053,13 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 		if mainCode == "" {
 			mainCode = code
 		}
+		responseFile, relErr := filepath.Rel(projectPath, rootMainFile)
+		if relErr != nil || responseFile == "." || strings.HasPrefix(responseFile, "..") {
+			responseFile = filepath.Base(rootMainFile)
+		}
 
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
-			"file": filepath.Join(syncWorkdir, "main"+ext),
+			"file": responseFile,
 			"code": mainCode,
 		})
 	})

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -329,6 +329,122 @@ func pulumiEnvDir(projectPath, env string) (string, error) {
 	return projectPath, nil
 }
 
+type projectToolDescriptor struct {
+	Layout           string            `json:"layout"`
+	Tool             string            `json:"tool"`
+	Environments     []string          `json:"environments"`
+	EnvironmentTools map[string]string `json:"environment_tools"`
+}
+
+func readProjectToolDescriptor(projectPath string) (projectToolDescriptor, error) {
+	var descriptor projectToolDescriptor
+	data, err := os.ReadFile(filepath.Join(projectPath, ".iac-studio.json"))
+	if err != nil {
+		return descriptor, err
+	}
+	if err := json.Unmarshal(data, &descriptor); err != nil {
+		return descriptor, err
+	}
+	return descriptor, nil
+}
+
+func concreteTool(tool string) bool {
+	switch tool {
+	case "terraform", "opentofu", "pulumi", "ansible":
+		return true
+	default:
+		return false
+	}
+}
+
+func effectiveProjectTool(projectPath, requestedTool, env string) string {
+	requestedDefaulted := false
+	if requestedTool == "" {
+		requestedTool = "terraform"
+		requestedDefaulted = true
+	}
+	descriptor, err := readProjectToolDescriptor(projectPath)
+	if err != nil {
+		return requestedTool
+	}
+	if env != "" {
+		if tool := descriptor.EnvironmentTools[env]; concreteTool(tool) {
+			return tool
+		}
+	}
+	if requestedDefaulted && descriptor.Tool != "" {
+		return descriptor.Tool
+	}
+	if requestedTool != "multi" {
+		return requestedTool
+	}
+	if concreteTool(descriptor.Tool) {
+		return descriptor.Tool
+	}
+	return requestedTool
+}
+
+func parseProjectResources(projectPath, tool, env string) ([]parser.Resource, error) {
+	if tool == "multi" && env == "" {
+		return parseHybridProjectResources(projectPath)
+	}
+	if tool == "pulumi" {
+		targetDir, envErr := pulumiEnvDir(projectPath, env)
+		if envErr != nil {
+			return nil, envErr
+		}
+		return (&pulumigen.TSParser{}).ParseDir(targetDir)
+	}
+	p := parser.ForTool(tool)
+	targetDir := projectPath
+	if env != "" {
+		subPath, err := safeSubdir(projectPath, "environments", env)
+		if err != nil {
+			return nil, err
+		}
+		targetDir = subPath
+	}
+	return p.ParseDir(targetDir)
+}
+
+func parseHybridProjectResources(projectPath string) ([]parser.Resource, error) {
+	descriptor, err := readProjectToolDescriptor(projectPath)
+	if err != nil {
+		return parser.ForTool("terraform").ParseDir(projectPath)
+	}
+	if len(descriptor.EnvironmentTools) == 0 {
+		return parser.ForTool("terraform").ParseDir(projectPath)
+	}
+	envs := descriptor.Environments
+	if len(envs) == 0 {
+		for env := range descriptor.EnvironmentTools {
+			envs = append(envs, env)
+		}
+	}
+	var resources []parser.Resource
+	for _, env := range envs {
+		tool := descriptor.EnvironmentTools[env]
+		if !concreteTool(tool) {
+			continue
+		}
+		envDir, subErr := safeSubdir(projectPath, "environments", env)
+		if subErr != nil {
+			return nil, fmt.Errorf("%s: %w", env, subErr)
+		}
+		var parsed []parser.Resource
+		if tool == "pulumi" {
+			parsed, err = (&pulumigen.TSParser{}).ParseDir(envDir)
+		} else {
+			parsed, err = parser.ForTool(tool).ParseDir(envDir)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("parse %s environment %q: %w", tool, env, err)
+		}
+		resources = append(resources, parsed...)
+	}
+	return resources, nil
+}
+
 func invalidatePlan(projectPaths ...string) {
 	planGate.mu.Lock()
 	defer planGate.mu.Unlock()
@@ -367,8 +483,8 @@ func envWorkdirForProjectFile(projectPath, target string) (string, bool) {
 	return filepath.Join(projectPath, "environments", parts[1]), true
 }
 
-func handlePulumiSync(w http.ResponseWriter, r *http.Request, fw *watcher.FileWatcher, projectPath string, body syncRequest) {
-	targetDir, err := pulumiEnvDir(projectPath, r.URL.Query().Get("env"))
+func handlePulumiSync(w http.ResponseWriter, fw *watcher.FileWatcher, projectPath, env string, body syncRequest) {
+	targetDir, err := pulumiEnvDir(projectPath, env)
 	if err != nil {
 		http.Error(w, "invalid env: "+err.Error(), 400)
 		return
@@ -693,31 +809,21 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 	// Parse project files and return resource graph
 	mux.HandleFunc("GET /api/projects/{name}/resources", func(w http.ResponseWriter, r *http.Request) {
 		name := r.PathValue("name")
-		tool := r.URL.Query().Get("tool")
+		requestedTool := r.URL.Query().Get("tool")
+		env := r.URL.Query().Get("env")
 		projectPath, err := safeProjectPath(projectsDir, name)
 		if err != nil {
 			http.Error(w, err.Error(), 400)
 			return
 		}
-		if tool == "pulumi" {
-			targetDir, envErr := pulumiEnvDir(projectPath, r.URL.Query().Get("env"))
-			if envErr != nil {
-				http.Error(w, "invalid env: "+envErr.Error(), 400)
-				return
-			}
-			resources, err := (&pulumigen.TSParser{}).ParseDir(targetDir)
-			if err != nil {
-				http.Error(w, err.Error(), 500)
-				return
-			}
-			_ = json.NewEncoder(w).Encode(resources)
-			return
-		}
-
-		p := parser.ForTool(tool)
-		resources, err := p.ParseDir(projectPath)
+		tool := effectiveProjectTool(projectPath, requestedTool, env)
+		resources, err := parseProjectResources(projectPath, tool, env)
 		if err != nil {
-			http.Error(w, err.Error(), 500)
+			status := http.StatusInternalServerError
+			if strings.Contains(err.Error(), "subdir") || strings.Contains(err.Error(), "env query parameter") {
+				status = http.StatusBadRequest
+			}
+			http.Error(w, err.Error(), status)
 			return
 		}
 		_ = json.NewEncoder(w).Encode(resources)
@@ -726,7 +832,8 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 	// Sync resources from UI to disk
 	mux.HandleFunc("POST /api/projects/{name}/sync", func(w http.ResponseWriter, r *http.Request) {
 		name := r.PathValue("name")
-		tool := r.URL.Query().Get("tool")
+		requestedTool := r.URL.Query().Get("tool")
+		env := r.URL.Query().Get("env")
 		projectPath, err := safeProjectPath(projectsDir, name)
 		if err != nil {
 			http.Error(w, err.Error(), 400)
@@ -738,19 +845,35 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 			http.Error(w, "invalid request body", 400)
 			return
 		}
+		tool := effectiveProjectTool(projectPath, requestedTool, env)
+		if tool == "multi" {
+			http.Error(w, "env query parameter is required for hybrid project sync", 400)
+			return
+		}
 		if tool == "pulumi" {
-			handlePulumiSync(w, r, fw, projectPath, body)
+			handlePulumiSync(w, fw, projectPath, env, body)
 			return
 		}
 
 		gen := generator.ForTool(tool)
 		ext := gen.FileExtension()
 		allowedExts := allowedGeneratedExtensions(tool, ext)
+		syncWorkdir := projectPath
+		if env != "" {
+			subPath, subErr := safeSubdir(projectPath, "environments", env)
+			if subErr != nil {
+				http.Error(w, "invalid env: "+subErr.Error(), 400)
+				return
+			}
+			syncWorkdir = subPath
+		}
 
 		if body.Code != nil {
 			target := body.File
 			if target == "" {
-				target = filepath.Join(projectPath, "main"+ext)
+				target = filepath.Join(syncWorkdir, "main"+ext)
+			} else if env != "" && !filepath.IsAbs(target) && !strings.Contains(filepath.ToSlash(target), "/") {
+				target = filepath.Join(syncWorkdir, target)
 			}
 			safeTarget, pathErr := safeProjectFile(projectPath, target, allowedExts...)
 			if pathErr != nil {
@@ -808,7 +931,7 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 		for _, r := range resources {
 			target := r.File
 			if target == "" {
-				target = filepath.Join(projectPath, "main"+ext)
+				target = filepath.Join(syncWorkdir, "main"+ext)
 			}
 			safeTarget, pathErr := safeProjectFile(projectPath, target, allowedExts...)
 			if pathErr != nil {
@@ -820,7 +943,7 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 
 		// If all resources have no file origin, write to main file
 		if len(fileGroups) == 0 {
-			mainFile, pathErr := safeProjectFile(projectPath, filepath.Join(projectPath, "main"+ext), allowedExts...)
+			mainFile, pathErr := safeProjectFile(projectPath, filepath.Join(syncWorkdir, "main"+ext), allowedExts...)
 			if pathErr != nil {
 				http.Error(w, "invalid main file: "+pathErr.Error(), 400)
 				return
@@ -840,7 +963,7 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 		preservedByFile := make(map[string][]parser.PreservedBlock)
 		projectHasProvider := false
 		if hclParser, ok := p.(*parser.HCLParser); ok && tool != "ansible" {
-			existingFiles, _ := filepath.Glob(filepath.Join(projectPath, "*.tf"))
+			existingFiles, _ := filepath.Glob(filepath.Join(syncWorkdir, "*.tf"))
 			for _, f := range existingFiles {
 				result, err := hclParser.ParseFileFull(f)
 				if err != nil || result == nil {
@@ -862,7 +985,7 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 
 		// Write each file atomically (temp file + rename)
 		var mainCode string
-		rootMainFile, pathErr := safeProjectFile(projectPath, filepath.Join(projectPath, "main"+ext), allowedExts...)
+		rootMainFile, pathErr := safeProjectFile(projectPath, filepath.Join(syncWorkdir, "main"+ext), allowedExts...)
 		if pathErr != nil {
 			http.Error(w, "invalid main file: "+pathErr.Error(), 400)
 			return
@@ -907,7 +1030,7 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 		}
 
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
-			"file": filepath.Join(projectPath, "main"+ext),
+			"file": filepath.Join(syncWorkdir, "main"+ext),
 			"code": mainCode,
 		})
 	})
@@ -938,6 +1061,12 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			http.Error(w, "invalid request", 400)
+			return
+		}
+
+		effectiveTool := effectiveProjectTool(projectPath, req.Tool, req.Env)
+		if effectiveTool == "multi" {
+			http.Error(w, "env is required when running commands for hybrid projects", 400)
 			return
 		}
 
@@ -985,7 +1114,7 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 				// error (engine crash, missing binary, malformed plan) we
 				// fall through to execution — apply should not be gated by
 				// a broken policy engine.
-				if findings, blocking := evaluateBlockingPolicies(r.Context(), projectPath, req.Tool); blocking {
+				if findings, blocking := evaluateBlockingPolicies(r.Context(), projectPath, effectiveTool); blocking {
 					w.Header().Set("Content-Type", "application/json")
 					w.WriteHeader(http.StatusConflict)
 					_ = json.NewEncoder(w).Encode(map[string]any{
@@ -996,7 +1125,7 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 					return
 				}
 			} else {
-				log.Printf("apply gate: policy findings acknowledged by client for %s (command=%s tool=%s)", name, req.Command, req.Tool)
+				log.Printf("apply gate: policy findings acknowledged by client for %s (command=%s tool=%s)", name, req.Command, effectiveTool)
 			}
 		}
 
@@ -1005,7 +1134,7 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 		// a request-scoped context and kill the command. SafeRunner applies its
 		// own per-command timeout (init=5m, plan=10m, apply=30m).
 		go func() {
-			result, err := run.Execute(context.Background(), projectPath, req.Tool, req.Command, req.Env)
+			result, err := run.Execute(context.Background(), projectPath, effectiveTool, req.Command, req.Env)
 			// Only record a successful plan — failed/cancelled plans don't count.
 			// 'preview' is Pulumi's equivalent of terraform plan; without it
 			// here, a pulumi up following a successful preview would be

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -390,8 +390,11 @@ func effectiveProjectTool(projectPath, requestedTool, env string) string {
 }
 
 func parseProjectResources(projectPath, tool, env string) ([]parser.Resource, error) {
-	if tool == "multi" && env == "" {
-		return parseHybridProjectResources(projectPath)
+	if tool == "multi" {
+		if env == "" {
+			return parseHybridProjectResources(projectPath)
+		}
+		return nil, fmt.Errorf("unresolved hybrid tool for env %q", env)
 	}
 	if tool == "pulumi" {
 		targetDir, envErr := pulumiEnvDir(projectPath, env)
@@ -458,7 +461,8 @@ func resourceParseErrorStatus(err error) int {
 	msg := err.Error()
 	if strings.Contains(msg, "subdir") ||
 		strings.Contains(msg, "env query parameter") ||
-		strings.Contains(msg, "invalid path segment") {
+		strings.Contains(msg, "invalid path segment") ||
+		strings.Contains(msg, "unresolved hybrid tool") {
 		return http.StatusBadRequest
 	}
 	return http.StatusInternalServerError

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -389,6 +389,13 @@ func effectiveProjectTool(projectPath, requestedTool, env string) string {
 	return requestedTool
 }
 
+func hybridToolResolutionMessage(missingEnvMessage, env string) string {
+	if env == "" {
+		return missingEnvMessage
+	}
+	return fmt.Sprintf("unresolved hybrid tool for env %q; check .iac-studio.json environment_tools", env)
+}
+
 func parseProjectResources(projectPath, tool, env string) ([]parser.Resource, error) {
 	if tool == "multi" {
 		if env == "" {
@@ -870,7 +877,7 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 		}
 		tool := effectiveProjectTool(projectPath, requestedTool, env)
 		if tool == "multi" {
-			http.Error(w, "env query parameter is required for hybrid project sync", 400)
+			http.Error(w, hybridToolResolutionMessage("env query parameter is required for hybrid project sync", env), 400)
 			return
 		}
 		if tool == "pulumi" {
@@ -1096,7 +1103,7 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 
 		effectiveTool := effectiveProjectTool(projectPath, req.Tool, req.Env)
 		if effectiveTool == "multi" {
-			http.Error(w, "env is required when running commands for hybrid projects", 400)
+			http.Error(w, hybridToolResolutionMessage("env is required when running commands for hybrid projects", req.Env), 400)
 			return
 		}
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1072,6 +1072,7 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 			http.Error(w, err.Error(), 400)
 			return
 		}
+		projectRoot := projectPath
 
 		limitBody(w, r)
 		var req struct {
@@ -1099,18 +1100,19 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 			return
 		}
 
-		// When Env is set, rebase projectPath into environments/<env>
+		// When Env is set, run from environments/<env>
 		// so the runner finds Pulumi.yaml / main.tf in the right
 		// working directory. The subdir must exist and be contained
 		// in projectPath — safeSubdir below rejects traversal and
 		// rejects paths that point at a file instead of a directory.
+		runPath := projectPath
 		if req.Env != "" {
 			subPath, subErr := safeSubdir(projectPath, "environments", req.Env)
 			if subErr != nil {
 				http.Error(w, "invalid env: "+subErr.Error(), 400)
 				return
 			}
-			projectPath = subPath
+			runPath = subPath
 		}
 
 		// Block apply/destroy unless:
@@ -1119,7 +1121,7 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 		// 3. No error-severity policy findings exist, OR the client sets
 		//    acknowledged:true after reading the findings.
 		if run.RequiresApproval(req.Command) {
-			if !hasPlan(projectPath) {
+			if !hasPlan(runPath) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusConflict)
 				_ = json.NewEncoder(w).Encode(map[string]string{
@@ -1143,7 +1145,7 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 				// error (engine crash, missing binary, malformed plan) we
 				// fall through to execution — apply should not be gated by
 				// a broken policy engine.
-				if findings, blocking := evaluateBlockingPolicies(r.Context(), projectPath, effectiveTool); blocking {
+				if findings, blocking := evaluateBlockingPolicies(r.Context(), projectRoot, runPath, effectiveTool); blocking {
 					w.Header().Set("Content-Type", "application/json")
 					w.WriteHeader(http.StatusConflict)
 					_ = json.NewEncoder(w).Encode(map[string]any{
@@ -1163,15 +1165,15 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 		// a request-scoped context and kill the command. SafeRunner applies its
 		// own per-command timeout (init=5m, plan=10m, apply=30m).
 		go func() {
-			result, err := run.Execute(context.Background(), projectPath, effectiveTool, req.Command, req.Env)
+			result, err := run.Execute(context.Background(), runPath, effectiveTool, req.Command, req.Env)
 			// Only record a successful plan — failed/cancelled plans don't count.
 			// 'preview' is Pulumi's equivalent of terraform plan; without it
 			// here, a pulumi up following a successful preview would be
-			// blocked with 'plan_required'. projectPath already reflects
-			// the env rebase so dev + prod track their plan state
+			// blocked with 'plan_required'. runPath reflects any env rebase
+			// so dev + prod track their plan state
 			// independently.
 			if err == nil && (req.Command == "plan" || req.Command == "preview" || req.Command == "check") {
-				recordPlan(projectPath)
+				recordPlan(runPath)
 			}
 			msg := map[string]interface{}{
 				"type":    "terminal",

--- a/internal/api/router_security_test.go
+++ b/internal/api/router_security_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -28,6 +29,20 @@ func fullRouterForTest(t *testing.T, projectsDir string) *http.ServeMux {
 		runner.NewSafeRunner(runner.DefaultSafetyConfig()),
 		projectsDir,
 	)
+}
+
+func assertResponseBodyContains(t *testing.T, resp *http.Response, want ...string) {
+	t.Helper()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response body: %v", err)
+	}
+	body := string(data)
+	for _, text := range want {
+		if !strings.Contains(body, text) {
+			t.Fatalf("response body %q does not contain %q", body, text)
+		}
+	}
 }
 
 func TestStateRoutesRejectTraversalProjectName(t *testing.T) {

--- a/internal/policy/engines/crossguard/crossguard.go
+++ b/internal/policy/engines/crossguard/crossguard.go
@@ -60,6 +60,10 @@ func (c *crossguardEngine) Evaluate(ctx context.Context, in engines.EvalInput) (
 		res.Error = "crossguard engine requires a project directory"
 		return res, nil
 	}
+	workDir := in.WorkDir
+	if workDir == "" {
+		workDir = in.ProjectDir
+	}
 	packs, err := discoverPolicyPacks(in.ProjectDir)
 	if err != nil {
 		res.Error = err.Error()
@@ -68,13 +72,13 @@ func (c *crossguardEngine) Evaluate(ctx context.Context, in engines.EvalInput) (
 	if len(packs) == 0 {
 		return res, nil
 	}
-	if !hasPulumiProject(in.ProjectDir) {
+	if !hasPulumiProject(workDir) {
 		res.Error = "crossguard engine requires a Pulumi project directory containing Pulumi.yaml"
 		return res, nil
 	}
 
 	args := []string{"preview", "--non-interactive", "--color=never"}
-	if stack := inferStackName(in.ProjectDir); stack != "" {
+	if stack := inferStackName(workDir); stack != "" {
 		args = append(args, "--stack", stack)
 	}
 	for _, pack := range packs {
@@ -82,7 +86,7 @@ func (c *crossguardEngine) Evaluate(ctx context.Context, in engines.EvalInput) (
 	}
 
 	cmd := exec.CommandContext(ctx, Binary, args...)
-	cmd.Dir = in.ProjectDir
+	cmd.Dir = workDir
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &out

--- a/internal/policy/engines/engines.go
+++ b/internal/policy/engines/engines.go
@@ -83,6 +83,10 @@ type EvalInput struct {
 	// policy bundles from disk (OPA, Conftest, Sentinel) resolve their files
 	// relative to here — typically policies/opa/*.rego, policies/sentinel/*.sentinel.
 	ProjectDir string
+	// WorkDir is the absolute path for the active IaC working directory. In
+	// layered projects this is usually environments/<env>; when empty, engines
+	// should treat ProjectDir as the working directory.
+	WorkDir string
 	// Resources is the parsed resource graph from the project's .tf/.yml
 	// files. The built-in Go engine walks this directly.
 	Resources []parser.Resource

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -20,6 +20,7 @@ type State struct {
 	ProjectName  string            `json:"project_name,omitempty"`
 	Cloud        string            `json:"cloud,omitempty"`
 	Environments []string          `json:"environments,omitempty"`
+	EnvTools     map[string]string `json:"environment_tools,omitempty"`
 	Modules      json.RawMessage   `json:"modules,omitempty"`
 	Tags         map[string]string `json:"tags,omitempty"`
 	CreatedAt    time.Time         `json:"created_at"`

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -18,6 +18,7 @@ func TestLoadAndSavePreservesLayeredMetadata(t *testing.T) {
   "tool": "terraform",
   "cloud": "aws",
   "environments": ["dev", "prod"],
+  "environment_tools": {"dev": "pulumi", "prod": "terraform"},
   "modules": ["networking", "compute"],
   "tags": {"ManagedBy": "iac-studio"}
 }`)
@@ -39,6 +40,9 @@ func TestLoadAndSavePreservesLayeredMetadata(t *testing.T) {
 	if state.Layout != "layered-v1" {
 		t.Fatalf("expected layered layout, got %q", state.Layout)
 	}
+	if state.EnvTools["dev"] != "pulumi" || state.EnvTools["prod"] != "terraform" {
+		t.Fatalf("expected environment tool map to be preserved, got %+v", state.EnvTools)
+	}
 	if !bytes.Contains(state.Modules, []byte(`"networking"`)) {
 		t.Fatalf("expected raw module metadata to be preserved, got %s", string(state.Modules))
 	}
@@ -54,6 +58,7 @@ func TestLoadAndSavePreservesLayeredMetadata(t *testing.T) {
 	for _, needle := range [][]byte{
 		[]byte(`"layout": "layered-v1"`),
 		[]byte(`"environments": [`),
+		[]byte(`"environment_tools": {`),
 		[]byte(`"networking"`),
 		[]byte(`"tags": {`),
 	} {

--- a/internal/scaffold/layered_hybrid.go
+++ b/internal/scaffold/layered_hybrid.go
@@ -1,0 +1,394 @@
+package scaffold
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/iac-studio/iac-studio/internal/pulumi"
+)
+
+// LayeredHybridBlueprint renders a layered-v1 project where each
+// environment can choose Terraform or Pulumi independently.
+type LayeredHybridBlueprint struct{}
+
+func (b *LayeredHybridBlueprint) ID() string   { return "layered-hybrid" }
+func (b *LayeredHybridBlueprint) Name() string { return "Layered Hybrid (Terraform + Pulumi)" }
+func (b *LayeredHybridBlueprint) Description() string {
+	return "Multi-environment project with a per-environment tool selector: Terraform roots and Pulumi TypeScript projects can live side by side."
+}
+func (b *LayeredHybridBlueprint) Tool() string { return "multi" }
+
+func (b *LayeredHybridBlueprint) Inputs() []Input {
+	return []Input{
+		{Key: "project_name", Label: "Project name", Type: "string", Required: true},
+		{Key: "cloud", Label: "Primary cloud provider", Type: "select",
+			Options: []string{"aws", "gcp", "azure"}, Default: "aws", Required: true},
+		{Key: "environments", Label: "Environments", Type: "multiselect",
+			Options: []string{"dev", "staging", "prod"}, Default: []string{"dev", "prod"}},
+		{Key: "pulumi_environments", Label: "Pulumi environments", Type: "multiselect",
+			Options: []string{"dev", "staging", "prod"}, Default: []string{"dev"},
+			Description: "Selected environments render as Pulumi TypeScript; the remaining environments render as Terraform."},
+		{Key: "modules", Label: "Terraform module scaffolds", Type: "multiselect",
+			Options: []string{"networking", "compute", "database", "security", "monitoring"},
+			Default: []string{"networking", "compute", "database", "security", "monitoring"}},
+		{Key: "backend", Label: "Terraform remote state backend", Type: "select",
+			Options: []string{"s3", "gcs", "azurerm", "none"}, Default: "s3"},
+		{Key: "state_bucket", Label: "Terraform state bucket/container name", Type: "string",
+			Description: "Used in Terraform backend.tf — leave blank to derive from project name."},
+		{Key: "state_region", Label: "Terraform state backend region", Type: "string", Default: "us-east-1"},
+		{Key: "region", Label: "Pulumi primary region / location", Type: "string", Default: "",
+			Description: "Baked into Pulumi.<env>.yaml for Pulumi environments. Leave empty to use the per-cloud default."},
+		{Key: "owner_tag", Label: "Owner tag", Type: "string", Default: "platform"},
+		{Key: "cost_center_tag", Label: "Cost center tag", Type: "string", Default: "shared"},
+	}
+}
+
+func (b *LayeredHybridBlueprint) Render(values map[string]any) ([]File, error) {
+	name := stringInput(values, "project_name", "")
+	if err := validateSafeName("project_name", name); err != nil {
+		return nil, err
+	}
+	cloud := stringInput(values, "cloud", "aws")
+	switch cloud {
+	case "aws", "gcp", "azure":
+	default:
+		return nil, fmt.Errorf("cloud %q is unsupported: must be one of aws, gcp, azure", cloud)
+	}
+	envs := stringSliceInput(values, "environments", []string{"dev", "prod"})
+	if len(envs) == 0 {
+		return nil, fmt.Errorf("at least one environment is required")
+	}
+	envSet := make(map[string]struct{}, len(envs))
+	for _, env := range envs {
+		if err := validatePathSegment("environment", env); err != nil {
+			return nil, err
+		}
+		envSet[env] = struct{}{}
+	}
+
+	pulumiEnvInputs := stringSliceInput(values, "pulumi_environments", nil)
+	if len(pulumiEnvInputs) == 0 {
+		pulumiEnvInputs = []string{envs[0]}
+	}
+	pulumiEnvSet := make(map[string]struct{}, len(pulumiEnvInputs))
+	for _, env := range pulumiEnvInputs {
+		if err := validatePathSegment("pulumi environment", env); err != nil {
+			return nil, err
+		}
+		if _, ok := envSet[env]; !ok {
+			return nil, fmt.Errorf("pulumi environment %q is not in environments", env)
+		}
+		pulumiEnvSet[env] = struct{}{}
+	}
+
+	modules := stringSliceInput(values, "modules", []string{"networking", "compute", "database", "security", "monitoring"})
+	for _, mod := range modules {
+		if err := validatePathSegment("module", mod); err != nil {
+			return nil, err
+		}
+	}
+	backend := stringInput(values, "backend", "s3")
+	switch backend {
+	case "s3", "gcs", "azurerm", "none":
+	default:
+		return nil, fmt.Errorf("backend %q is unsupported: must be one of s3, gcs, azurerm, none", backend)
+	}
+	stateBucket := stringInput(values, "state_bucket", defaultStateBucket(name, backend))
+	switch backend {
+	case "none":
+	case "azurerm":
+		if !azureStorageAccountRE.MatchString(stateBucket) {
+			return nil, fmt.Errorf("state_bucket %q is invalid for azurerm backend: must be 3-24 lowercase letters/digits with no hyphens", stateBucket)
+		}
+	default:
+		if err := validateSafeName("state_bucket", stateBucket); err != nil {
+			return nil, err
+		}
+	}
+	stateRegion := stringInput(values, "state_region", "us-east-1")
+	if err := validateSafeName("state_region", stateRegion); err != nil {
+		return nil, err
+	}
+	region, err := pulumiRegionInput(values, cloud)
+	if err != nil {
+		return nil, err
+	}
+	owner := stringInput(values, "owner_tag", "platform")
+	if err := validateTagValue("owner_tag", owner); err != nil {
+		return nil, err
+	}
+	costCenter := stringInput(values, "cost_center_tag", "shared")
+	if err := validateHCLSafeValue("cost_center_tag", costCenter); err != nil {
+		return nil, err
+	}
+
+	envTools := make(map[string]string, len(envs))
+	terraformEnvs := make([]string, 0, len(envs))
+	pulumiEnvs := make([]string, 0, len(envs))
+	for _, env := range envs {
+		if _, ok := pulumiEnvSet[env]; ok {
+			envTools[env] = "pulumi"
+			pulumiEnvs = append(pulumiEnvs, env)
+			continue
+		}
+		envTools[env] = "terraform"
+		terraformEnvs = append(terraformEnvs, env)
+	}
+
+	ctx := layeredCtx{
+		Name: name, Cloud: cloud, Envs: terraformEnvs, Modules: modules,
+		Backend: backend, StateBucket: stateBucket, StateRegion: stateRegion,
+		Owner: owner, CostCenter: costCenter,
+	}
+
+	descriptorModules := modules
+	if len(terraformEnvs) == 0 {
+		descriptorModules = nil
+	}
+
+	var files []File
+	files = append(files, hybridRootFiles(name, cloud, envs, envTools, descriptorModules, owner, costCenter)...)
+	for _, env := range terraformEnvs {
+		files = append(files, ctx.envFiles(env)...)
+	}
+	if len(terraformEnvs) > 0 {
+		for _, mod := range modules {
+			files = append(files, ctx.moduleFiles(mod)...)
+		}
+		files = append(files, ctx.policyFiles()...)
+	}
+	for _, env := range pulumiEnvs {
+		envFiles, err := renderPulumiEnvFiles(name, cloud, env, owner, region)
+		if err != nil {
+			return nil, err
+		}
+		files = append(files, envFiles...)
+	}
+	if len(pulumiEnvs) > 0 {
+		files = append(files, pulumiCrossGuardPolicyFiles()...)
+	}
+	files = append(files, hybridLifecycleScripts()...)
+	return files, nil
+}
+
+func pulumiRegionInput(values map[string]any, cloud string) (string, error) {
+	region := stringInput(values, "region", "")
+	if region == "" {
+		switch cloud {
+		case "gcp":
+			region = "us-central1"
+		case "azure":
+			region = "WestUS2"
+		default:
+			region = "us-east-1"
+		}
+	}
+	if cloud == "gcp" && !gcpRegionRE.MatchString(region) {
+		switch strings.ToUpper(region) {
+		case "US", "EU", "ASIA":
+			region = strings.ToUpper(region)
+		default:
+			return "", fmt.Errorf("region %q is not a valid GCP region (expected canonical form like us-central1 or short multi-region US/EU/ASIA)", region)
+		}
+	}
+	return region, nil
+}
+
+func renderPulumiEnvFiles(name, cloud, env, owner, region string) ([]File, error) {
+	const maxBase = 60
+	projName := truncateForBucketName(name, maxBase) + "-" + env
+	proj := pulumi.ProjectConfig{
+		Name:         projName,
+		Description:  fmt.Sprintf("%s - %s environment (Pulumi)", name, env),
+		Environments: []string{env},
+		Region:       region,
+		Resources:    seedResourcesFor(cloud, name, env, owner, region),
+	}
+	emitted, err := pulumi.GenerateProject(proj)
+	if err != nil {
+		return nil, fmt.Errorf("generate pulumi project for env %q: %w", env, err)
+	}
+	files := make([]File, 0, len(emitted))
+	for _, f := range emitted {
+		files = append(files, File{
+			Path:    fmt.Sprintf("environments/%s/%s", env, f.Path),
+			Content: f.Content,
+		})
+	}
+	return files, nil
+}
+
+func hybridRootFiles(name, cloud string, envs []string, envTools map[string]string, modules []string, owner, costCenter string) []File {
+	readme := renderHybridProjectReadme(name, cloud, envs, envTools)
+	gitignore := `# Terraform
+.terraform/
+*.tfstate
+*.tfstate.*
+*.tfplan
+tfplan.json
+crash.log
+crash.*.log
+
+# Sensitive inputs
+*.tfvars
+*.tfvars.json
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Pulumi / Node
+node_modules/
+bin/
+*.log
+*.tsbuildinfo
+.pulumi/
+
+# OS
+.DS_Store
+Thumbs.db
+`
+	metaObj := struct {
+		Layout           string            `json:"layout"`
+		Tool             string            `json:"tool"`
+		Blueprint        string            `json:"blueprint"`
+		ProjectName      string            `json:"project_name"`
+		Cloud            string            `json:"cloud"`
+		Environments     []string          `json:"environments"`
+		EnvironmentTools map[string]string `json:"environment_tools"`
+		Modules          []string          `json:"modules,omitempty"`
+		Tags             map[string]string `json:"tags"`
+	}{
+		Layout:           "layered-v1",
+		Tool:             "multi",
+		Blueprint:        "layered-hybrid",
+		ProjectName:      name,
+		Cloud:            cloud,
+		Environments:     envs,
+		EnvironmentTools: envTools,
+		Modules:          modules,
+		Tags: map[string]string{
+			"Owner":      owner,
+			"CostCenter": costCenter,
+			"ManagedBy":  "iac-studio",
+		},
+	}
+	studioMetaBytes, err := json.MarshalIndent(metaObj, "", "  ")
+	if err != nil {
+		panic(fmt.Sprintf("scaffold: failed to marshal .iac-studio.json (this is a bug, please report it): %v", err))
+	}
+	return []File{
+		{Path: "README.md", Content: []byte(readme)},
+		{Path: ".gitignore", Content: []byte(gitignore)},
+		{Path: ".iac-studio.json", Content: append(studioMetaBytes, '\n')},
+	}
+}
+
+func renderHybridProjectReadme(name, cloud string, envs []string, envTools map[string]string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# %s\n\n", name)
+	fmt.Fprintf(&b, "Hybrid layered project scaffolded by IaC Studio, targeting %s.\n\n", cloud)
+	b.WriteString("## Environment Tools\n\n")
+	for _, env := range envs {
+		fmt.Fprintf(&b, "- `%s`: %s\n", env, envTools[env])
+	}
+	b.WriteString("\n## Layout\n\n")
+	b.WriteString("- `environments/{env}/` - Terraform roots or Pulumi projects, depending on `.iac-studio.json`.\n")
+	b.WriteString("- `modules/` - reusable Terraform modules for Terraform environments.\n")
+	b.WriteString("- `policies/` - OPA/Sentinel for Terraform and CrossGuard packs for Pulumi.\n")
+	b.WriteString("- `scripts/` - lifecycle wrappers that detect each environment's tool.\n\n")
+	b.WriteString("## Daily use\n\n")
+	b.WriteString("```bash\n")
+	b.WriteString("./scripts/init.sh dev\n")
+	b.WriteString("./scripts/plan.sh dev\n")
+	b.WriteString("./scripts/apply.sh dev\n")
+	b.WriteString("```\n")
+	return b.String()
+}
+
+func hybridLifecycleScripts() []File {
+	helper := `env="${1:?env required - usage: $0 <env>}"
+root="$(cd "$(dirname "$0")/.." && pwd)"
+dir="$root/environments/$env"
+if [[ ! -d "$dir" ]]; then
+  echo "Unknown environment: $env" >&2
+  exit 1
+fi
+if [[ -f "$dir/Pulumi.yaml" ]]; then
+  tool="pulumi"
+elif compgen -G "$dir/*.tf" > /dev/null; then
+  tool="terraform"
+else
+  echo "Could not infer IaC tool for environment: $env" >&2
+  exit 1
+fi
+`
+	initSh := "#!/usr/bin/env bash\nset -euo pipefail\n" + helper + `if [[ "$tool" == "pulumi" ]]; then
+  if [[ -f "$root/policies/crossguard/package.json" ]]; then
+    (cd "$root/policies/crossguard" && npm install)
+  fi
+  (cd "$dir" && npm install)
+else
+  (cd "$dir" && terraform init -upgrade && terraform validate)
+fi
+`
+	planSh := "#!/usr/bin/env bash\nset -euo pipefail\n" + helper + `if [[ "$tool" == "pulumi" ]]; then
+  (cd "$dir" && pulumi preview --stack "$env" --non-interactive --color=never)
+else
+  (cd "$dir" && terraform plan -out=tfplan.binary -var-file=terraform.tfvars && terraform show -json tfplan.binary > tfplan.json && terraform show -no-color tfplan.binary > tfplan.txt)
+  echo "Plan written to $dir/tfplan.txt"
+fi
+`
+	applySh := "#!/usr/bin/env bash\nset -euo pipefail\n" + helper + `if [[ "$tool" == "pulumi" ]]; then
+  (cd "$dir" && pulumi up --stack "$env" --yes --non-interactive --color=never)
+else
+  if [[ ! -f "$dir/tfplan.binary" ]]; then
+    echo "No plan found - run scripts/plan.sh $env first" >&2
+    exit 1
+  fi
+  (cd "$dir" && terraform apply tfplan.binary && rm -f tfplan.binary tfplan.txt tfplan.json)
+fi
+`
+	destroySh := "#!/usr/bin/env bash\nset -euo pipefail\n" + helper + `if [[ "$tool" == "pulumi" ]]; then
+  (cd "$dir" && pulumi destroy --stack "$env" --yes --non-interactive --color=never)
+else
+  read -r -p "Type the environment name '$env' to confirm destruction: " confirm
+  if [[ "$confirm" != "$env" ]]; then
+    echo "aborted" >&2
+    exit 1
+  fi
+  (cd "$dir" && terraform destroy -var-file=terraform.tfvars)
+fi
+`
+	validateSh := `#!/usr/bin/env bash
+set -euo pipefail
+root="$(cd "$(dirname "$0")/.." && pwd)"
+for dir in "$root"/environments/*/; do
+  [[ -d "$dir" ]] || continue
+  if [[ -f "$dir/Pulumi.yaml" ]]; then
+    (cd "$dir" && npx tsc --noEmit)
+  elif compgen -G "$dir/*.tf" > /dev/null; then
+    (cd "$dir" && terraform init -backend=false -input=false >/dev/null && terraform validate)
+  fi
+done
+if [[ -d "$root/modules" ]]; then
+  terraform -chdir="$root" fmt -recursive
+  for mod in "$root"/modules/*/; do
+    [[ -d "$mod" ]] || continue
+    (cd "$mod" && terraform init -backend=false -input=false >/dev/null && terraform validate)
+  done
+fi
+`
+	return []File{
+		{Path: "scripts/init.sh", Content: []byte(initSh), Executable: true},
+		{Path: "scripts/plan.sh", Content: []byte(planSh), Executable: true},
+		{Path: "scripts/apply.sh", Content: []byte(applySh), Executable: true},
+		{Path: "scripts/destroy.sh", Content: []byte(destroySh), Executable: true},
+		{Path: "scripts/validate.sh", Content: []byte(validateSh), Executable: true},
+	}
+}
+
+func init() {
+	Default.Register(&LayeredHybridBlueprint{})
+}

--- a/internal/scaffold/layered_hybrid.go
+++ b/internal/scaffold/layered_hybrid.go
@@ -82,34 +82,6 @@ func (b *LayeredHybridBlueprint) Render(values map[string]any) ([]File, error) {
 		pulumiEnvSet[env] = struct{}{}
 	}
 
-	modules := stringSliceInput(values, "modules", []string{"networking", "compute", "database", "security", "monitoring"})
-	for _, mod := range modules {
-		if err := validatePathSegment("module", mod); err != nil {
-			return nil, err
-		}
-	}
-	backend := stringInput(values, "backend", "s3")
-	switch backend {
-	case "s3", "gcs", "azurerm", "none":
-	default:
-		return nil, fmt.Errorf("backend %q is unsupported: must be one of s3, gcs, azurerm, none", backend)
-	}
-	stateBucket := stringInput(values, "state_bucket", defaultStateBucket(name, backend))
-	switch backend {
-	case "none":
-	case "azurerm":
-		if !azureStorageAccountRE.MatchString(stateBucket) {
-			return nil, fmt.Errorf("state_bucket %q is invalid for azurerm backend: must be 3-24 lowercase letters/digits with no hyphens", stateBucket)
-		}
-	default:
-		if err := validateSafeName("state_bucket", stateBucket); err != nil {
-			return nil, err
-		}
-	}
-	stateRegion := stringInput(values, "state_region", "us-east-1")
-	if err := validateSafeName("state_region", stateRegion); err != nil {
-		return nil, err
-	}
 	region, err := pulumiRegionInput(values, cloud)
 	if err != nil {
 		return nil, err
@@ -136,19 +108,46 @@ func (b *LayeredHybridBlueprint) Render(values map[string]any) ([]File, error) {
 		terraformEnvs = append(terraformEnvs, env)
 	}
 
-	ctx := layeredCtx{
-		Name: name, Cloud: cloud, Envs: terraformEnvs, Modules: modules,
-		Backend: backend, StateBucket: stateBucket, StateRegion: stateRegion,
-		Owner: owner, CostCenter: costCenter,
-	}
-
-	descriptorModules := modules
-	if len(terraformEnvs) == 0 {
-		descriptorModules = nil
+	var modules []string
+	var ctx layeredCtx
+	if len(terraformEnvs) > 0 {
+		modules = stringSliceInput(values, "modules", []string{"networking", "compute", "database", "security", "monitoring"})
+		for _, mod := range modules {
+			if err := validatePathSegment("module", mod); err != nil {
+				return nil, err
+			}
+		}
+		backend := stringInput(values, "backend", "s3")
+		switch backend {
+		case "s3", "gcs", "azurerm", "none":
+		default:
+			return nil, fmt.Errorf("backend %q is unsupported: must be one of s3, gcs, azurerm, none", backend)
+		}
+		stateBucket := stringInput(values, "state_bucket", defaultStateBucket(name, backend))
+		switch backend {
+		case "none":
+		case "azurerm":
+			if !azureStorageAccountRE.MatchString(stateBucket) {
+				return nil, fmt.Errorf("state_bucket %q is invalid for azurerm backend: must be 3-24 lowercase letters/digits with no hyphens", stateBucket)
+			}
+		default:
+			if err := validateSafeName("state_bucket", stateBucket); err != nil {
+				return nil, err
+			}
+		}
+		stateRegion := stringInput(values, "state_region", "us-east-1")
+		if err := validateSafeName("state_region", stateRegion); err != nil {
+			return nil, err
+		}
+		ctx = layeredCtx{
+			Name: name, Cloud: cloud, Envs: terraformEnvs, Modules: modules,
+			Backend: backend, StateBucket: stateBucket, StateRegion: stateRegion,
+			Owner: owner, CostCenter: costCenter,
+		}
 	}
 
 	var files []File
-	files = append(files, hybridRootFiles(name, cloud, envs, envTools, descriptorModules, owner, costCenter)...)
+	files = append(files, hybridRootFiles(name, cloud, envs, envTools, modules, owner, costCenter)...)
 	for _, env := range terraformEnvs {
 		files = append(files, ctx.envFiles(env)...)
 	}
@@ -264,6 +263,16 @@ Thumbs.db
 
 func renderHybridProjectReadme(name, cloud string, envs []string, envTools map[string]string) string {
 	var b strings.Builder
+	hasTerraform := false
+	hasPulumi := false
+	for _, tool := range envTools {
+		switch tool {
+		case "terraform":
+			hasTerraform = true
+		case "pulumi":
+			hasPulumi = true
+		}
+	}
 	fmt.Fprintf(&b, "# %s\n\n", name)
 	fmt.Fprintf(&b, "Hybrid layered project scaffolded by IaC Studio, targeting %s.\n\n", cloud)
 	b.WriteString("## Environment Tools\n\n")
@@ -272,8 +281,17 @@ func renderHybridProjectReadme(name, cloud string, envs []string, envTools map[s
 	}
 	b.WriteString("\n## Layout\n\n")
 	b.WriteString("- `environments/{env}/` - Terraform roots or Pulumi projects, depending on `.iac-studio.json`.\n")
-	b.WriteString("- `modules/` - reusable Terraform modules for Terraform environments.\n")
-	b.WriteString("- `policies/` - OPA/Sentinel for Terraform and CrossGuard packs for Pulumi.\n")
+	if hasTerraform {
+		b.WriteString("- `modules/` - reusable Terraform modules for Terraform environments.\n")
+	}
+	switch {
+	case hasTerraform && hasPulumi:
+		b.WriteString("- `policies/` - OPA/Sentinel for Terraform and CrossGuard packs for Pulumi.\n")
+	case hasTerraform:
+		b.WriteString("- `policies/opa/` and `policies/sentinel/` - Terraform policy packs.\n")
+	case hasPulumi:
+		b.WriteString("- `policies/crossguard/` - CrossGuard policy pack for Pulumi environments.\n")
+	}
 	b.WriteString("- `scripts/` - lifecycle wrappers that detect each environment's tool.\n\n")
 	b.WriteString("## Daily use\n\n")
 	b.WriteString("```bash\n")

--- a/internal/scaffold/layered_hybrid.go
+++ b/internal/scaffold/layered_hybrid.go
@@ -172,29 +172,6 @@ func (b *LayeredHybridBlueprint) Render(values map[string]any) ([]File, error) {
 	return files, nil
 }
 
-func pulumiRegionInput(values map[string]any, cloud string) (string, error) {
-	region := stringInput(values, "region", "")
-	if region == "" {
-		switch cloud {
-		case "gcp":
-			region = "us-central1"
-		case "azure":
-			region = "WestUS2"
-		default:
-			region = "us-east-1"
-		}
-	}
-	if cloud == "gcp" && !gcpRegionRE.MatchString(region) {
-		switch strings.ToUpper(region) {
-		case "US", "EU", "ASIA":
-			region = strings.ToUpper(region)
-		default:
-			return "", fmt.Errorf("region %q is not a valid GCP region (expected canonical form like us-central1 or short multi-region US/EU/ASIA)", region)
-		}
-	}
-	return region, nil
-}
-
 func renderPulumiEnvFiles(name, cloud, env, owner, region string) ([]File, error) {
 	const maxBase = 60
 	projName := truncateForBucketName(name, maxBase) + "-" + env

--- a/internal/scaffold/layered_hybrid_test.go
+++ b/internal/scaffold/layered_hybrid_test.go
@@ -1,0 +1,95 @@
+package scaffold
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestLayeredHybridRendersPerEnvironmentTools(t *testing.T) {
+	bp := &LayeredHybridBlueprint{}
+	files, err := bp.Render(map[string]any{
+		"project_name":        "acme",
+		"cloud":               "aws",
+		"environments":        []any{"dev", "prod"},
+		"pulumi_environments": []any{"dev"},
+		"modules":             []any{"networking"},
+		"backend":             "s3",
+		"state_bucket":        "acme-tfstate",
+		"state_region":        "us-east-1",
+		"owner_tag":           "platform",
+		"cost_center_tag":     "shared",
+	})
+	if err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+
+	got := map[string]File{}
+	for _, file := range files {
+		got[file.Path] = file
+	}
+	for _, path := range []string{
+		".iac-studio.json",
+		"environments/dev/Pulumi.yaml",
+		"environments/dev/index.ts",
+		"environments/prod/main.tf",
+		"environments/prod/backend.tf",
+		"modules/networking/main.tf",
+		"policies/crossguard/PulumiPolicy.yaml",
+		"policies/opa/resource-tagging.rego",
+		"scripts/plan.sh",
+	} {
+		if _, ok := got[path]; !ok {
+			t.Fatalf("expected file missing from render output: %s", path)
+		}
+	}
+	for _, path := range []string{
+		"environments/dev/main.tf",
+		"environments/prod/Pulumi.yaml",
+	} {
+		if _, ok := got[path]; ok {
+			t.Fatalf("unexpected file rendered for wrong env tool: %s", path)
+		}
+	}
+
+	var descriptor struct {
+		Tool             string            `json:"tool"`
+		Blueprint        string            `json:"blueprint"`
+		Layout           string            `json:"layout"`
+		EnvironmentTools map[string]string `json:"environment_tools"`
+	}
+	if err := json.Unmarshal(got[".iac-studio.json"].Content, &descriptor); err != nil {
+		t.Fatalf("descriptor json: %v", err)
+	}
+	if descriptor.Tool != "multi" || descriptor.Blueprint != "layered-hybrid" || descriptor.Layout != "layered-v1" {
+		t.Fatalf("unexpected descriptor header: %+v", descriptor)
+	}
+	if descriptor.EnvironmentTools["dev"] != "pulumi" || descriptor.EnvironmentTools["prod"] != "terraform" {
+		t.Fatalf("unexpected environment tool map: %+v", descriptor.EnvironmentTools)
+	}
+	if !strings.Contains(string(got["scripts/plan.sh"].Content), "Pulumi.yaml") {
+		t.Fatalf("hybrid plan script should detect Pulumi envs:\n%s", string(got["scripts/plan.sh"].Content))
+	}
+}
+
+func TestLayeredHybridRejectsPulumiEnvironmentOutsideSelectedEnvs(t *testing.T) {
+	bp := &LayeredHybridBlueprint{}
+	_, err := bp.Render(map[string]any{
+		"project_name":        "acme",
+		"environments":        []any{"prod"},
+		"pulumi_environments": []any{"dev"},
+	})
+	if err == nil {
+		t.Fatal("expected mismatch validation error, got nil")
+	}
+}
+
+func TestLayeredHybridRegisteredInDefaultRegistry(t *testing.T) {
+	bp, ok := Default.Get("layered-hybrid")
+	if !ok {
+		t.Fatal("layered-hybrid blueprint not registered in Default registry")
+	}
+	if bp.Tool() != "multi" {
+		t.Fatalf("registered blueprint Tool() = %q, want multi", bp.Tool())
+	}
+}

--- a/internal/scaffold/layered_hybrid_test.go
+++ b/internal/scaffold/layered_hybrid_test.go
@@ -84,6 +84,20 @@ func TestLayeredHybridRejectsPulumiEnvironmentOutsideSelectedEnvs(t *testing.T) 
 	}
 }
 
+func TestLayeredHybridRejectsInvalidPulumiGCPRegion(t *testing.T) {
+	bp := &LayeredHybridBlueprint{}
+	_, err := bp.Render(map[string]any{
+		"project_name":        "acme",
+		"cloud":               "gcp",
+		"environments":        []any{"dev"},
+		"pulumi_environments": []any{"dev"},
+		"region":              "us-east-1",
+	})
+	if err == nil {
+		t.Fatal("expected GCP region validation error, got nil")
+	}
+}
+
 func TestLayeredHybridRegisteredInDefaultRegistry(t *testing.T) {
 	bp, ok := Default.Get("layered-hybrid")
 	if !ok {

--- a/internal/scaffold/layered_hybrid_test.go
+++ b/internal/scaffold/layered_hybrid_test.go
@@ -98,6 +98,84 @@ func TestLayeredHybridRejectsInvalidPulumiGCPRegion(t *testing.T) {
 	}
 }
 
+func TestLayeredHybridAllPulumiSkipsTerraformOnlyInputsAndDocs(t *testing.T) {
+	bp := &LayeredHybridBlueprint{}
+	files, err := bp.Render(map[string]any{
+		"project_name":        "acme",
+		"cloud":               "aws",
+		"environments":        []any{"dev", "prod"},
+		"pulumi_environments": []any{"dev", "prod"},
+		"modules":             []any{"../unused"},
+		"backend":             "azurerm",
+		"state_bucket":        "invalid-hyphenated-azure-name",
+		"state_region":        "not a region",
+	})
+	if err != nil {
+		t.Fatalf("all-Pulumi hybrid render should ignore unused Terraform inputs, got: %v", err)
+	}
+
+	got := map[string]File{}
+	for _, file := range files {
+		got[file.Path] = file
+	}
+	for _, path := range []string{
+		"environments/dev/Pulumi.yaml",
+		"environments/prod/Pulumi.yaml",
+		"policies/crossguard/PulumiPolicy.yaml",
+	} {
+		if _, ok := got[path]; !ok {
+			t.Fatalf("expected all-Pulumi file missing: %s", path)
+		}
+	}
+	for _, path := range []string{
+		"environments/dev/backend.tf",
+		"modules/networking/main.tf",
+		"policies/opa/resource-tagging.rego",
+		"policies/sentinel/cost-control.sentinel",
+	} {
+		if _, ok := got[path]; ok {
+			t.Fatalf("unexpected Terraform-only file rendered for all-Pulumi hybrid: %s", path)
+		}
+	}
+
+	var descriptor struct {
+		Modules []string `json:"modules"`
+	}
+	if err := json.Unmarshal(got[".iac-studio.json"].Content, &descriptor); err != nil {
+		t.Fatalf("descriptor json: %v", err)
+	}
+	if len(descriptor.Modules) != 0 {
+		t.Fatalf("all-Pulumi descriptor should omit Terraform modules, got %+v", descriptor.Modules)
+	}
+
+	readme := string(got["README.md"].Content)
+	for _, unexpected := range []string{"`modules/`", "OPA/Sentinel", "policies/opa", "policies/sentinel"} {
+		if strings.Contains(readme, unexpected) {
+			t.Fatalf("all-Pulumi README should not mention %q:\n%s", unexpected, readme)
+		}
+	}
+	if !strings.Contains(readme, "policies/crossguard") {
+		t.Fatalf("all-Pulumi README should mention CrossGuard policies:\n%s", readme)
+	}
+}
+
+func TestLayeredHybridValidatesTerraformBackendWhenTerraformEnvExists(t *testing.T) {
+	bp := &LayeredHybridBlueprint{}
+	_, err := bp.Render(map[string]any{
+		"project_name":        "acme",
+		"environments":        []any{"dev", "prod"},
+		"pulumi_environments": []any{"dev"},
+		"backend":             "azurerm",
+		"state_bucket":        "invalid-hyphenated-azure-name",
+	})
+	if err == nil {
+		t.Fatal("expected Terraform backend validation error, got nil")
+	}
+	if !strings.Contains(err.Error(), "state_bucket") {
+		t.Fatalf("expected state_bucket validation error, got: %v", err)
+	}
+}
+
 func TestLayeredHybridRegisteredInDefaultRegistry(t *testing.T) {
 	bp, ok := Default.Get("layered-hybrid")
 	if !ok {

--- a/internal/scaffold/layered_pulumi.go
+++ b/internal/scaffold/layered_pulumi.go
@@ -36,6 +36,29 @@ func validateTagValue(key, value string) error {
 	return nil
 }
 
+func pulumiRegionInput(values map[string]any, cloud string) (string, error) {
+	region := stringInput(values, "region", "")
+	if region == "" {
+		switch cloud {
+		case "gcp":
+			region = "us-central1"
+		case "azure":
+			region = "WestUS2"
+		default:
+			region = "us-east-1"
+		}
+	}
+	if cloud == "gcp" && !gcpRegionRE.MatchString(region) {
+		switch strings.ToUpper(region) {
+		case "US", "EU", "ASIA":
+			region = strings.ToUpper(region)
+		default:
+			return "", fmt.Errorf("region %q is not a valid GCP region (expected canonical form like us-central1 or short multi-region US/EU/ASIA)", region)
+		}
+	}
+	return region, nil
+}
+
 // truncateForBucketName clamps a base name to max chars while keeping
 // the name valid as an S3/GCS bucket (must end in an alphanumeric,
 // no trailing '-' or '_'). Used when composing `<project>-seed` +
@@ -138,39 +161,9 @@ func (b *LayeredPulumiBlueprint) Render(values map[string]any) ([]File, error) {
 			return nil, err
 		}
 	}
-	// Default is empty — per-cloud fallback happens inside Pulumi's
-	// generator (aws: us-east-1, gcp: us-central1, azure: WestUS2).
-	// Only substitute a cloud-appropriate default at scaffold time so
-	// the seed resource locations match what ends up in Pulumi.<env>.yaml.
-	region := stringInput(values, "region", "")
-	if region == "" {
-		switch cloud {
-		case "gcp":
-			region = "us-central1"
-		case "azure":
-			region = "WestUS2"
-		default:
-			region = "us-east-1"
-		}
-	}
-	// Cloud-shape validation: an AWS-shaped region (us-east-1) on a
-	// GCP scaffold would emit gcp:region: us-east-1 in the stack
-	// config — invalid at provider time, AND the seed bucket would
-	// silently fall back to "US" multi-region, producing a confusing
-	// mismatch. Reject up front so the caller fixes the input.
-	if cloud == "gcp" && !gcpRegionRE.MatchString(region) {
-		// Allow short multi-regions only — GCS accepts US, EU, ASIA
-		// (and a small set of named multi-regions). Anything outside
-		// that allowlist would silently uppercase to a still-invalid
-		// value and fail at provider time. Normalise casing so a
-		// lower/mixed input ("us", "Us") becomes canonical before
-		// hitting Pulumi.<env>.yaml.
-		switch strings.ToUpper(region) {
-		case "US", "EU", "ASIA":
-			region = strings.ToUpper(region)
-		default:
-			return nil, fmt.Errorf("region %q is not a valid GCP region (expected canonical form like us-central1 or short multi-region US/EU/ASIA)", region)
-		}
+	region, err := pulumiRegionInput(values, cloud)
+	if err != nil {
+		return nil, err
 	}
 	owner := stringInput(values, "owner_tag", "platform")
 	if err := validateTagValue("owner_tag", owner); err != nil {

--- a/internal/scaffold/layered_pulumi_test.go
+++ b/internal/scaffold/layered_pulumi_test.go
@@ -129,6 +129,28 @@ func TestLayeredPulumi_RejectsBadName(t *testing.T) {
 	}
 }
 
+func TestPulumiRegionInputDefaultsAndValidatesGCP(t *testing.T) {
+	region, err := pulumiRegionInput(map[string]any{}, "gcp")
+	if err != nil {
+		t.Fatalf("pulumiRegionInput default gcp: %v", err)
+	}
+	if region != "us-central1" {
+		t.Fatalf("default gcp region = %q, want us-central1", region)
+	}
+
+	region, err = pulumiRegionInput(map[string]any{"region": "eu"}, "gcp")
+	if err != nil {
+		t.Fatalf("pulumiRegionInput gcp multi-region: %v", err)
+	}
+	if region != "EU" {
+		t.Fatalf("gcp multi-region = %q, want EU", region)
+	}
+
+	if _, err := pulumiRegionInput(map[string]any{"region": "us-east-1"}, "gcp"); err == nil {
+		t.Fatal("expected GCP region validation error")
+	}
+}
+
 func TestLayeredPulumi_LifecycleScriptsAreExecutable(t *testing.T) {
 	bp := &LayeredPulumiBlueprint{}
 	files, err := bp.Render(map[string]any{

--- a/web/src/App.test.ts
+++ b/web/src/App.test.ts
@@ -18,11 +18,25 @@ describe('normalizeLayeredProject', () => {
   });
 
   it('keeps valid environment tool mappings', () => {
-    expect(normalizeLayeredProject({
+    const layered = normalizeLayeredProject({
       layout: 'layered-v1',
       environments: ['dev', 'prod'],
       environment_tools: { dev: 'pulumi', prod: 'terraform', qa: 'terraform' },
-    })?.environmentTools).toEqual({ dev: 'pulumi', prod: 'terraform' });
+    });
+
+    expect({ ...layered?.environmentTools }).toEqual({ dev: 'pulumi', prod: 'terraform' });
+  });
+
+  it('stores environment tool mappings in a null-prototype map', () => {
+    const layered = normalizeLayeredProject({
+      layout: 'layered-v1',
+      environments: ['__proto__', 'constructor'],
+      environment_tools: JSON.parse('{"__proto__":"pulumi","constructor":"terraform"}'),
+    });
+
+    expect(Object.getPrototypeOf(layered?.environmentTools)).toBeNull();
+    expect(layered?.environmentTools?.['__proto__']).toBe('pulumi');
+    expect(layered?.environmentTools?.['constructor']).toBe('terraform');
   });
 });
 

--- a/web/src/App.test.ts
+++ b/web/src/App.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { normalizeLayeredProject } from './App';
+import { normalizeLayeredProject, resourcesForEnv } from './App';
 
 describe('normalizeLayeredProject', () => {
   it('drops empty or invalid environment tool maps', () => {
@@ -23,5 +23,24 @@ describe('normalizeLayeredProject', () => {
       environments: ['dev', 'prod'],
       environment_tools: { dev: 'pulumi', prod: 'terraform', qa: 'terraform' },
     })?.environmentTools).toEqual({ dev: 'pulumi', prod: 'terraform' });
+  });
+});
+
+describe('resourcesForEnv', () => {
+  it('keeps only resources that are explicitly owned by the selected environment', () => {
+    const resources = [
+      { id: 'dev', file: 'environments/dev/main.tf' },
+      { id: 'prod', file: 'environments/prod/main.tf' },
+      { id: 'root', file: 'main.tf' },
+      { id: 'legacy' },
+    ];
+
+    expect(resourcesForEnv(resources, 'dev').map(resource => resource.id)).toEqual(['dev']);
+  });
+
+  it('does not filter resources when no environment is active', () => {
+    const resources = [{ id: 'root' }, { id: 'dev', file: 'environments/dev/main.tf' }];
+
+    expect(resourcesForEnv(resources).map(resource => resource.id)).toEqual(['root', 'dev']);
   });
 });

--- a/web/src/App.test.ts
+++ b/web/src/App.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeLayeredProject } from './App';
+
+describe('normalizeLayeredProject', () => {
+  it('drops empty or invalid environment tool maps', () => {
+    expect(normalizeLayeredProject({
+      layout: 'layered-v1',
+      environments: ['dev'],
+      environment_tools: { prod: 'terraform' },
+    })?.environmentTools).toBeUndefined();
+
+    expect(normalizeLayeredProject({
+      layout: 'layered-v1',
+      environments: ['dev'],
+      environment_tools: ['terraform'],
+    })?.environmentTools).toBeUndefined();
+  });
+
+  it('keeps valid environment tool mappings', () => {
+    expect(normalizeLayeredProject({
+      layout: 'layered-v1',
+      environments: ['dev', 'prod'],
+      environment_tools: { dev: 'pulumi', prod: 'terraform', qa: 'terraform' },
+    })?.environmentTools).toEqual({ dev: 'pulumi', prod: 'terraform' });
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -180,6 +180,7 @@ export default function App() {
   const chatEndRef = useRef<HTMLDivElement>(null);
   const isSyncing = useRef(false); // suppress file_changed echo from our own sync
   const isSwimlaneMode = Boolean(layeredProject && canvasMode === 'swimlane');
+  const showEnvironmentSelector = Boolean(layeredProject && (tool === 'pulumi' || tool === 'multi' || layeredProject.environmentTools));
   const pulumiEnv = envForTool(tool || '', layeredProject, activeEnvironment);
   const activeTool = toolForEnv(tool || '', layeredProject, pulumiEnv);
   const concreteTool = activeTool && activeTool !== 'multi'
@@ -1419,7 +1420,7 @@ export default function App() {
           onClick={() => { setSelectedNode(null); setSelectedEdge(null); }}>
           {layeredProject && (
             <div style={{ position: 'absolute', top: 12, right: 12, zIndex: 10, display: 'flex', gap: 6, padding: 4, background: 'var(--bg-elev-1)', border: '1px solid var(--border-main)', borderRadius: 8 }}>
-              {layeredProject.environments.map(env => {
+              {showEnvironmentSelector && layeredProject.environments.map(env => {
                 const envTool = layeredProject.environmentTools?.[env];
                 return (
                   <button

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -180,14 +180,17 @@ export default function App() {
   const chatEndRef = useRef<HTMLDivElement>(null);
   const isSyncing = useRef(false); // suppress file_changed echo from our own sync
   const isSwimlaneMode = Boolean(layeredProject && canvasMode === 'swimlane');
-  const showEnvironmentSelector = Boolean(layeredProject && (tool === 'pulumi' || tool === 'multi' || layeredProject.environmentTools));
+  const showEnvironmentSelector = Boolean(layeredProject && (tool === 'multi' || layeredProject.environmentTools));
   const pulumiEnv = envForTool(tool || '', layeredProject, activeEnvironment);
   const activeTool = toolForEnv(tool || '', layeredProject, pulumiEnv);
   const concreteTool = activeTool && activeTool !== 'multi'
     ? activeTool
     : (tool && tool !== 'multi' ? tool : 'terraform');
+  const activeResourceFile = concreteTool === 'pulumi'
+    ? (pulumiEnv ? `environments/${pulumiEnv}/index.ts` : undefined)
+    : (tool === 'multi' && pulumiEnv ? `environments/${pulumiEnv}/main${TOOLS[concreteTool]?.ext || '.tf'}` : undefined);
   const activeEnvNodes = useMemo(
-    () => resourcesForEnv(nodes, tool === 'multi' ? pulumiEnv : undefined),
+    () => resourcesForEnv(nodes, (tool === 'multi' || tool === 'pulumi') ? pulumiEnv : undefined),
     [nodes, pulumiEnv, tool],
   );
   const activeEnvEdges = useMemo(
@@ -479,14 +482,23 @@ export default function App() {
   const syncTimer = useRef<ReturnType<typeof setTimeout>>();
   const hasCreatedProject = useRef(false);
   const initialLoadDone = useRef(false);
+  const syncScope = `${projectId}:${tool || ''}:${pulumiEnv || ''}`;
+  const lastSyncScope = useRef('');
   useEffect(() => {
     if (!tool || !hasCreatedProject.current || !projectId) return;
     // Skip the first sync after opening a project — the restored state
     // doesn't need to be written back immediately (it came from disk).
     if (!initialLoadDone.current) {
       initialLoadDone.current = true;
+      lastSyncScope.current = syncScope;
       return;
     }
+    if (lastSyncScope.current && lastSyncScope.current !== syncScope) {
+      lastSyncScope.current = syncScope;
+      clearTimeout(syncTimer.current);
+      return;
+    }
+    lastSyncScope.current = syncScope;
     clearTimeout(syncTimer.current);
     syncTimer.current = setTimeout(() => {
       isSyncing.current = true;
@@ -494,7 +506,7 @@ export default function App() {
         setTimeout(() => { isSyncing.current = false; }, 1500);
       });
     }, 2000);
-  }, [activeEnvEdges, activeEnvNodes, tool, projectId, pulumiEnv]);
+  }, [activeEnvEdges, activeEnvNodes, projectId, pulumiEnv, syncScope, tool]);
 
   // ─── Handlers ───
 
@@ -506,6 +518,7 @@ export default function App() {
       label: resourceDef.label,
       icon: resourceDef.icon,
       properties: { ...(resourceDef.defaults || {}) },
+      file: activeResourceFile,
       x: 100 + Math.random() * 280,
       y: 80 + Math.random() * 180,
     };
@@ -536,7 +549,7 @@ export default function App() {
       return [...prev, node];
     });
     setSelectedNode(node.id);
-  }, [catalogResources]);
+  }, [activeResourceFile, catalogResources]);
 
   const removeNode = useCallback((id: string) => {
     setNodes(prev => prev.filter(n => n.id !== id));

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -480,10 +480,21 @@ export default function App() {
   // Sync to disk (debounced) — syncs even when nodes is empty so that
   // deleting the last resource clears the generated file on disk.
   const syncTimer = useRef<ReturnType<typeof setTimeout>>();
+  const pendingSync = useRef<{ projectId: string; tool: string; nodes: Resource[]; edges: Edge[]; env?: string } | null>(null);
   const hasCreatedProject = useRef(false);
   const initialLoadDone = useRef(false);
   const syncScope = `${projectId}:${tool || ''}:${pulumiEnv || ''}`;
   const lastSyncScope = useRef('');
+  const flushPendingSync = useCallback(() => {
+    const snapshot = pendingSync.current;
+    if (!snapshot) return;
+    pendingSync.current = null;
+    syncTimer.current = undefined;
+    isSyncing.current = true;
+    api.syncToDisk(snapshot.projectId, snapshot.tool, snapshot.nodes, snapshot.edges, snapshot.env).catch(() => {}).finally(() => {
+      setTimeout(() => { isSyncing.current = false; }, 1500);
+    });
+  }, []);
   useEffect(() => {
     if (!tool || !hasCreatedProject.current || !projectId) return;
     // Skip the first sync after opening a project — the restored state
@@ -494,19 +505,19 @@ export default function App() {
       return;
     }
     if (lastSyncScope.current && lastSyncScope.current !== syncScope) {
-      lastSyncScope.current = syncScope;
       clearTimeout(syncTimer.current);
+      syncTimer.current = undefined;
+      flushPendingSync();
+      lastSyncScope.current = syncScope;
       return;
     }
     lastSyncScope.current = syncScope;
     clearTimeout(syncTimer.current);
+    pendingSync.current = { projectId, tool, nodes: activeEnvNodes, edges: activeEnvEdges, env: pulumiEnv };
     syncTimer.current = setTimeout(() => {
-      isSyncing.current = true;
-      api.syncToDisk(projectId, tool, activeEnvNodes, activeEnvEdges, pulumiEnv).catch(() => {}).finally(() => {
-        setTimeout(() => { isSyncing.current = false; }, 1500);
-      });
+      flushPendingSync();
     }, 2000);
-  }, [activeEnvEdges, activeEnvNodes, projectId, pulumiEnv, syncScope, tool]);
+  }, [activeEnvEdges, activeEnvNodes, flushPendingSync, projectId, pulumiEnv, syncScope, tool]);
 
   // ─── Handlers ───
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -97,7 +97,7 @@ const normalizeLayeredProject = (state: any): LayeredProject | null => {
 
 const resourceEnv = (resource: { file?: string }) => {
   if (!resource.file) return null;
-  const parts = resource.file.split('/');
+  const parts = resource.file.replace(/\\/g, '/').split('/');
   const envIdx = parts.indexOf('environments');
   return envIdx >= 0 && parts.length > envIdx + 1 ? parts[envIdx + 1] : null;
 };

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef, useEffect } from 'react';
+import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
 import { api, ApiError, Resource, ToolInfo, CatalogResource, Suggestion, FileEntry, ImportResult, type PolicyFinding } from './api';
 import { useWebSocket, WSMessage } from './useWebSocket';
 import { useHistory } from './useHistory';
@@ -14,7 +14,7 @@ import { SwimlaneCanvas } from './components/Canvas';
 import { VisionDropzone } from './components/VisionDropzone';
 import { S } from './styles';
 import type { LayeredProject, LayeredModule } from './types';
-import { envForTool, shouldParseResourcesFromDisk } from './projectLoad';
+import { envForResourceLoad, envForTool, shouldParseResourcesFromDisk, toolForEnv } from './projectLoad';
 import {
   TOOLS,
   FALLBACK_RESOURCES,
@@ -47,7 +47,7 @@ const isPolicyBlockedError = (err: unknown): err is ApiError => (
 const extractLayoutMeta = (state: any) => {
   if (!state?.layout) return null;
   const meta: Record<string, any> = {};
-  for (const key of ['layout', 'blueprint', 'project_name', 'cloud', 'environments', 'modules', 'tags']) {
+  for (const key of ['layout', 'blueprint', 'project_name', 'cloud', 'environments', 'environment_tools', 'modules', 'tags']) {
     if (state[key] !== undefined) meta[key] = state[key];
   }
   return meta;
@@ -59,6 +59,12 @@ const normalizeLayeredProject = (state: any): LayeredProject | null => {
     ? state.environments.filter((env: unknown): env is string => typeof env === 'string' && env.length > 0)
     : [];
   if (environments.length === 0) return null;
+  const environmentTools = state.environment_tools && typeof state.environment_tools === 'object'
+    ? Object.fromEntries(
+        Object.entries(state.environment_tools)
+          .filter(([env, envTool]) => environments.includes(env) && typeof envTool === 'string' && envTool.length > 0)
+      ) as Record<string, string>
+    : undefined;
 
   const rawModules = Array.isArray(state.modules) ? state.modules : [];
   const modules: LayeredModule[] = rawModules
@@ -86,7 +92,27 @@ const normalizeLayeredProject = (state: any): LayeredProject | null => {
     modules.unshift({ name: 'root', path: 'environments', environments });
   }
 
-  return { layout: 'layered-v1', environments, modules };
+  return { layout: 'layered-v1', environments, environmentTools, modules };
+};
+
+const resourceEnv = (resource: { file?: string }) => {
+  if (!resource.file) return null;
+  const parts = resource.file.split('/');
+  const envIdx = parts.indexOf('environments');
+  return envIdx >= 0 && parts.length > envIdx + 1 ? parts[envIdx + 1] : null;
+};
+
+const resourcesForEnv = <T extends { id: string; file?: string }>(resources: T[], env?: string) => {
+  if (!env) return resources;
+  return resources.filter(resource => {
+    const envFromFile = resourceEnv(resource);
+    return !envFromFile || envFromFile === env;
+  });
+};
+
+const edgesForResources = (allEdges: Edge[], resources: { id: string }[]) => {
+  const ids = new Set(resources.map(resource => resource.id));
+  return allEdges.filter(edge => ids.has(edge.from) && ids.has(edge.to));
 };
 
 export default function App() {
@@ -130,6 +156,7 @@ export default function App() {
   const [rightTab, setRightTab] = useState<'inspect' | 'policy' | 'scan' | 'modules'>('inspect');
   const [projectLayoutMeta, setProjectLayoutMeta] = useState<Record<string, any> | null>(null);
   const [layeredProject, setLayeredProject] = useState<LayeredProject | null>(null);
+  const [activeEnvironment, setActiveEnvironment] = useState<string | null>(null);
   const [canvasMode, setCanvasMode] = useState<CanvasMode>('freeform');
 
   const [terminalOutput, setTerminalOutput] = useState<string[]>([]);
@@ -153,7 +180,19 @@ export default function App() {
   const chatEndRef = useRef<HTMLDivElement>(null);
   const isSyncing = useRef(false); // suppress file_changed echo from our own sync
   const isSwimlaneMode = Boolean(layeredProject && canvasMode === 'swimlane');
-  const pulumiEnv = envForTool(tool || '', layeredProject);
+  const pulumiEnv = envForTool(tool || '', layeredProject, activeEnvironment);
+  const activeTool = toolForEnv(tool || '', layeredProject, pulumiEnv);
+  const concreteTool = activeTool && activeTool !== 'multi'
+    ? activeTool
+    : (tool && tool !== 'multi' ? tool : 'terraform');
+  const activeEnvNodes = useMemo(
+    () => resourcesForEnv(nodes, tool === 'multi' ? pulumiEnv : undefined),
+    [nodes, pulumiEnv, tool],
+  );
+  const activeEnvEdges = useMemo(
+    () => edgesForResources(edges, activeEnvNodes),
+    [activeEnvNodes, edges],
+  );
 
   const buildPersistedState = useCallback(() => ({
     ...(projectLayoutMeta || {}),
@@ -172,6 +211,11 @@ export default function App() {
     const layered = normalizeLayeredProject(meta);
     setProjectLayoutMeta(meta);
     setLayeredProject(layered);
+    setActiveEnvironment(current => {
+      if (!layered) return null;
+      if (current && layered.environments.includes(current)) return current;
+      return layered.environments[0];
+    });
     setCanvasMode(layered ? 'swimlane' : 'freeform');
 
     if (state?.resources?.length > 0) {
@@ -235,7 +279,7 @@ export default function App() {
         const selectedLayered = normalizeLayeredProject(extractLayoutMeta(state));
         setTool(selectedTool);
         if (shouldParseResourcesFromDisk(state)) {
-          api.getResources(saved.current.projectId, selectedTool, envForTool(selectedTool, selectedLayered)).then(applyParsedResources).catch(() => {});
+          api.getResources(saved.current.projectId, selectedTool, envForResourceLoad(selectedTool, selectedLayered)).then(applyParsedResources).catch(() => {});
         }
       }).catch(() => {});
     }
@@ -273,7 +317,7 @@ export default function App() {
       const selectedLayered = normalizeLayeredProject(extractLayoutMeta(state));
       setTool(selectedTool);
       if (shouldParseResourcesFromDisk(state)) {
-        const parsed = await api.getResources(proj.name, selectedTool, envForTool(selectedTool, selectedLayered));
+        const parsed = await api.getResources(proj.name, selectedTool, envForResourceLoad(selectedTool, selectedLayered));
         applyParsedResources(parsed);
       }
       setNotification(`Opened project: ${proj.name}`);
@@ -282,6 +326,7 @@ export default function App() {
       // No saved state — start fresh
       setProjectLayoutMeta(null);
       setLayeredProject(null);
+      setActiveEnvironment(null);
       setCanvasMode('freeform');
     }
   }, [applyParsedResources, applyProjectState]);
@@ -411,12 +456,12 @@ export default function App() {
   // Fetch resource catalog from backend when tool changes
   useEffect(() => {
     if (!tool) return;
-    api.getCatalog(tool).then(cat => {
+    api.getCatalog(concreteTool).then(cat => {
       setCatalogResources(cat.resources || []);
     }).catch(() => {
       setCatalogResources(FALLBACK_RESOURCES);
     });
-  }, [tool]);
+  }, [concreteTool, tool]);
 
   // Generate code preview whenever nodes change
   useEffect(() => {
@@ -424,9 +469,9 @@ export default function App() {
       setSyncCode('');
       return;
     }
-    const code = generateLocalCode(tool, nodes, edges);
+    const code = generateLocalCode(concreteTool, activeEnvNodes, activeEnvEdges);
     setSyncCode(code);
-  }, [nodes, edges, tool]);
+  }, [activeEnvEdges, activeEnvNodes, concreteTool, tool]);
 
   // Sync to disk (debounced) — syncs even when nodes is empty so that
   // deleting the last resource clears the generated file on disk.
@@ -444,11 +489,11 @@ export default function App() {
     clearTimeout(syncTimer.current);
     syncTimer.current = setTimeout(() => {
       isSyncing.current = true;
-      api.syncToDisk(projectId, tool, nodes, edges, pulumiEnv).catch(() => {}).finally(() => {
+      api.syncToDisk(projectId, tool, activeEnvNodes, activeEnvEdges, pulumiEnv).catch(() => {}).finally(() => {
         setTimeout(() => { isSyncing.current = false; }, 1500);
       });
     }, 2000);
-  }, [nodes, edges, tool, projectId, pulumiEnv]);
+  }, [activeEnvEdges, activeEnvNodes, tool, projectId, pulumiEnv]);
 
   // ─── Handlers ───
 
@@ -748,7 +793,7 @@ export default function App() {
     setCodeSaving(true);
     isSyncing.current = true;
     try {
-      const fileName = tool === 'pulumi' ? 'index.ts' : `main${TOOLS[tool]?.ext || '.tf'}`;
+      const fileName = concreteTool === 'pulumi' ? 'index.ts' : `main${TOOLS[concreteTool]?.ext || '.tf'}`;
       await api.syncCodeToDisk(projectId, tool, value, fileName, pulumiEnv);
       setNotification(`Saved ${fileName}`);
       setTimeout(() => setNotification(null), 3000);
@@ -759,12 +804,13 @@ export default function App() {
       setCodeSaving(false);
       setTimeout(() => { isSyncing.current = false; }, 1500);
     }
-  }, [projectId, pulumiEnv, tool]);
+  }, [concreteTool, projectId, pulumiEnv, tool]);
 
   const handleCreateProject = async (selectedTool: string) => {
     setTool(selectedTool);
     setProjectLayoutMeta(null);
     setLayeredProject(null);
+    setActiveEnvironment(null);
     setCanvasMode('freeform');
     // Lock the project ID at creation time so renaming the display input
     // can't silently redirect API calls to a different directory.
@@ -1038,6 +1084,7 @@ export default function App() {
                             setProjectId(projectName);
                             setProjectLayoutMeta(null);
                             setLayeredProject(null);
+                            setActiveEnvironment(null);
                             setCanvasMode('freeform');
                             hasCreatedProject.current = true;
                             initialLoadDone.current = true;
@@ -1087,11 +1134,11 @@ export default function App() {
     );
   }
 
-  const ct = TOOLS[tool] || TOOLS.terraform;
+  const ct = TOOLS[tool] || TOOLS[concreteTool] || TOOLS.terraform;
   const selected = nodes.find(n => n.id === selectedNode);
-  const codeFileLabel = tool === 'pulumi'
+  const codeFileLabel = concreteTool === 'pulumi'
     ? (pulumiEnv ? `environments/${pulumiEnv}/index.ts` : 'index.ts')
-    : `main${ct.ext}`;
+    : (tool === 'multi' && pulumiEnv ? `environments/${pulumiEnv}/main${TOOLS[concreteTool]?.ext || '.tf'}` : `main${TOOLS[concreteTool]?.ext || ct.ext}`);
 
   // ─── Main UI ───
   return (
@@ -1112,7 +1159,7 @@ export default function App() {
             // Refresh saved projects list
             api.listProjectStates().then(setSavedProjects).catch(() => {});
             setTool(null); resetNodes([]); setEdges([]); setChatMessages([]); setTerminalOutput([]);
-            setProjectLayoutMeta(null); setLayeredProject(null); setCanvasMode('freeform');
+            setProjectLayoutMeta(null); setLayeredProject(null); setActiveEnvironment(null); setCanvasMode('freeform');
             initialLoadDone.current = false; hasCreatedProject.current = false;
           }}>←</button>
           <span style={{ ...S.badge, background: ct.color + '22', color: ct.color }}>{ct.icon} {ct.name}</span>
@@ -1372,6 +1419,19 @@ export default function App() {
           onClick={() => { setSelectedNode(null); setSelectedEdge(null); }}>
           {layeredProject && (
             <div style={{ position: 'absolute', top: 12, right: 12, zIndex: 10, display: 'flex', gap: 6, padding: 4, background: 'var(--bg-elev-1)', border: '1px solid var(--border-main)', borderRadius: 8 }}>
+              {layeredProject.environments.map(env => {
+                const envTool = layeredProject.environmentTools?.[env];
+                return (
+                  <button
+                    key={env}
+                    style={{ ...S.cmd, background: activeEnvironment === env ? ct.color + '22' : 'transparent', color: activeEnvironment === env ? ct.color : 'var(--text-muted)', padding: '5px 9px' }}
+                    onClick={(e) => { e.stopPropagation(); setActiveEnvironment(env); }}
+                    title={envTool ? `${env} uses ${envTool}` : env}
+                  >
+                    {envTool ? `${env} (${envTool})` : env}
+                  </button>
+                );
+              })}
               {(['swimlane', 'freeform'] as const).map(mode => (
                 <button
                   key={mode}
@@ -1647,7 +1707,7 @@ export default function App() {
                 )}
                 <CodeEditor
                   value={syncCode}
-                  filePath={tool === 'pulumi' ? 'index.ts' : `main${ct.ext}`}
+                  filePath={concreteTool === 'pulumi' ? 'index.ts' : `main${TOOLS[concreteTool]?.ext || ct.ext}`}
                   readOnly={false}
                   onChange={setSyncCode}
                   onSave={saveCodeToDisk}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -17,6 +17,7 @@ import type { LayeredProject, LayeredModule } from './types';
 import { envForResourceLoad, envForTool, shouldParseResourcesFromDisk, toolForEnv } from './projectLoad';
 import {
   TOOLS,
+  ALL_TOOLS,
   PROJECT_CREATION_TOOLS,
   FALLBACK_RESOURCES,
   uid,
@@ -873,7 +874,7 @@ export default function App() {
               <UIKicker style={{ marginBottom: 12 }}>Recent Projects</UIKicker>
               <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
                 {savedProjects.filter(p => p.tool).slice(0, 5).map(p => {
-                  const t = TOOLS[p.tool] || TOOLS.terraform;
+                  const t = ALL_TOOLS[p.tool] || TOOLS.terraform;
                   const count = p.resources?.length || 0;
                   return (
                     <button key={p.name} className="tool-card" style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '10px 16px', background: 'var(--bg-elev-1)', border: '1px solid var(--border-main)', borderRadius: 10, cursor: 'pointer', textAlign: 'left', transition: 'border-color 0.2s' }}
@@ -1168,7 +1169,7 @@ export default function App() {
     );
   }
 
-  const ct = TOOLS[tool] || TOOLS[concreteTool] || TOOLS.terraform;
+  const ct = ALL_TOOLS[tool] || TOOLS[concreteTool] || TOOLS.terraform;
   const selected = nodes.find(n => n.id === selectedNode);
   const codeFileLabel = concreteTool === 'pulumi'
     ? (activeEnv ? `environments/${activeEnv}/index.ts` : 'index.ts')

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -69,10 +69,14 @@ export const normalizeLayeredProject = (state: any): LayeredProject | null => {
     !Array.isArray(rawEnvironmentTools) &&
     [Object.prototype, null].includes(Object.getPrototypeOf(rawEnvironmentTools))
   ) {
-    const entries = Object.entries(rawEnvironmentTools)
-      .filter(([env, envTool]) => environments.includes(env) && typeof envTool === 'string' && envTool.length > 0);
-    if (entries.length > 0) {
-      environmentTools = Object.fromEntries(entries) as Record<string, string>;
+    const normalizedEnvironmentTools = Object.create(null) as Record<string, string>;
+    for (const [env, envTool] of Object.entries(rawEnvironmentTools)) {
+      if (environments.includes(env) && typeof envTool === 'string' && envTool.length > 0) {
+        normalizedEnvironmentTools[env] = envTool;
+      }
+    }
+    if (Object.keys(normalizedEnvironmentTools).length > 0) {
+      environmentTools = normalizedEnvironmentTools;
     }
   }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -105,18 +105,18 @@ export const normalizeLayeredProject = (state: any): LayeredProject | null => {
   return { layout: 'layered-v1', environments, environmentTools, modules };
 };
 
-const resourceEnv = (resource: { file?: string }) => {
+export const resourceEnv = (resource: { file?: string }) => {
   if (!resource.file) return null;
   const parts = resource.file.replace(/\\/g, '/').split('/');
   const envIdx = parts.indexOf('environments');
   return envIdx >= 0 && parts.length > envIdx + 1 ? parts[envIdx + 1] : null;
 };
 
-const resourcesForEnv = <T extends { id: string; file?: string }>(resources: T[], env?: string) => {
+export const resourcesForEnv = <T extends { id: string; file?: string }>(resources: T[], env?: string) => {
   if (!env) return resources;
   return resources.filter(resource => {
     const envFromFile = resourceEnv(resource);
-    return !envFromFile || envFromFile === env;
+    return envFromFile === env;
   });
 };
 
@@ -193,12 +193,15 @@ export default function App() {
   const showEnvironmentSelector = Boolean(layeredProject && (tool === 'multi' || layeredProject.environmentTools));
   const activeEnv = envForTool(tool || '', layeredProject, activeEnvironment);
   const activeTool = toolForEnv(tool || '', layeredProject, activeEnv);
+  const unresolvedHybridEnv = tool === 'multi' && Boolean(activeEnv) && !activeTool;
   const concreteTool = activeTool && activeTool !== 'multi'
     ? activeTool
     : (tool && tool !== 'multi' ? tool : 'terraform');
-  const activeResourceFile = concreteTool === 'pulumi'
-    ? (activeEnv ? `environments/${activeEnv}/index.ts` : undefined)
-    : (tool === 'multi' && activeEnv ? `environments/${activeEnv}/main${TOOLS[concreteTool]?.ext || '.tf'}` : undefined);
+  const activeResourceFile = unresolvedHybridEnv
+    ? undefined
+    : concreteTool === 'pulumi'
+      ? (activeEnv ? `environments/${activeEnv}/index.ts` : undefined)
+      : (tool === 'multi' && activeEnv ? `environments/${activeEnv}/main${TOOLS[concreteTool]?.ext || '.tf'}` : undefined);
   const activeEnvNodes = useMemo(
     () => resourcesForEnv(nodes, (tool === 'multi' || tool === 'pulumi') ? activeEnv : undefined),
     [nodes, activeEnv, tool],
@@ -479,13 +482,13 @@ export default function App() {
 
   // Generate code preview whenever nodes change
   useEffect(() => {
-    if (!tool || !nodes.length) {
+    if (!tool || unresolvedHybridEnv || !nodes.length) {
       setSyncCode('');
       return;
     }
     const code = generateLocalCode(concreteTool, activeEnvNodes, activeEnvEdges);
     setSyncCode(code);
-  }, [activeEnvEdges, activeEnvNodes, concreteTool, tool]);
+  }, [activeEnvEdges, activeEnvNodes, concreteTool, tool, unresolvedHybridEnv]);
 
   // Sync to disk (debounced) — syncs even when nodes is empty so that
   // deleting the last resource clears the generated file on disk.
@@ -507,6 +510,12 @@ export default function App() {
   }, []);
   useEffect(() => {
     if (!tool || !hasCreatedProject.current || !projectId) return;
+    if (unresolvedHybridEnv) {
+      clearTimeout(syncTimer.current);
+      syncTimer.current = undefined;
+      pendingSync.current = null;
+      return;
+    }
     // Skip the first sync after opening a project — the restored state
     // doesn't need to be written back immediately (it came from disk).
     if (!initialLoadDone.current) {
@@ -527,11 +536,16 @@ export default function App() {
     syncTimer.current = setTimeout(() => {
       flushPendingSync();
     }, 2000);
-  }, [activeEnvEdges, activeEnvNodes, flushPendingSync, projectId, activeEnv, syncScope, tool]);
+  }, [activeEnvEdges, activeEnvNodes, flushPendingSync, projectId, activeEnv, syncScope, tool, unresolvedHybridEnv]);
 
   // ─── Handlers ───
 
   const addNode = useCallback((resourceDef: any) => {
+    if (unresolvedHybridEnv) {
+      setNotification(`Environment "${activeEnv}" has no configured IaC tool`);
+      setTimeout(() => setNotification(null), 4000);
+      return;
+    }
     const node = {
       id: uid(),
       type: resourceDef.type,
@@ -570,7 +584,7 @@ export default function App() {
       return [...prev, node];
     });
     setSelectedNode(node.id);
-  }, [activeResourceFile, catalogResources]);
+  }, [activeEnv, activeResourceFile, catalogResources, unresolvedHybridEnv]);
 
   const removeNode = useCallback((id: string) => {
     setNodes(prev => prev.filter(n => n.id !== id));
@@ -718,6 +732,10 @@ export default function App() {
 
   const runCmd = (command: string) => {
     if (!tool) return;
+    if (unresolvedHybridEnv) {
+      setTerminalOutput(prev => [...prev, `Error: environment "${activeEnv}" has no configured IaC tool`]);
+      return;
+    }
     // apply/destroy require explicit confirmation
     const needsApproval = command === 'apply' || command === 'destroy';
     if (needsApproval && !confirm(`Are you sure you want to run "${command}"? This will modify real infrastructure.`)) {
@@ -820,6 +838,11 @@ export default function App() {
 
   const saveCodeToDisk = useCallback(async (value: string) => {
     if (!tool || !projectId) return;
+    if (unresolvedHybridEnv) {
+      setNotification(`Save failed: environment "${activeEnv}" has no configured IaC tool`);
+      setTimeout(() => setNotification(null), 5000);
+      return;
+    }
     if (!value.trim()) {
       setNotification('Nothing to save yet');
       setTimeout(() => setNotification(null), 3000);
@@ -839,7 +862,7 @@ export default function App() {
       setCodeSaving(false);
       setTimeout(() => { isSyncing.current = false; }, 1500);
     }
-  }, [concreteTool, projectId, activeEnv, tool]);
+  }, [activeEnv, concreteTool, projectId, tool, unresolvedHybridEnv]);
 
   const handleCreateProject = async (selectedTool: string) => {
     setTool(selectedTool);
@@ -1723,8 +1746,8 @@ export default function App() {
             <div style={S.codeHead}>
               <span>FILE {codeFileLabel}</span>
               <button
-                style={{ ...S.copyBtn, color: codeSaving || !syncCode.trim() ? '#555' : ct.color }}
-                disabled={codeSaving || !syncCode.trim()}
+                style={{ ...S.copyBtn, color: codeSaving || unresolvedHybridEnv || !syncCode.trim() ? '#555' : ct.color }}
+                disabled={codeSaving || unresolvedHybridEnv || !syncCode.trim()}
                 title="Save editor buffer to disk"
                 onClick={() => saveCodeToDisk(syncCode)}
               >
@@ -1754,7 +1777,13 @@ export default function App() {
           )}
           {rightTab === 'policy' && (
             <div style={{ flex: 1, minHeight: 0 }}>
-              <PolicyStudioPanel projectName={projectId} tool={tool} env={activeEnv} />
+              {unresolvedHybridEnv ? (
+                <div style={{ padding: 16, color: 'var(--text-muted)', fontSize: 13 }}>
+                  Environment "{activeEnv}" has no configured IaC tool in .iac-studio.json.
+                </div>
+              ) : (
+                <PolicyStudioPanel projectName={projectId} tool={tool} env={activeEnv} />
+              )}
             </div>
           )}
           {rightTab === 'scan' && (

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -17,6 +17,7 @@ import type { LayeredProject, LayeredModule } from './types';
 import { envForResourceLoad, envForTool, shouldParseResourcesFromDisk, toolForEnv } from './projectLoad';
 import {
   TOOLS,
+  PROJECT_CREATION_TOOLS,
   FALLBACK_RESOURCES,
   uid,
   edgeId,
@@ -53,18 +54,26 @@ const extractLayoutMeta = (state: any) => {
   return meta;
 };
 
-const normalizeLayeredProject = (state: any): LayeredProject | null => {
+export const normalizeLayeredProject = (state: any): LayeredProject | null => {
   if (state?.layout !== 'layered-v1') return null;
   const environments = Array.isArray(state.environments)
     ? state.environments.filter((env: unknown): env is string => typeof env === 'string' && env.length > 0)
     : [];
   if (environments.length === 0) return null;
-  const environmentTools = state.environment_tools && typeof state.environment_tools === 'object'
-    ? Object.fromEntries(
-        Object.entries(state.environment_tools)
-          .filter(([env, envTool]) => environments.includes(env) && typeof envTool === 'string' && envTool.length > 0)
-      ) as Record<string, string>
-    : undefined;
+  const rawEnvironmentTools = state.environment_tools;
+  let environmentTools: Record<string, string> | undefined;
+  if (
+    rawEnvironmentTools &&
+    typeof rawEnvironmentTools === 'object' &&
+    !Array.isArray(rawEnvironmentTools) &&
+    [Object.prototype, null].includes(Object.getPrototypeOf(rawEnvironmentTools))
+  ) {
+    const entries = Object.entries(rawEnvironmentTools)
+      .filter(([env, envTool]) => environments.includes(env) && typeof envTool === 'string' && envTool.length > 0);
+    if (entries.length > 0) {
+      environmentTools = Object.fromEntries(entries) as Record<string, string>;
+    }
+  }
 
   const rawModules = Array.isArray(state.modules) ? state.modules : [];
   const modules: LayeredModule[] = rawModules
@@ -181,17 +190,17 @@ export default function App() {
   const isSyncing = useRef(false); // suppress file_changed echo from our own sync
   const isSwimlaneMode = Boolean(layeredProject && canvasMode === 'swimlane');
   const showEnvironmentSelector = Boolean(layeredProject && (tool === 'multi' || layeredProject.environmentTools));
-  const pulumiEnv = envForTool(tool || '', layeredProject, activeEnvironment);
-  const activeTool = toolForEnv(tool || '', layeredProject, pulumiEnv);
+  const activeEnv = envForTool(tool || '', layeredProject, activeEnvironment);
+  const activeTool = toolForEnv(tool || '', layeredProject, activeEnv);
   const concreteTool = activeTool && activeTool !== 'multi'
     ? activeTool
     : (tool && tool !== 'multi' ? tool : 'terraform');
   const activeResourceFile = concreteTool === 'pulumi'
-    ? (pulumiEnv ? `environments/${pulumiEnv}/index.ts` : undefined)
-    : (tool === 'multi' && pulumiEnv ? `environments/${pulumiEnv}/main${TOOLS[concreteTool]?.ext || '.tf'}` : undefined);
+    ? (activeEnv ? `environments/${activeEnv}/index.ts` : undefined)
+    : (tool === 'multi' && activeEnv ? `environments/${activeEnv}/main${TOOLS[concreteTool]?.ext || '.tf'}` : undefined);
   const activeEnvNodes = useMemo(
-    () => resourcesForEnv(nodes, (tool === 'multi' || tool === 'pulumi') ? pulumiEnv : undefined),
-    [nodes, pulumiEnv, tool],
+    () => resourcesForEnv(nodes, (tool === 'multi' || tool === 'pulumi') ? activeEnv : undefined),
+    [nodes, activeEnv, tool],
   );
   const activeEnvEdges = useMemo(
     () => edgesForResources(edges, activeEnvNodes),
@@ -483,7 +492,7 @@ export default function App() {
   const pendingSync = useRef<{ projectId: string; tool: string; nodes: Resource[]; edges: Edge[]; env?: string } | null>(null);
   const hasCreatedProject = useRef(false);
   const initialLoadDone = useRef(false);
-  const syncScope = `${projectId}:${tool || ''}:${pulumiEnv || ''}`;
+  const syncScope = `${projectId}:${tool || ''}:${activeEnv || ''}`;
   const lastSyncScope = useRef('');
   const flushPendingSync = useCallback(() => {
     const snapshot = pendingSync.current;
@@ -513,11 +522,11 @@ export default function App() {
     }
     lastSyncScope.current = syncScope;
     clearTimeout(syncTimer.current);
-    pendingSync.current = { projectId, tool, nodes: activeEnvNodes, edges: activeEnvEdges, env: pulumiEnv };
+    pendingSync.current = { projectId, tool, nodes: activeEnvNodes, edges: activeEnvEdges, env: activeEnv };
     syncTimer.current = setTimeout(() => {
       flushPendingSync();
     }, 2000);
-  }, [activeEnvEdges, activeEnvNodes, flushPendingSync, projectId, pulumiEnv, syncScope, tool]);
+  }, [activeEnvEdges, activeEnvNodes, flushPendingSync, projectId, activeEnv, syncScope, tool]);
 
   // ─── Handlers ───
 
@@ -716,7 +725,7 @@ export default function App() {
     setTerminalOutput(prev => [...prev, `$ ${command}`, '']);
     api.runCommand(projectId, tool, command, {
       approved: needsApproval,
-      env: pulumiEnv,
+      env: activeEnv,
     }).catch(err => {
       if (needsApproval && isPolicyBlockedError(err)) {
         const findings = err.payload?.findings ?? [];
@@ -734,7 +743,7 @@ export default function App() {
         setTerminalOutput(prev => [...prev, `$ ${command} --acknowledged`, '']);
         api.runCommand(projectId, tool, command, {
           approved: true,
-          env: pulumiEnv,
+          env: activeEnv,
           acknowledged: true,
         }).catch(overrideErr => {
           setTerminalOutput(prev => [...prev, `Error: ${overrideErr.message}`]);
@@ -819,7 +828,7 @@ export default function App() {
     isSyncing.current = true;
     try {
       const fileName = concreteTool === 'pulumi' ? 'index.ts' : `main${TOOLS[concreteTool]?.ext || '.tf'}`;
-      await api.syncCodeToDisk(projectId, tool, value, fileName, pulumiEnv);
+      await api.syncCodeToDisk(projectId, tool, value, fileName, activeEnv);
       setNotification(`Saved ${fileName}`);
       setTimeout(() => setNotification(null), 3000);
     } catch (err: any) {
@@ -829,7 +838,7 @@ export default function App() {
       setCodeSaving(false);
       setTimeout(() => { isSyncing.current = false; }, 1500);
     }
-  }, [concreteTool, projectId, pulumiEnv, tool]);
+  }, [concreteTool, projectId, activeEnv, tool]);
 
   const handleCreateProject = async (selectedTool: string) => {
     setTool(selectedTool);
@@ -905,7 +914,7 @@ export default function App() {
           <h1 style={S.title}>{savedProjects.length > 0 ? 'New Project' : 'Choose your IaC tool'}</h1>
           <p style={S.subtitle}>Visual infrastructure builder with AI-powered assistance</p>
           <div style={S.cardGrid}>
-            {Object.entries(TOOLS).map(([key, t]) => {
+            {Object.entries(PROJECT_CREATION_TOOLS).map(([key, t]) => {
               const detected = detectedTools.find(d => d.name === t.name);
               return (
                 <button key={key} className="tool-card panel-reveal" style={{ ...S.card, borderColor: t.color + '33' }}
@@ -1162,8 +1171,8 @@ export default function App() {
   const ct = TOOLS[tool] || TOOLS[concreteTool] || TOOLS.terraform;
   const selected = nodes.find(n => n.id === selectedNode);
   const codeFileLabel = concreteTool === 'pulumi'
-    ? (pulumiEnv ? `environments/${pulumiEnv}/index.ts` : 'index.ts')
-    : (tool === 'multi' && pulumiEnv ? `environments/${pulumiEnv}/main${TOOLS[concreteTool]?.ext || '.tf'}` : `main${TOOLS[concreteTool]?.ext || ct.ext}`);
+    ? (activeEnv ? `environments/${activeEnv}/index.ts` : 'index.ts')
+    : (tool === 'multi' && activeEnv ? `environments/${activeEnv}/main${TOOLS[concreteTool]?.ext || '.tf'}` : `main${TOOLS[concreteTool]?.ext || ct.ext}`);
 
   // ─── Main UI ───
   return (
@@ -1744,7 +1753,7 @@ export default function App() {
           )}
           {rightTab === 'policy' && (
             <div style={{ flex: 1, minHeight: 0 }}>
-              <PolicyStudioPanel projectName={projectId} tool={tool} env={pulumiEnv} />
+              <PolicyStudioPanel projectName={projectId} tool={tool} env={activeEnv} />
             </div>
           )}
           {rightTab === 'scan' && (

--- a/web/src/components/Canvas/SwimlaneCanvas.tsx
+++ b/web/src/components/Canvas/SwimlaneCanvas.tsx
@@ -75,7 +75,7 @@ export function defaultLayeredClassifier(envs: string[], modules: string[]) {
     if (envIdx >= 0 && parts.length > envIdx + 1 && envSet.has(parts[envIdx + 1])) {
       const env = parts[envIdx + 1];
       const fileName = parts[parts.length - 1] ?? '';
-      const stem = fileName.replace(/\.tf$/, '');
+      const stem = fileName.replace(/\.(tf|ts)$/, '');
       const module = modSet.has(stem) ? stem : 'root';
       if (!modSet.has(module)) return null;
       return { environment: env, module };

--- a/web/src/components/Canvas/SwimlaneCanvas.tsx
+++ b/web/src/components/Canvas/SwimlaneCanvas.tsx
@@ -61,7 +61,7 @@ export function defaultLayeredClassifier(envs: string[], modules: string[]) {
   const modSet = new Set(modules);
   return (r: Resource) => {
     if (!r.file) return null;
-    const parts = r.file.split('/');
+    const parts = r.file.replace(/\\/g, '/').split('/');
 
     // modules/<mod>/...  → shared template, hide from the per-env view.
     const modIdx = parts.indexOf('modules');

--- a/web/src/components/Canvas/classifier.test.ts
+++ b/web/src/components/Canvas/classifier.test.ts
@@ -29,6 +29,10 @@ describe('defaultLayeredClassifier (layered-v1 scaffold)', () => {
       environment: 'prod',
       module: 'root',
     });
+    expect(classify(make('pulumi', 'environments/dev/index.ts'))).toEqual({
+      environment: 'dev',
+      module: 'root',
+    });
   });
 
   it('omits "root" when the caller does not register it', () => {

--- a/web/src/components/Canvas/classifier.test.ts
+++ b/web/src/components/Canvas/classifier.test.ts
@@ -58,4 +58,11 @@ describe('defaultLayeredClassifier (layered-v1 scaffold)', () => {
       module: 'compute',
     });
   });
+
+  it('handles Windows-style path separators', () => {
+    expect(classify(make('h', String.raw`projects\demo\environments\dev\index.ts`))).toEqual({
+      environment: 'dev',
+      module: 'root',
+    });
+  });
 });

--- a/web/src/legacy.test.ts
+++ b/web/src/legacy.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from 'vitest';
 
-import { generateLocalCode, type Edge } from './legacy';
+import { generateLocalCode, PROJECT_CREATION_TOOLS, TOOLS, type Edge } from './legacy';
+
+describe('tool metadata', () => {
+  it('keeps hybrid metadata available without exposing it to direct project creation', () => {
+    expect(TOOLS.multi).toBeDefined();
+    expect(PROJECT_CREATION_TOOLS.multi).toBeUndefined();
+    expect(Object.keys(PROJECT_CREATION_TOOLS)).toEqual(['terraform', 'opentofu', 'pulumi', 'ansible']);
+  });
+});
 
 describe('generateLocalCode pulumi preview', () => {
   it('uses guessed provider packages for fallback Pulumi resource types', () => {

--- a/web/src/legacy.test.ts
+++ b/web/src/legacy.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { generateLocalCode, PROJECT_CREATION_TOOLS, TOOLS, type Edge } from './legacy';
+import { ALL_TOOLS, generateLocalCode, PROJECT_CREATION_TOOLS, TOOLS, type Edge } from './legacy';
 
 describe('tool metadata', () => {
   it('keeps hybrid metadata available without exposing it to direct project creation', () => {
-    expect(TOOLS.multi).toBeDefined();
+    expect(ALL_TOOLS.multi).toBeDefined();
+    expect(TOOLS.multi).toBeUndefined();
     expect(PROJECT_CREATION_TOOLS.multi).toBeUndefined();
     expect(Object.keys(PROJECT_CREATION_TOOLS)).toEqual(['terraform', 'opentofu', 'pulumi', 'ansible']);
   });

--- a/web/src/legacy.ts
+++ b/web/src/legacy.ts
@@ -12,6 +12,7 @@ export const TOOLS: Record<string, { name: string; icon: string; color: string; 
   opentofu: { name: 'OpenTofu', icon: 'TO', color: '#F2B447', ext: '.tf' },
   pulumi: { name: 'Pulumi', icon: 'PU', color: '#8A63D2', ext: '.ts' },
   ansible: { name: 'Ansible', icon: 'AN', color: '#D95757', ext: '.yml' },
+  multi: { name: 'Hybrid', icon: 'HY', color: '#66B7D8', ext: '.tf' },
 };
 
 // Fallback resource list for when the backend catalog is unreachable —

--- a/web/src/legacy.ts
+++ b/web/src/legacy.ts
@@ -15,6 +15,10 @@ export const TOOLS: Record<string, { name: string; icon: string; color: string; 
   multi: { name: 'Hybrid', icon: 'HY', color: '#66B7D8', ext: '.tf' },
 };
 
+export const PROJECT_CREATION_TOOLS = Object.fromEntries(
+  Object.entries(TOOLS).filter(([key]) => key !== 'multi')
+) as Record<string, { name: string; icon: string; color: string; ext: string }>;
+
 // Fallback resource list for when the backend catalog is unreachable —
 // keeps the palette usable offline so the user isn't stuck on an empty
 // sidebar.

--- a/web/src/legacy.ts
+++ b/web/src/legacy.ts
@@ -5,19 +5,21 @@ import type { CatalogResource, FileEntry } from './api';
 // top-of-file declarations; the rest are small pure functions that
 // several panels will need once the extraction is done.
 
-// UI metadata for the supported IaC tools. Resource catalogs come from
+// UI metadata for direct project creation. Resource catalogs come from
 // the backend at runtime; this just decorates the tool selector.
 export const TOOLS: Record<string, { name: string; icon: string; color: string; ext: string }> = {
   terraform: { name: 'Terraform', icon: 'TF', color: '#2FB5A8', ext: '.tf' },
   opentofu: { name: 'OpenTofu', icon: 'TO', color: '#F2B447', ext: '.tf' },
   pulumi: { name: 'Pulumi', icon: 'PU', color: '#8A63D2', ext: '.ts' },
   ansible: { name: 'Ansible', icon: 'AN', color: '#D95757', ext: '.yml' },
-  multi: { name: 'Hybrid', icon: 'HY', color: '#66B7D8', ext: '.tf' },
 };
 
-export const PROJECT_CREATION_TOOLS = Object.fromEntries(
-  Object.entries(TOOLS).filter(([key]) => key !== 'multi')
-) as Record<string, { name: string; icon: string; color: string; ext: string }>;
+export const PROJECT_CREATION_TOOLS = TOOLS;
+
+export const ALL_TOOLS: Record<string, { name: string; icon: string; color: string; ext: string }> = {
+  ...TOOLS,
+  multi: { name: 'Hybrid', icon: 'HY', color: '#66B7D8', ext: '.tf' },
+};
 
 // Fallback resource list for when the backend catalog is unreachable —
 // keeps the palette usable offline so the user isn't stuck on an empty

--- a/web/src/projectLoad.test.ts
+++ b/web/src/projectLoad.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { envForTool, shouldParseResourcesFromDisk } from './projectLoad';
+import { envForResourceLoad, envForTool, shouldParseResourcesFromDisk, toolForEnv } from './projectLoad';
 
 describe('project load helpers', () => {
   it('does not force Pulumi disk parsing when saved canvas resources exist', () => {
@@ -23,6 +23,18 @@ describe('project load helpers', () => {
 
   it('uses the first layered environment for Pulumi resource parsing', () => {
     expect(envForTool('pulumi', { environments: ['dev', 'prod'] })).toBe('dev');
+    expect(envForTool('pulumi', { environments: ['dev', 'prod'] }, 'prod')).toBe('prod');
     expect(envForTool('terraform', { environments: ['dev'] })).toBeUndefined();
+  });
+
+  it('lets hybrid resource parsing cover every environment', () => {
+    const layered = {
+      environments: ['dev', 'prod'],
+      environmentTools: { dev: 'pulumi', prod: 'terraform' },
+    };
+    expect(envForResourceLoad('multi', layered)).toBeUndefined();
+    expect(envForTool('multi', layered, 'prod')).toBe('prod');
+    expect(toolForEnv('multi', layered, 'dev')).toBe('pulumi');
+    expect(toolForEnv('multi', layered, 'prod')).toBe('terraform');
   });
 });

--- a/web/src/projectLoad.test.ts
+++ b/web/src/projectLoad.test.ts
@@ -37,4 +37,14 @@ describe('project load helpers', () => {
     expect(toolForEnv('multi', layered, 'dev')).toBe('pulumi');
     expect(toolForEnv('multi', layered, 'prod')).toBe('terraform');
   });
+
+  it('does not invent a concrete tool for unresolved hybrid environments', () => {
+    const layered = {
+      environments: ['dev', 'prod'],
+      environmentTools: { dev: 'not-a-tool' },
+    };
+    expect(toolForEnv('multi', layered, 'dev')).toBeUndefined();
+    expect(toolForEnv('multi', layered, 'prod')).toBeUndefined();
+    expect(toolForEnv('terraform', layered, 'dev')).toBe('terraform');
+  });
 });

--- a/web/src/projectLoad.ts
+++ b/web/src/projectLoad.ts
@@ -5,6 +5,7 @@ type ProjectStateForLoad = {
 
 type LayeredForLoad = {
   environments?: string[];
+  environmentTools?: Record<string, string>;
 } | null;
 
 export const shouldParseResourcesFromDisk = (state: ProjectStateForLoad | null | undefined) => {
@@ -12,6 +13,27 @@ export const shouldParseResourcesFromDisk = (state: ProjectStateForLoad | null |
   return state.layout === 'layered-v1' && state.resources.some((resource) => !resource.file);
 };
 
-export const envForTool = (selectedTool: string, layered: LayeredForLoad) => (
-  selectedTool === 'pulumi' ? layered?.environments?.[0] : undefined
-);
+const preferredLayeredEnv = (layered: LayeredForLoad, preferredEnv?: string | null) => {
+  if (!layered?.environments?.length) return undefined;
+  if (preferredEnv && layered.environments.includes(preferredEnv)) return preferredEnv;
+  return layered.environments[0];
+};
+
+export const toolForEnv = (selectedTool: string, layered: LayeredForLoad, env?: string | null) => {
+  if (selectedTool === 'multi' && env) {
+    return layered?.environmentTools?.[env] || selectedTool;
+  }
+  return selectedTool;
+};
+
+export const envForTool = (selectedTool: string, layered: LayeredForLoad, preferredEnv?: string | null) => {
+  if (selectedTool !== 'pulumi' && selectedTool !== 'multi') return undefined;
+  return preferredLayeredEnv(layered, preferredEnv);
+};
+
+export const envForResourceLoad = (selectedTool: string, layered: LayeredForLoad) => {
+  if (selectedTool === 'pulumi') return preferredLayeredEnv(layered);
+  // Hybrid resources are parsed across all environments server-side.
+  if (selectedTool === 'multi') return undefined;
+  return undefined;
+};

--- a/web/src/projectLoad.ts
+++ b/web/src/projectLoad.ts
@@ -8,6 +8,8 @@ type LayeredForLoad = {
   environmentTools?: Record<string, string>;
 } | null;
 
+const concreteTools = new Set(['terraform', 'opentofu', 'pulumi', 'ansible']);
+
 export const shouldParseResourcesFromDisk = (state: ProjectStateForLoad | null | undefined) => {
   if (!state?.resources || state.resources.length === 0) return true;
   return state.layout === 'layered-v1' && state.resources.some((resource) => !resource.file);
@@ -21,7 +23,8 @@ const preferredLayeredEnv = (layered: LayeredForLoad, preferredEnv?: string | nu
 
 export const toolForEnv = (selectedTool: string, layered: LayeredForLoad, env?: string | null) => {
   if (selectedTool === 'multi' && env) {
-    return layered?.environmentTools?.[env] || selectedTool;
+    const envTool = layered?.environmentTools?.[env];
+    return envTool && concreteTools.has(envTool) ? envTool : undefined;
   }
   return selectedTool;
 };

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -12,6 +12,7 @@ export type { Resource, ToolInfo, CatalogResource, Suggestion, FileEntry, Import
 export interface LayeredProject {
   layout: 'layered-v1' | 'flat';
   environments: string[];
+  environmentTools?: Record<string, string>;
   modules: LayeredModule[];
 }
 


### PR DESCRIPTION
## Summary
- add a layered-hybrid blueprint that renders Terraform and Pulumi environments side by side with an environment_tools map in .iac-studio.json
- resolve hybrid environment tools server-side for resource parsing, sync, policy runs, and command execution
- preserve hybrid metadata through project state saves and teach the frontend swimlane/code paths to respect per-env tools

## Tests
- GOCACHE=/private/tmp/iacstudio-go-cache go test ./...
- npm test -- --run from web/
- npm run build from web/

Closes #25