### PR TITLE
[codex] Extract right inspector panel

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,14 +5,11 @@ import { useHistory } from './useHistory';
 import { useKeyboardShortcuts } from './useKeyboardShortcuts';
 import { AISettingsModal, type AISettingsConfig } from './components/AISettings';
 import { AppHeader } from './components/AppHeader';
-import { CodeEditor } from './components/CodeEditor';
 import { ChatPanel } from './components/Chat';
+import { InspectorPanel, type RightPanelTab } from './components/Inspector';
 import { ProjectLauncher, type SavedProject } from './components/ProjectLauncher';
 import { WorkspaceSidebar, type SidebarPanel } from './components/Sidebar';
 import { TerminalPanel } from './components/Terminal';
-import { ModuleRegistryPanel } from './components/ModuleRegistry';
-import { PolicyStudioPanel } from './components/PolicyStudio';
-import { ScanPanel } from './components/ScanPanel';
 import { SwimlaneCanvas } from './components/Canvas';
 import { S } from './styles';
 import type { LayeredProject, LayeredModule } from './types';
@@ -29,7 +26,6 @@ import {
 } from './legacy';
 
 type CanvasMode = 'freeform' | 'swimlane';
-const EMPTY_CODE_PLACEHOLDER = 'Add resources from the palette or write code here';
 
 const summarizePolicyFindings = (findings: PolicyFinding[]) => {
   if (findings.length === 0) return 'No finding details were returned.';
@@ -168,7 +164,7 @@ export default function App() {
   const [chatLoading, setChatLoading] = useState(false);
   const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
   const [activePanel, setActivePanel] = useState<SidebarPanel>('palette');
-  const [rightTab, setRightTab] = useState<'inspect' | 'policy' | 'scan' | 'modules'>('inspect');
+  const [rightTab, setRightTab] = useState<RightPanelTab>('inspect');
   const [projectLayoutMeta, setProjectLayoutMeta] = useState<Record<string, any> | null>(null);
   const [layeredProject, setLayeredProject] = useState<LayeredProject | null>(null);
   const [activeEnvironment, setActiveEnvironment] = useState<string | null>(null);
@@ -1066,10 +1062,10 @@ export default function App() {
   }
 
   const ct = ALL_TOOLS[tool] || TOOLS[concreteTool] || TOOLS.terraform;
-  const selected = nodes.find(n => n.id === selectedNode);
   const codeFileLabel = concreteTool === 'pulumi'
     ? (activeEnv ? `environments/${activeEnv}/index.ts` : 'index.ts')
     : (tool === 'multi' && activeEnv ? `environments/${activeEnv}/main${TOOLS[concreteTool]?.ext || '.tf'}` : `main${TOOLS[concreteTool]?.ext || ct.ext}`);
+  const codeEditorFilePath = concreteTool === 'pulumi' ? 'index.ts' : `main${TOOLS[concreteTool]?.ext || ct.ext}`;
 
   // ─── Main UI ───
   return (
@@ -1306,164 +1302,33 @@ export default function App() {
           onMouseDown={e => setResizing({ panel: 'right', startPos: e.clientX, startSize: rightWidth })}
           onMouseEnter={e => { if (!resizing) (e.currentTarget as any).style.background = 'var(--border-main)'; }}
           onMouseLeave={e => { if (!resizing) (e.currentTarget as any).style.background = 'transparent'; }} />
-        <aside style={{ ...S.right, width: rightWidth }}>
-          <div style={S.tabs}>
-            {[
-              { key: 'inspect', label: selected || selectedEdge ? 'Inspect' : 'Code' },
-              { key: 'policy', label: 'Policy' },
-              { key: 'scan', label: 'Scan' },
-              ...(tool === 'ansible' ? [] : [{ key: 'modules', label: 'Modules' }]),
-            ].map(t => (
-              <button
-                key={t.key}
-                style={{
-                  ...S.tab,
-                  ...(rightTab === t.key ? { color: ct.color, borderBottomColor: ct.color } : {}),
-                  fontSize: 10,
-                }}
-                onClick={() => setRightTab(t.key as typeof rightTab)}
-              >
-                {t.label}
-              </button>
-            ))}
-          </div>
-          {rightTab === 'inspect' && (
-            <>
-          {/* Selected edge info */}
-          {selectedEdge && (() => {
-            const edge = edges.find(e => e.id === selectedEdge);
-            if (!edge) return null;
-            const fromNode = nodes.find(n => n.id === edge.from);
-            const toNode = nodes.find(n => n.id === edge.to);
-            return (
-              <div style={S.props}>
-                <div style={{ fontSize: 13, fontWeight: 600, color: '#bbb', marginBottom: 12 }}>🔗 Connection</div>
-                <div style={S.field}>
-                  <label style={S.flabel}>From</label>
-                  <div style={{ fontSize: 12, color: '#aaa', fontFamily: 'JetBrains Mono' }}>{fromNode?.icon} {fromNode?.type}.{fromNode?.name}</div>
-                </div>
-                <div style={S.field}>
-                  <label style={S.flabel}>To</label>
-                  <div style={{ fontSize: 12, color: '#aaa', fontFamily: 'JetBrains Mono' }}>{toNode?.icon} {toNode?.type}.{toNode?.name}</div>
-                </div>
-                <div style={S.field}>
-                  <label style={S.flabel}>Via Field</label>
-                  <div style={{ fontSize: 12, color: ct.color, fontFamily: 'JetBrains Mono' }}>{edge.field}</div>
-                </div>
-                <div style={S.field}>
-                  <label style={S.flabel}>Generated Reference</label>
-                  <div style={{ fontSize: 11, color: '#888', fontFamily: 'JetBrains Mono', background: '#111120', padding: '6px 8px', borderRadius: 4 }}>
-                    {edge.field} = {toNode?.type}.{toNode?.name}.id
-                  </div>
-                </div>
-                <button style={{ ...S.cmd, background: '#ef444433', color: '#ef4444', width: '100%', marginTop: 8 }}
-                  onClick={() => { setEdges(prev => prev.filter(e => e.id !== selectedEdge)); setSelectedEdge(null); }}>
-                  Delete Connection
-                </button>
-              </div>
-            );
-          })()}
-          {/* Selected node properties */}
-          {selected && !selectedEdge && (
-            <div style={S.props}>
-              <div style={{ fontSize: 13, fontWeight: 600, color: '#bbb', marginBottom: 12 }}>{selected.icon} Properties</div>
-              <div style={S.field}>
-                <label style={S.flabel}>Name</label>
-                <input style={S.finput} value={selected.name} onChange={e => updateName(selected.id, e.target.value)} />
-              </div>
-              {Object.entries(selected.properties).map(([k, v]) => (
-                <div key={k} style={S.field}>
-                  <label style={S.flabel}>{k}</label>
-                  {typeof v === 'boolean' ? (
-                      <button style={{ ...S.ftoggle, background: v ? ct.color + '33' : 'var(--bg-elev-2)', color: v ? ct.color : 'var(--text-muted)' }}
-                      onClick={() => updateProp(selected.id, k, !v)}>
-                      {v ? 'true' : 'false'}
-                    </button>
-                  ) : (
-                    <input style={S.finput} value={String(v)} onChange={e => updateProp(selected.id, k, e.target.value)} />
-                  )}
-                </div>
-              ))}
-              {/* Show connections for this node */}
-              {(() => {
-                const nodeEdges = edges.filter(e => e.from === selected.id || e.to === selected.id);
-                if (nodeEdges.length === 0) return null;
-                return (
-                  <div style={{ marginTop: 12, paddingTop: 12, borderTop: '1px solid var(--border-soft)' }}>
-                    <label style={S.flabel}>Connections ({nodeEdges.length})</label>
-                    {nodeEdges.map(e => {
-                      const other = nodes.find(n => n.id === (e.from === selected.id ? e.to : e.from));
-                      const direction = e.from === selected.id ? '→' : '←';
-                      return (
-                        <div key={e.id} style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '4px 0', fontSize: 11, color: '#777', fontFamily: 'JetBrains Mono', cursor: 'pointer' }}
-                          onClick={() => setSelectedEdge(e.id)}>
-                          <span>{direction}</span>
-                          <span>{other?.icon}</span>
-                          <span style={{ color: '#aaa' }}>{other?.name}</span>
-                          <span style={{ color: ct.color, marginLeft: 'auto', fontSize: 9 }}>{e.field}</span>
-                        </div>
-                      );
-                    })}
-                  </div>
-                );
-              })()}
-            </div>
-          )}
-          <div style={S.codePanel}>
-            <div style={S.codeHead}>
-              <span>FILE {codeFileLabel}</span>
-              <button
-                style={{ ...S.copyBtn, color: codeSaving || unresolvedHybridEnv || !syncCode.trim() ? '#555' : ct.color }}
-                disabled={codeSaving || unresolvedHybridEnv || !syncCode.trim()}
-                title="Save editor buffer to disk"
-                onClick={() => saveCodeToDisk(syncCode)}
-              >
-                {codeSaving ? 'Saving...' : 'Save'}
-              </button>
-              <button style={{ ...S.copyBtn, color: ct.color }}
-                onClick={() => navigator.clipboard?.writeText(syncCode)}>Copy</button>
-            </div>
-            <div style={S.codePre}>
-              <div style={{ position: 'relative', flex: 1, minWidth: 0, height: '100%', display: 'flex' }}>
-                {!syncCode && (
-                  <div style={{ position: 'absolute', top: 14, left: 18, zIndex: 1, color: '#555', fontFamily: 'JetBrains Mono', fontSize: 13, pointerEvents: 'none' }}>
-                    {EMPTY_CODE_PLACEHOLDER}
-                  </div>
-                )}
-                <CodeEditor
-                  value={syncCode}
-                  filePath={concreteTool === 'pulumi' ? 'index.ts' : `main${TOOLS[concreteTool]?.ext || ct.ext}`}
-                  readOnly={false}
-                  onChange={setSyncCode}
-                  onSave={saveCodeToDisk}
-                />
-              </div>
-            </div>
-          </div>
-            </>
-          )}
-          {rightTab === 'policy' && (
-            <div style={{ flex: 1, minHeight: 0 }}>
-              {unresolvedHybridEnv ? (
-                <div style={{ padding: 16, color: 'var(--text-muted)', fontSize: 13 }}>
-                  Environment "{activeEnv}" has no configured IaC tool in .iac-studio.json.
-                </div>
-              ) : (
-                <PolicyStudioPanel projectName={projectId} tool={tool} env={activeEnv} />
-              )}
-            </div>
-          )}
-          {rightTab === 'scan' && (
-            <div style={{ flex: 1, minHeight: 0 }}>
-              <ScanPanel projectName={projectId} tool={tool} />
-            </div>
-          )}
-          {rightTab === 'modules' && tool !== 'ansible' && (
-            <div style={{ flex: 1, minHeight: 0 }}>
-              <ModuleRegistryPanel initialQuery="vpc" />
-            </div>
-          )}
-        </aside>
+        <InspectorPanel
+          width={rightWidth}
+          activeTab={rightTab}
+          tool={tool}
+          toolMeta={ct}
+          activeEnv={activeEnv}
+          projectId={projectId}
+          nodes={nodes}
+          edges={edges}
+          selectedNodeId={selectedNode}
+          selectedEdgeId={selectedEdge}
+          syncCode={syncCode}
+          codeFileLabel={codeFileLabel}
+          codeEditorFilePath={codeEditorFilePath}
+          codeSaving={codeSaving}
+          unresolvedHybridEnv={unresolvedHybridEnv}
+          onTabChange={setRightTab}
+          onDeleteEdge={(edgeId) => {
+            setEdges(prev => prev.filter(edge => edge.id !== edgeId));
+            setSelectedEdge(null);
+          }}
+          onSelectEdge={setSelectedEdge}
+          onUpdateNodeName={updateName}
+          onUpdateNodeProp={updateProp}
+          onSyncCodeChange={setSyncCode}
+          onSaveCode={saveCodeToDisk}
+        />
       </div>
 
       {/* Bottom: Chat + Terminal */}

--- a/web/src/components/Inspector/InspectorPanel.test.tsx
+++ b/web/src/components/Inspector/InspectorPanel.test.tsx
@@ -107,9 +107,13 @@ describe('InspectorPanel', () => {
 
     expect(screen.getByText('V Properties')).toBeInTheDocument();
 
+    const booleanToggle = screen.getByLabelText('enable_dns_hostnames');
+
+    expect(booleanToggle).toHaveAttribute('aria-pressed', 'true');
+
     fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'core' } });
     fireEvent.change(screen.getByLabelText('cidr_block'), { target: { value: '10.1.0.0/16' } });
-    fireEvent.click(screen.getByLabelText('enable_dns_hostnames'));
+    fireEvent.click(booleanToggle);
     fireEvent.click(screen.getByRole('button', { name: /app.*vpc_id/ }));
 
     expect(props.onUpdateNodeName).toHaveBeenCalledWith('vpc', 'core');
@@ -144,6 +148,16 @@ describe('InspectorPanel', () => {
     expect(props.onSaveCode).toHaveBeenCalledWith('resource "aws_vpc" "main" {}');
     expect(props.onCopyCode).toHaveBeenCalledWith('resource "aws_vpc" "main" {}');
     expect(props.onTabChange).toHaveBeenCalledWith('policy');
+  });
+
+  it('keeps editor save disabled when the save button is disabled', () => {
+    const props = renderInspector({ unresolvedHybridEnv: true });
+
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Editor Save' }));
+
+    expect(props.onSaveCode).not.toHaveBeenCalled();
   });
 
   it('handles clipboard fallback failures without unhandled rejections', async () => {

--- a/web/src/components/Inspector/InspectorPanel.test.tsx
+++ b/web/src/components/Inspector/InspectorPanel.test.tsx
@@ -153,15 +153,20 @@ describe('InspectorPanel', () => {
     expect(screen.getByText('Module registry vpc')).toBeInTheDocument();
   });
 
-  it('guards unresolved hybrid environments and hides modules for Ansible', () => {
+  it('guards unresolved hybrid environments', () => {
     renderInspector({
       activeTab: 'policy',
-      tool: 'ansible',
+      tool: 'multi',
       activeEnv: 'qa',
       unresolvedHybridEnv: true,
     });
 
-    expect(screen.queryByRole('button', { name: 'Modules' })).not.toBeInTheDocument();
     expect(screen.getByText('Environment "qa" has no configured IaC tool in .iac-studio.json.')).toBeInTheDocument();
+  });
+
+  it('hides modules for Ansible projects', () => {
+    renderInspector({ tool: 'ansible' });
+
+    expect(screen.queryByRole('button', { name: 'Modules' })).not.toBeInTheDocument();
   });
 });

--- a/web/src/components/Inspector/InspectorPanel.test.tsx
+++ b/web/src/components/Inspector/InspectorPanel.test.tsx
@@ -1,0 +1,167 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Edge } from '../../legacy';
+import { InspectorPanel, type InspectorPanelProps, type InspectorResource } from './index';
+
+vi.mock('../CodeEditor', () => ({
+  CodeEditor: ({ value, filePath, onChange, onSave }: any) => (
+    <div>
+      <textarea
+        aria-label="Code editor"
+        data-filepath={filePath}
+        value={value}
+        onChange={event => onChange?.(event.target.value)}
+      />
+      <button onClick={() => onSave?.(value)}>Editor Save</button>
+    </div>
+  ),
+}));
+
+vi.mock('../PolicyStudio', () => ({
+  PolicyStudioPanel: ({ projectName, tool, env }: any) => (
+    <div>Policy panel {projectName} {tool} {env}</div>
+  ),
+}));
+
+vi.mock('../ScanPanel', () => ({
+  ScanPanel: ({ projectName, tool }: any) => (
+    <div>Scan panel {projectName} {tool}</div>
+  ),
+}));
+
+vi.mock('../ModuleRegistry', () => ({
+  ModuleRegistryPanel: ({ initialQuery }: any) => (
+    <div>Module registry {initialQuery}</div>
+  ),
+}));
+
+const nodes: InspectorResource[] = [
+  {
+    id: 'vpc',
+    type: 'aws_vpc',
+    name: 'main',
+    properties: { cidr_block: '10.0.0.0/16', enable_dns_hostnames: true },
+    icon: 'V',
+    label: 'VPC',
+  },
+  {
+    id: 'subnet',
+    type: 'aws_subnet',
+    name: 'app',
+    properties: { cidr_block: '10.0.1.0/24' },
+    icon: 'S',
+    label: 'Subnet',
+  },
+];
+
+const edges: Edge[] = [
+  {
+    id: 'subnet->vpc:vpc_id',
+    from: 'subnet',
+    to: 'vpc',
+    fromType: 'aws_subnet',
+    toType: 'aws_vpc',
+    field: 'vpc_id',
+    label: 'vpc id',
+  },
+];
+
+function baseProps(): InspectorPanelProps {
+  return {
+    width: 320,
+    activeTab: 'inspect',
+    tool: 'terraform',
+    toolMeta: { color: '#2FB5A8', ext: '.tf' },
+    activeEnv: null,
+    projectId: 'demo',
+    nodes,
+    edges,
+    selectedNodeId: null,
+    selectedEdgeId: null,
+    syncCode: 'resource "aws_vpc" "main" {}',
+    codeFileLabel: 'main.tf',
+    codeEditorFilePath: 'main.tf',
+    codeSaving: false,
+    unresolvedHybridEnv: false,
+    onTabChange: vi.fn(),
+    onDeleteEdge: vi.fn(),
+    onSelectEdge: vi.fn(),
+    onUpdateNodeName: vi.fn(),
+    onUpdateNodeProp: vi.fn(),
+    onSyncCodeChange: vi.fn(),
+    onSaveCode: vi.fn(),
+    onCopyCode: vi.fn(),
+  };
+}
+
+function renderInspector(overrides: Partial<InspectorPanelProps> = {}) {
+  const props = { ...baseProps(), ...overrides };
+  render(<InspectorPanel {...props} />);
+  return props;
+}
+
+describe('InspectorPanel', () => {
+  it('renders selected node properties and dispatches edits', () => {
+    const props = renderInspector({ selectedNodeId: 'vpc' });
+
+    expect(screen.getByText('V Properties')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByDisplayValue('main'), { target: { value: 'core' } });
+    fireEvent.change(screen.getByDisplayValue('10.0.0.0/16'), { target: { value: '10.1.0.0/16' } });
+    fireEvent.click(screen.getByRole('button', { name: 'true' }));
+    fireEvent.click(screen.getByText('app'));
+
+    expect(props.onUpdateNodeName).toHaveBeenCalledWith('vpc', 'core');
+    expect(props.onUpdateNodeProp).toHaveBeenCalledWith('vpc', 'cidr_block', '10.1.0.0/16');
+    expect(props.onUpdateNodeProp).toHaveBeenCalledWith('vpc', 'enable_dns_hostnames', false);
+    expect(props.onSelectEdge).toHaveBeenCalledWith('subnet->vpc:vpc_id');
+  });
+
+  it('renders selected edge details and dispatches deletion', () => {
+    const props = renderInspector({ selectedEdgeId: 'subnet->vpc:vpc_id' });
+
+    expect(screen.getByText('🔗 Connection')).toBeInTheDocument();
+    expect(screen.getByText('vpc_id = aws_vpc.main.id')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Connection' }));
+
+    expect(props.onDeleteEdge).toHaveBeenCalledWith('subnet->vpc:vpc_id');
+  });
+
+  it('renders code controls and dispatches code callbacks', () => {
+    const props = renderInspector();
+
+    expect(screen.getByText('FILE main.tf')).toBeInTheDocument();
+    expect(screen.getByLabelText('Code editor')).toHaveAttribute('data-filepath', 'main.tf');
+
+    fireEvent.change(screen.getByLabelText('Code editor'), { target: { value: 'resource "aws_s3_bucket" "logs" {}' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Copy' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Policy' }));
+
+    expect(props.onSyncCodeChange).toHaveBeenCalledWith('resource "aws_s3_bucket" "logs" {}');
+    expect(props.onSaveCode).toHaveBeenCalledWith('resource "aws_vpc" "main" {}');
+    expect(props.onCopyCode).toHaveBeenCalledWith('resource "aws_vpc" "main" {}');
+    expect(props.onTabChange).toHaveBeenCalledWith('policy');
+  });
+
+  it('renders tool tabs and mounted panels', () => {
+    renderInspector({ activeTab: 'modules' });
+
+    expect(screen.getByRole('button', { name: 'Modules' })).toBeInTheDocument();
+    expect(screen.getByText('Module registry vpc')).toBeInTheDocument();
+  });
+
+  it('guards unresolved hybrid environments and hides modules for Ansible', () => {
+    renderInspector({
+      activeTab: 'policy',
+      tool: 'ansible',
+      activeEnv: 'qa',
+      unresolvedHybridEnv: true,
+    });
+
+    expect(screen.queryByRole('button', { name: 'Modules' })).not.toBeInTheDocument();
+    expect(screen.getByText('Environment "qa" has no configured IaC tool in .iac-studio.json.')).toBeInTheDocument();
+  });
+});

--- a/web/src/components/Inspector/InspectorPanel.test.tsx
+++ b/web/src/components/Inspector/InspectorPanel.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { Edge } from '../../legacy';
@@ -107,10 +107,10 @@ describe('InspectorPanel', () => {
 
     expect(screen.getByText('V Properties')).toBeInTheDocument();
 
-    fireEvent.change(screen.getByDisplayValue('main'), { target: { value: 'core' } });
-    fireEvent.change(screen.getByDisplayValue('10.0.0.0/16'), { target: { value: '10.1.0.0/16' } });
-    fireEvent.click(screen.getByRole('button', { name: 'true' }));
-    fireEvent.click(screen.getByText('app'));
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'core' } });
+    fireEvent.change(screen.getByLabelText('cidr_block'), { target: { value: '10.1.0.0/16' } });
+    fireEvent.click(screen.getByLabelText('enable_dns_hostnames'));
+    fireEvent.click(screen.getByRole('button', { name: /app.*vpc_id/ }));
 
     expect(props.onUpdateNodeName).toHaveBeenCalledWith('vpc', 'core');
     expect(props.onUpdateNodeProp).toHaveBeenCalledWith('vpc', 'cidr_block', '10.1.0.0/16');
@@ -144,6 +144,36 @@ describe('InspectorPanel', () => {
     expect(props.onSaveCode).toHaveBeenCalledWith('resource "aws_vpc" "main" {}');
     expect(props.onCopyCode).toHaveBeenCalledWith('resource "aws_vpc" "main" {}');
     expect(props.onTabChange).toHaveBeenCalledWith('policy');
+  });
+
+  it('handles clipboard fallback failures without unhandled rejections', async () => {
+    const originalClipboard = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
+    const writeText = vi.fn().mockRejectedValue(new Error('denied'));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+
+    try {
+      renderInspector({ onCopyCode: undefined });
+
+      fireEvent.click(screen.getByRole('button', { name: 'Copy' }));
+
+      await waitFor(() => {
+        expect(writeText).toHaveBeenCalledWith('resource "aws_vpc" "main" {}');
+      });
+      await waitFor(() => {
+        expect(warn).toHaveBeenCalledWith('Failed to copy code to clipboard', expect.any(Error));
+      });
+    } finally {
+      warn.mockRestore();
+      if (originalClipboard) {
+        Object.defineProperty(navigator, 'clipboard', originalClipboard);
+      } else {
+        Reflect.deleteProperty(navigator, 'clipboard');
+      }
+    }
   });
 
   it('renders tool tabs and mounted panels', () => {

--- a/web/src/components/Inspector/index.tsx
+++ b/web/src/components/Inspector/index.tsx
@@ -77,6 +77,7 @@ export function InspectorPanel({
 }: InspectorPanelProps) {
   const selected = nodes.find(node => node.id === selectedNodeId);
   const selectedEdge = edges.find(edge => edge.id === selectedEdgeId);
+  const saveDisabled = codeSaving || unresolvedHybridEnv || !syncCode.trim();
 
   const copyCode = async () => {
     if (onCopyCode) {
@@ -169,6 +170,7 @@ export function InspectorPanel({
                   {typeof value === 'boolean' ? (
                     <button
                       id={fieldId(selected.id, key)}
+                      aria-pressed={value}
                       style={{ ...S.ftoggle, background: value ? toolMeta.color + '33' : 'var(--bg-elev-2)', color: value ? toolMeta.color : 'var(--text-muted)' }}
                       onClick={() => onUpdateNodeProp(selected.id, key, !value)}
                     >
@@ -218,8 +220,8 @@ export function InspectorPanel({
             <div style={S.codeHead}>
               <span>FILE {codeFileLabel}</span>
               <button
-                style={{ ...S.copyBtn, color: codeSaving || unresolvedHybridEnv || !syncCode.trim() ? '#555' : toolMeta.color }}
-                disabled={codeSaving || unresolvedHybridEnv || !syncCode.trim()}
+                style={{ ...S.copyBtn, color: saveDisabled ? '#555' : toolMeta.color }}
+                disabled={saveDisabled}
                 title="Save editor buffer to disk"
                 onClick={() => onSaveCode(syncCode)}
               >
@@ -239,7 +241,7 @@ export function InspectorPanel({
                   filePath={codeEditorFilePath}
                   readOnly={false}
                   onChange={onSyncCodeChange}
-                  onSave={onSaveCode}
+                  onSave={saveDisabled ? undefined : onSaveCode}
                 />
               </div>
             </div>

--- a/web/src/components/Inspector/index.tsx
+++ b/web/src/components/Inspector/index.tsx
@@ -125,19 +125,19 @@ export function InspectorPanel({
               <div style={S.props}>
                 <div style={{ fontSize: 13, fontWeight: 600, color: '#bbb', marginBottom: 12 }}>🔗 Connection</div>
                 <div style={S.field}>
-                  <label style={S.flabel}>From</label>
+                  <div style={S.flabel}>From</div>
                   <div style={{ fontSize: 12, color: '#aaa', fontFamily: 'JetBrains Mono' }}>{fromNode?.icon} {fromNode?.type}.{fromNode?.name}</div>
                 </div>
                 <div style={S.field}>
-                  <label style={S.flabel}>To</label>
+                  <div style={S.flabel}>To</div>
                   <div style={{ fontSize: 12, color: '#aaa', fontFamily: 'JetBrains Mono' }}>{toNode?.icon} {toNode?.type}.{toNode?.name}</div>
                 </div>
                 <div style={S.field}>
-                  <label style={S.flabel}>Via Field</label>
+                  <div style={S.flabel}>Via Field</div>
                   <div style={{ fontSize: 12, color: toolMeta.color, fontFamily: 'JetBrains Mono' }}>{selectedEdge.field}</div>
                 </div>
                 <div style={S.field}>
-                  <label style={S.flabel}>Generated Reference</label>
+                  <div style={S.flabel}>Generated Reference</div>
                   <div style={{ fontSize: 11, color: '#888', fontFamily: 'JetBrains Mono', background: '#111120', padding: '6px 8px', borderRadius: 4 }}>
                     {selectedEdge.field} = {toNode?.type}.{toNode?.name}.id
                   </div>
@@ -192,7 +192,7 @@ export function InspectorPanel({
                 if (nodeEdges.length === 0) return null;
                 return (
                   <div style={{ marginTop: 12, paddingTop: 12, borderTop: '1px solid var(--border-soft)' }}>
-                    <label style={S.flabel}>Connections ({nodeEdges.length})</label>
+                    <div style={S.flabel}>Connections ({nodeEdges.length})</div>
                     {nodeEdges.map(edge => {
                       const other = nodes.find(node => node.id === (edge.from === selected.id ? edge.to : edge.from));
                       const direction = edge.from === selected.id ? '→' : '←';

--- a/web/src/components/Inspector/index.tsx
+++ b/web/src/components/Inspector/index.tsx
@@ -46,6 +46,10 @@ export interface InspectorPanelProps {
 
 const EMPTY_CODE_PLACEHOLDER = 'Add resources from the palette or write code here';
 
+const fieldId = (nodeId: string, field: string) => (
+  `inspector-${nodeId}-${field}`.replace(/[^a-zA-Z0-9_-]/g, '-')
+);
+
 export function InspectorPanel({
   width,
   activeTab,
@@ -74,12 +78,16 @@ export function InspectorPanel({
   const selected = nodes.find(node => node.id === selectedNodeId);
   const selectedEdge = edges.find(edge => edge.id === selectedEdgeId);
 
-  const copyCode = () => {
+  const copyCode = async () => {
     if (onCopyCode) {
       onCopyCode(syncCode);
       return;
     }
-    navigator.clipboard?.writeText(syncCode);
+    try {
+      await navigator.clipboard?.writeText(syncCode);
+    } catch (err) {
+      console.warn('Failed to copy code to clipboard', err);
+    }
   };
 
   const tabs: { key: RightPanelTab; label: string }[] = [
@@ -147,21 +155,32 @@ export function InspectorPanel({
             <div style={S.props}>
               <div style={{ fontSize: 13, fontWeight: 600, color: '#bbb', marginBottom: 12 }}>{selected.icon} Properties</div>
               <div style={S.field}>
-                <label style={S.flabel}>Name</label>
-                <input style={S.finput} value={selected.name} onChange={event => onUpdateNodeName(selected.id, event.target.value)} />
+                <label style={S.flabel} htmlFor={fieldId(selected.id, 'name')}>Name</label>
+                <input
+                  id={fieldId(selected.id, 'name')}
+                  style={S.finput}
+                  value={selected.name}
+                  onChange={event => onUpdateNodeName(selected.id, event.target.value)}
+                />
               </div>
               {Object.entries(selected.properties).map(([key, value]) => (
                 <div key={key} style={S.field}>
-                  <label style={S.flabel}>{key}</label>
+                  <label style={S.flabel} htmlFor={fieldId(selected.id, key)}>{key}</label>
                   {typeof value === 'boolean' ? (
                     <button
+                      id={fieldId(selected.id, key)}
                       style={{ ...S.ftoggle, background: value ? toolMeta.color + '33' : 'var(--bg-elev-2)', color: value ? toolMeta.color : 'var(--text-muted)' }}
                       onClick={() => onUpdateNodeProp(selected.id, key, !value)}
                     >
                       {value ? 'true' : 'false'}
                     </button>
                   ) : (
-                    <input style={S.finput} value={String(value)} onChange={event => onUpdateNodeProp(selected.id, key, event.target.value)} />
+                    <input
+                      id={fieldId(selected.id, key)}
+                      style={S.finput}
+                      value={String(value)}
+                      onChange={event => onUpdateNodeProp(selected.id, key, event.target.value)}
+                    />
                   )}
                 </div>
               ))}
@@ -176,16 +195,17 @@ export function InspectorPanel({
                       const other = nodes.find(node => node.id === (edge.from === selected.id ? edge.to : edge.from));
                       const direction = edge.from === selected.id ? '→' : '←';
                       return (
-                        <div
+                        <button
                           key={edge.id}
-                          style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '4px 0', fontSize: 11, color: '#777', fontFamily: 'JetBrains Mono', cursor: 'pointer' }}
+                          type="button"
+                          style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '4px 0', fontSize: 11, color: '#777', fontFamily: 'JetBrains Mono', cursor: 'pointer', background: 'transparent', border: 0, width: '100%', textAlign: 'left' }}
                           onClick={() => onSelectEdge(edge.id)}
                         >
                           <span>{direction}</span>
                           <span>{other?.icon}</span>
                           <span style={{ color: '#aaa' }}>{other?.name}</span>
                           <span style={{ color: toolMeta.color, marginLeft: 'auto', fontSize: 9 }}>{edge.field}</span>
-                        </div>
+                        </button>
                       );
                     })}
                   </div>

--- a/web/src/components/Inspector/index.tsx
+++ b/web/src/components/Inspector/index.tsx
@@ -1,5 +1,255 @@
-// Inspector panel — right-rail resource detail + field editing. Stub
-// until the App.tsx split commit extracts the existing inspector UI.
-export function InspectorPanel() {
-  return null;
+import type { Resource } from '../../api';
+import type { Edge } from '../../legacy';
+import { S } from '../../styles';
+import { CodeEditor } from '../CodeEditor';
+import { ModuleRegistryPanel } from '../ModuleRegistry';
+import { PolicyStudioPanel } from '../PolicyStudio';
+import { ScanPanel } from '../ScanPanel';
+
+export type RightPanelTab = 'inspect' | 'policy' | 'scan' | 'modules';
+
+export interface InspectorResource extends Resource {
+  icon: string;
+  label: string;
+}
+
+export interface InspectorToolMeta {
+  color: string;
+  ext: string;
+}
+
+export interface InspectorPanelProps {
+  width: number;
+  activeTab: RightPanelTab;
+  tool: string;
+  toolMeta: InspectorToolMeta;
+  activeEnv?: string | null;
+  projectId: string;
+  nodes: InspectorResource[];
+  edges: Edge[];
+  selectedNodeId: string | null;
+  selectedEdgeId: string | null;
+  syncCode: string;
+  codeFileLabel: string;
+  codeEditorFilePath: string;
+  codeSaving: boolean;
+  unresolvedHybridEnv: boolean;
+  onTabChange: (_tab: RightPanelTab) => void;
+  onDeleteEdge: (_edgeId: string) => void;
+  onSelectEdge: (_edgeId: string) => void;
+  onUpdateNodeName: (_nodeId: string, _name: string) => void;
+  onUpdateNodeProp: (_nodeId: string, _key: string, _value: any) => void;
+  onSyncCodeChange: (_value: string) => void;
+  onSaveCode: (_value: string) => void;
+  onCopyCode?: (_value: string) => void;
+}
+
+const EMPTY_CODE_PLACEHOLDER = 'Add resources from the palette or write code here';
+
+export function InspectorPanel({
+  width,
+  activeTab,
+  tool,
+  toolMeta,
+  activeEnv,
+  projectId,
+  nodes,
+  edges,
+  selectedNodeId,
+  selectedEdgeId,
+  syncCode,
+  codeFileLabel,
+  codeEditorFilePath,
+  codeSaving,
+  unresolvedHybridEnv,
+  onTabChange,
+  onDeleteEdge,
+  onSelectEdge,
+  onUpdateNodeName,
+  onUpdateNodeProp,
+  onSyncCodeChange,
+  onSaveCode,
+  onCopyCode,
+}: InspectorPanelProps) {
+  const selected = nodes.find(node => node.id === selectedNodeId);
+  const selectedEdge = edges.find(edge => edge.id === selectedEdgeId);
+
+  const copyCode = () => {
+    if (onCopyCode) {
+      onCopyCode(syncCode);
+      return;
+    }
+    navigator.clipboard?.writeText(syncCode);
+  };
+
+  const tabs: { key: RightPanelTab; label: string }[] = [
+    { key: 'inspect', label: selected || selectedEdge ? 'Inspect' : 'Code' },
+    { key: 'policy', label: 'Policy' },
+    { key: 'scan', label: 'Scan' },
+    ...(tool === 'ansible' ? [] : [{ key: 'modules' as const, label: 'Modules' }]),
+  ];
+
+  return (
+    <aside style={{ ...S.right, width }}>
+      <div style={S.tabs}>
+        {tabs.map(tab => (
+          <button
+            key={tab.key}
+            style={{
+              ...S.tab,
+              ...(activeTab === tab.key ? { color: toolMeta.color, borderBottomColor: toolMeta.color } : {}),
+              fontSize: 10,
+            }}
+            onClick={() => onTabChange(tab.key)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {activeTab === 'inspect' && (
+        <>
+          {selectedEdge && (() => {
+            const fromNode = nodes.find(node => node.id === selectedEdge.from);
+            const toNode = nodes.find(node => node.id === selectedEdge.to);
+            return (
+              <div style={S.props}>
+                <div style={{ fontSize: 13, fontWeight: 600, color: '#bbb', marginBottom: 12 }}>🔗 Connection</div>
+                <div style={S.field}>
+                  <label style={S.flabel}>From</label>
+                  <div style={{ fontSize: 12, color: '#aaa', fontFamily: 'JetBrains Mono' }}>{fromNode?.icon} {fromNode?.type}.{fromNode?.name}</div>
+                </div>
+                <div style={S.field}>
+                  <label style={S.flabel}>To</label>
+                  <div style={{ fontSize: 12, color: '#aaa', fontFamily: 'JetBrains Mono' }}>{toNode?.icon} {toNode?.type}.{toNode?.name}</div>
+                </div>
+                <div style={S.field}>
+                  <label style={S.flabel}>Via Field</label>
+                  <div style={{ fontSize: 12, color: toolMeta.color, fontFamily: 'JetBrains Mono' }}>{selectedEdge.field}</div>
+                </div>
+                <div style={S.field}>
+                  <label style={S.flabel}>Generated Reference</label>
+                  <div style={{ fontSize: 11, color: '#888', fontFamily: 'JetBrains Mono', background: '#111120', padding: '6px 8px', borderRadius: 4 }}>
+                    {selectedEdge.field} = {toNode?.type}.{toNode?.name}.id
+                  </div>
+                </div>
+                <button
+                  style={{ ...S.cmd, background: '#ef444433', color: '#ef4444', width: '100%', marginTop: 8 }}
+                  onClick={() => onDeleteEdge(selectedEdge.id)}
+                >
+                  Delete Connection
+                </button>
+              </div>
+            );
+          })()}
+
+          {selected && !selectedEdge && (
+            <div style={S.props}>
+              <div style={{ fontSize: 13, fontWeight: 600, color: '#bbb', marginBottom: 12 }}>{selected.icon} Properties</div>
+              <div style={S.field}>
+                <label style={S.flabel}>Name</label>
+                <input style={S.finput} value={selected.name} onChange={event => onUpdateNodeName(selected.id, event.target.value)} />
+              </div>
+              {Object.entries(selected.properties).map(([key, value]) => (
+                <div key={key} style={S.field}>
+                  <label style={S.flabel}>{key}</label>
+                  {typeof value === 'boolean' ? (
+                    <button
+                      style={{ ...S.ftoggle, background: value ? toolMeta.color + '33' : 'var(--bg-elev-2)', color: value ? toolMeta.color : 'var(--text-muted)' }}
+                      onClick={() => onUpdateNodeProp(selected.id, key, !value)}
+                    >
+                      {value ? 'true' : 'false'}
+                    </button>
+                  ) : (
+                    <input style={S.finput} value={String(value)} onChange={event => onUpdateNodeProp(selected.id, key, event.target.value)} />
+                  )}
+                </div>
+              ))}
+
+              {(() => {
+                const nodeEdges = edges.filter(edge => edge.from === selected.id || edge.to === selected.id);
+                if (nodeEdges.length === 0) return null;
+                return (
+                  <div style={{ marginTop: 12, paddingTop: 12, borderTop: '1px solid var(--border-soft)' }}>
+                    <label style={S.flabel}>Connections ({nodeEdges.length})</label>
+                    {nodeEdges.map(edge => {
+                      const other = nodes.find(node => node.id === (edge.from === selected.id ? edge.to : edge.from));
+                      const direction = edge.from === selected.id ? '→' : '←';
+                      return (
+                        <div
+                          key={edge.id}
+                          style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '4px 0', fontSize: 11, color: '#777', fontFamily: 'JetBrains Mono', cursor: 'pointer' }}
+                          onClick={() => onSelectEdge(edge.id)}
+                        >
+                          <span>{direction}</span>
+                          <span>{other?.icon}</span>
+                          <span style={{ color: '#aaa' }}>{other?.name}</span>
+                          <span style={{ color: toolMeta.color, marginLeft: 'auto', fontSize: 9 }}>{edge.field}</span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                );
+              })()}
+            </div>
+          )}
+
+          <div style={S.codePanel}>
+            <div style={S.codeHead}>
+              <span>FILE {codeFileLabel}</span>
+              <button
+                style={{ ...S.copyBtn, color: codeSaving || unresolvedHybridEnv || !syncCode.trim() ? '#555' : toolMeta.color }}
+                disabled={codeSaving || unresolvedHybridEnv || !syncCode.trim()}
+                title="Save editor buffer to disk"
+                onClick={() => onSaveCode(syncCode)}
+              >
+                {codeSaving ? 'Saving...' : 'Save'}
+              </button>
+              <button style={{ ...S.copyBtn, color: toolMeta.color }} onClick={copyCode}>Copy</button>
+            </div>
+            <div style={S.codePre}>
+              <div style={{ position: 'relative', flex: 1, minWidth: 0, height: '100%', display: 'flex' }}>
+                {!syncCode && (
+                  <div style={{ position: 'absolute', top: 14, left: 18, zIndex: 1, color: '#555', fontFamily: 'JetBrains Mono', fontSize: 13, pointerEvents: 'none' }}>
+                    {EMPTY_CODE_PLACEHOLDER}
+                  </div>
+                )}
+                <CodeEditor
+                  value={syncCode}
+                  filePath={codeEditorFilePath}
+                  readOnly={false}
+                  onChange={onSyncCodeChange}
+                  onSave={onSaveCode}
+                />
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+
+      {activeTab === 'policy' && (
+        <div style={{ flex: 1, minHeight: 0 }}>
+          {unresolvedHybridEnv ? (
+            <div style={{ padding: 16, color: 'var(--text-muted)', fontSize: 13 }}>
+              Environment "{activeEnv}" has no configured IaC tool in .iac-studio.json.
+            </div>
+          ) : (
+            <PolicyStudioPanel projectName={projectId} tool={tool} env={activeEnv || undefined} />
+          )}
+        </div>
+      )}
+
+      {activeTab === 'scan' && (
+        <div style={{ flex: 1, minHeight: 0 }}>
+          <ScanPanel projectName={projectId} tool={tool} />
+        </div>
+      )}
+
+      {activeTab === 'modules' && tool !== 'ansible' && (
+        <div style={{ flex: 1, minHeight: 0 }}>
+          <ModuleRegistryPanel initialQuery="vpc" />
+        </div>
+      )}
+    </aside>
+  );
 }


### PR DESCRIPTION
Refs #22.

Extracts the right-hand inspect/code/tools panel from `App.tsx` into `components/Inspector/InspectorPanel`.

The new component owns the right-panel tabs, selected node/edge detail rendering, code editor controls, and the mounted Policy Studio, Scan, and Module Registry panels. `App.tsx` keeps the application state and passes explicit callbacks for node edits, edge selection/deletion, code changes, tab changes, and saving.

Adds focused Inspector tests covering node property edits, edge deletion, code editor callbacks, tab dispatch, module-tab visibility, and the unresolved hybrid environment guard.

Validation:
- `npm test -- --run` from `web/`
- `npm run lint` from `web/` (passes with existing warnings)
- `npm run build` from `web/`