### PR TITLE
[codex] Extract sidebar palette

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,6 +8,7 @@ import { AppHeader } from './components/AppHeader';
 import { CodeEditor } from './components/CodeEditor';
 import { ChatPanel } from './components/Chat';
 import { ProjectLauncher, type SavedProject } from './components/ProjectLauncher';
+import { WorkspaceSidebar, type SidebarPanel } from './components/Sidebar';
 import { TerminalPanel } from './components/Terminal';
 import { ModuleRegistryPanel } from './components/ModuleRegistry';
 import { PolicyStudioPanel } from './components/PolicyStudio';
@@ -166,7 +167,7 @@ export default function App() {
   const [chatInput, setChatInput] = useState('');
   const [chatLoading, setChatLoading] = useState(false);
   const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
-  const [activePanel, setActivePanel] = useState('palette');
+  const [activePanel, setActivePanel] = useState<SidebarPanel>('palette');
   const [rightTab, setRightTab] = useState<'inspect' | 'policy' | 'scan' | 'modules'>('inspect');
   const [projectLayoutMeta, setProjectLayoutMeta] = useState<Record<string, any> | null>(null);
   const [layeredProject, setLayeredProject] = useState<LayeredProject | null>(null);
@@ -494,15 +495,6 @@ export default function App() {
       setConnecting(null);
     },
   });
