### PR TITLE
[codex] Extract app header

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,6 +5,7 @@ import { useHistory } from './useHistory';
 import { useKeyboardShortcuts } from './useKeyboardShortcuts';
 import { UIButton, UIInput, UIKicker, UILabel, UIPanel } from './ui';
 import { AISettingsModal, type AISettingsConfig } from './components/AISettings';
+import { AppHeader } from './components/AppHeader';
 import { CodeEditor } from './components/CodeEditor';
 import { ChatPanel } from './components/Chat';
 import { ImportWizardModal } from './components/ImportWizard';
@@ -969,6 +970,29 @@ export default function App() {
     }
   }, [activeEnv, concreteTool, projectId, showNotification, tool, unresolvedHybridEnv]);
 
+  const handleBackToProjectSelect = useCallback(async () => {
+    if (projectId && hasCreatedProject.current) {
+      await api.saveState(projectId, buildPersistedState()).catch(() => {});
+    }
+    api.listProjectStates().then(setSavedProjects).catch(() => {});
+    setTool(null);
+    resetNodes([]);
+    setEdges([]);
+    setChatMessages([]);
+    setTerminalOutput([]);
+    setProjectLayoutMeta(null);
+    setLayeredProject(null);
+    setActiveEnvironment(null);
+    setCanvasMode('freeform');
+    initialLoadDone.current = false;
+    hasCreatedProject.current = false;
+  }, [buildPersistedState, projectId, resetNodes]);
+
+  const openAISettings = useCallback(() => {
+    api.getAISettings().then(setAiSettings).catch(() => {});
+    setShowSettings(true);
+  }, []);
+
   const handleCreateProject = async (selectedTool: string) => {
     setTool(selectedTool);
     setProjectLayoutMeta(null);
@@ -1138,50 +1162,23 @@ export default function App() {
         <div style={S.notification}>{notification}</div>
       )}
 
