### PR TITLE
[codex] Document release binary install paths

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -16,6 +16,10 @@ This interactive script will:
 5. Download the model and build the app
 6. Start IaC Studio
 
+The setup script builds `bin/iac-studio` from source. It does not download the
+prebuilt release binaries. To download the latest release binary from a script,
+use `scripts/install.sh` instead.
+
 ## Manual Setup
 
 ### Prerequisites
@@ -27,8 +31,8 @@ This interactive script will:
 
 ```bash
 # Clone the repo
-git clone https://github.com/iac-studio/iac-studio.git
-cd iac-studio
+git clone https://github.com/olandodeflexy/IaCStudio.git
+cd IaCStudio
 
 # Install dependencies
 make deps
@@ -41,6 +45,52 @@ make build
 ```
 
 Open **http://localhost:3000** in your browser.
+
+## Release Binaries
+
+Release binaries are the local server that serves the web UI and API. Download
+the asset for your machine, make it executable on macOS or Linux, run it, then
+open **http://localhost:3000**.
+
+| Machine | Asset |
+|---------|-------|
+| Apple Silicon Mac | `iac-studio-darwin-arm64` |
+| Intel Mac | `iac-studio-darwin-amd64` |
+| Linux x86_64 | `iac-studio-linux-amd64` |
+| Linux ARM64 | `iac-studio-linux-arm64` |
+| Windows x64 | `iac-studio-windows-amd64.exe` |
+| Windows ARM64 | `iac-studio-windows-arm64.exe` |
+
+macOS or Linux:
+
+```bash
+chmod +x ./iac-studio-darwin-arm64
+./iac-studio-darwin-arm64
+```
+
+Optional rename:
+
+```bash
+mv iac-studio-darwin-arm64 iac-studio
+chmod +x ./iac-studio
+./iac-studio
+```
+
+If macOS blocks an unsigned binary:
+
+```bash
+xattr -d com.apple.quarantine ./iac-studio
+./iac-studio
+```
+
+`checksums.txt` verifies download integrity. It is not executable.
+
+Scripted release install:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/olandodeflexy/IaCStudio/main/scripts/install.sh | bash
+iac-studio
+```
 
 ### AI Setup (Optional)
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ See [QUICKSTART.md](QUICKSTART.md) for detailed instructions.
 The full user, operator, API, and developer guide is published at
 **https://olandodeflexy.github.io/IaCStudio/**.
 
+The release assets are local server binaries. Download the asset for your OS
+and CPU, run it, then open **http://localhost:3000**. `scripts/install.sh`
+downloads and installs the latest release binary. `scripts/setup.sh` is a
+source-build path: it checks dependencies, builds `bin/iac-studio`, and can
+start the local server for you.
+
 ## Features
 
 | Feature | Description |
@@ -136,8 +142,8 @@ IaC Studio runs locally and is designed to be secure by default:
 ## Development
 
 ```bash
-git clone https://github.com/iac-studio/iac-studio.git
-cd iac-studio
+git clone https://github.com/olandodeflexy/IaCStudio.git
+cd IaCStudio
 
 ./scripts/setup.sh    # Interactive setup (recommended)
 # or:

--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -397,6 +397,12 @@ p {
   color: #23352f;
 }
 
