### PR TITLE
[codex] Extract AI settings modal

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,7 +3,8 @@ import { api, ApiError, Resource, ToolInfo, CatalogResource, Suggestion, FileEnt
 import { useWebSocket, WSMessage } from './useWebSocket';
 import { useHistory } from './useHistory';
 import { useKeyboardShortcuts } from './useKeyboardShortcuts';
-import { UIButton, UIInput, UIKicker, UILabel, UIModal, UIPanel } from './ui';
+import { UIButton, UIInput, UIKicker, UILabel, UIPanel } from './ui';
+import { AISettingsModal, type AISettingsConfig } from './components/AISettings';
 import { CodeEditor } from './components/CodeEditor';
 import { ChatPanel } from './components/Chat';
 import { ImportWizardModal } from './components/ImportWizard';
@@ -155,7 +156,7 @@ export default function App() {
   const [visionImages, setVisionImages] = useState<File[]>([]);
   const [visionError, setVisionError] = useState<string | null>(null);
   const [showSettings, setShowSettings] = useState(false);
-  const [aiSettings, setAiSettings] = useState({ type: 'ollama', endpoint: '', model: '', api_key: '' });
+  const [aiSettings, setAiSettings] = useState<AISettingsConfig>({ type: 'ollama', endpoint: '', model: '', api_key: '' });
   const [savedProjects, setSavedProjects] = useState<any[]>([]);
   const { state: nodes, set: setNodes, undo: undoNodes, redo: redoNodes, canUndo, canRedo, reset: resetNodes } = useHistory<(Resource & { x: number; y: number; icon: string; label: string })[]>([]);
   const [edges, setEdges] = useState<Edge[]>([]);
@@ -945,6 +946,11 @@ export default function App() {
     }
   }, [activeEnv, concreteTool, projectId, tool, unresolvedHybridEnv]);
 