-
-  // Filter resources by search query
-  const filteredResources = searchQuery
-    ? catalogResources.filter(r =>
-        r.label.toLowerCase().includes(searchQuery.toLowerCase()) ||
-        r.type.toLowerCase().includes(searchQuery.toLowerCase()) ||
-        r.category.toLowerCase().includes(searchQuery.toLowerCase()))
-    : catalogResources;
-  const filteredCategories = [...new Set(filteredResources.map(r => r.category))];
 
   // Fetch resource catalog from backend when tool changes
   useEffect(() => {
@@ -1117,142 +1109,25 @@ export default function App() {
 
       <div style={S.main}>
         {/* Sidebar — resizable */}
-        <aside style={{ ...S.sidebar, width: sidebarWidth }}>
-          <div style={S.tabs}>
-            {[
-              { key: 'palette', label: 'Resources' },
-              { key: 'suggest', label: 'Next' },
-              { key: 'guide', label: 'Guide' },
-            ].map(t => (
-              <button key={t.key} style={{ ...S.tab, ...(activePanel === t.key ? { color: ct.color, borderBottomColor: ct.color } : {}), fontSize: 10 }}
-                onClick={() => setActivePanel(t.key)}>
-                {t.label}
-                {t.key === 'suggest' && suggestions.length > 0 && (
-                  <span style={{ marginLeft: 4, background: ct.color + '33', color: ct.color, padding: '1px 5px', borderRadius: 8, fontSize: 9 }}>{suggestions.length}</span>
-                )}
-              </button>
-            ))}
-          </div>
-          {activePanel === 'palette' && (
-            <>
-              {/* Search */}
-              <div style={{ padding: '8px 10px', borderBottom: '1px solid var(--border-soft)' }}>
-                <input
-                  style={{ ...S.finput, fontSize: 12, padding: '6px 10px', background: 'var(--bg-app)' }}
-                  placeholder="Search resources..."
-                  value={searchQuery}
-                  onChange={e => setSearchQuery(e.target.value)}
-                />
-                {searchQuery && (
-                  <div style={{ fontSize: 10, color: '#555', marginTop: 4, fontFamily: 'JetBrains Mono' }}>
-                    {filteredResources.length} result{filteredResources.length !== 1 ? 's' : ''}
-                  </div>
-                )}
-              </div>
-              <div style={S.palScroll}>
-                {filteredCategories.map(cat => (
-                  <div key={cat}>
-                    <div style={S.catTitle}>{cat}</div>
-                    {filteredResources.filter((r: any) => r.category === cat).map((r: any) => (
-                      <button key={r.type} style={S.palItem} onClick={() => addNode(r)}
-                        onMouseEnter={e => {
-                          (e.currentTarget as any).style.background = 'var(--bg-elev-2)';
-                          const rect = e.currentTarget.getBoundingClientRect();
-                          setHoverPos({ x: rect.right + 8, y: rect.top });
-                          setHoveredResource(r);
-                        }}
-                        onMouseLeave={e => {
-                          (e.currentTarget as any).style.background = 'transparent';
-                          setHoveredResource(null);
-                        }}>
-                        <span>{r.icon}</span>
-                        <span style={{ flex: 1 }}>{r.label}</span>
-                        <span style={{ color: '#444' }}>+</span>
-                      </button>
-                    ))}
-                  </div>
-                ))}
-                {filteredResources.length === 0 && searchQuery && (
-                  <div style={{ padding: '20px 16px', color: '#444', fontSize: 12, textAlign: 'center' }}>
-                    No resources matching "{searchQuery}"
-                  </div>
-                )}
-              </div>
-            </>
-          )}
-          {activePanel === 'files' && (
-            <div style={{ padding: 16 }}>
-              <div style={{ fontSize: 13, fontWeight: 600, color: '#bbb', marginBottom: 12, fontFamily: 'JetBrains Mono' }}>DIR {projectName}/</div>
-              {['main' + ct.ext, 'variables' + ct.ext, 'outputs' + ct.ext, '.gitignore'].map(f => (
-                <div key={f} style={{ fontSize: 12, color: '#777', padding: '5px 0 5px 12px', fontFamily: 'JetBrains Mono', cursor: 'pointer' }}>FILE {f}</div>
-              ))}
-              <div style={{ marginTop: 24, padding: 12, background: '#111122', borderRadius: 8, fontSize: 11, color: '#555', lineHeight: 1.6 }}>
-                Files sync to:<br /><code style={{ color: ct.color, fontFamily: 'JetBrains Mono' }}>~/{projectName}/</code>
-              </div>
-            </div>
-          )}
-          {/* Suggestions panel */}
-          {activePanel === 'suggest' && (
-            <div style={S.palScroll}>
-              {suggestions.length === 0 ? (
-                <div style={{ padding: 20, textAlign: 'center', color: '#555', fontSize: 12 }}>
-                  Add resources to get smart suggestions based on IaC best practices.
-                </div>
-              ) : (
-                suggestions.map(s => {
-                  const meta = catalogResources.find(c => c.type === s.type);
-                  return (
-                    <button key={s.type} style={{ ...S.palItem, flexDirection: 'column' as const, alignItems: 'flex-start', gap: 4, padding: '10px 16px' }}
-                      onClick={() => meta && addNode(meta)}
-                      onMouseEnter={e => { (e.currentTarget as any).style.background = 'var(--bg-elev-2)'; }}
-                      onMouseLeave={e => { (e.currentTarget as any).style.background = 'transparent'; }}>
-                      <div style={{ display: 'flex', alignItems: 'center', gap: 8, width: '100%' }}>
-                        <span>{meta?.icon ?? '📦'}</span>
-                        <span style={{ flex: 1, fontWeight: 600, color: '#ddd' }}>{s.label}</span>
-                        <span style={{ color: s.priority === 1 ? ct.color : s.priority === 2 ? '#888' : '#555', fontSize: 9, fontFamily: 'JetBrains Mono' }}>
-                          {s.priority === 1 ? 'NEXT' : s.priority === 2 ? 'RECOMMENDED' : 'OPTIONAL'}
-                        </span>
-                      </div>
-                      <div style={{ fontSize: 11, color: '#666', lineHeight: 1.4, paddingLeft: 28 }}>{s.reason}</div>
-                    </button>
-                  );
-                })
-              )}
-            </div>
-          )}
-          {/* Guide panel */}
-          {activePanel === 'guide' && (
-            <div style={{ ...S.palScroll, padding: 16 }}>
-              <div style={{ fontSize: 14, fontWeight: 700, color: '#ddd', marginBottom: 16 }}>Getting Started</div>
-              {[
-                { step: '1', title: 'Add a foundation', desc: tool === 'ansible' ? 'Start with package installation (apt/yum)' : detectProvider() === 'google' ? 'Start with a VPC Network (google_compute_network)' : detectProvider() === 'azurerm' ? 'Start with a Resource Group (azurerm_resource_group)' : 'Start with a VPC (aws_vpc)' },
-                { step: '2', title: 'Build networking', desc: tool === 'ansible' ? 'Configure services and users' : 'Add subnets, security groups, and routing' },
-                { step: '3', title: 'Add compute', desc: tool === 'ansible' ? 'Deploy application files and templates' : 'Deploy VMs, containers, or serverless functions' },
-                { step: '4', title: 'Add data layer', desc: tool === 'ansible' ? 'Configure databases and cron jobs' : 'Add databases, caches, and storage buckets' },
-                { step: '5', title: 'Secure & monitor', desc: tool === 'ansible' ? 'Configure firewall and enable services' : 'Add IAM roles, encryption keys, and alarms' },
-              ].map(g => (
-                <div key={g.step} style={{ display: 'flex', gap: 12, marginBottom: 14 }}>
-                  <div style={{ width: 24, height: 24, borderRadius: '50%', background: ct.color + '22', color: ct.color, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 12, fontWeight: 700, flexShrink: 0 }}>{g.step}</div>
-                  <div>
-                    <div style={{ fontSize: 12, fontWeight: 600, color: '#bbb' }}>{g.title}</div>
-                    <div style={{ fontSize: 11, color: '#666', marginTop: 2 }}>{g.desc}</div>
-                  </div>
-                </div>
-              ))}
-              <div style={{ marginTop: 20, padding: 12, background: '#111122', borderRadius: 8, fontSize: 11, color: '#666', lineHeight: 1.6 }}>
-                <div style={{ fontWeight: 600, color: '#888', marginBottom: 6 }}>Tips</div>
-                <div>Drag the <span style={{ color: ct.color }}>circle port</span> on a node to connect it to another resource.</div>
-                <div style={{ marginTop: 4 }}>Use the <span style={{ color: ct.color }}>AI chat</span> below to describe what you need in plain language.</div>
-                <div style={{ marginTop: 4 }}>Check the <span style={{ color: ct.color }}>Next</span> tab for smart suggestions based on what's on your canvas.</div>
-                <div style={{ marginTop: 4 }}>The code preview on the right updates live as you build.</div>
-              </div>
-              <button style={{ ...S.cmd, background: ct.color + '22', color: ct.color, width: '100%', marginTop: 16, padding: '8px 0' }}
-                onClick={() => setActivePanel('suggest')}>
-                View Suggestions →
-              </button>
-            </div>
-          )}
-        </aside>
+        <WorkspaceSidebar
+          width={sidebarWidth}
+          activePanel={activePanel}
+          tool={tool}
+          toolMeta={ct}
+          projectName={projectName}
+          provider={detectProvider()}
+          resources={catalogResources}
+          suggestions={suggestions}
+          searchQuery={searchQuery}
+          onActivePanelChange={setActivePanel}
+          onSearchQueryChange={setSearchQuery}
+          onAddResource={addNode}
+          onResourceHover={(resource, position) => {
+            setHoverPos(position);
+            setHoveredResource(resource);
+          }}
+          onResourceHoverEnd={() => setHoveredResource(null)}
+        />
         {/* Sidebar resize handle */}
         <div style={{ width: 4, cursor: 'col-resize', background: resizing?.panel === 'sidebar' ? ct.color + '44' : 'transparent', flexShrink: 0, transition: 'background 0.15s' }}
           onMouseDown={e => setResizing({ panel: 'sidebar', startPos: e.clientX, startSize: sidebarWidth })}

--- a/web/src/components/Sidebar/WorkspaceSidebar.test.tsx
+++ b/web/src/components/Sidebar/WorkspaceSidebar.test.tsx
@@ -89,8 +89,11 @@ describe('WorkspaceSidebar', () => {
   });
 
   it('renders file names for the project tool extension', () => {
-    renderSidebar({ activePanel: 'files', toolMeta: { color: '#8A63D2', ext: '.ts' } });
+    const props = renderSidebar({ activePanel: 'files', toolMeta: { color: '#8A63D2', ext: '.ts' } });
 
+    fireEvent.click(screen.getByRole('button', { name: 'Files' }));
+
+    expect(props.onActivePanelChange).toHaveBeenCalledWith('files');
     expect(screen.getByText('DIR demo/')).toBeInTheDocument();
     expect(screen.getByText('FILE main.ts')).toBeInTheDocument();
     expect(screen.getByText('FILE variables.ts')).toBeInTheDocument();

--- a/web/src/components/Sidebar/WorkspaceSidebar.test.tsx
+++ b/web/src/components/Sidebar/WorkspaceSidebar.test.tsx
@@ -1,0 +1,98 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { CatalogResource, Suggestion } from '../../api';
+import { WorkspaceSidebar, type WorkspaceSidebarProps } from './WorkspaceSidebar';
+
+const resources: CatalogResource[] = [
+  { type: 'aws_vpc', label: 'VPC', icon: 'V', category: 'Networking' },
+  { type: 'aws_subnet', label: 'Subnet', icon: 'S', category: 'Networking' },
+  { type: 'aws_s3_bucket', label: 'S3 Bucket', icon: 'B', category: 'Storage' },
+];
+
+const suggestions: Suggestion[] = [
+  { type: 'aws_subnet', label: 'Add subnet', reason: 'VPCs usually need subnets.', priority: 1 },
+];
+
+function baseProps(): WorkspaceSidebarProps {
+  return {
+    width: 240,
+    activePanel: 'palette',
+    tool: 'terraform',
+    toolMeta: { color: '#2FB5A8', ext: '.tf' },
+    projectName: 'demo',
+    provider: 'aws',
+    resources,
+    suggestions: [],
+    searchQuery: '',
+    onActivePanelChange: vi.fn(),
+    onSearchQueryChange: vi.fn(),
+    onAddResource: vi.fn(),
+    onResourceHover: vi.fn(),
+    onResourceHoverEnd: vi.fn(),
+  };
+}
+
+function renderSidebar(overrides: Partial<WorkspaceSidebarProps> = {}) {
+  const props = { ...baseProps(), ...overrides };
+  render(<WorkspaceSidebar {...props} />);
+  return props;
+}
+
+describe('WorkspaceSidebar', () => {
+  it('filters palette resources and dispatches resource interactions', () => {
+    const props = renderSidebar({ searchQuery: 'bucket' });
+
+    expect(screen.getByText('1 result')).toBeInTheDocument();
+    expect(screen.getByText('Storage')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Add S3 Bucket' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Add VPC' })).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Search resources' }), { target: { value: 'vpc' } });
+    fireEvent.mouseEnter(screen.getByRole('button', { name: 'Add S3 Bucket' }));
+    fireEvent.mouseLeave(screen.getByRole('button', { name: 'Add S3 Bucket' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Add S3 Bucket' }));
+
+    expect(props.onSearchQueryChange).toHaveBeenCalledWith('vpc');
+    expect(props.onResourceHover).toHaveBeenCalledWith(resources[2], expect.objectContaining({ x: expect.any(Number), y: expect.any(Number) }));
+    expect(props.onResourceHoverEnd).toHaveBeenCalled();
+    expect(props.onAddResource).toHaveBeenCalledWith(resources[2]);
+  });
+
+  it('shows empty search results', () => {
+    renderSidebar({ searchQuery: 'database' });
+
+    expect(screen.getByText('0 results')).toBeInTheDocument();
+    expect(screen.getByText('No resources matching "database"')).toBeInTheDocument();
+  });
+
+  it('renders suggestions and dispatches suggestion resource adds', () => {
+    const props = renderSidebar({ activePanel: 'suggest', suggestions });
+
+    expect(screen.getByRole('button', { name: /Resources/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Next 1/i })).toBeInTheDocument();
+    expect(screen.getByText('VPCs usually need subnets.')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add suggested resource Add subnet' }));
+
+    expect(props.onAddResource).toHaveBeenCalledWith(resources[1]);
+  });
+
+  it('renders provider-specific guide content and switches to suggestions', () => {
+    const props = renderSidebar({ activePanel: 'guide', provider: 'google' });
+
+    expect(screen.getByText('Start with a VPC Network (google_compute_network)')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'View Suggestions →' }));
+
+    expect(props.onActivePanelChange).toHaveBeenCalledWith('suggest');
+  });
+
+  it('renders file names for the project tool extension', () => {
+    renderSidebar({ activePanel: 'files', toolMeta: { color: '#8A63D2', ext: '.ts' } });
+
+    expect(screen.getByText('DIR demo/')).toBeInTheDocument();
+    expect(screen.getByText('FILE main.ts')).toBeInTheDocument();
+    expect(screen.getByText('FILE variables.ts')).toBeInTheDocument();
+  });
+});

--- a/web/src/components/Sidebar/WorkspaceSidebar.tsx
+++ b/web/src/components/Sidebar/WorkspaceSidebar.tsx
@@ -1,0 +1,216 @@
+import type { CatalogResource, Suggestion } from '../../api';
+import { S } from '../../styles';
+
+export type SidebarPanel = 'palette' | 'files' | 'suggest' | 'guide';
+
+export interface SidebarToolMeta {
+  color: string;
+  ext: string;
+}
+
+export interface WorkspaceSidebarProps {
+  width: number;
+  activePanel: SidebarPanel;
+  tool: string;
+  toolMeta: SidebarToolMeta;
+  projectName: string;
+  provider: string;
+  resources: CatalogResource[];
+  suggestions: Suggestion[];
+  searchQuery: string;
+  onActivePanelChange: (_panel: SidebarPanel) => void;
+  onSearchQueryChange: (_query: string) => void;
+  onAddResource: (_resource: CatalogResource) => void;
+  onResourceHover: (_resource: CatalogResource, _position: { x: number; y: number }) => void;
+  onResourceHoverEnd: () => void;
+}
+
+function guideFoundation(tool: string, provider: string) {
+  if (tool === 'ansible') return 'Start with package installation (apt/yum)';
+  if (provider === 'google') return 'Start with a VPC Network (google_compute_network)';
+  if (provider === 'azurerm') return 'Start with a Resource Group (azurerm_resource_group)';
+  return 'Start with a VPC (aws_vpc)';
+}
+
+export function WorkspaceSidebar({
+  width,
+  activePanel,
+  tool,
+  toolMeta,
+  projectName,
+  provider,
+  resources,
+  suggestions,
+  searchQuery,
+  onActivePanelChange,
+  onSearchQueryChange,
+  onAddResource,
+  onResourceHover,
+  onResourceHoverEnd,
+}: WorkspaceSidebarProps) {
+  const normalizedSearch = searchQuery.trim().toLowerCase();
+  const filteredResources = normalizedSearch
+    ? resources.filter(resource =>
+        resource.label.toLowerCase().includes(normalizedSearch) ||
+        resource.type.toLowerCase().includes(normalizedSearch) ||
+        resource.category.toLowerCase().includes(normalizedSearch))
+    : resources;
+  const filteredCategories = [...new Set(filteredResources.map(resource => resource.category))];
+
+  return (
+    <aside style={{ ...S.sidebar, width }}>
+      <div style={S.tabs}>
+        {[
+          { key: 'palette' as const, label: 'Resources' },
+          { key: 'suggest' as const, label: 'Next' },
+          { key: 'guide' as const, label: 'Guide' },
+        ].map(tab => (
+          <button
+            key={tab.key}
+            style={{ ...S.tab, ...(activePanel === tab.key ? { color: toolMeta.color, borderBottomColor: toolMeta.color } : {}), fontSize: 10 }}
+            aria-label={tab.key === 'suggest' && suggestions.length > 0 ? `${tab.label} ${suggestions.length}` : tab.label}
+            onClick={() => onActivePanelChange(tab.key)}
+          >
+            {tab.label}
+            {tab.key === 'suggest' && suggestions.length > 0 && (
+              <span style={{ marginLeft: 4, background: toolMeta.color + '33', color: toolMeta.color, padding: '1px 5px', borderRadius: 8, fontSize: 9 }}>
+                {suggestions.length}
+              </span>
+            )}
+          </button>
+        ))}
+      </div>
+
+      {activePanel === 'palette' && (
+        <>
+          <div style={{ padding: '8px 10px', borderBottom: '1px solid var(--border-soft)' }}>
+            <input
+              style={{ ...S.finput, fontSize: 12, padding: '6px 10px', background: 'var(--bg-app)' }}
+              placeholder="Search resources..."
+              aria-label="Search resources"
+              value={searchQuery}
+              onChange={event => onSearchQueryChange(event.target.value)}
+            />
+            {searchQuery && (
+              <div style={{ fontSize: 10, color: '#555', marginTop: 4, fontFamily: 'JetBrains Mono' }}>
+                {filteredResources.length} result{filteredResources.length !== 1 ? 's' : ''}
+              </div>
+            )}
+          </div>
+          <div style={S.palScroll}>
+            {filteredCategories.map(category => (
+              <div key={category}>
+                <div style={S.catTitle}>{category}</div>
+                {filteredResources.filter(resource => resource.category === category).map(resource => (
+                  <button
+                    key={resource.type}
+                    style={S.palItem}
+                    aria-label={`Add ${resource.label}`}
+                    onClick={() => onAddResource(resource)}
+                    onMouseEnter={event => {
+                      event.currentTarget.style.background = 'var(--bg-elev-2)';
+                      const rect = event.currentTarget.getBoundingClientRect();
+                      onResourceHover(resource, { x: rect.right + 8, y: rect.top });
+                    }}
+                    onMouseLeave={event => {
+                      event.currentTarget.style.background = 'transparent';
+                      onResourceHoverEnd();
+                    }}
+                  >
+                    <span>{resource.icon}</span>
+                    <span style={{ flex: 1 }}>{resource.label}</span>
+                    <span style={{ color: '#444' }}>+</span>
+                  </button>
+                ))}
+              </div>
+            ))}
+            {filteredResources.length === 0 && searchQuery && (
+              <div style={{ padding: '20px 16px', color: '#444', fontSize: 12, textAlign: 'center' }}>
+                No resources matching "{searchQuery}"
+              </div>
+            )}
+          </div>
+        </>
+      )}
+
+      {activePanel === 'files' && (
+        <div style={{ padding: 16 }}>
+          <div style={{ fontSize: 13, fontWeight: 600, color: '#bbb', marginBottom: 12, fontFamily: 'JetBrains Mono' }}>DIR {projectName}/</div>
+          {['main' + toolMeta.ext, 'variables' + toolMeta.ext, 'outputs' + toolMeta.ext, '.gitignore'].map(file => (
+            <div key={file} style={{ fontSize: 12, color: '#777', padding: '5px 0 5px 12px', fontFamily: 'JetBrains Mono', cursor: 'pointer' }}>FILE {file}</div>
+          ))}
+          <div style={{ marginTop: 24, padding: 12, background: '#111122', borderRadius: 8, fontSize: 11, color: '#555', lineHeight: 1.6 }}>
+            Files sync to:<br /><code style={{ color: toolMeta.color, fontFamily: 'JetBrains Mono' }}>~/{projectName}/</code>
+          </div>
+        </div>
+      )}
+
+      {activePanel === 'suggest' && (
+        <div style={S.palScroll}>
+          {suggestions.length === 0 ? (
+            <div style={{ padding: 20, textAlign: 'center', color: '#555', fontSize: 12 }}>
+              Add resources to get smart suggestions based on IaC best practices.
+            </div>
+          ) : (
+            suggestions.map(suggestion => {
+              const meta = resources.find(resource => resource.type === suggestion.type);
+              return (
+                <button
+                  key={suggestion.type}
+                  style={{ ...S.palItem, flexDirection: 'column', alignItems: 'flex-start', gap: 4, padding: '10px 16px' }}
+                  aria-label={`Add suggested resource ${suggestion.label}`}
+                  onClick={() => meta && onAddResource(meta)}
+                  onMouseEnter={event => { event.currentTarget.style.background = 'var(--bg-elev-2)'; }}
+                  onMouseLeave={event => { event.currentTarget.style.background = 'transparent'; }}
+                >
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 8, width: '100%' }}>
+                    <span>{meta?.icon ?? '📦'}</span>
+                    <span style={{ flex: 1, fontWeight: 600, color: '#ddd' }}>{suggestion.label}</span>
+                    <span style={{ color: suggestion.priority === 1 ? toolMeta.color : suggestion.priority === 2 ? '#888' : '#555', fontSize: 9, fontFamily: 'JetBrains Mono' }}>
+                      {suggestion.priority === 1 ? 'NEXT' : suggestion.priority === 2 ? 'RECOMMENDED' : 'OPTIONAL'}
+                    </span>
+                  </div>
+                  <div style={{ fontSize: 11, color: '#666', lineHeight: 1.4, paddingLeft: 28 }}>{suggestion.reason}</div>
+                </button>
+              );
+            })
+          )}
+        </div>
+      )}
+
+      {activePanel === 'guide' && (
+        <div style={{ ...S.palScroll, padding: 16 }}>
+          <div style={{ fontSize: 14, fontWeight: 700, color: '#ddd', marginBottom: 16 }}>Getting Started</div>
+          {[
+            { step: '1', title: 'Add a foundation', desc: guideFoundation(tool, provider) },
+            { step: '2', title: 'Build networking', desc: tool === 'ansible' ? 'Configure services and users' : 'Add subnets, security groups, and routing' },
+            { step: '3', title: 'Add compute', desc: tool === 'ansible' ? 'Deploy application files and templates' : 'Deploy VMs, containers, or serverless functions' },
+            { step: '4', title: 'Add data layer', desc: tool === 'ansible' ? 'Configure databases and cron jobs' : 'Add databases, caches, and storage buckets' },
+            { step: '5', title: 'Secure & monitor', desc: tool === 'ansible' ? 'Configure firewall and enable services' : 'Add IAM roles, encryption keys, and alarms' },
+          ].map(guide => (
+            <div key={guide.step} style={{ display: 'flex', gap: 12, marginBottom: 14 }}>
+              <div style={{ width: 24, height: 24, borderRadius: '50%', background: toolMeta.color + '22', color: toolMeta.color, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 12, fontWeight: 700, flexShrink: 0 }}>{guide.step}</div>
+              <div>
+                <div style={{ fontSize: 12, fontWeight: 600, color: '#bbb' }}>{guide.title}</div>
+                <div style={{ fontSize: 11, color: '#666', marginTop: 2 }}>{guide.desc}</div>
+              </div>
+            </div>
+          ))}
+          <div style={{ marginTop: 20, padding: 12, background: '#111122', borderRadius: 8, fontSize: 11, color: '#666', lineHeight: 1.6 }}>
+            <div style={{ fontWeight: 600, color: '#888', marginBottom: 6 }}>Tips</div>
+            <div>Drag the <span style={{ color: toolMeta.color }}>circle port</span> on a node to connect it to another resource.</div>
+            <div style={{ marginTop: 4 }}>Use the <span style={{ color: toolMeta.color }}>AI chat</span> below to describe what you need in plain language.</div>
+            <div style={{ marginTop: 4 }}>Check the <span style={{ color: toolMeta.color }}>Next</span> tab for smart suggestions based on what's on your canvas.</div>
+            <div style={{ marginTop: 4 }}>The code preview on the right updates live as you build.</div>
+          </div>
+          <button
+            style={{ ...S.cmd, background: toolMeta.color + '22', color: toolMeta.color, width: '100%', marginTop: 16, padding: '8px 0' }}
+            onClick={() => onActivePanelChange('suggest')}
+          >
+            View Suggestions →
+          </button>
+        </div>
+      )}
+    </aside>
+  );
+}

--- a/web/src/components/Sidebar/WorkspaceSidebar.tsx
+++ b/web/src/components/Sidebar/WorkspaceSidebar.tsx
@@ -62,6 +62,7 @@ export function WorkspaceSidebar({
       <div style={S.tabs}>
         {[
           { key: 'palette' as const, label: 'Resources' },
+          { key: 'files' as const, label: 'Files' },
           { key: 'suggest' as const, label: 'Next' },
           { key: 'guide' as const, label: 'Guide' },
         ].map(tab => (

--- a/web/src/components/Sidebar/index.tsx
+++ b/web/src/components/Sidebar/index.tsx
@@ -1,0 +1,2 @@
+export { WorkspaceSidebar } from './WorkspaceSidebar';
+export type { SidebarPanel } from './WorkspaceSidebar';


### PR DESCRIPTION
Refs #22.

Extracts the left resource sidebar from `App.tsx` into `components/Sidebar/WorkspaceSidebar`, including palette search/filtering, suggestion rendering, guide content, and the preserved files panel.

Canvas mutations, hover tooltip state, and resize state remain in `App.tsx`; the sidebar receives explicit callbacks for resource add, hover, search, and tab changes.

Adds focused component tests for filtering, suggestions, guide navigation, files rendering, and hover/add callbacks.

Validation:
- `npm test -- --run` from `web/`
- `npm run lint` from `web/` (passes with existing warnings)
- `npm run build` from `web/`