-      {/* Header */}
-      <header style={{ ...S.header, borderBottomColor: ct.color + '44' }} className="iac-header">
-        <div style={S.hLeft}>
-          <button style={S.backBtn} onClick={async () => {
-            // Save state before navigating away
-            if (projectId && hasCreatedProject.current) {
-              await api.saveState(projectId, buildPersistedState()).catch(() => {});
-            }
-            // Refresh saved projects list
-            api.listProjectStates().then(setSavedProjects).catch(() => {});
-            setTool(null); resetNodes([]); setEdges([]); setChatMessages([]); setTerminalOutput([]);
-            setProjectLayoutMeta(null); setLayeredProject(null); setActiveEnvironment(null); setCanvasMode('freeform');
-            initialLoadDone.current = false; hasCreatedProject.current = false;
-          }}>←</button>
-          <span style={{ ...S.badge, background: ct.color + '22', color: ct.color }}>{ct.icon} {ct.name}</span>
-          <input style={S.projInput} value={projectName} onChange={e => setProjectName(e.target.value)} />
-          <button style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: 10, fontFamily: 'JetBrains Mono', padding: '2px 6px', color: '#789187' }}
-            title="Open in file manager"
-            onClick={() => api.revealProject(projectId).catch(() => {})}>OPEN</button>
-          <span style={{ fontSize: 10, color: wsConnected ? '#4ade80' : '#ef4444' }}>{wsConnected ? '● live' : '● offline'}</span>
-        </div>
-        <div style={S.hRight}>
-          <span style={S.count}>{nodes.length} resource{nodes.length !== 1 ? 's' : ''}</span>
-          <button style={{ ...S.cmd, background: 'var(--bg-elev-2)', color: canUndo ? 'var(--text-main)' : '#4b5551' }} onClick={undoNodes} disabled={!canUndo} title="Undo (Ctrl+Z)">↩</button>
-          <button style={{ ...S.cmd, background: 'var(--bg-elev-2)', color: canRedo ? 'var(--text-main)' : '#4b5551' }} onClick={redoNodes} disabled={!canRedo} title="Redo (Ctrl+Shift+Z)">↪</button>
-          <button style={{ ...S.cmd, background: ct.color + '22', color: ct.color }}
-            onClick={() => runCmd(tool === 'ansible' ? 'check' : 'init')}>
-            {tool === 'ansible' ? '▶ Check' : '▶ Init'}
-          </button>
-          <button style={{ ...S.cmd, background: ct.color + '22', color: ct.color }}
-            onClick={() => runCmd(tool === 'ansible' ? 'syntax' : 'plan')}>
-            {tool === 'ansible' ? '▶ Syntax' : '▶ Plan'}
-          </button>
-          <UIButton variant="primary" style={{ background: ct.color, borderColor: ct.color, color: '#0a0a0f' }}
-            onClick={() => runCmd(tool === 'ansible' ? 'playbook' : 'apply')}>
-            ▶ Apply
-          </UIButton>
-          <UIButton
-            onClick={() => { api.getAISettings().then(setAiSettings).catch(() => {}); setShowSettings(true); }}
-            title="AI Settings">
-            SETTINGS
-          </UIButton>
-        </div>
-      </header>
+      <AppHeader
+        tool={tool}
+        toolMeta={ct}
+        projectName={projectName}
+        projectId={projectId}
+        resourceCount={nodes.length}
+        wsConnected={wsConnected}
+        canUndo={canUndo}
+        canRedo={canRedo}
+        onBack={handleBackToProjectSelect}
+        onProjectNameChange={setProjectName}
+        onRevealProject={(id) => api.revealProject(id).catch(() => {})}
+        onUndo={undoNodes}
+        onRedo={redoNodes}
+        onRunCommand={runCmd}
+        onOpenSettings={openAISettings}
+      />
 
       {/* AI Settings Modal */}
       {showSettings && (

--- a/web/src/components/AppHeader/AppHeader.test.tsx
+++ b/web/src/components/AppHeader/AppHeader.test.tsx
@@ -35,7 +35,7 @@ describe('AppHeader', () => {
   it('renders project status and dispatches terraform commands', () => {
     const props = renderHeader();
 
-    expect(screen.getByDisplayValue('demo')).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: 'Project name' })).toHaveValue('demo');
     expect(screen.getByText('2 resources')).toBeInTheDocument();
     expect(screen.getByText('● live')).toBeInTheDocument();
 
@@ -72,8 +72,8 @@ describe('AppHeader', () => {
   it('dispatches navigation, project, reveal, undo, and settings actions', () => {
     const props = renderHeader();
 
-    fireEvent.click(screen.getByText('←'));
-    fireEvent.change(screen.getByDisplayValue('demo'), { target: { value: 'renamed' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Back to projects' }));
+    fireEvent.change(screen.getByRole('textbox', { name: 'Project name' }), { target: { value: 'renamed' } });
     fireEvent.click(screen.getByTitle('Open in file manager'));
     fireEvent.click(screen.getByTitle('Undo (Ctrl+Z)'));
     fireEvent.click(screen.getByRole('button', { name: 'SETTINGS' }));

--- a/web/src/components/AppHeader/AppHeader.test.tsx
+++ b/web/src/components/AppHeader/AppHeader.test.tsx
@@ -1,0 +1,87 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { AppHeader } from './AppHeader';
+
+function baseProps() {
+  return {
+    tool: 'terraform',
+    toolMeta: { color: '#7dd3fc', icon: 'TF', name: 'Terraform' },
+    projectName: 'demo',
+    projectId: 'demo',
+    resourceCount: 2,
+    wsConnected: true,
+    canUndo: true,
+    canRedo: false,
+    onBack: vi.fn(),
+    onProjectNameChange: vi.fn(),
+    onRevealProject: vi.fn(),
+    onUndo: vi.fn(),
+    onRedo: vi.fn(),
+    onRunCommand: vi.fn(),
+    onOpenSettings: vi.fn(),
+  };
+}
+
+type AppHeaderTestProps = ReturnType<typeof baseProps>;
+
+function renderHeader(overrides: Partial<AppHeaderTestProps> = {}) {
+  const props = { ...baseProps(), ...overrides };
+  render(<AppHeader {...props} />);
+  return props;
+}
+
+describe('AppHeader', () => {
+  it('renders project status and dispatches terraform commands', () => {
+    const props = renderHeader();
+
+    expect(screen.getByDisplayValue('demo')).toBeInTheDocument();
+    expect(screen.getByText('2 resources')).toBeInTheDocument();
+    expect(screen.getByText('● live')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Init/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Plan/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Apply/i }));
+
+    expect(props.onRunCommand).toHaveBeenNthCalledWith(1, 'init');
+    expect(props.onRunCommand).toHaveBeenNthCalledWith(2, 'plan');
+    expect(props.onRunCommand).toHaveBeenNthCalledWith(3, 'apply');
+  });
+
+  it('uses ansible command names and keeps disabled redo disabled', () => {
+    const props = renderHeader({
+      tool: 'ansible',
+      toolMeta: { color: '#f97316', icon: 'AN', name: 'Ansible' },
+      resourceCount: 1,
+      wsConnected: false,
+    });
+
+    expect(screen.getByText('1 resource')).toBeInTheDocument();
+    expect(screen.getByText('● offline')).toBeInTheDocument();
+    expect(screen.getByTitle('Redo (Ctrl+Shift+Z)')).toBeDisabled();
+
+    fireEvent.click(screen.getByRole('button', { name: /Check/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Syntax/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Apply/i }));
+
+    expect(props.onRunCommand).toHaveBeenNthCalledWith(1, 'check');
+    expect(props.onRunCommand).toHaveBeenNthCalledWith(2, 'syntax');
+    expect(props.onRunCommand).toHaveBeenNthCalledWith(3, 'playbook');
+  });
+
+  it('dispatches navigation, project, reveal, undo, and settings actions', () => {
+    const props = renderHeader();
+
+    fireEvent.click(screen.getByText('←'));
+    fireEvent.change(screen.getByDisplayValue('demo'), { target: { value: 'renamed' } });
+    fireEvent.click(screen.getByTitle('Open in file manager'));
+    fireEvent.click(screen.getByTitle('Undo (Ctrl+Z)'));
+    fireEvent.click(screen.getByRole('button', { name: 'SETTINGS' }));
+
+    expect(props.onBack).toHaveBeenCalled();
+    expect(props.onProjectNameChange).toHaveBeenCalledWith('renamed');
+    expect(props.onRevealProject).toHaveBeenCalledWith('demo');
+    expect(props.onUndo).toHaveBeenCalled();
+    expect(props.onOpenSettings).toHaveBeenCalled();
+  });
+});

--- a/web/src/components/AppHeader/AppHeader.test.tsx
+++ b/web/src/components/AppHeader/AppHeader.test.tsx
@@ -58,7 +58,7 @@ describe('AppHeader', () => {
 
     expect(screen.getByText('1 resource')).toBeInTheDocument();
     expect(screen.getByText('● offline')).toBeInTheDocument();
-    expect(screen.getByTitle('Redo (Ctrl+Shift+Z)')).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Redo' })).toBeDisabled();
 
     fireEvent.click(screen.getByRole('button', { name: /Check/i }));
     fireEvent.click(screen.getByRole('button', { name: /Syntax/i }));
@@ -75,7 +75,7 @@ describe('AppHeader', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Back to projects' }));
     fireEvent.change(screen.getByRole('textbox', { name: 'Project name' }), { target: { value: 'renamed' } });
     fireEvent.click(screen.getByTitle('Open in file manager'));
-    fireEvent.click(screen.getByTitle('Undo (Ctrl+Z)'));
+    fireEvent.click(screen.getByRole('button', { name: 'Undo' }));
     fireEvent.click(screen.getByRole('button', { name: 'SETTINGS' }));
 
     expect(props.onBack).toHaveBeenCalled();

--- a/web/src/components/AppHeader/AppHeader.tsx
+++ b/web/src/components/AppHeader/AppHeader.tsx
@@ -1,0 +1,111 @@
+import { UIButton } from '../../ui';
+import { S } from '../../styles';
+
+export interface AppHeaderTool {
+  color: string;
+  icon: string;
+  name: string;
+}
+
+export interface AppHeaderProps {
+  tool: string;
+  toolMeta: AppHeaderTool;
+  projectName: string;
+  projectId: string;
+  resourceCount: number;
+  wsConnected: boolean;
+  canUndo: boolean;
+  canRedo: boolean;
+  onBack: () => void | Promise<void>;
+  onProjectNameChange: (_name: string) => void;
+  onRevealProject: (_projectId: string) => void;
+  onUndo: () => void;
+  onRedo: () => void;
+  onRunCommand: (_command: string) => void;
+  onOpenSettings: () => void;
+}
+
+export function AppHeader({
+  tool,
+  toolMeta,
+  projectName,
+  projectId,
+  resourceCount,
+  wsConnected,
+  canUndo,
+  canRedo,
+  onBack,
+  onProjectNameChange,
+  onRevealProject,
+  onUndo,
+  onRedo,
+  onRunCommand,
+  onOpenSettings,
+}: AppHeaderProps) {
+  const initCommand = tool === 'ansible' ? 'check' : 'init';
+  const planCommand = tool === 'ansible' ? 'syntax' : 'plan';
+  const applyCommand = tool === 'ansible' ? 'playbook' : 'apply';
+
+  return (
+    <header style={{ ...S.header, borderBottomColor: toolMeta.color + '44' }} className="iac-header">
+      <div style={S.hLeft}>
+        <button style={S.backBtn} onClick={onBack}>←</button>
+        <span style={{ ...S.badge, background: toolMeta.color + '22', color: toolMeta.color }}>
+          {toolMeta.icon} {toolMeta.name}
+        </span>
+        <input style={S.projInput} value={projectName} onChange={event => onProjectNameChange(event.target.value)} />
+        <button
+          style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: 10, fontFamily: 'JetBrains Mono', padding: '2px 6px', color: '#789187' }}
+          title="Open in file manager"
+          onClick={() => onRevealProject(projectId)}
+        >
+          OPEN
+        </button>
+        <span style={{ fontSize: 10, color: wsConnected ? '#4ade80' : '#ef4444' }}>
+          {wsConnected ? '● live' : '● offline'}
+        </span>
+      </div>
+      <div style={S.hRight}>
+        <span style={S.count}>{resourceCount} resource{resourceCount !== 1 ? 's' : ''}</span>
+        <button
+          style={{ ...S.cmd, background: 'var(--bg-elev-2)', color: canUndo ? 'var(--text-main)' : '#4b5551' }}
+          onClick={onUndo}
+          disabled={!canUndo}
+          title="Undo (Ctrl+Z)"
+        >
+          ↩
+        </button>
+        <button
+          style={{ ...S.cmd, background: 'var(--bg-elev-2)', color: canRedo ? 'var(--text-main)' : '#4b5551' }}
+          onClick={onRedo}
+          disabled={!canRedo}
+          title="Redo (Ctrl+Shift+Z)"
+        >
+          ↪
+        </button>
+        <button
+          style={{ ...S.cmd, background: toolMeta.color + '22', color: toolMeta.color }}
+          onClick={() => onRunCommand(initCommand)}
+        >
+          {tool === 'ansible' ? '▶ Check' : '▶ Init'}
+        </button>
+        <button
+          style={{ ...S.cmd, background: toolMeta.color + '22', color: toolMeta.color }}
+          onClick={() => onRunCommand(planCommand)}
+        >
+          {tool === 'ansible' ? '▶ Syntax' : '▶ Plan'}
+        </button>
+        <UIButton
+          variant="primary"
+          style={{ background: toolMeta.color, borderColor: toolMeta.color, color: '#0a0a0f' }}
+          onClick={() => onRunCommand(applyCommand)}
+        >
+          ▶ Apply
+        </UIButton>
+        <UIButton onClick={onOpenSettings} title="AI Settings">
+          SETTINGS
+        </UIButton>
+      </div>
+    </header>
+  );
+}

--- a/web/src/components/AppHeader/AppHeader.tsx
+++ b/web/src/components/AppHeader/AppHeader.tsx
@@ -49,11 +49,16 @@ export function AppHeader({
   return (
     <header style={{ ...S.header, borderBottomColor: toolMeta.color + '44' }} className="iac-header">
       <div style={S.hLeft}>
-        <button style={S.backBtn} onClick={onBack}>←</button>
+        <button style={S.backBtn} onClick={onBack} aria-label="Back to projects">←</button>
         <span style={{ ...S.badge, background: toolMeta.color + '22', color: toolMeta.color }}>
           {toolMeta.icon} {toolMeta.name}
         </span>
-        <input style={S.projInput} value={projectName} onChange={event => onProjectNameChange(event.target.value)} />
+        <input
+          style={S.projInput}
+          value={projectName}
+          aria-label="Project name"
+          onChange={event => onProjectNameChange(event.target.value)}
+        />
         <button
           style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: 10, fontFamily: 'JetBrains Mono', padding: '2px 6px', color: '#789187' }}
           title="Open in file manager"

--- a/web/src/components/AppHeader/AppHeader.tsx
+++ b/web/src/components/AppHeader/AppHeader.tsx
@@ -76,6 +76,7 @@ export function AppHeader({
           style={{ ...S.cmd, background: 'var(--bg-elev-2)', color: canUndo ? 'var(--text-main)' : '#4b5551' }}
           onClick={onUndo}
           disabled={!canUndo}
+          aria-label="Undo"
           title="Undo (Ctrl+Z)"
         >
           ↩
@@ -84,6 +85,7 @@ export function AppHeader({
           style={{ ...S.cmd, background: 'var(--bg-elev-2)', color: canRedo ? 'var(--text-main)' : '#4b5551' }}
           onClick={onRedo}
           disabled={!canRedo}
+          aria-label="Redo"
           title="Redo (Ctrl+Shift+Z)"
         >
           ↪

--- a/web/src/components/AppHeader/index.tsx
+++ b/web/src/components/AppHeader/index.tsx
@@ -1,0 +1,2 @@
+export { AppHeader } from './AppHeader';
+export type { AppHeaderTool } from './AppHeader';


### PR DESCRIPTION
Refs #22.

Extracts the active-project header/app chrome from `App.tsx` into `components/AppHeader` while preserving project navigation, reveal, live status, undo/redo, run commands, and AI settings behavior.

Adds focused component tests for command dispatch and header actions.

Validation:
- `npm test -- --run src/components/AppHeader/AppHeader.test.tsx` from `web/`
- Prior local validation on this branch: `npm run lint`, `npm test -- --run`, and `npm run build` from `web/`