+  const showNotification = useCallback((message: string, duration = 3000) => {
+    setNotification(message);
+    window.setTimeout(() => setNotification(null), duration);
+  }, []);
+
   const handleCreateProject = async (selectedTool: string) => {
     setTool(selectedTool);
     setProjectLayoutMeta(null);
@@ -1163,74 +1169,12 @@ export default function App() {
 
       {/* AI Settings Modal */}
       {showSettings && (
-        <UIModal onClose={() => setShowSettings(false)} width={480} className="ui-panel--raised">
-          <div style={{ padding: 24 }}>
-            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 20 }}>
-              <span className="ui-modal-title">AI Settings</span>
-              <button className="ui-close" onClick={() => setShowSettings(false)}>×</button>
-            </div>
-
-            <div style={{ marginBottom: 16 }}>
-              <UILabel>Provider Type</UILabel>
-              <div className="ui-choice-grid" style={{ marginTop: 8 }}>
-                {[
-                  { key: 'ollama', label: 'Ollama (Local)', desc: 'Free, private, runs on your machine' },
-                  { key: 'openai', label: 'OpenAI API', desc: 'GPT-4o, GPT-4-turbo' },
-                  { key: 'anthropic', label: 'Anthropic', desc: 'Claude Opus, Claude Haiku' },
-                  { key: 'custom', label: 'Custom API', desc: 'Any OpenAI-compatible endpoint' },
-                ].map(p => (
-                  <button key={p.key} className={aiSettings.type === p.key ? 'ui-choice-card is-active' : 'ui-choice-card'}
-                    onClick={() => {
-                      if (p.key === 'ollama') setAiSettings(s => ({ ...s, type: 'ollama', endpoint: 'http://localhost:11434', api_key: '' }));
-                      else if (p.key === 'openai') setAiSettings(s => ({ ...s, type: 'openai', endpoint: 'https://api.openai.com/v1', model: 'gpt-4o' }));
-                      else if (p.key === 'anthropic') setAiSettings(s => ({ ...s, type: 'anthropic', endpoint: '', model: 'claude-haiku-4-5', api_key: '' }));
-                      else setAiSettings(s => ({ ...s, type: 'custom' }));
-                    }}>
-                    <div className="ui-choice-title">{p.label}</div>
-                    <div className="ui-choice-desc">{p.desc}</div>
-                  </button>
-                ))}
-              </div>
-            </div>
-
-            <div style={{ marginBottom: 12 }}>
-              <UILabel>Endpoint</UILabel>
-              <UIInput value={aiSettings.endpoint} onChange={e => setAiSettings(s => ({ ...s, endpoint: e.target.value }))}
-                placeholder={aiSettings.type === 'ollama' ? 'http://localhost:11434' : aiSettings.type === 'anthropic' ? 'https://api.anthropic.com (optional)' : 'https://api.openai.com/v1'} />
-            </div>
-
-            <div style={{ marginBottom: 12 }}>
-              <UILabel>Model</UILabel>
-              <UIInput value={aiSettings.model} onChange={e => setAiSettings(s => ({ ...s, model: e.target.value }))}
-                placeholder={aiSettings.type === 'ollama' ? 'gemma4' : aiSettings.type === 'anthropic' ? 'claude-haiku-4-5' : 'gpt-4o'} />
-            </div>
-
-            {aiSettings.type !== 'ollama' && (
-              <div style={{ marginBottom: 12 }}>
-                <UILabel>API Key</UILabel>
-                <UIInput type="password" value={aiSettings.api_key} onChange={e => setAiSettings(s => ({ ...s, api_key: e.target.value }))}
-                  placeholder="sk-..." />
-                <div className="ui-note ui-note--small" style={{ marginTop: 4 }}>Your key is sent to the backend only — never stored on disk or sent to third parties.</div>
-              </div>
-            )}
-
-            <div style={{ display: 'flex', gap: 10, marginTop: 20 }}>
-              <UIButton block onClick={() => setShowSettings(false)}>Cancel</UIButton>
-              <UIButton block variant="primary"
-                onClick={async () => {
-                  try {
-                    await api.updateAISettings(aiSettings);
-                    setNotification('AI settings updated');
-                    setTimeout(() => setNotification(null), 3000);
-                    setShowSettings(false);
-                  } catch (e: any) {
-                    setNotification(`Failed: ${e.message}`);
-                    setTimeout(() => setNotification(null), 4000);
-                  }
-                }}>Save</UIButton>
-            </div>
-          </div>
-        </UIModal>
+        <AISettingsModal
+          settings={aiSettings}
+          onSettingsChange={setAiSettings}
+          onNotify={showNotification}
+          onClose={() => setShowSettings(false)}
+        />
       )}
 
       <div style={S.main}>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -194,6 +194,7 @@ export default function App() {
   const canvasRef = useRef<HTMLDivElement>(null);
   const chatEndRef = useRef<HTMLDivElement>(null);
   const isSyncing = useRef(false); // suppress file_changed echo from our own sync
+  const notificationTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isSwimlaneMode = Boolean(layeredProject && canvasMode === 'swimlane');
   const showEnvironmentSelector = Boolean(layeredProject && (tool === 'multi' || layeredProject.environmentTools));
   const activeEnv = envForTool(tool || '', layeredProject, activeEnvironment);
@@ -207,6 +208,37 @@ export default function App() {
     : concreteTool === 'pulumi'
       ? (activeEnv ? `environments/${activeEnv}/index.ts` : undefined)
       : (tool === 'multi' && activeEnv ? `environments/${activeEnv}/main${TOOLS[concreteTool]?.ext || '.tf'}` : undefined);
+
+  const clearNotificationTimer = useCallback(() => {
+    if (notificationTimer.current !== null) {
+      clearTimeout(notificationTimer.current);
+      notificationTimer.current = null;
+    }
+  }, []);
+
+  const showNotification = useCallback((message: string, duration = 3000) => {
+    clearNotificationTimer();
+    setNotification(message);
+    notificationTimer.current = setTimeout(() => {
+      setNotification(null);
+      notificationTimer.current = null;
+    }, duration);
+  }, [clearNotificationTimer]);
+
+  const showPersistentNotification = useCallback((message: string) => {
+    clearNotificationTimer();
+    setNotification(message);
+  }, [clearNotificationTimer]);
+
+  const clearNotification = useCallback(() => {
+    clearNotificationTimer();
+    setNotification(null);
+  }, [clearNotificationTimer]);
+
+  useEffect(() => () => {
+    clearNotificationTimer();
+  }, [clearNotificationTimer]);
+
   const activeEnvNodes = useMemo(
     () => resourcesForEnv(nodes, (tool === 'multi' || tool === 'pulumi') ? activeEnv : undefined),
     [nodes, activeEnv, tool],
@@ -342,8 +374,7 @@ export default function App() {
         const parsed = await api.getResources(proj.name, selectedTool, envForResourceLoad(selectedTool, selectedLayered));
         applyParsedResources(parsed);
       }
-      setNotification(`Opened project: ${proj.name}`);
-      setTimeout(() => setNotification(null), 3000);
+      showNotification(`Opened project: ${proj.name}`);
     } catch {
       // No saved state — start fresh
       setProjectLayoutMeta(null);
@@ -351,7 +382,7 @@ export default function App() {
       setActiveEnvironment(null);
       setCanvasMode('freeform');
     }
-  }, [applyParsedResources, applyProjectState]);
+  }, [applyParsedResources, applyProjectState, showNotification]);
 
   useEffect(() => {
     if (tool === 'ansible' && rightTab === 'modules') {
@@ -372,11 +403,11 @@ export default function App() {
       }
     }
     if (msg.type === 'ai_progress') {
-      setNotification(msg.message || 'AI is working...');
+      showPersistentNotification(msg.message || 'AI is working...');
     }
     if (msg.type === 'ai_topology_result') {
       setImportLoading(false);
-      setNotification(null);
+      clearNotification();
       if (msg.error) {
         setImportPreview({ tool: 'unknown', provider: 'unknown', files: [], resources: [], edges: [], summary: msg.error, warnings: [msg.error] });
       } else if (msg.resources) {
@@ -399,10 +430,9 @@ export default function App() {
       // Only show notification, don't re-parse. The canvas is the source of
       // truth — if the user wants to import external changes, they can
       // re-open the project or use the import feature.
-      setNotification(`File updated: ${msg.file?.split('/').pop()}`);
-      setTimeout(() => setNotification(null), 3000);
+      showNotification(`File updated: ${msg.file?.split('/').pop()}`);
     }
-  }, []);
+  }, [clearNotification, showNotification, showPersistentNotification, topologyProvider]);
 
   const { connected } = useWebSocket(handleWSMessage);
 
