### PR TITLE
[codex] Fix Docker release build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY web/ ./
 RUN npm run build
 
 # ─── Stage 2: Build Go backend ───
-FROM golang:1.22-alpine AS backend
+FROM golang:1.25-alpine AS backend
 RUN apk add --no-cache git
 WORKDIR /app
 COPY go.mod go.sum ./
@@ -18,23 +18,30 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-s -w" -o /iac-studio ./cmd/serv
 
 # ─── Stage 3: Runtime ───
 FROM alpine:3.19
-RUN apk add --no-cache ca-certificates curl git openssh-client
+RUN apk add --no-cache ca-certificates curl git openssh-client unzip
 
 # Install Terraform (for running plan/apply) — with checksum verification
+ARG TARGETARCH=amd64
 ARG TERRAFORM_VERSION=1.9.0
-RUN curl -fsSL "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" -o tf.zip \
-    && curl -fsSL "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_SHA256SUMS" -o tf.sha256 \
-    && grep "linux_amd64.zip" tf.sha256 | sha256sum -c - \
-    && unzip tf.zip -d /usr/local/bin/ \
-    && rm tf.zip tf.sha256
+RUN set -eux; \
+    case "${TARGETARCH}" in amd64|arm64) terraform_arch="${TARGETARCH}" ;; *) echo "unsupported Terraform arch: ${TARGETARCH}" >&2; exit 1 ;; esac; \
+    terraform_zip="terraform_${TERRAFORM_VERSION}_linux_${terraform_arch}.zip"; \
+    curl -fsSL "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/${terraform_zip}" -o "${terraform_zip}"; \
+    curl -fsSL "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_SHA256SUMS" -o terraform.sha256; \
+    grep " ${terraform_zip}$" terraform.sha256 | sha256sum -c -; \
+    unzip "${terraform_zip}" -d /usr/local/bin/; \
+    rm "${terraform_zip}" terraform.sha256
 
 # Install OpenTofu — with checksum verification
 ARG TOFU_VERSION=1.8.0
-RUN curl -fsSL "https://github.com/opentofu/opentofu/releases/download/v${TOFU_VERSION}/tofu_${TOFU_VERSION}_linux_amd64.zip" -o tofu.zip \
-    && curl -fsSL "https://github.com/opentofu/opentofu/releases/download/v${TOFU_VERSION}/tofu_${TOFU_VERSION}_SHA256SUMS" -o tofu.sha256 \
-    && grep "linux_amd64.zip" tofu.sha256 | sha256sum -c - \
-    && unzip tofu.zip -d /usr/local/bin/ \
-    && rm tofu.zip tofu.sha256
+RUN set -eux; \
+    case "${TARGETARCH}" in amd64|arm64) tofu_arch="${TARGETARCH}" ;; *) echo "unsupported OpenTofu arch: ${TARGETARCH}" >&2; exit 1 ;; esac; \
+    tofu_zip="tofu_${TOFU_VERSION}_linux_${tofu_arch}.zip"; \
+    curl -fsSL "https://github.com/opentofu/opentofu/releases/download/v${TOFU_VERSION}/${tofu_zip}" -o "${tofu_zip}"; \
+    curl -fsSL "https://github.com/opentofu/opentofu/releases/download/v${TOFU_VERSION}/tofu_${TOFU_VERSION}_SHA256SUMS" -o tofu.sha256; \
+    grep " ${tofu_zip}$" tofu.sha256 | sha256sum -c -; \
+    unzip "${tofu_zip}" -d /usr/local/bin/; \
+    rm "${tofu_zip}" tofu.sha256
 
 WORKDIR /app
 COPY --from=backend /iac-studio /app/iac-studio

--- a/internal/runner/process_unix.go
+++ b/internal/runner/process_unix.go
@@ -1,0 +1,20 @@
+//go:build !windows
+
+package runner
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func configureCommandCancel(cmd *exec.Cmd) {
+	// Create a new process group so cancellation kills Terraform/OpenTofu and
+	// child provider plugins together instead of orphaning state-lock holders.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+}

--- a/internal/runner/process_windows.go
+++ b/internal/runner/process_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package runner
+
+import "os/exec"
+
+func configureCommandCancel(cmd *exec.Cmd) {
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		return cmd.Process.Kill()
+	}
+}

