### PR TITLE
[codex] Extract project launcher

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -846,8 +846,8 @@ export default function App() {
       await api.deleteProject(name);
       setSavedProjects(prev => prev.filter(project => project.name !== name));
       showNotification(`Deleted project: ${name}`);
-    } catch (err: any) {
-      showNotification(`Failed to delete: ${err.message}`, 4000);
+    } catch (err: unknown) {
+      showNotification(`Failed to delete: ${errorMessage(err, 'Unable to delete project')}`, 4000);
     }
   }, [showNotification]);
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,12 +3,11 @@ import { api, ApiError, Resource, ToolInfo, CatalogResource, Suggestion, FileEnt
 import { useWebSocket, WSMessage } from './useWebSocket';
 import { useHistory } from './useHistory';
 import { useKeyboardShortcuts } from './useKeyboardShortcuts';
-import { UIButton, UIInput, UIKicker, UILabel, UIPanel } from './ui';
 import { AISettingsModal, type AISettingsConfig } from './components/AISettings';
 import { AppHeader } from './components/AppHeader';
 import { CodeEditor } from './components/CodeEditor';
 import { ChatPanel } from './components/Chat';
-import { ImportWizardModal } from './components/ImportWizard';
+import { ProjectLauncher, type SavedProject } from './components/ProjectLauncher';
 import { TerminalPanel } from './components/Terminal';
 import { ModuleRegistryPanel } from './components/ModuleRegistry';
 import { PolicyStudioPanel } from './components/PolicyStudio';
@@ -21,7 +20,6 @@ import { errorMessage } from './lib/errors';
 import {
   TOOLS,
   ALL_TOOLS,
-  PROJECT_CREATION_TOOLS,
   FALLBACK_RESOURCES,
   uid,
   edgeId,
@@ -158,7 +156,7 @@ export default function App() {
   const [visionError, setVisionError] = useState<string | null>(null);
   const [showSettings, setShowSettings] = useState(false);
   const [aiSettings, setAiSettings] = useState<AISettingsConfig>({ type: 'ollama', endpoint: '', model: '', api_key: '' });
-  const [savedProjects, setSavedProjects] = useState<any[]>([]);
+  const [savedProjects, setSavedProjects] = useState<SavedProject[]>([]);
   const { state: nodes, set: setNodes, undo: undoNodes, redo: redoNodes, canUndo, canRedo, reset: resetNodes } = useHistory<(Resource & { x: number; y: number; icon: string; label: string })[]>([]);
   const [edges, setEdges] = useState<Edge[]>([]);
   const [selectedNode, setSelectedNode] = useState<string | null>(null);
@@ -360,7 +358,7 @@ export default function App() {
   }, [buildPersistedState, tool, projectId]);
 
   // Open a saved project
-  const openProject = useCallback(async (proj: any) => {
+  const openProject = useCallback(async (proj: SavedProject) => {
     setProjectName(proj.name);
     setProjectId(proj.name);
     setTool(proj.tool || 'terraform');
@@ -830,6 +828,29 @@ export default function App() {
     }
   }, [handleBrowseLoaded]);
 
+  const startImportBrowse = useCallback(() => {
+    setImportTab('browse');
+    setVisionImages([]);
+    setVisionError(null);
+    setShowImportWizard(true);
+    loadBrowsePath();
+  }, [loadBrowsePath]);
+
+  const startTopologyBuilder = useCallback(() => {
+    setImportTab('topology');
+    setShowImportWizard(true);
+  }, []);
+
+  const handleDeleteSavedProject = useCallback(async (name: string) => {
+    try {
+      await api.deleteProject(name);
+      setSavedProjects(prev => prev.filter(project => project.name !== name));
+      showNotification(`Deleted project: ${name}`);
+    } catch (err: any) {
+      showNotification(`Failed to delete: ${err.message}`, 4000);
+    }
+  }, [showNotification]);
+
   const handleGenerateTopology = async () => {
     const toolKey = detectedTools.find(t => t.available && t.name !== 'Ansible')?.name === 'OpenTofu' ? 'opentofu' : 'terraform';
 
@@ -1014,137 +1035,41 @@ export default function App() {
   // ─── Tool Selection ───
   if (!tool) {
     return (
-      <div style={S.selectScreen} className="select-screen">
-        <div className="ambient-orb ambient-orb-a" />
-        <div className="ambient-orb ambient-orb-b" />
-        <div style={S.selectBg} />
-        <div style={S.selectContent}>
-          <div style={S.logo}><span style={{ fontSize: 28, color: 'var(--accent-action)' }}>◆</span> <span style={S.logoText}>IaC Studio</span></div>
-          {/* Saved projects */}
-          {savedProjects.length > 0 && (
-            <div style={{ marginBottom: 32, width: '100%', maxWidth: 600 }}>
-              <UIKicker style={{ marginBottom: 12 }}>Recent Projects</UIKicker>
-              <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-                {savedProjects.filter(p => p.tool).slice(0, 5).map(p => {
-                  const t = ALL_TOOLS[p.tool] || TOOLS.terraform;
-                  const count = p.resources?.length || 0;
-                  return (
-                    <button key={p.name} className="tool-card" style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '10px 16px', background: 'var(--bg-elev-1)', border: '1px solid var(--border-main)', borderRadius: 10, cursor: 'pointer', textAlign: 'left', transition: 'border-color 0.2s' }}
-                      onClick={() => openProject(p)}
-                      onMouseEnter={e => { (e.currentTarget as any).style.borderColor = t.color; }}
-                      onMouseLeave={e => { (e.currentTarget as any).style.borderColor = 'var(--border-main)'; }}>
-                      <span style={{ fontSize: 20 }}>{t.icon}</span>
-                      <div style={{ flex: 1 }}>
-                        <div style={{ fontSize: 14, fontWeight: 600, color: '#ccc', fontFamily: 'JetBrains Mono' }}>{p.name}</div>
-                        <div style={{ fontSize: 11, color: '#555' }}>{t.name} · {count} resource{count !== 1 ? 's' : ''}{p.updated_at ? ' · ' + new Date(p.updated_at).toLocaleDateString() : ''}</div>
-                      </div>
-                      <span style={{ fontSize: 11, color: '#555', cursor: 'pointer', fontFamily: 'JetBrains Mono' }}
-                        title="Open in file manager"
-                        onClick={(e) => { e.stopPropagation(); api.revealProject(p.name).catch(() => {}); }}>OPEN</span>
-                      <span style={{ fontSize: 12, color: '#555', cursor: 'pointer', padding: '0 8px' }}
-                        title="Delete project"
-                        onClick={async (e) => {
-                          e.stopPropagation();
-                          if (!confirm(`Delete project "${p.name}"?\n\nThis will permanently remove the project directory and all its files.\n\nThis cannot be undone.`)) return;
-                          try {
-                            await api.deleteProject(p.name);
-                            setSavedProjects(prev => prev.filter(sp => sp.name !== p.name));
-                            showNotification(`Deleted project: ${p.name}`);
-                          } catch (err: any) {
-                            showNotification(`Failed to delete: ${err.message}`, 4000);
-                          }
-                        }}>✕</span>
-                      <span style={{ fontSize: 11, color: t.color, fontWeight: 700, fontFamily: 'JetBrains Mono' }}>OPEN</span>
-                    </button>
-                  );
-                })}
-              </div>
-            </div>
-          )}
-
-          <h1 style={S.title}>{savedProjects.length > 0 ? 'New Project' : 'Choose your IaC tool'}</h1>
-          <p style={S.subtitle}>Visual infrastructure builder with AI-powered assistance</p>
-          <div style={S.cardGrid}>
-            {Object.entries(PROJECT_CREATION_TOOLS).map(([key, t]) => {
-              const detected = detectedTools.find(d => d.name === t.name);
-              return (
-                <button key={key} className="tool-card panel-reveal" style={{ ...S.card, borderColor: t.color + '33' }}
-                  onClick={() => handleCreateProject(key)}
-                  onMouseEnter={e => { (e.currentTarget as any).style.borderColor = t.color; (e.currentTarget as any).style.transform = 'translateY(-4px)'; }}
-                  onMouseLeave={e => { (e.currentTarget as any).style.borderColor = t.color + '33'; (e.currentTarget as any).style.transform = 'translateY(0)'; }}>
-                  <span style={{ fontSize: 26, fontWeight: 700, letterSpacing: 0.8, fontFamily: 'JetBrains Mono', color: t.color }}>{t.icon}</span>
-                  <span style={{ fontSize: 18, fontWeight: 600, color: t.color }}>{t.name}</span>
-                  <span style={{ fontSize: 12, color: '#555', fontFamily: 'JetBrains Mono' }}>{t.ext} files</span>
-                  {detected && (
-                    <span style={{ fontSize: 10, color: detected.available ? '#4ade80' : '#666', marginTop: 4 }}>
-                      {detected.available ? `✓ ${detected.version?.slice(0, 30)}` : '✗ Not installed'}
-                    </span>
-                  )}
-                </button>
-              );
-            })}
-          </div>
-          <div style={S.features}>
-            {['Visual drag-and-drop builder', 'AI chat to generate resources', 'Real-time code generation', 'Files editable on disk'].map(f => (
-              <div key={f} style={{ fontSize: 13, color: '#555', display: 'flex', alignItems: 'center', gap: 6 }}>
-                <span style={{ fontSize: 8, color: 'var(--accent-action)' }}>●</span> {f}
-              </div>
-            ))}
-          </div>
-
-          {/* Project name & directory */}
-          <UIPanel style={{ marginTop: 32, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10, padding: '16px 24px', width: '100%', maxWidth: 480 }}>
-            <div style={{ display: 'flex', gap: 8, alignItems: 'center', width: '100%' }}>
-              <UILabel style={{ whiteSpace: 'nowrap' }}>Project name:</UILabel>
-              <UIInput style={{ flex: 1, minWidth: 0 }}
-                value={projectName} onChange={e => setProjectName(e.target.value)} placeholder="my-infra-project" />
-            </div>
-            <div className="ui-path">
-              ROOT ~/iac-projects/<span style={{ color: 'var(--accent-action)' }}>{projectName}</span>/
-            </div>
-
-            {/* Import / Topology buttons */}
-            <div style={{ marginTop: 12, display: 'flex', gap: 10 }}>
-              <UIButton
-                onClick={() => { setImportTab('browse'); setVisionImages([]); setVisionError(null); setShowImportWizard(true); loadBrowsePath(); }}>
-                Import Existing Project
-              </UIButton>
-              <UIButton variant="primary"
-                onClick={() => { setImportTab('topology'); setShowImportWizard(true); }}>
-                Build with AI
-              </UIButton>
-            </div>
-          </UIPanel>
-
-          {/* ─── Import Wizard Modal ─── */}
-          {showImportWizard && (
-            <ImportWizardModal
-              importTab={importTab}
-              onImportTabChange={setImportTab}
-              browsePath={browsePath}
-              browseParent={browseParent}
-              browseEntries={browseEntries}
-              onBrowseLoaded={handleBrowseLoaded}
-              importPreview={importPreview}
-              onImportPreviewChange={setImportPreview}
-              importLoading={importLoading}
-              onImportLoadingChange={setImportLoading}
-              topologyDesc={topologyDesc}
-              onTopologyDescChange={setTopologyDesc}
-              topologyProvider={topologyProvider}
-              onTopologyProviderChange={setTopologyProvider}
-              visionImages={visionImages}
-              onVisionImagesChange={setVisionImages}
-              visionError={visionError}
-              onVisionErrorChange={setVisionError}
-              catalogResources={catalogResources}
-              onGenerateTopology={handleGenerateTopology}
-              onImportToCanvas={handleImportToCanvas}
-              onClose={closeImportWizard}
-            />
-          )}
-        </div>
-      </div>
+      <ProjectLauncher
+        savedProjects={savedProjects}
+        detectedTools={detectedTools}
+        projectName={projectName}
+        showImportWizard={showImportWizard}
+        importTab={importTab}
+        browsePath={browsePath}
+        browseParent={browseParent}
+        browseEntries={browseEntries}
+        importPreview={importPreview}
+        importLoading={importLoading}
+        topologyDesc={topologyDesc}
+        topologyProvider={topologyProvider}
+        visionImages={visionImages}
+        visionError={visionError}
+        catalogResources={catalogResources}
+        onProjectNameChange={setProjectName}
+        onCreateProject={handleCreateProject}
+        onOpenProject={openProject}
+        onRevealProject={(name) => api.revealProject(name).catch(() => {})}
+        onDeleteProject={handleDeleteSavedProject}
+        onStartImportBrowse={startImportBrowse}
+        onStartTopology={startTopologyBuilder}
+        onImportTabChange={setImportTab}
+        onBrowseLoaded={handleBrowseLoaded}
+        onImportPreviewChange={setImportPreview}
+        onImportLoadingChange={setImportLoading}
+        onTopologyDescChange={setTopologyDesc}
+        onTopologyProviderChange={setTopologyProvider}
+        onVisionImagesChange={setVisionImages}
+        onVisionErrorChange={setVisionError}
+        onGenerateTopology={handleGenerateTopology}
+        onImportToCanvas={handleImportToCanvas}
+        onCloseImportWizard={closeImportWizard}
+      />
     );
   }
 

--- a/web/src/components/ProjectLauncher/ProjectLauncher.test.tsx
+++ b/web/src/components/ProjectLauncher/ProjectLauncher.test.tsx
@@ -87,7 +87,7 @@ describe('ProjectLauncher', () => {
     expect(screen.getByText(/1 resource/)).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Open project existing-project' }));
-    fireEvent.click(screen.getByRole('button', { name: 'FILES' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Open files for existing-project' }));
     fireEvent.click(screen.getByRole('button', { name: 'Delete project existing-project' }));
 
     expect(props.onOpenProject).toHaveBeenCalledWith(savedProject);

--- a/web/src/components/ProjectLauncher/ProjectLauncher.test.tsx
+++ b/web/src/components/ProjectLauncher/ProjectLauncher.test.tsx
@@ -1,0 +1,109 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ProjectLauncher, type ProjectLauncherProps } from './ProjectLauncher';
+
+function baseProps(): ProjectLauncherProps {
+  return {
+    savedProjects: [],
+    detectedTools: [],
+    projectName: 'demo-project',
+    showImportWizard: false,
+    importTab: 'browse',
+    browsePath: '',
+    browseParent: '',
+    browseEntries: [],
+    importPreview: null,
+    importLoading: false,
+    topologyDesc: '',
+    topologyProvider: 'aws',
+    visionImages: [],
+    visionError: null,
+    catalogResources: [],
+    onProjectNameChange: vi.fn(),
+    onCreateProject: vi.fn(),
+    onOpenProject: vi.fn(),
+    onRevealProject: vi.fn(),
+    onDeleteProject: vi.fn(),
+    onStartImportBrowse: vi.fn(),
+    onStartTopology: vi.fn(),
+    onImportTabChange: vi.fn(),
+    onBrowseLoaded: vi.fn(),
+    onImportPreviewChange: vi.fn(),
+    onImportLoadingChange: vi.fn(),
+    onTopologyDescChange: vi.fn(),
+    onTopologyProviderChange: vi.fn(),
+    onVisionImagesChange: vi.fn(),
+    onVisionErrorChange: vi.fn(),
+    onGenerateTopology: vi.fn(),
+    onImportToCanvas: vi.fn(),
+    onCloseImportWizard: vi.fn(),
+  };
+}
+
+function renderLauncher(overrides: Partial<ProjectLauncherProps> = {}) {
+  const props = { ...baseProps(), ...overrides };
+  render(<ProjectLauncher {...props} />);
+  return props;
+}
+
+describe('ProjectLauncher', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('dispatches new-project and import actions', () => {
+    const props = renderLauncher({
+      detectedTools: [{ name: 'Terraform', binary: 'terraform', version: 'v1.9.0', available: true }],
+    });
+
+    expect(screen.getByRole('heading', { name: 'Choose your IaC tool' })).toBeInTheDocument();
+    expect(screen.getByText(/v1.9.0/)).toBeInTheDocument();
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Project name' }), { target: { value: 'renamed' } });
+    fireEvent.click(screen.getByRole('button', { name: /Terraform/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Import Existing Project' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Build with AI' }));
+
+    expect(props.onProjectNameChange).toHaveBeenCalledWith('renamed');
+    expect(props.onCreateProject).toHaveBeenCalledWith('terraform');
+    expect(props.onStartImportBrowse).toHaveBeenCalled();
+    expect(props.onStartTopology).toHaveBeenCalled();
+  });
+
+  it('renders saved projects and dispatches project actions', () => {
+    const savedProject = {
+      name: 'existing-project',
+      tool: 'terraform',
+      resources: [{ id: 'vpc' }],
+      updated_at: '2026-05-01T00:00:00Z',
+    };
+    const confirm = vi.fn(() => true);
+    vi.stubGlobal('confirm', confirm);
+    const props = renderLauncher({ savedProjects: [savedProject] });
+
+    expect(screen.getByRole('heading', { name: 'New Project' })).toBeInTheDocument();
+    expect(screen.getByText('Recent Projects')).toBeInTheDocument();
+    expect(screen.getByText(/1 resource/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open project existing-project' }));
+    fireEvent.click(screen.getByRole('button', { name: 'FILES' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete project existing-project' }));
+
+    expect(props.onOpenProject).toHaveBeenCalledWith(savedProject);
+    expect(props.onRevealProject).toHaveBeenCalledWith('existing-project');
+    expect(confirm).toHaveBeenCalled();
+    expect(props.onDeleteProject).toHaveBeenCalledWith('existing-project');
+  });
+
+  it('does not delete a saved project when confirmation is cancelled', () => {
+    vi.stubGlobal('confirm', vi.fn(() => false));
+    const props = renderLauncher({
+      savedProjects: [{ name: 'existing-project', tool: 'terraform' }],
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete project existing-project' }));
+
+    expect(props.onDeleteProject).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/components/ProjectLauncher/ProjectLauncher.tsx
+++ b/web/src/components/ProjectLauncher/ProjectLauncher.tsx
@@ -43,7 +43,7 @@ export interface ProjectLauncherProps {
   onVisionImagesChange: (_images: File[]) => void;
   onVisionErrorChange: (_error: string | null) => void;
   onGenerateTopology: () => void;
-  onImportToCanvas: (_preview: ImportResult) => void;
+  onImportToCanvas: (_preview: ImportResult) => void | Promise<void>;
   onCloseImportWizard: () => void;
 }
 
@@ -131,6 +131,7 @@ export function ProjectLauncher({
                       type="button"
                       style={{ background: 'transparent', border: 0, fontSize: 11, color: '#555', cursor: 'pointer', fontFamily: 'JetBrains Mono', padding: '2px 4px' }}
                       title="Open in file manager"
+                      aria-label={`Open files for ${project.name}`}
                       onClick={() => onRevealProject(project.name)}
                     >
                       FILES

--- a/web/src/components/ProjectLauncher/ProjectLauncher.tsx
+++ b/web/src/components/ProjectLauncher/ProjectLauncher.tsx
@@ -1,0 +1,251 @@
+import { UIButton, UIInput, UIKicker, UILabel, UIPanel } from '../../ui';
+import type { CatalogResource, FileEntry, ImportResult, ToolInfo } from '../../api';
+import { ImportWizardModal } from '../ImportWizard';
+import { PROJECT_CREATION_TOOLS, ALL_TOOLS, TOOLS } from '../../legacy';
+import { S } from '../../styles';
+
+export interface SavedProject {
+  name: string;
+  tool?: string;
+  resources?: unknown[];
+  updated_at?: string;
+}
+
+export interface ProjectLauncherProps {
+  savedProjects: SavedProject[];
+  detectedTools: ToolInfo[];
+  projectName: string;
+  showImportWizard: boolean;
+  importTab: 'browse' | 'topology';
+  browsePath: string;
+  browseParent: string;
+  browseEntries: FileEntry[];
+  importPreview: ImportResult | null;
+  importLoading: boolean;
+  topologyDesc: string;
+  topologyProvider: string;
+  visionImages: File[];
+  visionError: string | null;
+  catalogResources: CatalogResource[];
+  onProjectNameChange: (_name: string) => void;
+  onCreateProject: (_tool: string) => void;
+  onOpenProject: (_project: SavedProject) => void;
+  onRevealProject: (_projectName: string) => void;
+  onDeleteProject: (_projectName: string) => void;
+  onStartImportBrowse: () => void;
+  onStartTopology: () => void;
+  onImportTabChange: (_tab: 'browse' | 'topology') => void;
+  onBrowseLoaded: (_path: string, _entries: FileEntry[], _parent: string) => void;
+  onImportPreviewChange: (_preview: ImportResult | null) => void;
+  onImportLoadingChange: (_loading: boolean) => void;
+  onTopologyDescChange: (_description: string) => void;
+  onTopologyProviderChange: (_provider: string) => void;
+  onVisionImagesChange: (_images: File[]) => void;
+  onVisionErrorChange: (_error: string | null) => void;
+  onGenerateTopology: () => void;
+  onImportToCanvas: (_preview: ImportResult) => void;
+  onCloseImportWizard: () => void;
+}
+
+export function ProjectLauncher({
+  savedProjects,
+  detectedTools,
+  projectName,
+  showImportWizard,
+  importTab,
+  browsePath,
+  browseParent,
+  browseEntries,
+  importPreview,
+  importLoading,
+  topologyDesc,
+  topologyProvider,
+  visionImages,
+  visionError,
+  catalogResources,
+  onProjectNameChange,
+  onCreateProject,
+  onOpenProject,
+  onRevealProject,
+  onDeleteProject,
+  onStartImportBrowse,
+  onStartTopology,
+  onImportTabChange,
+  onBrowseLoaded,
+  onImportPreviewChange,
+  onImportLoadingChange,
+  onTopologyDescChange,
+  onTopologyProviderChange,
+  onVisionImagesChange,
+  onVisionErrorChange,
+  onGenerateTopology,
+  onImportToCanvas,
+  onCloseImportWizard,
+}: ProjectLauncherProps) {
+  const visibleSavedProjects = savedProjects.filter(project => project.tool).slice(0, 5);
+
+  return (
+    <div style={S.selectScreen} className="select-screen">
+      <div className="ambient-orb ambient-orb-a" />
+      <div className="ambient-orb ambient-orb-b" />
+      <div style={S.selectBg} />
+      <div style={S.selectContent}>
+        <div style={S.logo}>
+          <span style={{ fontSize: 28, color: 'var(--accent-action)' }}>◆</span>
+          <span style={S.logoText}>IaC Studio</span>
+        </div>
+
+        {visibleSavedProjects.length > 0 && (
+          <div style={{ marginBottom: 32, width: '100%', maxWidth: 600 }}>
+            <UIKicker style={{ marginBottom: 12 }}>Recent Projects</UIKicker>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+              {visibleSavedProjects.map(project => {
+                const toolMeta = ALL_TOOLS[project.tool || 'terraform'] || TOOLS.terraform;
+                const count = project.resources?.length || 0;
+                const updated = project.updated_at ? ` · ${new Date(project.updated_at).toLocaleDateString()}` : '';
+
+                return (
+                  <div
+                    key={project.name}
+                    className="tool-card"
+                    style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '10px 16px', background: 'var(--bg-elev-1)', border: '1px solid var(--border-main)', borderRadius: 10, textAlign: 'left', transition: 'border-color 0.2s' }}
+                    onMouseEnter={event => { event.currentTarget.style.borderColor = toolMeta.color; }}
+                    onMouseLeave={event => { event.currentTarget.style.borderColor = 'var(--border-main)'; }}
+                  >
+                    <button
+                      type="button"
+                      aria-label={`Open project ${project.name}`}
+                      style={{ flex: 1, display: 'flex', alignItems: 'center', gap: 12, minWidth: 0, padding: 0, background: 'transparent', border: 0, cursor: 'pointer', textAlign: 'left' }}
+                      onClick={() => onOpenProject(project)}
+                    >
+                      <span style={{ fontSize: 20 }}>{toolMeta.icon}</span>
+                      <span style={{ flex: 1, minWidth: 0 }}>
+                        <span style={{ display: 'block', fontSize: 14, fontWeight: 600, color: '#ccc', fontFamily: 'JetBrains Mono' }}>{project.name}</span>
+                        <span style={{ display: 'block', fontSize: 11, color: '#555' }}>
+                          {toolMeta.name} · {count} resource{count !== 1 ? 's' : ''}{updated}
+                        </span>
+                      </span>
+                      <span style={{ fontSize: 11, color: toolMeta.color, fontWeight: 700, fontFamily: 'JetBrains Mono' }}>OPEN</span>
+                    </button>
+                    <button
+                      type="button"
+                      style={{ background: 'transparent', border: 0, fontSize: 11, color: '#555', cursor: 'pointer', fontFamily: 'JetBrains Mono', padding: '2px 4px' }}
+                      title="Open in file manager"
+                      onClick={() => onRevealProject(project.name)}
+                    >
+                      FILES
+                    </button>
+                    <button
+                      type="button"
+                      style={{ background: 'transparent', border: 0, fontSize: 12, color: '#555', cursor: 'pointer', padding: '0 8px' }}
+                      title="Delete project"
+                      aria-label={`Delete project ${project.name}`}
+                      onClick={() => {
+                        if (!confirm(`Delete project "${project.name}"?\n\nThis will permanently remove the project directory and all its files.\n\nThis cannot be undone.`)) return;
+                        onDeleteProject(project.name);
+                      }}
+                    >
+                      ✕
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        <h1 style={S.title}>{savedProjects.length > 0 ? 'New Project' : 'Choose your IaC tool'}</h1>
+        <p style={S.subtitle}>Visual infrastructure builder with AI-powered assistance</p>
+        <div style={S.cardGrid}>
+          {Object.entries(PROJECT_CREATION_TOOLS).map(([key, toolMeta]) => {
+            const detected = detectedTools.find(tool => tool.name === toolMeta.name);
+            return (
+              <button
+                key={key}
+                className="tool-card panel-reveal"
+                style={{ ...S.card, borderColor: toolMeta.color + '33' }}
+                onClick={() => onCreateProject(key)}
+                onMouseEnter={event => {
+                  event.currentTarget.style.borderColor = toolMeta.color;
+                  event.currentTarget.style.transform = 'translateY(-4px)';
+                }}
+                onMouseLeave={event => {
+                  event.currentTarget.style.borderColor = toolMeta.color + '33';
+                  event.currentTarget.style.transform = 'translateY(0)';
+                }}
+              >
+                <span style={{ fontSize: 26, fontWeight: 700, letterSpacing: 0.8, fontFamily: 'JetBrains Mono', color: toolMeta.color }}>{toolMeta.icon}</span>
+                <span style={{ fontSize: 18, fontWeight: 600, color: toolMeta.color }}>{toolMeta.name}</span>
+                <span style={{ fontSize: 12, color: '#555', fontFamily: 'JetBrains Mono' }}>{toolMeta.ext} files</span>
+                {detected && (
+                  <span style={{ fontSize: 10, color: detected.available ? '#4ade80' : '#666', marginTop: 4 }}>
+                    {detected.available ? `✓ ${detected.version?.slice(0, 30)}` : '✗ Not installed'}
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+        <div style={S.features}>
+          {['Visual drag-and-drop builder', 'AI chat to generate resources', 'Real-time code generation', 'Files editable on disk'].map(feature => (
+            <div key={feature} style={{ fontSize: 13, color: '#555', display: 'flex', alignItems: 'center', gap: 6 }}>
+              <span style={{ fontSize: 8, color: 'var(--accent-action)' }}>●</span> {feature}
+            </div>
+          ))}
+        </div>
+
+        <UIPanel style={{ marginTop: 32, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10, padding: '16px 24px', width: '100%', maxWidth: 480 }}>
+          <div style={{ display: 'flex', gap: 8, alignItems: 'center', width: '100%' }}>
+            <UILabel style={{ whiteSpace: 'nowrap' }}>Project name:</UILabel>
+            <UIInput
+              style={{ flex: 1, minWidth: 0 }}
+              value={projectName}
+              aria-label="Project name"
+              onChange={event => onProjectNameChange(event.target.value)}
+              placeholder="my-infra-project"
+            />
+          </div>
+          <div className="ui-path">
+            ROOT ~/iac-projects/<span style={{ color: 'var(--accent-action)' }}>{projectName}</span>/
+          </div>
+
+          <div style={{ marginTop: 12, display: 'flex', gap: 10 }}>
+            <UIButton onClick={onStartImportBrowse}>
+              Import Existing Project
+            </UIButton>
+            <UIButton variant="primary" onClick={onStartTopology}>
+              Build with AI
+            </UIButton>
+          </div>
+        </UIPanel>
+
+        {showImportWizard && (
+          <ImportWizardModal
+            importTab={importTab}
+            onImportTabChange={onImportTabChange}
+            browsePath={browsePath}
+            browseParent={browseParent}
+            browseEntries={browseEntries}
+            onBrowseLoaded={onBrowseLoaded}
+            importPreview={importPreview}
+            onImportPreviewChange={onImportPreviewChange}
+            importLoading={importLoading}
+            onImportLoadingChange={onImportLoadingChange}
+            topologyDesc={topologyDesc}
+            onTopologyDescChange={onTopologyDescChange}
+            topologyProvider={topologyProvider}
+            onTopologyProviderChange={onTopologyProviderChange}
+            visionImages={visionImages}
+            onVisionImagesChange={onVisionImagesChange}
+            visionError={visionError}
+            onVisionErrorChange={onVisionErrorChange}
+            catalogResources={catalogResources}
+            onGenerateTopology={onGenerateTopology}
+            onImportToCanvas={onImportToCanvas}
+            onClose={onCloseImportWizard}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/ProjectLauncher/index.tsx
+++ b/web/src/components/ProjectLauncher/index.tsx
@@ -1,0 +1,2 @@
+export { ProjectLauncher } from './ProjectLauncher';
+export type { SavedProject } from './ProjectLauncher';


### PR DESCRIPTION
Refs #22.

Extracts the project selection/start screen from `App.tsx` into `components/ProjectLauncher`, including recent projects, tool selection, project naming, and the import/topology launcher flow.

This keeps API-side project actions in `App.tsx` while moving the visible launcher UI and import wizard mounting behind focused props. The saved-project row also avoids nested clickable controls and adds explicit accessible labels for project open/delete actions.

Validation:
- `npm test -- --run` from `web/`
- `npm run lint` from `web/` (passes with existing warnings)
- `npm run build` from `web/`