@@ -547,8 +577,7 @@ export default function App() {
 
   const addNode = useCallback((resourceDef: any) => {
     if (unresolvedHybridEnv) {
-      setNotification(`Environment "${activeEnv}" has no configured IaC tool`);
-      setTimeout(() => setNotification(null), 4000);
+      showNotification(`Environment "${activeEnv}" has no configured IaC tool`, 4000);
       return;
     }
     const node = {
@@ -589,7 +618,7 @@ export default function App() {
       return [...prev, node];
     });
     setSelectedNode(node.id);
-  }, [activeEnv, activeResourceFile, catalogResources, unresolvedHybridEnv]);
+  }, [activeEnv, activeResourceFile, catalogResources, showNotification, unresolvedHybridEnv]);
 
   const removeNode = useCallback((id: string) => {
     setNodes(prev => prev.filter(n => n.id !== id));
@@ -805,7 +834,7 @@ export default function App() {
 
     if (visionImages.length > 0) {
       setImportLoading(true);
-      setNotification('AI is reading your diagram...');
+      showPersistentNotification('AI is reading your diagram...');
       try {
         const result = await api.generateTopologyFromImages({
           description: topologyDesc,
@@ -836,14 +865,14 @@ export default function App() {
         });
       } finally {
         setImportLoading(false);
-        setNotification(null);
+        clearNotification();
       }
       return;
     }
 
     if (!topologyDesc.trim()) return;
     setImportLoading(true);
-    setNotification('AI is designing your infrastructure...');
+    showPersistentNotification('AI is designing your infrastructure...');
     try {
       // Fire and forget — result arrives via WebSocket
       await api.generateTopology(topologyDesc, toolKey, topologyProvider);
@@ -852,7 +881,7 @@ export default function App() {
       const message = e?.message || 'Generation failed';
       setImportPreview({ tool: 'unknown', provider: 'unknown', files: [], resources: [], edges: [], summary: message, warnings: [message] });
       setImportLoading(false);
-      setNotification(null);
+      clearNotification();
     }
   };
 
@@ -861,8 +890,7 @@ export default function App() {
     try {
       await api.createProject(projectName, selectedTool);
     } catch (err: unknown) {
-      setNotification(`Import failed: ${errorMessage(err, 'Unable to create project')}`);
-      setTimeout(() => setNotification(null), 5000);
+      showNotification(`Import failed: ${errorMessage(err, 'Unable to create project')}`, 5000);
       return;
     }
     setTool(selectedTool);
@@ -914,20 +942,17 @@ export default function App() {
     setImportPreview(null);
     setVisionImages([]);
     setVisionError(null);
-    setNotification(`Imported ${preview.resources.length} resources`);
-    setTimeout(() => setNotification(null), 4000);
-  }, [catalogResources, projectName, resetNodes]);
+    showNotification(`Imported ${preview.resources.length} resources`, 4000);
+  }, [catalogResources, projectName, resetNodes, showNotification]);
 
   const saveCodeToDisk = useCallback(async (value: string) => {
     if (!tool || !projectId) return;
     if (unresolvedHybridEnv) {
-      setNotification(`Save failed: environment "${activeEnv}" has no configured IaC tool`);
-      setTimeout(() => setNotification(null), 5000);
+      showNotification(`Save failed: environment "${activeEnv}" has no configured IaC tool`, 5000);
       return;
     }
     if (!value.trim()) {
-      setNotification('Nothing to save yet');
-      setTimeout(() => setNotification(null), 3000);
+      showNotification('Nothing to save yet');
       return;
     }
     setCodeSaving(true);
@@ -935,21 +960,14 @@ export default function App() {
     try {
       const fileName = concreteTool === 'pulumi' ? 'index.ts' : `main${TOOLS[concreteTool]?.ext || '.tf'}`;
       await api.syncCodeToDisk(projectId, tool, value, fileName, activeEnv);
-      setNotification(`Saved ${fileName}`);
-      setTimeout(() => setNotification(null), 3000);
+      showNotification(`Saved ${fileName}`);
     } catch (err: any) {
-      setNotification(`Save failed: ${err.message}`);
-      setTimeout(() => setNotification(null), 5000);
+      showNotification(`Save failed: ${err.message}`, 5000);
     } finally {
       setCodeSaving(false);
       setTimeout(() => { isSyncing.current = false; }, 1500);
     }
-  }, [activeEnv, concreteTool, projectId, tool, unresolvedHybridEnv]);
-
-  const showNotification = useCallback((message: string, duration = 3000) => {
-    setNotification(message);
-    window.setTimeout(() => setNotification(null), duration);
-  }, []);
+  }, [activeEnv, concreteTool, projectId, showNotification, tool, unresolvedHybridEnv]);
 
   const handleCreateProject = async (selectedTool: string) => {
     setTool(selectedTool);
@@ -1007,11 +1025,9 @@ export default function App() {
                           try {
                             await api.deleteProject(p.name);
                             setSavedProjects(prev => prev.filter(sp => sp.name !== p.name));
-                            setNotification(`Deleted project: ${p.name}`);
-                            setTimeout(() => setNotification(null), 3000);
+                            showNotification(`Deleted project: ${p.name}`);
                           } catch (err: any) {
-                            setNotification(`Failed to delete: ${err.message}`);
-                            setTimeout(() => setNotification(null), 4000);
+                            showNotification(`Failed to delete: ${err.message}`, 4000);
                           }
                         }}>✕</span>
                       <span style={{ fontSize: 11, color: t.color, fontWeight: 700, fontFamily: 'JetBrains Mono' }}>OPEN</span>

--- a/web/src/components/AISettings/AISettingsModal.test.tsx
+++ b/web/src/components/AISettings/AISettingsModal.test.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { api } from '../../api';
+import { AISettingsModal, type AISettingsConfig } from './AISettingsModal';
+
+function renderModal({
+  onClose = vi.fn(),
+  onNotify = vi.fn(),
+}: {
+  onClose?: () => void;
+  onNotify?: (_message: string, _duration?: number) => void;
+} = {}) {
+  function Harness() {
+    const [settings, setSettings] = useState<AISettingsConfig>({
+      type: 'ollama',
+      endpoint: '',
+      model: '',
+      api_key: '',
+    });
+
+    return (
+      <AISettingsModal
+        settings={settings}
+        onSettingsChange={setSettings}
+        onNotify={onNotify}
+        onClose={onClose}
+      />
+    );
+  }
+
+  render(<Harness />);
+  return { onClose, onNotify };
+}
+
+describe('AISettingsModal', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('applies provider presets to the editable fields', () => {
+    renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /OpenAI API/i }));
+
+    expect(screen.getByDisplayValue('https://api.openai.com/v1')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('gpt-4o')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('sk-...')).toBeInTheDocument();
+  });
+
+  it('saves settings and closes the modal', async () => {
+    const updateSettings = vi.spyOn(api, 'updateAISettings').mockResolvedValue({});
+    const { onClose, onNotify } = renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /OpenAI API/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(updateSettings).toHaveBeenCalledWith({
+        type: 'openai',
+        endpoint: 'https://api.openai.com/v1',
+        model: 'gpt-4o',
+        api_key: '',
+      });
+    });
+    expect(onNotify).toHaveBeenCalledWith('AI settings updated');
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/web/src/components/AISettings/AISettingsModal.test.tsx
+++ b/web/src/components/AISettings/AISettingsModal.test.tsx
@@ -44,11 +44,13 @@ describe('AISettingsModal', () => {
   it('applies provider presets to the editable fields', () => {
     renderModal();
 
-    fireEvent.click(screen.getByRole('button', { name: /OpenAI API/i }));
+    fireEvent.click(screen.getByRole('radio', { name: /OpenAI API/i }));
 
     expect(screen.getByDisplayValue('https://api.openai.com/v1')).toBeInTheDocument();
     expect(screen.getByDisplayValue('gpt-4o')).toBeInTheDocument();
     expect(screen.getByPlaceholderText('sk-...')).toBeInTheDocument();
+    expect(screen.getByRole('radiogroup', { name: /Provider Type/i })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /OpenAI API/i })).toHaveAttribute('aria-checked', 'true');
     expect(screen.getByText(/IaC Studio backend/i)).toHaveTextContent(/kept in process memory/i);
     expect(screen.getByText(/IaC Studio backend/i)).toHaveTextContent(/not stored on disk/i);
   });