--- a/internal/runner/safe_runner.go
+++ b/internal/runner/safe_runner.go
@@ -5,58 +5,56 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
-	"runtime"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 )
 
 // SafeRunner wraps Runner with timeouts, cancellation, approval gates, and kill switch.
 type SafeRunner struct {
-	runner    *Runner
-	mu        sync.Mutex
-	active    map[string]*Execution // projectDir -> running execution
-	defaults  SafetyConfig
+	runner   *Runner
+	mu       sync.Mutex
+	active   map[string]*Execution // projectDir -> running execution
+	defaults SafetyConfig
 }
 
 // SafetyConfig defines execution safety parameters.
 type SafetyConfig struct {
-	DefaultTimeout time.Duration `json:"default_timeout"` // max time for any command
-	PlanTimeout    time.Duration `json:"plan_timeout"`
-	ApplyTimeout   time.Duration `json:"apply_timeout"`
-	InitTimeout    time.Duration `json:"init_timeout"`
-	RequireApproval bool         `json:"require_approval"` // require plan review before apply
-	MaxOutputBytes  int          `json:"max_output_bytes"` // prevent OOM from huge plans
+	DefaultTimeout  time.Duration `json:"default_timeout"` // max time for any command
+	PlanTimeout     time.Duration `json:"plan_timeout"`
+	ApplyTimeout    time.Duration `json:"apply_timeout"`
+	InitTimeout     time.Duration `json:"init_timeout"`
+	RequireApproval bool          `json:"require_approval"` // require plan review before apply
+	MaxOutputBytes  int           `json:"max_output_bytes"` // prevent OOM from huge plans
 }
 
 // Execution tracks a running command with cancellation support.
 type Execution struct {
-	ID         string        `json:"id"`
-	Project    string        `json:"project"`
-	Tool       string        `json:"tool"`
-	Command    string        `json:"command"`
-	StartedAt  time.Time     `json:"started_at"`
-	Status     string        `json:"status"` // running | completed | failed | cancelled | timed_out
-	cancel     context.CancelFunc
+	ID        string    `json:"id"`
+	Project   string    `json:"project"`
+	Tool      string    `json:"tool"`
+	Command   string    `json:"command"`
+	StartedAt time.Time `json:"started_at"`
+	Status    string    `json:"status"` // running | completed | failed | cancelled | timed_out
+	cancel    context.CancelFunc
 }
 
 // ExecutionResult is returned when a command completes.
 type ExecutionResult struct {
-	ID         string        `json:"id"`
-	Output     string        `json:"output"`
-	ExitCode   int           `json:"exit_code"`
-	Duration   time.Duration `json:"duration"`
-	Status     string        `json:"status"`
-	Truncated  bool          `json:"truncated"` // true if output was cut
+	ID        string        `json:"id"`
+	Output    string        `json:"output"`
+	ExitCode  int           `json:"exit_code"`
+	Duration  time.Duration `json:"duration"`
+	Status    string        `json:"status"`
+	Truncated bool          `json:"truncated"` // true if output was cut
 }
 
 // PlanGate holds a pending plan that needs approval before apply.
 type PlanGate struct {
-	Project    string `json:"project"`
-	Tool       string `json:"tool"`
-	PlanOutput string `json:"plan_output"`
-	Summary    string `json:"summary"` // "3 to add, 1 to change, 0 to destroy"
+	Project    string     `json:"project"`
+	Tool       string     `json:"tool"`
+	PlanOutput string     `json:"plan_output"`
+	Summary    string     `json:"summary"` // "3 to add, 1 to change, 0 to destroy"
 	ApprovedAt *time.Time `json:"approved_at,omitempty"`
 }
 
@@ -130,23 +128,7 @@ func (sr *SafeRunner) Execute(ctx context.Context, projectDir, tool, command, en
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
 	cmd.Dir = projectDir
 
-	// Create a new process group so we can kill Terraform AND its child
-	// provider plugin processes (terraform-provider-aws, etc.) together.
-	// Without this, context cancellation only kills the parent process,
-	// orphaning provider plugins that hold state locks and leak memory.
-	if runtime.GOOS != "windows" {
-		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	}
-	cmd.Cancel = func() error {
-		if cmd.Process == nil {
-			return nil
-		}
-		if runtime.GOOS == "windows" {
-			return cmd.Process.Kill()
-		}
-		// Kill the entire process group (negative PID)
-		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
-	}
+	configureCommandCancel(cmd)
 
 	var stdout, stderr bytes.Buffer
 	// Limit output to prevent OOM
@@ -244,18 +226,7 @@ func (sr *SafeRunner) ExecutePlanJSON(ctx context.Context, projectDir, tool stri
 
 	cmd := exec.CommandContext(ctx, binary, "plan", "-json", "-no-color")
 	cmd.Dir = projectDir
-	if runtime.GOOS != "windows" {
-		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	}
-	cmd.Cancel = func() error {
-		if cmd.Process == nil {
-			return nil
-		}
-		if runtime.GOOS == "windows" {
-			return cmd.Process.Kill()
-		}
-		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
-	}
+	configureCommandCancel(cmd)
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &limitedWriter{buf: &stdout, limit: sr.defaults.MaxOutputBytes}


### PR DESCRIPTION
## Summary
- update the Docker backend builder to Go 1.25 to match go.mod and CI
- verify Terraform/OpenTofu checksums against the downloaded archive filename
- select Terraform/OpenTofu linux amd64 or arm64 archives via TARGETARCH
- install unzip explicitly in the runtime image
- move Unix process-group cancellation behind build tags so Windows release binaries compile

## Verification
- npm test -- --run
- npm run build
- GOCACHE=/private/tmp/iacstudio-go-cache go test ./cmd/... ./internal/...
- GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/runner
- GOCACHE=/private/tmp/iacstudio-go-cache GOOS=windows GOARCH=amd64 go build -o /private/tmp/iac-studio-windows-amd64.exe ./cmd/server
- GOCACHE=/private/tmp/iacstudio-go-cache GOOS=windows GOARCH=arm64 go build -o /private/tmp/iac-studio-windows-arm64.exe ./cmd/server
- fetched Terraform/OpenTofu checksum manifests and confirmed amd64/arm64 archive names exist

Local Docker daemon is not running, so the GitHub Actions docker job after merge is the image-build validation.