+.callout.secondary {
+  border-left-color: var(--accent-3);
+  background: #eef2f8;
+  color: #24304a;
+}
+
 .steps {
   display: grid;
   gap: 12px;
@@ -418,6 +424,14 @@ p {
   margin-top: 18px;
   border: 1px solid var(--border);
   border-radius: 8px;
+}
+
+.table-wrap.compact-table table {
+  min-width: 820px;
+}
+
+.table-wrap.compact-table td {
+  font-size: 0.92rem;
 }
 
 table {

--- a/docs/index.html
+++ b/docs/index.html
@@ -109,9 +109,26 @@
           <h2>Quick Start</h2>
           <p>
             The fastest path is the interactive setup script. It checks dependencies,
-            asks how you want AI configured, builds the app, and starts the server.
+            asks how you want AI configured, builds the app from source, and starts
+            the local server.
           </p>
           <pre><code>./scripts/setup.sh</code></pre>
+
+          <div class="callout">
+            <strong>What the setup script does:</strong>
+            <code>./scripts/setup.sh</code> does not download the release binaries.
+            It checks your platform, installs missing dependencies when you approve,
+            configures optional AI, builds <code>bin/iac-studio</code> locally, and
+            can start that freshly built local server for you.
+          </div>
+
+          <div class="callout secondary">
+            <strong>What the install script does:</strong>
+            <code>scripts/install.sh</code> downloads the latest matching release
+            binary from GitHub, verifies it with <code>checksums.txt</code> when
+            available, installs it as <code>iac-studio</code>, and leaves source
+            builds out of the path.
+          </div>
 
           <h3>Manual local install</h3>
           <p>Use this path when you want predictable commands for a development machine.</p>
@@ -122,20 +139,90 @@ make build
 ./bin/iac-studio</code></pre>
           <p>Open <a href="http://localhost:3000">http://localhost:3000</a>.</p>
 
+          <h3>Download a release binary</h3>
+          <p>
+            Release assets are local server binaries. They are useful when you want to
+            run IaC Studio without Docker and without building from source. Download the
+            file that matches your operating system and CPU, make it executable on macOS
+            or Linux, run it, then open <code>http://localhost:3000</code>.
+          </p>
+
+          <div class="table-wrap compact-table">
+            <table>
+              <thead>
+                <tr>
+                  <th>Machine</th>
+                  <th>Release asset</th>
+                  <th>How to run</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Apple Silicon Mac</td>
+                  <td><code>iac-studio-darwin-arm64</code></td>
+                  <td><code>chmod +x ./iac-studio-darwin-arm64 && ./iac-studio-darwin-arm64</code></td>
+                </tr>
+                <tr>
+                  <td>Intel Mac</td>
+                  <td><code>iac-studio-darwin-amd64</code></td>
+                  <td><code>chmod +x ./iac-studio-darwin-amd64 && ./iac-studio-darwin-amd64</code></td>
+                </tr>
+                <tr>
+                  <td>Linux x86_64</td>
+                  <td><code>iac-studio-linux-amd64</code></td>
+                  <td><code>chmod +x ./iac-studio-linux-amd64 && ./iac-studio-linux-amd64</code></td>
+                </tr>
+                <tr>
+                  <td>Linux ARM64</td>
+                  <td><code>iac-studio-linux-arm64</code></td>
+                  <td><code>chmod +x ./iac-studio-linux-arm64 && ./iac-studio-linux-arm64</code></td>
+                </tr>
+                <tr>
+                  <td>Windows x64</td>
+                  <td><code>iac-studio-windows-amd64.exe</code></td>
+                  <td><code>.\iac-studio-windows-amd64.exe</code></td>
+                </tr>
+                <tr>
+                  <td>Windows ARM64</td>
+                  <td><code>iac-studio-windows-arm64.exe</code></td>
+                  <td><code>.\iac-studio-windows-arm64.exe</code></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <pre><code># Optional: rename the downloaded macOS or Linux asset first
+mv iac-studio-darwin-arm64 iac-studio
+chmod +x ./iac-studio
+./iac-studio --projects-dir "$HOME/iac-projects"</code></pre>
+
+          <p>
+            On macOS, unsigned release binaries may be quarantined by Gatekeeper after
+            download. If the binary is blocked, remove the quarantine attribute and run it again.
+          </p>
+          <pre><code>xattr -d com.apple.quarantine ./iac-studio
+./iac-studio</code></pre>
+
+          <p>
+            <code>checksums.txt</code> is for verifying download integrity. It is not an
+            executable and does not start the app.
+          </p>
+
+          <h3>Install the latest release with a script</h3>
+          <p>
+            Use this when you want the release binary path but do not want to manually
+            pick the asset. The installer detects your OS and CPU, downloads the matching
+            asset, verifies the checksum, and installs <code>iac-studio</code>.
+          </p>
+          <pre><code>curl -fsSL https://raw.githubusercontent.com/olandodeflexy/IaCStudio/main/scripts/install.sh | bash
+iac-studio</code></pre>
+
           <h3>Run with Docker</h3>
           <p>The container includes the server, built web UI, Terraform, and OpenTofu.</p>
           <pre><code>docker run --rm -it \
   -p 3000:3000 \
   -v "$HOME/iac-projects:/projects" \
   ghcr.io/olandodeflexy/iacstudio:latest</code></pre>
-
-          <h3>Download a release binary</h3>
-          <p>
-            Release assets are published for Linux, macOS, and Windows on amd64 and arm64.
-            Download the right archive from GitHub Releases, unpack it, and run the binary.
-          </p>
-          <pre><code># Example after unpacking a release archive
-./iac-studio --projects-dir "$HOME/iac-projects"</code></pre>
 
           <div class="callout">
             <strong>Default server behavior:</strong>

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,9 +2,9 @@
 set -euo pipefail
 
 # IaC Studio Installer
-# Usage: curl -fsSL https://raw.githubusercontent.com/iac-studio/iac-studio/main/scripts/install.sh | bash
+# Usage: curl -fsSL https://raw.githubusercontent.com/olandodeflexy/IaCStudio/main/scripts/install.sh | bash
 
-REPO="iac-studio/iac-studio"
+REPO="olandodeflexy/IaCStudio"
 INSTALL_DIR="${IAC_STUDIO_INSTALL_DIR:-/usr/local/bin}"
 BINARY="iac-studio"
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 # configures the AI model based on your system, and gets you running.
 #
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/iac-studio/iac-studio/main/scripts/setup.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/olandodeflexy/IaCStudio/main/scripts/setup.sh | bash
 #   or:  ./scripts/setup.sh
 
 # ─── Colors & Helpers ───
@@ -19,6 +19,7 @@ CYAN='\033[0;36m'
 BOLD='\033[1m'
 DIM='\033[2m'
 NC='\033[0m'
+MIN_GO_VERSION="1.25.0"
 
 info()    { echo -e "${BLUE}  ℹ${NC}  $1"; }
 ok()      { echo -e "${GREEN}  ✓${NC}  $1"; }
@@ -115,6 +116,47 @@ check_command() {
     fi
 }
 
+version_at_least() {
+    local current="$1"
+    local required="$2"
+    local c_major c_minor c_patch r_major r_minor r_patch
+
+    IFS=. read -r c_major c_minor c_patch <<< "$current"
+    IFS=. read -r r_major r_minor r_patch <<< "$required"
+
+    c_major=${c_major:-0}
+    c_minor=${c_minor:-0}
+    c_patch=${c_patch:-0}
+    r_major=${r_major:-0}
+    r_minor=${r_minor:-0}
+    r_patch=${r_patch:-0}
+
+    if [ "$c_major" -gt "$r_major" ]; then return 0; fi
+    if [ "$c_major" -lt "$r_major" ]; then return 1; fi
+    if [ "$c_minor" -gt "$r_minor" ]; then return 0; fi
+    if [ "$c_minor" -lt "$r_minor" ]; then return 1; fi
+    [ "$c_patch" -ge "$r_patch" ]
+}
+
+check_go() {
+    if ! command -v go &>/dev/null; then
+        return 1
+    fi
+
+    local display raw version
+    display=$(go version 2>&1 | head -1 || echo "go version unknown")
+    raw=$(echo "$display" | awk '{print $3}' | sed 's/^go//')
+    version=$(echo "$raw" | sed 's/[^0-9.].*$//')
+
+    if version_at_least "$version" "$MIN_GO_VERSION"; then
+        ok "go found — ${DIM}${display}${NC}"
+        return 0
+    fi
+
+    warn "go found, but ${display} is older than required Go ${MIN_GO_VERSION}"
+    return 1
+}
+
 install_go() {
     case "$PLATFORM" in
         macos)
@@ -128,7 +170,7 @@ install_go() {
             ;;
         linux)
             info "Installing Go..."
-            local GO_VERSION="1.22.5"
+            local GO_VERSION="${MIN_GO_VERSION}"
             curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${ARCH}.tar.gz" -o /tmp/go.tar.gz
             sudo rm -rf /usr/local/go
             sudo tar -C /usr/local -xzf /tmp/go.tar.gz
@@ -212,9 +254,9 @@ main() {
 
     MISSING_DEPS=()
 
-    if check_command "go" "go version"; then true
+    if check_go; then true
     else
-        warn "Go not found"
+        warn "Go ${MIN_GO_VERSION}+ not found"
         MISSING_DEPS+=("go")
     fi
 


### PR DESCRIPTION
## Summary

Clarifies how the macOS, Linux, and Windows release binaries are used and distinguishes the release installer from the source-build setup script.

## What changed

- Added release binary usage instructions to the GitHub Pages docs and Quickstart.
- Documented which asset to use for Apple Silicon, Intel Mac, Linux x86_64, Linux ARM64, and Windows.
- Clarified that `scripts/setup.sh` builds `bin/iac-studio` from source.
- Clarified that `scripts/install.sh` downloads and installs the latest release binary.
- Fixed `scripts/install.sh` to point at `olandodeflexy/IaCStudio`.
- Updated `scripts/setup.sh` Linux Go install and Go version check to require Go 1.25.0+.

## Validation

- `git diff --check`
- `bash -n scripts/setup.sh`
- `bash -n scripts/install.sh`
- `node --check docs/assets/app.js`
- Served `docs/` locally and verified `/` and `/assets/styles.css` return HTTP 200