@@ -63,15 +65,31 @@ describe('AISettingsModal', () => {
       },
     });
 
-    expect(screen.getByRole('button', { name: /Custom API/i })).toHaveClass('is-active');
-    expect(screen.getByRole('button', { name: /OpenAI API/i })).not.toHaveClass('is-active');
+    expect(screen.getByRole('radio', { name: /Custom API/i })).toHaveClass('is-active');
+    expect(screen.getByRole('radio', { name: /Custom API/i })).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByRole('radio', { name: /OpenAI API/i })).not.toHaveClass('is-active');
+    expect(screen.getByRole('radio', { name: /OpenAI API/i })).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('shows OpenAI selected for the default chat completions endpoint', () => {
+    renderModal({
+      initialSettings: {
+        type: 'openai',
+        endpoint: 'https://api.openai.com/v1/chat/completions',
+        model: 'gpt-4o',
+        api_key: '********',
+      },
+    });
+
+    expect(screen.getByRole('radio', { name: /OpenAI API/i })).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByRole('radio', { name: /Custom API/i })).toHaveAttribute('aria-checked', 'false');
   });
 
   it('saves settings and closes the modal', async () => {
     const updateSettings = vi.spyOn(api, 'updateAISettings').mockResolvedValue({});
     const { onClose, onNotify } = renderModal();
 
-    fireEvent.click(screen.getByRole('button', { name: /OpenAI API/i }));
+    fireEvent.click(screen.getByRole('radio', { name: /OpenAI API/i }));
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => {

--- a/web/src/components/AISettings/AISettingsModal.test.tsx
+++ b/web/src/components/AISettings/AISettingsModal.test.tsx
@@ -47,6 +47,7 @@ describe('AISettingsModal', () => {
     expect(screen.getByDisplayValue('https://api.openai.com/v1')).toBeInTheDocument();
     expect(screen.getByDisplayValue('gpt-4o')).toBeInTheDocument();
     expect(screen.getByPlaceholderText('sk-...')).toBeInTheDocument();
+    expect(screen.getByText(/not stored on disk/i)).toHaveTextContent(/selected provider endpoint/i);
   });
 
   it('saves settings and closes the modal', async () => {

--- a/web/src/components/AISettings/AISettingsModal.test.tsx
+++ b/web/src/components/AISettings/AISettingsModal.test.tsx
@@ -47,7 +47,8 @@ describe('AISettingsModal', () => {
     expect(screen.getByDisplayValue('https://api.openai.com/v1')).toBeInTheDocument();
     expect(screen.getByDisplayValue('gpt-4o')).toBeInTheDocument();
     expect(screen.getByPlaceholderText('sk-...')).toBeInTheDocument();
-    expect(screen.getByText(/not stored on disk/i)).toHaveTextContent(/selected provider endpoint/i);
+    expect(screen.getByText(/IaC Studio backend/i)).toHaveTextContent(/kept in process memory/i);
+    expect(screen.getByText(/IaC Studio backend/i)).toHaveTextContent(/not stored on disk/i);
   });
 
   it('saves settings and closes the modal', async () => {

--- a/web/src/components/AISettings/AISettingsModal.test.tsx
+++ b/web/src/components/AISettings/AISettingsModal.test.tsx
@@ -6,19 +6,21 @@ import { api } from '../../api';
 import { AISettingsModal, type AISettingsConfig } from './AISettingsModal';
 
 function renderModal({
+  initialSettings = {
+    type: 'ollama',
+    endpoint: '',
+    model: '',
+    api_key: '',
+  },
   onClose = vi.fn(),
   onNotify = vi.fn(),
 }: {
+  initialSettings?: AISettingsConfig;
   onClose?: () => void;
   onNotify?: (_message: string, _duration?: number) => void;
 } = {}) {
   function Harness() {
-    const [settings, setSettings] = useState<AISettingsConfig>({
-      type: 'ollama',
-      endpoint: '',
-      model: '',
-      api_key: '',
-    });
+    const [settings, setSettings] = useState<AISettingsConfig>(initialSettings);
 
     return (
       <AISettingsModal
@@ -49,6 +51,20 @@ describe('AISettingsModal', () => {
     expect(screen.getByPlaceholderText('sk-...')).toBeInTheDocument();
     expect(screen.getByText(/IaC Studio backend/i)).toHaveTextContent(/kept in process memory/i);
     expect(screen.getByText(/IaC Studio backend/i)).toHaveTextContent(/not stored on disk/i);
+  });
+
+  it('shows custom selected for an OpenAI-compatible custom endpoint', () => {
+    renderModal({
+      initialSettings: {
+        type: 'openai',
+        endpoint: 'https://llm.example.com/v1',
+        model: 'gpt-compatible',
+        api_key: '********',
+      },
+    });
+
+    expect(screen.getByRole('button', { name: /Custom API/i })).toHaveClass('is-active');
+    expect(screen.getByRole('button', { name: /OpenAI API/i })).not.toHaveClass('is-active');
   });
 
   it('saves settings and closes the modal', async () => {

--- a/web/src/components/AISettings/AISettingsModal.test.tsx
+++ b/web/src/components/AISettings/AISettingsModal.test.tsx
@@ -49,8 +49,8 @@ describe('AISettingsModal', () => {
     expect(screen.getByDisplayValue('https://api.openai.com/v1')).toBeInTheDocument();
     expect(screen.getByDisplayValue('gpt-4o')).toBeInTheDocument();
     expect(screen.getByPlaceholderText('sk-...')).toBeInTheDocument();
-    expect(screen.getByRole('radiogroup', { name: /Provider Type/i })).toBeInTheDocument();
-    expect(screen.getByRole('radio', { name: /OpenAI API/i })).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByRole('group', { name: /Provider Type/i })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /OpenAI API/i })).toBeChecked();
     expect(screen.getByText(/IaC Studio backend/i)).toHaveTextContent(/kept in process memory/i);
     expect(screen.getByText(/IaC Studio backend/i)).toHaveTextContent(/not stored on disk/i);
   });
@@ -65,10 +65,10 @@ describe('AISettingsModal', () => {
       },
     });
 
-    expect(screen.getByRole('radio', { name: /Custom API/i })).toHaveClass('is-active');
-    expect(screen.getByRole('radio', { name: /Custom API/i })).toHaveAttribute('aria-checked', 'true');
-    expect(screen.getByRole('radio', { name: /OpenAI API/i })).not.toHaveClass('is-active');
-    expect(screen.getByRole('radio', { name: /OpenAI API/i })).toHaveAttribute('aria-checked', 'false');
+    expect(screen.getByRole('radio', { name: /Custom API/i })).toBeChecked();
+    expect(screen.getByRole('radio', { name: /Custom API/i }).closest('label')).toHaveClass('is-active');
+    expect(screen.getByRole('radio', { name: /OpenAI API/i })).not.toBeChecked();
+    expect(screen.getByRole('radio', { name: /OpenAI API/i }).closest('label')).not.toHaveClass('is-active');
   });
 
   it('shows OpenAI selected for the default chat completions endpoint', () => {
@@ -81,8 +81,8 @@ describe('AISettingsModal', () => {
       },
     });
 
-    expect(screen.getByRole('radio', { name: /OpenAI API/i })).toHaveAttribute('aria-checked', 'true');
-    expect(screen.getByRole('radio', { name: /Custom API/i })).toHaveAttribute('aria-checked', 'false');
+    expect(screen.getByRole('radio', { name: /OpenAI API/i })).toBeChecked();
+    expect(screen.getByRole('radio', { name: /Custom API/i })).not.toBeChecked();
   });
 
   it('saves settings and closes the modal', async () => {

--- a/web/src/components/AISettings/AISettingsModal.test.tsx
+++ b/web/src/components/AISettings/AISettingsModal.test.tsx
@@ -85,6 +85,34 @@ describe('AISettingsModal', () => {
     expect(screen.getByRole('radio', { name: /Custom API/i })).not.toBeChecked();
   });
 
+  it('applies complete provider presets when switching providers', () => {
+    renderModal({
+      initialSettings: {
+        type: 'openai',
+        endpoint: 'https://api.openai.com/v1',
+        model: 'gpt-4o',
+        api_key: 'sk-existing',
+      },
+    });
+
+    fireEvent.click(screen.getByRole('radio', { name: /Ollama/i }));
+    expect(screen.getByRole('radio', { name: /Ollama/i })).toBeChecked();
+    expect(screen.getByDisplayValue('http://localhost:11434')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('gemma4')).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('sk-...')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('radio', { name: /Anthropic/i }));
+    expect(screen.getByRole('radio', { name: /Anthropic/i })).toBeChecked();
+    expect(screen.getByPlaceholderText('https://api.anthropic.com (optional)')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('claude-haiku-4-5')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('sk-...')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('radio', { name: /Custom API/i }));
+    expect(screen.getByRole('radio', { name: /Custom API/i })).toBeChecked();
+    expect(screen.getByDisplayValue('https://api.openai.com/v1')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('gpt-4o')).toBeInTheDocument();
+  });
+
   it('saves settings and closes the modal', async () => {
     const updateSettings = vi.spyOn(api, 'updateAISettings').mockResolvedValue({});
     const { onClose, onNotify } = renderModal();

--- a/web/src/components/AISettings/AISettingsModal.tsx
+++ b/web/src/components/AISettings/AISettingsModal.tsx
@@ -104,27 +104,32 @@ export function AISettingsModal({
           <button className="ui-close" aria-label="Close AI settings" onClick={onClose}>x</button>
         </div>
 
-        <div style={{ marginBottom: 16 }}>
-          <UILabel>Provider Type</UILabel>
-          <div className="ui-choice-grid" role="radiogroup" aria-label="Provider Type" style={{ marginTop: 8 }}>
+        <fieldset style={{ margin: '0 0 16px', padding: 0, border: 0 }}>
+          <legend className="ui-label">Provider Type</legend>
+          <div className="ui-choice-grid" style={{ marginTop: 8 }}>
             {providers.map(provider => {
               const isSelected = selectedProviderKey === provider.key;
               return (
-                <button
+                <label
                   key={provider.key}
-                  type="button"
-                  role="radio"
-                  aria-checked={isSelected}
-                  className={isSelected ? 'ui-choice-card is-active' : 'ui-choice-card'}
-                  onClick={() => onSettingsChange(current => settingsForProvider(provider.key, current))}
+                  className={isSelected ? 'ui-choice-card ai-provider-choice is-active' : 'ui-choice-card ai-provider-choice'}
                 >
-                  <div className="ui-choice-title">{provider.label}</div>
-                  <div className="ui-choice-desc">{provider.desc}</div>
-                </button>
+                  <input
+                    type="radio"
+                    name="ai-provider-type"
+                    value={provider.key}
+                    checked={isSelected}
+                    onChange={() => onSettingsChange(current => settingsForProvider(provider.key, current))}
+                  />
+                  <span>
+                    <span className="ui-choice-title">{provider.label}</span>
+                    <span className="ui-choice-desc">{provider.desc}</span>
+                  </span>
+                </label>
               );
             })}
           </div>
-        </div>
+        </fieldset>
 
         <div style={{ marginBottom: 12 }}>
           <UILabel>Endpoint</UILabel>

--- a/web/src/components/AISettings/AISettingsModal.tsx
+++ b/web/src/components/AISettings/AISettingsModal.tsx
@@ -124,7 +124,7 @@ export function AISettingsModal({
               placeholder="sk-..."
             />
             <div className="ui-note ui-note--small" style={{ marginTop: 4 }}>
-              Your key is not stored on disk. It is sent only to the selected provider endpoint, or to your configured custom endpoint.
+              Your key is sent to the IaC Studio backend, kept in process memory, and used only for requests to the selected provider endpoint or your configured custom endpoint. It is not stored on disk.
             </div>
           </div>
         )}

--- a/web/src/components/AISettings/AISettingsModal.tsx
+++ b/web/src/components/AISettings/AISettingsModal.tsx
@@ -1,0 +1,139 @@
+import type { Dispatch, SetStateAction } from 'react';
+
+import { api } from '../../api';
+import { errorMessage } from '../../lib/errors';
+import { UIButton, UIInput, UILabel, UIModal } from '../../ui';
+
+export interface AISettingsConfig {
+  type: string;
+  endpoint: string;
+  model: string;
+  api_key: string;
+}
+
+interface ProviderOption {
+  key: string;
+  label: string;
+  desc: string;
+}
+
+export interface AISettingsModalProps {
+  settings: AISettingsConfig;
+  onSettingsChange: Dispatch<SetStateAction<AISettingsConfig>>;
+  onNotify: (_message: string, _duration?: number) => void;
+  onClose: () => void;
+}
+
+const providers: ProviderOption[] = [
+  { key: 'ollama', label: 'Ollama (Local)', desc: 'Free, private, runs on your machine' },
+  { key: 'openai', label: 'OpenAI API', desc: 'GPT-4o, GPT-4-turbo' },
+  { key: 'anthropic', label: 'Anthropic', desc: 'Claude Opus, Claude Haiku' },
+  { key: 'custom', label: 'Custom API', desc: 'Any OpenAI-compatible endpoint' },
+];
+
+function settingsForProvider(provider: string, settings: AISettingsConfig): AISettingsConfig {
+  if (provider === 'ollama') {
+    return { ...settings, type: 'ollama', endpoint: 'http://localhost:11434', api_key: '' };
+  }
+  if (provider === 'openai') {
+    return { ...settings, type: 'openai', endpoint: 'https://api.openai.com/v1', model: 'gpt-4o' };
+  }
+  if (provider === 'anthropic') {
+    return { ...settings, type: 'anthropic', endpoint: '', model: 'claude-haiku-4-5', api_key: '' };
+  }
+  return { ...settings, type: 'custom' };
+}
+
+function endpointPlaceholder(provider: string) {
+  if (provider === 'ollama') return 'http://localhost:11434';
+  if (provider === 'anthropic') return 'https://api.anthropic.com (optional)';
+  return 'https://api.openai.com/v1';
+}
+
+function modelPlaceholder(provider: string) {
+  if (provider === 'ollama') return 'gemma4';
+  if (provider === 'anthropic') return 'claude-haiku-4-5';
+  return 'gpt-4o';
+}
+
+export function AISettingsModal({
+  settings,
+  onSettingsChange,
+  onNotify,
+  onClose,
+}: AISettingsModalProps) {
+  const saveSettings = async () => {
+    try {
+      await api.updateAISettings(settings);
+      onNotify('AI settings updated');
+      onClose();
+    } catch (err: unknown) {
+      onNotify(`Failed: ${errorMessage(err, 'Unknown error')}`, 4000);
+    }
+  };
+
+  return (
+    <UIModal onClose={onClose} width={480} className="ui-panel--raised">
+      <div style={{ padding: 24 }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 20 }}>
+          <span className="ui-modal-title">AI Settings</span>
+          <button className="ui-close" aria-label="Close AI settings" onClick={onClose}>x</button>
+        </div>
+
+        <div style={{ marginBottom: 16 }}>
+          <UILabel>Provider Type</UILabel>
+          <div className="ui-choice-grid" style={{ marginTop: 8 }}>
+            {providers.map(provider => (
+              <button
+                key={provider.key}
+                className={settings.type === provider.key ? 'ui-choice-card is-active' : 'ui-choice-card'}
+                onClick={() => onSettingsChange(current => settingsForProvider(provider.key, current))}
+              >
+                <div className="ui-choice-title">{provider.label}</div>
+                <div className="ui-choice-desc">{provider.desc}</div>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div style={{ marginBottom: 12 }}>
+          <UILabel>Endpoint</UILabel>
+          <UIInput
+            value={settings.endpoint}
+            onChange={event => onSettingsChange(current => ({ ...current, endpoint: event.target.value }))}
+            placeholder={endpointPlaceholder(settings.type)}
+          />
+        </div>
+
+        <div style={{ marginBottom: 12 }}>
+          <UILabel>Model</UILabel>
+          <UIInput
+            value={settings.model}
+            onChange={event => onSettingsChange(current => ({ ...current, model: event.target.value }))}
+            placeholder={modelPlaceholder(settings.type)}
+          />
+        </div>
+
+        {settings.type !== 'ollama' && (
+          <div style={{ marginBottom: 12 }}>
+            <UILabel>API Key</UILabel>
+            <UIInput
+              type="password"
+              value={settings.api_key}
+              onChange={event => onSettingsChange(current => ({ ...current, api_key: event.target.value }))}
+              placeholder="sk-..."
+            />
+            <div className="ui-note ui-note--small" style={{ marginTop: 4 }}>
+              Your key is sent to the backend only - never stored on disk or sent to third parties.
+            </div>
+          </div>
+        )}
+
+        <div style={{ display: 'flex', gap: 10, marginTop: 20 }}>
+          <UIButton block onClick={onClose}>Cancel</UIButton>
+          <UIButton block variant="primary" onClick={saveSettings}>Save</UIButton>
+        </div>
+      </div>
+    </UIModal>
+  );
+}

--- a/web/src/components/AISettings/AISettingsModal.tsx
+++ b/web/src/components/AISettings/AISettingsModal.tsx
@@ -32,6 +32,10 @@ const providers: ProviderOption[] = [
 ];
 
 const OPENAI_DEFAULT_ENDPOINT = 'https://api.openai.com/v1';
+const OLLAMA_DEFAULT_ENDPOINT = 'http://localhost:11434';
+const OLLAMA_DEFAULT_MODEL = 'gemma4';
+const OPENAI_DEFAULT_MODEL = 'gpt-4o';
+const ANTHROPIC_DEFAULT_MODEL = 'claude-haiku-4-5';
 
 function normalizeEndpoint(endpoint: string) {
   return endpoint.trim().replace(/\/+$/, '');
@@ -55,27 +59,27 @@ function selectedProvider(settings: AISettingsConfig) {
 
 function settingsForProvider(provider: string, settings: AISettingsConfig): AISettingsConfig {
   if (provider === 'ollama') {
-    return { ...settings, type: 'ollama', endpoint: 'http://localhost:11434', api_key: '' };
+    return { ...settings, type: 'ollama', endpoint: OLLAMA_DEFAULT_ENDPOINT, model: OLLAMA_DEFAULT_MODEL, api_key: '' };
   }
   if (provider === 'openai') {
-    return { ...settings, type: 'openai', endpoint: OPENAI_DEFAULT_ENDPOINT, model: 'gpt-4o' };
+    return { ...settings, type: 'openai', endpoint: OPENAI_DEFAULT_ENDPOINT, model: OPENAI_DEFAULT_MODEL };
   }
   if (provider === 'anthropic') {
-    return { ...settings, type: 'anthropic', endpoint: '', model: 'claude-haiku-4-5', api_key: '' };
+    return { ...settings, type: 'anthropic', endpoint: '', model: ANTHROPIC_DEFAULT_MODEL, api_key: '' };
   }
-  return { ...settings, type: 'custom' };
+  return { ...settings, type: 'custom', endpoint: OPENAI_DEFAULT_ENDPOINT, model: OPENAI_DEFAULT_MODEL };
 }
 
 function endpointPlaceholder(provider: string) {
-  if (provider === 'ollama') return 'http://localhost:11434';
+  if (provider === 'ollama') return OLLAMA_DEFAULT_ENDPOINT;
   if (provider === 'anthropic') return 'https://api.anthropic.com (optional)';
   return OPENAI_DEFAULT_ENDPOINT;
 }
 
 function modelPlaceholder(provider: string) {
-  if (provider === 'ollama') return 'gemma4';
-  if (provider === 'anthropic') return 'claude-haiku-4-5';
-  return 'gpt-4o';
+  if (provider === 'ollama') return OLLAMA_DEFAULT_MODEL;
+  if (provider === 'anthropic') return ANTHROPIC_DEFAULT_MODEL;
+  return OPENAI_DEFAULT_MODEL;
 }
 
 export function AISettingsModal({

--- a/web/src/components/AISettings/AISettingsModal.tsx
+++ b/web/src/components/AISettings/AISettingsModal.tsx
@@ -124,7 +124,7 @@ export function AISettingsModal({
               placeholder="sk-..."
             />
             <div className="ui-note ui-note--small" style={{ marginTop: 4 }}>
-              Your key is sent to the backend only - never stored on disk or sent to third parties.
+              Your key is not stored on disk. It is sent only to the selected provider endpoint, or to your configured custom endpoint.
             </div>
           </div>
         )}

--- a/web/src/components/AISettings/AISettingsModal.tsx
+++ b/web/src/components/AISettings/AISettingsModal.tsx
@@ -37,9 +37,17 @@ function normalizeEndpoint(endpoint: string) {
   return endpoint.trim().replace(/\/+$/, '');
 }
 
+function normalizeOpenAIEndpoint(endpoint: string) {
+  const normalized = normalizeEndpoint(endpoint);
+  if (normalized.endsWith('/chat/completions')) {
+    return normalized.slice(0, -'/chat/completions'.length);
+  }
+  return normalized;
+}
+
 function selectedProvider(settings: AISettingsConfig) {
   if (settings.type === 'openai') {
-    const endpoint = normalizeEndpoint(settings.endpoint);
+    const endpoint = normalizeOpenAIEndpoint(settings.endpoint);
     return endpoint && endpoint !== OPENAI_DEFAULT_ENDPOINT ? 'custom' : 'openai';
   }
   return settings.type;
@@ -50,7 +58,7 @@ function settingsForProvider(provider: string, settings: AISettingsConfig): AISe
     return { ...settings, type: 'ollama', endpoint: 'http://localhost:11434', api_key: '' };
   }
   if (provider === 'openai') {
-    return { ...settings, type: 'openai', endpoint: 'https://api.openai.com/v1', model: 'gpt-4o' };
+    return { ...settings, type: 'openai', endpoint: OPENAI_DEFAULT_ENDPOINT, model: 'gpt-4o' };
   }
   if (provider === 'anthropic') {
     return { ...settings, type: 'anthropic', endpoint: '', model: 'claude-haiku-4-5', api_key: '' };
@@ -61,7 +69,7 @@ function settingsForProvider(provider: string, settings: AISettingsConfig): AISe
 function endpointPlaceholder(provider: string) {
   if (provider === 'ollama') return 'http://localhost:11434';
   if (provider === 'anthropic') return 'https://api.anthropic.com (optional)';
-  return 'https://api.openai.com/v1';
+  return OPENAI_DEFAULT_ENDPOINT;
 }
 
 function modelPlaceholder(provider: string) {
@@ -98,17 +106,23 @@ export function AISettingsModal({
 
         <div style={{ marginBottom: 16 }}>
           <UILabel>Provider Type</UILabel>
-          <div className="ui-choice-grid" style={{ marginTop: 8 }}>
-            {providers.map(provider => (
-              <button
-                key={provider.key}
-                className={selectedProviderKey === provider.key ? 'ui-choice-card is-active' : 'ui-choice-card'}
-                onClick={() => onSettingsChange(current => settingsForProvider(provider.key, current))}
-              >
-                <div className="ui-choice-title">{provider.label}</div>
-                <div className="ui-choice-desc">{provider.desc}</div>
-              </button>
-            ))}
+          <div className="ui-choice-grid" role="radiogroup" aria-label="Provider Type" style={{ marginTop: 8 }}>
+            {providers.map(provider => {
+              const isSelected = selectedProviderKey === provider.key;
+              return (
+                <button
+                  key={provider.key}
+                  type="button"
+                  role="radio"
+                  aria-checked={isSelected}
+                  className={isSelected ? 'ui-choice-card is-active' : 'ui-choice-card'}
+                  onClick={() => onSettingsChange(current => settingsForProvider(provider.key, current))}
+                >
+                  <div className="ui-choice-title">{provider.label}</div>
+                  <div className="ui-choice-desc">{provider.desc}</div>
+                </button>
+              );
+            })}
           </div>
         </div>
 

--- a/web/src/components/AISettings/AISettingsModal.tsx
+++ b/web/src/components/AISettings/AISettingsModal.tsx
@@ -31,6 +31,20 @@ const providers: ProviderOption[] = [
   { key: 'custom', label: 'Custom API', desc: 'Any OpenAI-compatible endpoint' },
 ];
 
+const OPENAI_DEFAULT_ENDPOINT = 'https://api.openai.com/v1';
+
+function normalizeEndpoint(endpoint: string) {
+  return endpoint.trim().replace(/\/+$/, '');
+}
+
+function selectedProvider(settings: AISettingsConfig) {
+  if (settings.type === 'openai') {
+    const endpoint = normalizeEndpoint(settings.endpoint);
+    return endpoint && endpoint !== OPENAI_DEFAULT_ENDPOINT ? 'custom' : 'openai';
+  }
+  return settings.type;
+}
+
 function settingsForProvider(provider: string, settings: AISettingsConfig): AISettingsConfig {
   if (provider === 'ollama') {
     return { ...settings, type: 'ollama', endpoint: 'http://localhost:11434', api_key: '' };
@@ -62,6 +76,8 @@ export function AISettingsModal({
   onNotify,
   onClose,
 }: AISettingsModalProps) {
+  const selectedProviderKey = selectedProvider(settings);
+
   const saveSettings = async () => {
     try {
       await api.updateAISettings(settings);
@@ -86,7 +102,7 @@ export function AISettingsModal({
             {providers.map(provider => (
               <button
                 key={provider.key}
-                className={settings.type === provider.key ? 'ui-choice-card is-active' : 'ui-choice-card'}
+                className={selectedProviderKey === provider.key ? 'ui-choice-card is-active' : 'ui-choice-card'}
                 onClick={() => onSettingsChange(current => settingsForProvider(provider.key, current))}
               >
                 <div className="ui-choice-title">{provider.label}</div>
@@ -101,7 +117,7 @@ export function AISettingsModal({
           <UIInput
             value={settings.endpoint}
             onChange={event => onSettingsChange(current => ({ ...current, endpoint: event.target.value }))}
-            placeholder={endpointPlaceholder(settings.type)}
+            placeholder={endpointPlaceholder(selectedProviderKey)}
           />
         </div>
 
@@ -110,7 +126,7 @@ export function AISettingsModal({
           <UIInput
             value={settings.model}
             onChange={event => onSettingsChange(current => ({ ...current, model: event.target.value }))}
-            placeholder={modelPlaceholder(settings.type)}
+            placeholder={modelPlaceholder(selectedProviderKey)}
           />
         </div>
 

--- a/web/src/components/AISettings/index.tsx
+++ b/web/src/components/AISettings/index.tsx
@@ -1,0 +1,2 @@
+export { AISettingsModal } from './AISettingsModal';
+export type { AISettingsConfig } from './AISettingsModal';

--- a/web/src/theme.css
+++ b/web/src/theme.css
@@ -353,6 +353,18 @@ body {
   transition: border-color 180ms ease, background 180ms ease;
 }
 
+.ai-provider-choice {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 8px;
+  align-items: flex-start;
+}
+
+.ai-provider-choice input {
+  margin-top: 2px;
+  accent-color: var(--accent-action);
+}
+
 .ui-choice-card.is-active {
   border-color: var(--accent-action);
   background: var(--accent-action-soft);
@@ -369,6 +381,7 @@ body {
 }
 
 .ui-choice-desc {
+  display: block;
   font-size: 10px;
   color: var(--text-muted);
   margin-top: 2px;


### PR DESCRIPTION
Refs #22.

Extracts the AI Settings dialog from App.tsx into components/AISettings, keeping App as the state owner while the modal owns provider presets and the save call. Adds focused component coverage for provider preset changes and successful save/close behavior.

Validation:
- npm run lint from web/ (passes with existing warnings)
- npm test -- --run from web/
- npm run build from web/