### PR TITLE
[codex] Extract import wizard modal

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,15 +3,15 @@ import { api, ApiError, Resource, ToolInfo, CatalogResource, Suggestion, FileEnt
 import { useWebSocket, WSMessage } from './useWebSocket';
 import { useHistory } from './useHistory';
 import { useKeyboardShortcuts } from './useKeyboardShortcuts';
-import { UIButton, UIInput, UIKicker, UILabel, UIModal, UIPanel, UITextArea } from './ui';
+import { UIButton, UIInput, UIKicker, UILabel, UIModal, UIPanel } from './ui';
 import { CodeEditor } from './components/CodeEditor';
 import { ChatPanel } from './components/Chat';
+import { ImportWizardModal } from './components/ImportWizard';
 import { TerminalPanel } from './components/Terminal';
 import { ModuleRegistryPanel } from './components/ModuleRegistry';
 import { PolicyStudioPanel } from './components/PolicyStudio';
 import { ScanPanel } from './components/ScanPanel';
 import { SwimlaneCanvas } from './components/Canvas';
-import { VisionDropzone } from './components/VisionDropzone';
 import { S } from './styles';
 import type { LayeredProject, LayeredModule } from './types';
 import { envForResourceLoad, envForTool, shouldParseResourcesFromDisk, toolForEnv } from './projectLoad';
@@ -22,7 +22,6 @@ import {
   FALLBACK_RESOURCES,
   uid,
   edgeId,
-  fileGlyph,
   generateLocalCode,
   type Edge,
 } from './legacy';
@@ -784,6 +783,21 @@ export default function App() {
     setVisionError(null);
   };
 
+  const handleBrowseLoaded = useCallback((path: string, entries: FileEntry[], parent: string) => {
+    setBrowsePath(path);
+    setBrowseEntries(entries);
+    setBrowseParent(parent);
+  }, []);
+
+  const loadBrowsePath = useCallback(async (path?: string) => {
+    try {
+      const result = await api.browse(path);
+      handleBrowseLoaded(result.path, result.entries, result.parent);
+    } catch {
+      // Preserve local-only behavior when the backend browse endpoint is unavailable.
+    }
+  }, [handleBrowseLoaded]);
+
   const handleGenerateTopology = async () => {
     const toolKey = detectedTools.find(t => t.available && t.name !== 'Ansible')?.name === 'OpenTofu' ? 'opentofu' : 'terraform';
 
@@ -839,6 +853,58 @@ export default function App() {
       setNotification(null);
     }
   };
+
+  const handleImportToCanvas = useCallback(async (preview: ImportResult) => {
+    const selectedTool = preview.tool === 'opentofu' ? 'opentofu' : preview.tool === 'ansible' ? 'ansible' : 'terraform';
+    try {
+      await api.createProject(projectName, selectedTool);
+    } catch (err: any) {
+      setNotification(`Import failed: ${err.message}`);
+      setTimeout(() => setNotification(null), 5000);
+      return;
+    }
+    setTool(selectedTool);
+    setProjectId(projectName);
+    setProjectLayoutMeta(null);
+    setLayeredProject(null);
+    setActiveEnvironment(null);
+    setCanvasMode('freeform');
+    hasCreatedProject.current = true;
+    initialLoadDone.current = true;
+
+    const imported = preview.resources.map((resource, index) => ({
+      ...(() => {
+        const { file: _file, line: _line, ...rest } = resource;
+        return rest;
+      })(),
+      id: resource.id || `imp_${index}_${Date.now()}`,
+      x: 80 + (index % 5) * 200,
+      y: 80 + Math.floor(index / 5) * 130,
+      icon: catalogResources.find(candidate => candidate.type === resource.type)?.icon ?? '📦',
+      label: catalogResources.find(candidate => candidate.type === resource.type)?.label ?? resource.type,
+    }));
+    resetNodes(imported);
+
+    if (preview.edges.length > 0) {
+      const newEdges = preview.edges.map(edge => ({
+        id: `${edge.from_id}->${edge.to_id}:${edge.field}`,
+        from: edge.from_id,
+        to: edge.to_id,
+        fromType: preview.resources.find(resource => resource.id === edge.from_id)?.type || '',
+        toType: preview.resources.find(resource => resource.id === edge.to_id)?.type || '',
+        field: edge.field,
+        label: edge.field.replace(/_/g, ' '),
+      }));
+      setEdges(newEdges);
+    }
+
+    setShowImportWizard(false);
+    setImportPreview(null);
+    setVisionImages([]);
+    setVisionError(null);
+    setNotification(`Imported ${preview.resources.length} resources`);
+    setTimeout(() => setNotification(null), 4000);
+  }, [catalogResources, projectName, resetNodes]);
 
   const saveCodeToDisk = useCallback(async (value: string) => {
     if (!tool || !projectId) return;
@@ -983,7 +1049,7 @@ export default function App() {
             {/* Import / Topology buttons */}
             <div style={{ marginTop: 12, display: 'flex', gap: 10 }}>
               <UIButton
-                onClick={() => { setImportTab('browse'); setVisionImages([]); setVisionError(null); setShowImportWizard(true); api.browse().then(r => { setBrowsePath(r.path); setBrowseEntries(r.entries); setBrowseParent(r.parent); }).catch(() => {}); }}>
+                onClick={() => { setImportTab('browse'); setVisionImages([]); setVisionError(null); setShowImportWizard(true); loadBrowsePath(); }}>
                 Import Existing Project
               </UIButton>
               <UIButton variant="primary"
@@ -995,201 +1061,30 @@ export default function App() {
 
           {/* ─── Import Wizard Modal ─── */}
           {showImportWizard && (
-            <UIModal onClose={closeImportWizard}>
-              {/* Wizard header */}
-              <div className="ui-modal-header">
-                <div style={{ display: 'flex', gap: 12 }}>
-                    {(['browse', 'topology'] as const).map(t => (
-                      <UIButton key={t} variant="tab" active={importTab === t}
-                        onClick={() => { setImportTab(t); setImportPreview(null); if (t === 'browse') { setVisionImages([]); setVisionError(null); } }}>
-                        {t === 'browse' ? 'Browse Files' : 'AI Topology'}
-                      </UIButton>
-                    ))}
-                </div>
-                <button className="ui-close" onClick={closeImportWizard}>×</button>
-              </div>
-
-                {/* Browse tab */}
-                {importTab === 'browse' && !importPreview && (
-                  <div style={{ flex: 1, overflow: 'auto', minHeight: 300 }}>
-                    <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '10px 20px', borderBottom: '1px solid var(--border-soft)', background: 'var(--bg-elev-1)' }}>
-                      <UIButton
-                        onClick={() => { api.browse(browseParent).then(r => { setBrowsePath(r.path); setBrowseEntries(r.entries); setBrowseParent(r.parent); }).catch(() => {}); }}>
-                        ↑
-                      </UIButton>
-                      <span style={{ fontSize: 11, color: 'var(--text-muted)', fontFamily: 'JetBrains Mono', flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{browsePath}</span>
-                      <UIButton variant="primary"
-                        disabled={importLoading}
-                        onClick={async () => {
-                          setImportLoading(true);
-                          try {
-                            const result = await api.importProject(browsePath);
-                            setImportPreview(result);
-                          } catch (e: any) {
-                            setImportPreview({ tool: 'unknown', provider: 'unknown', files: [], resources: [], edges: [], summary: e.message || 'Import failed', warnings: [e.message] });
-                          }
-                          setImportLoading(false);
-                        }}>
-                        {importLoading ? 'Scanning...' : 'Import this folder'}
-                      </UIButton>
-                    </div>
-                    <div style={{ padding: '4px 0' }}>
-                      {browseEntries.map(entry => (
-                        <div key={entry.path} style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '7px 20px', cursor: entry.is_dir ? 'pointer' : 'default', fontSize: 13, color: entry.is_dir ? '#ccc' : '#777', fontFamily: 'JetBrains Mono' }}
-                          onClick={() => {
-                            if (entry.is_dir) {
-                              api.browse(entry.path).then(r => { setBrowsePath(r.path); setBrowseEntries(r.entries); setBrowseParent(r.parent); }).catch(() => {});
-                            }
-                          }}
-                          onMouseEnter={e => { if (entry.is_dir) (e.currentTarget as any).style.background = 'var(--bg-elev-2)'; }}
-                          onMouseLeave={e => { (e.currentTarget as any).style.background = 'transparent'; }}>
-                          <span style={{ fontSize: 10, fontFamily: 'JetBrains Mono', color: '#7b8d84', minWidth: 30 }}>{fileGlyph(entry)}</span>
-                          <span style={{ flex: 1 }}>{entry.name}</span>
-                          {entry.is_dir && entry.children !== undefined && <span style={{ color: '#444', fontSize: 10 }}>{entry.children} items</span>}
-                          {!entry.is_dir && <span style={{ color: '#444', fontSize: 10 }}>{entry.size > 1024 ? Math.round(entry.size / 1024) + 'KB' : entry.size + 'B'}</span>}
-                        </div>
-                      ))}
-                      {browseEntries.length === 0 && <div style={{ padding: 20, textAlign: 'center', color: '#444' }}>Empty directory</div>}
-                    </div>
-                  </div>
-                )}
-
-                {/* Topology tab */}
-                {importTab === 'topology' && !importPreview && (
-                  <div style={{ flex: 1, padding: 20, display: 'flex', flexDirection: 'column', gap: 16 }}>
-                    <div style={{ fontSize: 14, color: 'var(--text-main)', fontWeight: 600 }}>Describe your infrastructure</div>
-                    <div className="ui-note">
-                      Tell us what you want to build in plain language, or upload a diagram for vision analysis.
-                    </div>
-                    <VisionDropzone
-                      files={visionImages}
-                      onFilesChange={setVisionImages}
-                      onError={setVisionError}
-                      error={visionError}
-                      disabled={importLoading}
-                    />
-                    <UITextArea style={{ flex: 1, minHeight: 120 }}
-                      value={topologyDesc} onChange={e => setTopologyDesc(e.target.value)}
-                      placeholder={"Optional context:\nA three-tier web app with VPC, ALB, auto-scaling EC2, RDS PostgreSQL, and S3 for static assets\nA GKE cluster with Cloud SQL, Redis cache, and Cloud Storage for a microservices platform"} />
-                    <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-                      <UILabel>Provider:</UILabel>
-                      {['aws', 'google', 'azurerm'].map(p => (
-                        <UIButton key={p} variant="tab" active={topologyProvider === p}
-                          onClick={() => setTopologyProvider(p)}>
-                          {p === 'aws' ? 'AWS' : p === 'google' ? 'GCP' : 'Azure'}
-                        </UIButton>
-                      ))}
-                    </div>
-                    <UIButton variant="primary"
-                      disabled={(!topologyDesc.trim() && visionImages.length === 0) || Boolean(visionError) || importLoading}
-                      onClick={handleGenerateTopology}>
-                      {importLoading ? 'Generating... (this may take a minute)' : visionImages.length > 0 ? 'Generate from Diagram' : 'Generate Infrastructure'}
-                    </UIButton>
-                  </div>
-                )}
-
-                {/* Preview panel — shown after scan or generation */}
-                {importPreview && (
-                  <div style={{ flex: 1, overflow: 'auto', padding: 20, display: 'flex', flexDirection: 'column', gap: 12 }}>
-                    <div style={{ fontSize: 14, fontWeight: 600, color: '#bbb' }}>
-                      {importPreview.tool === 'unknown' ? 'Import Failed' : 'Preview'}
-                    </div>
-                    <div className="ui-note">{importPreview.summary}</div>
-
-                    {importPreview.warnings && importPreview.warnings.length > 0 && (
-                      <div style={{ background: '#ef444411', border: '1px solid #ef444433', borderRadius: 8, padding: 10 }}>
-                        {importPreview.warnings.map((w, i) => (
-                          <div key={i} style={{ fontSize: 11, color: '#ef4444', fontFamily: 'JetBrains Mono' }}>{w}</div>
-                        ))}
-                      </div>
-                    )}
-
-                    {importPreview.resources.length > 0 && (
-                      <>
-                        <div style={{ fontSize: 11, color: '#555', fontFamily: 'JetBrains Mono', textTransform: 'uppercase', letterSpacing: 1 }}>
-                          {importPreview.resources.length} Resources
-                        </div>
-                        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
-                          {importPreview.resources.map((r, i) => {
-                            const meta = catalogResources.find(c => c.type === r.type);
-                            return (
-                              <span key={i} style={{ background: 'var(--bg-elev-2)', borderRadius: 6, padding: '4px 10px', fontSize: 11, color: 'var(--text-main)', fontFamily: 'JetBrains Mono' }}>
-                                {meta?.icon ?? '📦'} {r.type}.{r.name}
-                              </span>
-                            );
-                          })}
-                        </div>
-                        {importPreview.edges.length > 0 && (
-                          <div style={{ fontSize: 11, color: '#555', fontFamily: 'JetBrains Mono' }}>
-                            {importPreview.edges.length} connections detected
-                          </div>
-                        )}
-                      </>
-                    )}
-
-                    <div style={{ display: 'flex', gap: 10, marginTop: 8 }}>
-                      <UIButton onClick={() => setImportPreview(null)}>
-                        ← Back
-                      </UIButton>
-                      {importPreview.resources.length > 0 && (
-                        <UIButton variant="primary"
-                          onClick={async () => {
-                            const t = importPreview!.tool === 'opentofu' ? 'opentofu' : importPreview!.tool === 'ansible' ? 'ansible' : 'terraform';
-                            try {
-                              await api.createProject(projectName, t);
-                            } catch (e: any) {
-                              setNotification(`Import failed: ${e.message}`);
-                              setTimeout(() => setNotification(null), 5000);
-                              return;
-                            }
-                            setTool(t);
-                            setProjectId(projectName);
-                            setProjectLayoutMeta(null);
-                            setLayeredProject(null);
-                            setActiveEnvironment(null);
-                            setCanvasMode('freeform');
-                            hasCreatedProject.current = true;
-                            initialLoadDone.current = true;
-                            // Place resources on canvas in a grid layout
-                            const imported = importPreview!.resources.map((r, i) => ({
-                              ...(() => {
-                                const { file: _file, line: _line, ...rest } = r;
-                                return rest;
-                              })(),
-                              id: r.id || `imp_${i}_${Date.now()}`,
-                              x: 80 + (i % 5) * 200,
-                              y: 80 + Math.floor(i / 5) * 130,
-                              icon: catalogResources.find(c => c.type === r.type)?.icon ?? '📦',
-                              label: catalogResources.find(c => c.type === r.type)?.label ?? r.type,
-                            }));
-                            resetNodes(imported);
-                            // Create edges from detected connections
-                            if (importPreview!.edges.length > 0) {
-                              const newEdges = importPreview!.edges.map(e => ({
-                                id: `${e.from_id}->${e.to_id}:${e.field}`,
-                                from: e.from_id,
-                                to: e.to_id,
-                                fromType: importPreview!.resources.find(r => r.id === e.from_id)?.type || '',
-                                toType: importPreview!.resources.find(r => r.id === e.to_id)?.type || '',
-                                field: e.field,
-                                label: e.field.replace(/_/g, ' '),
-                              }));
-                              setEdges(newEdges);
-                            }
-                            setShowImportWizard(false);
-                            setImportPreview(null);
-                            setVisionImages([]);
-                            setVisionError(null);
-                            setNotification(`Imported ${importPreview!.resources.length} resources`);
-                            setTimeout(() => setNotification(null), 4000);
-                          }}>
-                          Import to Canvas
-                        </UIButton>
-                      )}
-                    </div>
-                  </div>
-                )}
-            </UIModal>
+            <ImportWizardModal
+              importTab={importTab}
+              onImportTabChange={setImportTab}
+              browsePath={browsePath}
+              browseParent={browseParent}
+              browseEntries={browseEntries}
+              onBrowseLoaded={handleBrowseLoaded}
+              importPreview={importPreview}
+              onImportPreviewChange={setImportPreview}
+              importLoading={importLoading}
+              onImportLoadingChange={setImportLoading}
+              topologyDesc={topologyDesc}
+              onTopologyDescChange={setTopologyDesc}
+              topologyProvider={topologyProvider}
+              onTopologyProviderChange={setTopologyProvider}
+              visionImages={visionImages}
+              onVisionImagesChange={setVisionImages}
+              visionError={visionError}
+              onVisionErrorChange={setVisionError}
+              catalogResources={catalogResources}
+              onGenerateTopology={handleGenerateTopology}
+              onImportToCanvas={handleImportToCanvas}
+              onClose={closeImportWizard}
+            />
           )}
         </div>
       </div>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -898,7 +898,7 @@ export default function App() {
       const toType = nodeTypeById.get(to);
       if (!fromType || !toType) return [];
       return [{
-        id: `${from}->${to}:${edge.field}`,
+        id: edgeId(from, to, edge.field),
         from,
         to,
         fromType,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -45,6 +45,12 @@ const isPolicyBlockedError = (err: unknown): err is ApiError => (
   err instanceof ApiError && err.status === 409 && err.payload?.error === 'policy_blocked'
 );
 
+const errorMessage = (err: unknown, fallback: string) => {
+  if (err instanceof Error && err.message) return err.message;
+  if (typeof err === 'string' && err) return err;
+  return fallback;
+};
+
 const extractLayoutMeta = (state: any) => {
   if (!state?.layout) return null;
   const meta: Record<string, any> = {};
@@ -858,8 +864,8 @@ export default function App() {
     const selectedTool = preview.tool === 'opentofu' ? 'opentofu' : preview.tool === 'ansible' ? 'ansible' : 'terraform';
     try {
       await api.createProject(projectName, selectedTool);
-    } catch (err: any) {
-      setNotification(`Import failed: ${err.message}`);
+    } catch (err: unknown) {
+      setNotification(`Import failed: ${errorMessage(err, 'Unable to create project')}`);
       setTimeout(() => setNotification(null), 5000);
       return;
     }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -15,6 +15,7 @@ import { SwimlaneCanvas } from './components/Canvas';
 import { S } from './styles';
 import type { LayeredProject, LayeredModule } from './types';
 import { envForResourceLoad, envForTool, shouldParseResourcesFromDisk, toolForEnv } from './projectLoad';
+import { errorMessage } from './lib/errors';
 import {
   TOOLS,
   ALL_TOOLS,
@@ -44,12 +45,6 @@ const summarizePolicyFindings = (findings: PolicyFinding[]) => {
 const isPolicyBlockedError = (err: unknown): err is ApiError => (
   err instanceof ApiError && err.status === 409 && err.payload?.error === 'policy_blocked'
 );
-
-const errorMessage = (err: unknown, fallback: string) => {
-  if (err instanceof Error && err.message) return err.message;
-  if (typeof err === 'string' && err) return err;
-  return fallback;
-};
 
 const extractLayoutMeta = (state: any) => {
   if (!state?.layout) return null;
@@ -879,13 +874,10 @@ export default function App() {
     initialLoadDone.current = true;
 
     const catalogByType = new Map(catalogResources.map(resource => [resource.type, resource]));
-    const idMap = new Map<string, string>();
     const generatedIdPrefix = `imp_${Date.now()}`;
     const imported = preview.resources.map((resource, index) => {
       const id = resource.id || `${generatedIdPrefix}_${index}`;
       const meta = catalogByType.get(resource.type);
-      idMap.set(id, id);
-      if (resource.id) idMap.set(resource.id, id);
       const { file: _file, line: _line, ...rest } = resource;
       return {
         ...rest,
@@ -900,8 +892,8 @@ export default function App() {
 
     const nodeTypeById = new Map(imported.map(resource => [resource.id, resource.type]));
     const newEdges = preview.edges.flatMap(edge => {
-      const from = idMap.get(edge.from_id) ?? edge.from_id;
-      const to = idMap.get(edge.to_id) ?? edge.to_id;
+      const from = edge.from_id;
+      const to = edge.to_id;
       const fromType = nodeTypeById.get(from);
       const toType = nodeTypeById.get(to);
       if (!fromType || !toType) return [];

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -872,31 +872,44 @@ export default function App() {
     hasCreatedProject.current = true;
     initialLoadDone.current = true;
 
-    const imported = preview.resources.map((resource, index) => ({
-      ...(() => {
-        const { file: _file, line: _line, ...rest } = resource;
-        return rest;
-      })(),
-      id: resource.id || `imp_${index}_${Date.now()}`,
-      x: 80 + (index % 5) * 200,
-      y: 80 + Math.floor(index / 5) * 130,
-      icon: catalogResources.find(candidate => candidate.type === resource.type)?.icon ?? '📦',
-      label: catalogResources.find(candidate => candidate.type === resource.type)?.label ?? resource.type,
-    }));
+    const catalogByType = new Map(catalogResources.map(resource => [resource.type, resource]));
+    const idMap = new Map<string, string>();
+    const generatedIdPrefix = `imp_${Date.now()}`;
+    const imported = preview.resources.map((resource, index) => {
+      const id = resource.id || `${generatedIdPrefix}_${index}`;
+      const meta = catalogByType.get(resource.type);
+      idMap.set(id, id);
+      if (resource.id) idMap.set(resource.id, id);
+      const { file: _file, line: _line, ...rest } = resource;
+      return {
+        ...rest,
+        id,
+        x: 80 + (index % 5) * 200,
+        y: 80 + Math.floor(index / 5) * 130,
+        icon: meta?.icon ?? '📦',
+        label: meta?.label ?? resource.type,
+      };
+    });
     resetNodes(imported);
 
-    if (preview.edges.length > 0) {
-      const newEdges = preview.edges.map(edge => ({
-        id: `${edge.from_id}->${edge.to_id}:${edge.field}`,
-        from: edge.from_id,
-        to: edge.to_id,
-        fromType: preview.resources.find(resource => resource.id === edge.from_id)?.type || '',
-        toType: preview.resources.find(resource => resource.id === edge.to_id)?.type || '',
+    const nodeTypeById = new Map(imported.map(resource => [resource.id, resource.type]));
+    const newEdges = preview.edges.flatMap(edge => {
+      const from = idMap.get(edge.from_id) ?? edge.from_id;
+      const to = idMap.get(edge.to_id) ?? edge.to_id;
+      const fromType = nodeTypeById.get(from);
+      const toType = nodeTypeById.get(to);
+      if (!fromType || !toType) return [];
+      return [{
+        id: `${from}->${to}:${edge.field}`,
+        from,
+        to,
+        fromType,
+        toType,
         field: edge.field,
         label: edge.field.replace(/_/g, ' '),
-      }));
-      setEdges(newEdges);
-    }
+      }];
+    });
+    setEdges(newEdges);
 
     setShowImportWizard(false);
     setImportPreview(null);

--- a/web/src/components/ImportWizard/ImportWizardModal.tsx
+++ b/web/src/components/ImportWizard/ImportWizardModal.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import { api, type CatalogResource, type FileEntry, type ImportResult } from '../../api';
 import { fileGlyph } from '../../legacy';
 import { UIButton, UILabel, UIModal, UITextArea } from '../../ui';
@@ -38,6 +40,10 @@ function providerLabel(provider: string) {
   return 'Azure';
 }
 
+function errorMessage(err: unknown, fallback: string) {
+  return err instanceof Error && err.message ? err.message : fallback;
+}
+
 export function ImportWizardModal({
   importTab,
   onImportTabChange,
@@ -62,6 +68,11 @@ export function ImportWizardModal({
   onImportToCanvas,
   onClose,
 }: ImportWizardModalProps) {
+  const catalogByType = useMemo(
+    () => new Map(catalogResources.map(resource => [resource.type, resource])),
+    [catalogResources],
+  );
+
   const browseTo = async (path?: string) => {
     try {
       const result = await api.browse(path);
@@ -76,8 +87,8 @@ export function ImportWizardModal({
     try {
       const result = await api.importProject(browsePath);
       onImportPreviewChange(result);
-    } catch (err: any) {
-      const message = err?.message || 'Import failed';
+    } catch (err: unknown) {
+      const message = errorMessage(err, 'Import failed');
       onImportPreviewChange({
         tool: 'unknown',
         provider: 'unknown',
@@ -231,7 +242,7 @@ export function ImportWizardModal({
               </div>
               <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
                 {importPreview.resources.map((resource, index) => {
-                  const meta = catalogResources.find(candidate => candidate.type === resource.type);
+                  const meta = catalogByType.get(resource.type);
                   return (
                     <span key={index} style={{ background: 'var(--bg-elev-2)', borderRadius: 6, padding: '4px 10px', fontSize: 11, color: 'var(--text-main)', fontFamily: 'JetBrains Mono' }}>
                       {meta?.icon ?? '📦'} {resource.type}.{resource.name}

--- a/web/src/components/ImportWizard/ImportWizardModal.tsx
+++ b/web/src/components/ImportWizard/ImportWizardModal.tsx
@@ -1,0 +1,259 @@
+import { api, type CatalogResource, type FileEntry, type ImportResult } from '../../api';
+import { fileGlyph } from '../../legacy';
+import { UIButton, UILabel, UIModal, UITextArea } from '../../ui';
+import { VisionDropzone } from '../VisionDropzone';
+
+export type ImportWizardTab = 'browse' | 'topology';
+
+export interface ImportWizardModalProps {
+  importTab: ImportWizardTab;
+  onImportTabChange: (_tab: ImportWizardTab) => void;
+  browsePath: string;
+  browseParent: string;
+  browseEntries: FileEntry[];
+  onBrowseLoaded: (_path: string, _entries: FileEntry[], _parent: string) => void;
+  importPreview: ImportResult | null;
+  onImportPreviewChange: (_preview: ImportResult | null) => void;
+  importLoading: boolean;
+  onImportLoadingChange: (_loading: boolean) => void;
+  topologyDesc: string;
+  onTopologyDescChange: (_description: string) => void;
+  topologyProvider: string;
+  onTopologyProviderChange: (_provider: string) => void;
+  visionImages: File[];
+  onVisionImagesChange: (_images: File[]) => void;
+  visionError: string | null;
+  onVisionErrorChange: (_error: string | null) => void;
+  catalogResources: CatalogResource[];
+  onGenerateTopology: () => void;
+  onImportToCanvas: (_preview: ImportResult) => Promise<void> | void;
+  onClose: () => void;
+}
+
+const providerOptions = ['aws', 'google', 'azurerm'];
+
+function providerLabel(provider: string) {
+  if (provider === 'aws') return 'AWS';
+  if (provider === 'google') return 'GCP';
+  return 'Azure';
+}
+
+export function ImportWizardModal({
+  importTab,
+  onImportTabChange,
+  browsePath,
+  browseParent,
+  browseEntries,
+  onBrowseLoaded,
+  importPreview,
+  onImportPreviewChange,
+  importLoading,
+  onImportLoadingChange,
+  topologyDesc,
+  onTopologyDescChange,
+  topologyProvider,
+  onTopologyProviderChange,
+  visionImages,
+  onVisionImagesChange,
+  visionError,
+  onVisionErrorChange,
+  catalogResources,
+  onGenerateTopology,
+  onImportToCanvas,
+  onClose,
+}: ImportWizardModalProps) {
+  const browseTo = async (path?: string) => {
+    try {
+      const result = await api.browse(path);
+      onBrowseLoaded(result.path, result.entries, result.parent);
+    } catch {
+      // Keep the existing quiet failure behavior for unavailable local browsing.
+    }
+  };
+
+  const importFolder = async () => {
+    onImportLoadingChange(true);
+    try {
+      const result = await api.importProject(browsePath);
+      onImportPreviewChange(result);
+    } catch (err: any) {
+      const message = err?.message || 'Import failed';
+      onImportPreviewChange({
+        tool: 'unknown',
+        provider: 'unknown',
+        files: [],
+        resources: [],
+        edges: [],
+        summary: message,
+        warnings: [message],
+      });
+    } finally {
+      onImportLoadingChange(false);
+    }
+  };
+
+  const changeTab = (tab: ImportWizardTab) => {
+    onImportTabChange(tab);
+    onImportPreviewChange(null);
+    if (tab === 'browse') {
+      onVisionImagesChange([]);
+      onVisionErrorChange(null);
+    }
+  };
+
+  return (
+    <UIModal onClose={onClose}>
+      <div className="ui-modal-header">
+        <div style={{ display: 'flex', gap: 12 }}>
+          {(['browse', 'topology'] as const).map(tab => (
+            <UIButton
+              key={tab}
+              variant="tab"
+              active={importTab === tab}
+              onClick={() => changeTab(tab)}
+            >
+              {tab === 'browse' ? 'Browse Files' : 'AI Topology'}
+            </UIButton>
+          ))}
+        </div>
+        <button className="ui-close" onClick={onClose}>×</button>
+      </div>
+
+      {importTab === 'browse' && !importPreview && (
+        <div style={{ flex: 1, overflow: 'auto', minHeight: 300 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '10px 20px', borderBottom: '1px solid var(--border-soft)', background: 'var(--bg-elev-1)' }}>
+            <UIButton onClick={() => browseTo(browseParent)}>
+              ↑
+            </UIButton>
+            <span style={{ fontSize: 11, color: 'var(--text-muted)', fontFamily: 'JetBrains Mono', flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{browsePath}</span>
+            <UIButton
+              variant="primary"
+              disabled={importLoading}
+              onClick={importFolder}
+            >
+              {importLoading ? 'Scanning...' : 'Import this folder'}
+            </UIButton>
+          </div>
+          <div style={{ padding: '4px 0' }}>
+            {browseEntries.map(entry => (
+              <div
+                key={entry.path}
+                style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '7px 20px', cursor: entry.is_dir ? 'pointer' : 'default', fontSize: 13, color: entry.is_dir ? '#ccc' : '#777', fontFamily: 'JetBrains Mono' }}
+                onClick={() => {
+                  if (entry.is_dir) {
+                    browseTo(entry.path);
+                  }
+                }}
+                onMouseEnter={event => {
+                  if (entry.is_dir) (event.currentTarget as any).style.background = 'var(--bg-elev-2)';
+                }}
+                onMouseLeave={event => {
+                  (event.currentTarget as any).style.background = 'transparent';
+                }}
+              >
+                <span style={{ fontSize: 10, fontFamily: 'JetBrains Mono', color: '#7b8d84', minWidth: 30 }}>{fileGlyph(entry)}</span>
+                <span style={{ flex: 1 }}>{entry.name}</span>
+                {entry.is_dir && entry.children !== undefined && <span style={{ color: '#444', fontSize: 10 }}>{entry.children} items</span>}
+                {!entry.is_dir && <span style={{ color: '#444', fontSize: 10 }}>{entry.size > 1024 ? Math.round(entry.size / 1024) + 'KB' : entry.size + 'B'}</span>}
+              </div>
+            ))}
+            {browseEntries.length === 0 && <div style={{ padding: 20, textAlign: 'center', color: '#444' }}>Empty directory</div>}
+          </div>
+        </div>
+      )}
+
+      {importTab === 'topology' && !importPreview && (
+        <div style={{ flex: 1, padding: 20, display: 'flex', flexDirection: 'column', gap: 16 }}>
+          <div style={{ fontSize: 14, color: 'var(--text-main)', fontWeight: 600 }}>Describe your infrastructure</div>
+          <div className="ui-note">
+            Tell us what you want to build in plain language, or upload a diagram for vision analysis.
+          </div>
+          <VisionDropzone
+            files={visionImages}
+            onFilesChange={onVisionImagesChange}
+            onError={onVisionErrorChange}
+            error={visionError}
+            disabled={importLoading}
+          />
+          <UITextArea
+            style={{ flex: 1, minHeight: 120 }}
+            value={topologyDesc}
+            onChange={event => onTopologyDescChange(event.target.value)}
+            placeholder={"Optional context:\nA three-tier web app with VPC, ALB, auto-scaling EC2, RDS PostgreSQL, and S3 for static assets\nA GKE cluster with Cloud SQL, Redis cache, and Cloud Storage for a microservices platform"}
+          />
+          <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+            <UILabel>Provider:</UILabel>
+            {providerOptions.map(provider => (
+              <UIButton
+                key={provider}
+                variant="tab"
+                active={topologyProvider === provider}
+                onClick={() => onTopologyProviderChange(provider)}
+              >
+                {providerLabel(provider)}
+              </UIButton>
+            ))}
+          </div>
+          <UIButton
+            variant="primary"
+            disabled={(!topologyDesc.trim() && visionImages.length === 0) || Boolean(visionError) || importLoading}
+            onClick={onGenerateTopology}
+          >
+            {importLoading ? 'Generating... (this may take a minute)' : visionImages.length > 0 ? 'Generate from Diagram' : 'Generate Infrastructure'}
+          </UIButton>
+        </div>
+      )}
+
+      {importPreview && (
+        <div style={{ flex: 1, overflow: 'auto', padding: 20, display: 'flex', flexDirection: 'column', gap: 12 }}>
+          <div style={{ fontSize: 14, fontWeight: 600, color: '#bbb' }}>
+            {importPreview.tool === 'unknown' ? 'Import Failed' : 'Preview'}
+          </div>
+          <div className="ui-note">{importPreview.summary}</div>
+
+          {importPreview.warnings && importPreview.warnings.length > 0 && (
+            <div style={{ background: '#ef444411', border: '1px solid #ef444433', borderRadius: 8, padding: 10 }}>
+              {importPreview.warnings.map((warning, index) => (
+                <div key={index} style={{ fontSize: 11, color: '#ef4444', fontFamily: 'JetBrains Mono' }}>{warning}</div>
+              ))}
+            </div>
+          )}
+
+          {importPreview.resources.length > 0 && (
+            <>
+              <div style={{ fontSize: 11, color: '#555', fontFamily: 'JetBrains Mono', textTransform: 'uppercase', letterSpacing: 1 }}>
+                {importPreview.resources.length} Resources
+              </div>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+                {importPreview.resources.map((resource, index) => {
+                  const meta = catalogResources.find(candidate => candidate.type === resource.type);
+                  return (
+                    <span key={index} style={{ background: 'var(--bg-elev-2)', borderRadius: 6, padding: '4px 10px', fontSize: 11, color: 'var(--text-main)', fontFamily: 'JetBrains Mono' }}>
+                      {meta?.icon ?? '📦'} {resource.type}.{resource.name}
+                    </span>
+                  );
+                })}
+              </div>
+              {importPreview.edges.length > 0 && (
+                <div style={{ fontSize: 11, color: '#555', fontFamily: 'JetBrains Mono' }}>
+                  {importPreview.edges.length} connections detected
+                </div>
+              )}
+            </>
+          )}
+
+          <div style={{ display: 'flex', gap: 10, marginTop: 8 }}>
+            <UIButton onClick={() => onImportPreviewChange(null)}>
+              ← Back
+            </UIButton>
+            {importPreview.resources.length > 0 && (
+              <UIButton variant="primary" onClick={() => onImportToCanvas(importPreview)}>
+                Import to Canvas
+              </UIButton>
+            )}
+          </div>
+        </div>
+      )}
+    </UIModal>
+  );
+}

--- a/web/src/components/ImportWizard/ImportWizardModal.tsx
+++ b/web/src/components/ImportWizard/ImportWizardModal.tsx
@@ -35,13 +35,24 @@ export interface ImportWizardModalProps {
 const providerOptions = ['aws', 'google', 'azurerm'];
 
 function providerLabel(provider: string) {
-  if (provider === 'aws') return 'AWS';
-  if (provider === 'google') return 'GCP';
-  return 'Azure';
+  switch (provider) {
+    case 'aws':
+      return 'AWS';
+    case 'google':
+      return 'GCP';
+    case 'azurerm':
+      return 'Azure';
+    default:
+      return provider || 'Unknown';
+  }
 }
 
 function errorMessage(err: unknown, fallback: string) {
   return err instanceof Error && err.message ? err.message : fallback;
+}
+
+function resourcePreviewKey(resource: ImportResult['resources'][number]) {
+  return resource.id || [resource.type, resource.name, resource.file, resource.line].filter(Boolean).join(':');
 }
 
 export function ImportWizardModal({
@@ -133,7 +144,7 @@ export function ImportWizardModal({
       {importTab === 'browse' && !importPreview && (
         <div style={{ flex: 1, overflow: 'auto', minHeight: 300 }}>
           <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '10px 20px', borderBottom: '1px solid var(--border-soft)', background: 'var(--bg-elev-1)' }}>
-            <UIButton onClick={() => browseTo(browseParent)}>
+            <UIButton aria-label="Browse to parent directory" onClick={() => browseTo(browseParent)}>
               ↑
             </UIButton>
             <span style={{ fontSize: 11, color: 'var(--text-muted)', fontFamily: 'JetBrains Mono', flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{browsePath}</span>
@@ -241,10 +252,10 @@ export function ImportWizardModal({
                 {importPreview.resources.length} Resources
               </div>
               <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
-                {importPreview.resources.map((resource, index) => {
+                {importPreview.resources.map(resource => {
                   const meta = catalogByType.get(resource.type);
                   return (
-                    <span key={index} style={{ background: 'var(--bg-elev-2)', borderRadius: 6, padding: '4px 10px', fontSize: 11, color: 'var(--text-main)', fontFamily: 'JetBrains Mono' }}>
+                    <span key={resourcePreviewKey(resource)} style={{ background: 'var(--bg-elev-2)', borderRadius: 6, padding: '4px 10px', fontSize: 11, color: 'var(--text-main)', fontFamily: 'JetBrains Mono' }}>
                       {meta?.icon ?? '📦'} {resource.type}.{resource.name}
                     </span>
                   );
@@ -263,7 +274,7 @@ export function ImportWizardModal({
               ← Back
             </UIButton>
             {importPreview.resources.length > 0 && (
-              <UIButton variant="primary" onClick={() => onImportToCanvas(importPreview)}>
+              <UIButton variant="primary" onClick={() => { void onImportToCanvas(importPreview); }}>
                 Import to Canvas
               </UIButton>
             )}

--- a/web/src/components/ImportWizard/ImportWizardModal.tsx
+++ b/web/src/components/ImportWizard/ImportWizardModal.tsx
@@ -116,7 +116,7 @@ export function ImportWizardModal({
             </UIButton>
           ))}
         </div>
-        <button className="ui-close" onClick={onClose}>×</button>
+        <button className="ui-close" aria-label="Close import wizard" onClick={onClose}>×</button>
       </div>
 
       {importTab === 'browse' && !importPreview && (
@@ -135,28 +135,33 @@ export function ImportWizardModal({
             </UIButton>
           </div>
           <div style={{ padding: '4px 0' }}>
-            {browseEntries.map(entry => (
-              <div
-                key={entry.path}
-                style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '7px 20px', cursor: entry.is_dir ? 'pointer' : 'default', fontSize: 13, color: entry.is_dir ? '#ccc' : '#777', fontFamily: 'JetBrains Mono' }}
-                onClick={() => {
-                  if (entry.is_dir) {
-                    browseTo(entry.path);
-                  }
-                }}
-                onMouseEnter={event => {
-                  if (entry.is_dir) (event.currentTarget as any).style.background = 'var(--bg-elev-2)';
-                }}
-                onMouseLeave={event => {
-                  (event.currentTarget as any).style.background = 'transparent';
-                }}
-              >
-                <span style={{ fontSize: 10, fontFamily: 'JetBrains Mono', color: '#7b8d84', minWidth: 30 }}>{fileGlyph(entry)}</span>
-                <span style={{ flex: 1 }}>{entry.name}</span>
-                {entry.is_dir && entry.children !== undefined && <span style={{ color: '#444', fontSize: 10 }}>{entry.children} items</span>}
-                {!entry.is_dir && <span style={{ color: '#444', fontSize: 10 }}>{entry.size > 1024 ? Math.round(entry.size / 1024) + 'KB' : entry.size + 'B'}</span>}
-              </div>
-            ))}
+            {browseEntries.map(entry => {
+              const contents = (
+                <>
+                  <span style={{ fontSize: 10, fontFamily: 'JetBrains Mono', color: '#7b8d84', minWidth: 30 }}>{fileGlyph(entry)}</span>
+                  <span style={{ flex: 1 }}>{entry.name}</span>
+                  {entry.is_dir && entry.children !== undefined && <span style={{ color: '#444', fontSize: 10 }}>{entry.children} items</span>}
+                  {!entry.is_dir && <span style={{ color: '#444', fontSize: 10 }}>{entry.size > 1024 ? Math.round(entry.size / 1024) + 'KB' : entry.size + 'B'}</span>}
+                </>
+              );
+              if (entry.is_dir) {
+                return (
+                  <button
+                    key={entry.path}
+                    type="button"
+                    className="import-wizard-entry import-wizard-entry--dir"
+                    onClick={() => browseTo(entry.path)}
+                  >
+                    {contents}
+                  </button>
+                );
+              }
+              return (
+                <div key={entry.path} className="import-wizard-entry import-wizard-entry--file">
+                  {contents}
+                </div>
+              );
+            })}
             {browseEntries.length === 0 && <div style={{ padding: 20, textAlign: 'center', color: '#444' }}>Empty directory</div>}
           </div>
         </div>
@@ -214,7 +219,7 @@ export function ImportWizardModal({
           {importPreview.warnings && importPreview.warnings.length > 0 && (
             <div style={{ background: '#ef444411', border: '1px solid #ef444433', borderRadius: 8, padding: 10 }}>
               {importPreview.warnings.map((warning, index) => (
-                <div key={index} style={{ fontSize: 11, color: '#ef4444', fontFamily: 'JetBrains Mono' }}>{warning}</div>
+                <div key={`${warning}-${index}`} style={{ fontSize: 11, color: '#ef4444', fontFamily: 'JetBrains Mono' }}>{warning}</div>
               ))}
             </div>
           )}

--- a/web/src/components/ImportWizard/ImportWizardModal.tsx
+++ b/web/src/components/ImportWizard/ImportWizardModal.tsx
@@ -91,6 +91,7 @@ export function ImportWizardModal({
   };
 
   const importFolder = async () => {
+    if (!browsePath.trim()) return;
     onImportLoadingChange(true);
     try {
       const result = await api.importProject(browsePath);
@@ -147,7 +148,7 @@ export function ImportWizardModal({
             <span style={{ fontSize: 11, color: 'var(--text-muted)', fontFamily: 'JetBrains Mono', flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{browsePath}</span>
             <UIButton
               variant="primary"
-              disabled={importLoading}
+              disabled={importLoading || !browsePath.trim()}
               onClick={importFolder}
             >
               {importLoading ? 'Scanning...' : 'Import this folder'}

--- a/web/src/components/ImportWizard/ImportWizardModal.tsx
+++ b/web/src/components/ImportWizard/ImportWizardModal.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 
 import { api, type CatalogResource, type FileEntry, type ImportResult } from '../../api';
+import { errorMessage } from '../../lib/errors';
 import { fileGlyph } from '../../legacy';
 import { UIButton, UILabel, UIModal, UITextArea } from '../../ui';
 import { VisionDropzone } from '../VisionDropzone';
@@ -45,10 +46,6 @@ function providerLabel(provider: string) {
     default:
       return provider || 'Unknown';
   }
-}
-
-function errorMessage(err: unknown, fallback: string) {
-  return err instanceof Error && err.message ? err.message : fallback;
 }
 
 function resourcePreviewKey(resource: ImportResult['resources'][number]) {

--- a/web/src/components/ImportWizard/index.tsx
+++ b/web/src/components/ImportWizard/index.tsx
@@ -1,0 +1,2 @@
+export { ImportWizardModal } from './ImportWizardModal';
+export type { ImportWizardModalProps, ImportWizardTab } from './ImportWizardModal';

--- a/web/src/lib/errors.ts
+++ b/web/src/lib/errors.ts
@@ -1,0 +1,5 @@
+export function errorMessage(err: unknown, fallback: string) {
+  if (err instanceof Error && err.message) return err.message;
+  if (typeof err === 'string' && err) return err;
+  return fallback;
+}

--- a/web/src/theme.css
+++ b/web/src/theme.css
@@ -323,10 +323,14 @@ body {
   cursor: pointer;
 }
 
-.import-wizard-entry--dir:hover,
+.import-wizard-entry--dir:hover {
+  background: var(--bg-elev-2);
+}
+
 .import-wizard-entry--dir:focus-visible {
   background: var(--bg-elev-2);
-  outline: none;
+  outline: 2px solid var(--accent-action);
+  outline-offset: -2px;
 }
 
 .import-wizard-entry--file {

--- a/web/src/theme.css
+++ b/web/src/theme.css
@@ -305,6 +305,34 @@ body {
   font-size: 10px;
 }
 
+.import-wizard-entry {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 20px;
+  border: 0;
+  background: transparent;
+  font-size: 13px;
+  font-family: 'JetBrains Mono', monospace;
+  text-align: left;
+}
+
+.import-wizard-entry--dir {
+  color: #ccc;
+  cursor: pointer;
+}
+
+.import-wizard-entry--dir:hover,
+.import-wizard-entry--dir:focus-visible {
+  background: var(--bg-elev-2);
+  outline: none;
+}
+
+.import-wizard-entry--file {
+  color: #777;
+}
+
 .ui-choice-grid {
   display: flex;
   gap: 8px;


### PR DESCRIPTION
Refs #22. Extracts the import/topology wizard modal from App.tsx into components/ImportWizard while keeping browse import, AI topology, diagram upload, preview, and import-to-canvas behavior wired through existing App state. Validation: npm test -- --run, npm run build, npm run lint from web/.