### PR TITLE
Split App shell into focused workspace modules

### DIFF
--- a/web/src/App.test.ts
+++ b/web/src/App.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { normalizeLayeredProject, resourcesForEnv } from './App';
+import { normalizeLayeredProject, resourcesForEnv } from './app/layered';
 
 describe('normalizeLayeredProject', () => {
   it('drops empty or invalid environment tool maps', () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,128 +1,29 @@
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
-import { api, ApiError, normalizeSuggestions, Resource, ToolInfo, CatalogResource, Suggestion, FileEntry, ImportResult, type PolicyFinding } from './api';
+import { api, Resource, ToolInfo, CatalogResource, Suggestion } from './api';
 import { useWebSocket, WSMessage } from './useWebSocket';
 import { useHistory } from './useHistory';
 import { useKeyboardShortcuts } from './useKeyboardShortcuts';
-import { AISettingsModal, type AISettingsConfig } from './components/AISettings';
-import { AppHeader } from './components/AppHeader';
-import { ChatPanel } from './components/Chat';
-import { InspectorPanel, type RightPanelTab } from './components/Inspector';
+import type { AISettingsConfig } from './components/AISettings';
+import type { RightPanelTab } from './components/Inspector';
 import { ProjectLauncher, type SavedProject } from './components/ProjectLauncher';
-import { WorkspaceSidebar, type SidebarPanel } from './components/Sidebar';
-import { TerminalPanel } from './components/Terminal';
-import { CanvasPanel, type CanvasMode } from './components/Canvas';
-import { S } from './styles';
-import type { LayeredProject, LayeredModule } from './types';
-import { envForResourceLoad, envForTool, shouldParseResourcesFromDisk, toolForEnv } from './projectLoad';
+import type { SidebarPanel } from './components/Sidebar';
+import type { CanvasMode } from './components/Canvas';
+import { WorkspaceShell } from './components/Workspace';
+import type { LayeredProject } from './types';
+import { envForTool, toolForEnv } from './projectLoad';
 import { errorMessage } from './lib/errors';
 import {
   TOOLS,
   ALL_TOOLS,
   FALLBACK_RESOURCES,
-  uid,
-  edgeId,
   generateLocalCode,
   type Edge,
 } from './legacy';
-
-const summarizePolicyFindings = (findings: PolicyFinding[]) => {
-  if (findings.length === 0) return 'No finding details were returned.';
-  const shown = findings.slice(0, 5).map((f, i) => {
-    const target = f.resource ? ` on ${f.resource}` : '';
-    return `${i + 1}. [${f.engine}] ${f.policy_id}${target}: ${f.message}`;
-  });
-  if (findings.length > shown.length) {
-    shown.push(`...and ${findings.length - shown.length} more.`);
-  }
-  return shown.join('\n');
-};
-
-const isPolicyBlockedError = (err: unknown): err is ApiError => (
-  err instanceof ApiError && err.status === 409 && err.payload?.error === 'policy_blocked'
-);
-
-const extractLayoutMeta = (state: any) => {
-  if (!state?.layout) return null;
-  const meta: Record<string, any> = {};
-  for (const key of ['layout', 'blueprint', 'project_name', 'cloud', 'environments', 'environment_tools', 'modules', 'tags']) {
-    if (state[key] !== undefined) meta[key] = state[key];
-  }
-  return meta;
-};
-
-export const normalizeLayeredProject = (state: any): LayeredProject | null => {
-  if (state?.layout !== 'layered-v1') return null;
-  const environments = Array.isArray(state.environments)
-    ? state.environments.filter((env: unknown): env is string => typeof env === 'string' && env.length > 0)
-    : [];
-  if (environments.length === 0) return null;
-  const rawEnvironmentTools = state.environment_tools;
-  let environmentTools: Record<string, string> | undefined;
-  if (
-    rawEnvironmentTools &&
-    typeof rawEnvironmentTools === 'object' &&
-    !Array.isArray(rawEnvironmentTools) &&
-    [Object.prototype, null].includes(Object.getPrototypeOf(rawEnvironmentTools))
-  ) {
-    const normalizedEnvironmentTools = Object.create(null) as Record<string, string>;
-    for (const [env, envTool] of Object.entries(rawEnvironmentTools)) {
-      if (environments.includes(env) && typeof envTool === 'string' && envTool.length > 0) {
-        normalizedEnvironmentTools[env] = envTool;
-      }
-    }
-    if (Object.keys(normalizedEnvironmentTools).length > 0) {
-      environmentTools = normalizedEnvironmentTools;
-    }
-  }
-
-  const rawModules = Array.isArray(state.modules) ? state.modules : [];
-  const modules: LayeredModule[] = rawModules
-    .map((mod: unknown) => {
-      if (typeof mod === 'string') {
-        return { name: mod, path: `modules/${mod}`, environments };
-      }
-      if (mod && typeof mod === 'object') {
-        const candidate = mod as Partial<LayeredModule>;
-        if (!candidate.name) return null;
-        return {
-          name: candidate.name,
-          path: candidate.path || `modules/${candidate.name}`,
-          source: candidate.source,
-          environments: Array.isArray(candidate.environments) && candidate.environments.length > 0
-            ? candidate.environments
-            : environments,
-        };
-      }
-      return null;
-    })
-    .filter((mod): mod is LayeredModule => Boolean(mod?.name));
-
-  if (!modules.some((mod) => mod.name === 'root')) {
-    modules.unshift({ name: 'root', path: 'environments', environments });
-  }
-
-  return { layout: 'layered-v1', environments, environmentTools, modules };
-};
-
-export const resourceEnv = (resource: { file?: string }) => {
-  if (!resource.file) return null;
-  const parts = resource.file.replace(/\\/g, '/').split('/');
-  const envIdx = parts.indexOf('environments');
-  return envIdx >= 0 && parts.length > envIdx + 1 ? parts[envIdx + 1] : null;
-};
-
-export const resourcesForEnv = <T extends { id: string; file?: string }>(resources: T[], env?: string) => {
-  if (!env) return resources;
-  return resources.filter(resource => {
-    const envFromFile = resourceEnv(resource);
-    return envFromFile === env;
-  });
-};
-
-const edgesForResources = (allEdges: Edge[], resources: { id: string }[]) => {
-  const ids = new Set(resources.map(resource => resource.id));
-  return allEdges.filter(edge => ids.has(edge.from) && ids.has(edge.to));
-};
+import { edgesForResources, resourcesForEnv } from './app/layered';
+import { useImportWorkflow } from './app/useImportWorkflow';
+import { useProjectLifecycle } from './app/useProjectLifecycle';
+import { useWorkspaceActions } from './app/useWorkspaceActions';
+import type { AppResource, ChatMessage, ResizeState } from './app/types';
 
 export default function App() {
   // Restore active project from localStorage on mount
@@ -138,26 +39,15 @@ export default function App() {
   const [projectName, setProjectName] = useState(saved.current?.projectName || 'my-infra-project');
   const [catalogResources, setCatalogResources] = useState<CatalogResource[]>([]);
   const [projectId, setProjectId] = useState(saved.current?.projectId || '');
-  const [showImportWizard, setShowImportWizard] = useState(false);
-  const [importTab, setImportTab] = useState<'browse' | 'topology'>('browse');
-  const [browsePath, setBrowsePath] = useState('');
-  const [browseEntries, setBrowseEntries] = useState<FileEntry[]>([]);
-  const [browseParent, setBrowseParent] = useState('');
-  const [importPreview, setImportPreview] = useState<ImportResult | null>(null);
-  const [importLoading, setImportLoading] = useState(false);
-  const [topologyDesc, setTopologyDesc] = useState('');
-  const [topologyProvider, setTopologyProvider] = useState('aws');
-  const [visionImages, setVisionImages] = useState<File[]>([]);
-  const [visionError, setVisionError] = useState<string | null>(null);
   const [showSettings, setShowSettings] = useState(false);
   const [aiSettings, setAiSettings] = useState<AISettingsConfig>({ type: 'ollama', endpoint: '', model: '', api_key: '' });
   const [savedProjects, setSavedProjects] = useState<SavedProject[]>([]);
-  const { state: nodes, set: setNodes, undo: undoNodes, redo: redoNodes, canUndo, canRedo, reset: resetNodes } = useHistory<(Resource & { x: number; y: number; icon: string; label: string })[]>([]);
+  const { state: nodes, set: setNodes, undo: undoNodes, redo: redoNodes, canUndo, canRedo, reset: resetNodes } = useHistory<AppResource[]>([]);
   const [edges, setEdges] = useState<Edge[]>([]);
   const [selectedNode, setSelectedNode] = useState<string | null>(null);
   const [selectedEdge, setSelectedEdge] = useState<string | null>(null);
   const [connecting, setConnecting] = useState<{ fromId: string; x: number; y: number } | null>(null);
-  const [chatMessages, setChatMessages] = useState<{ role: string; text: string }[]>([]);
+  const [chatMessages, setChatMessages] = useState<ChatMessage[]>([]);
   const [chatInput, setChatInput] = useState('');
   const [chatLoading, setChatLoading] = useState(false);
   const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
@@ -183,11 +73,13 @@ export default function App() {
   const [sidebarWidth, setSidebarWidth] = useState(240);
   const [rightWidth, setRightWidth] = useState(300);
   const [bottomHeight, setBottomHeight] = useState(220);
-  const [resizing, setResizing] = useState<{ panel: string; startPos: number; startSize: number } | null>(null);
+  const [resizing, setResizing] = useState<ResizeState | null>(null);
 
   const canvasRef = useRef<HTMLElement>(null);
   const chatEndRef = useRef<HTMLDivElement>(null);
   const isSyncing = useRef(false); // suppress file_changed echo from our own sync
+  const hasCreatedProject = useRef(false);
+  const initialLoadDone = useRef(false);
   const notificationTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const showEnvironmentSelector = Boolean(layeredProject && (tool === 'multi' || layeredProject.environmentTools));
   const activeEnv = envForTool(tool || '', layeredProject, activeEnvironment);
@@ -232,6 +124,26 @@ export default function App() {
     clearNotificationTimer();
   }, [clearNotificationTimer]);
 
+  const importWorkflow = useImportWorkflow({
+    detectedTools,
+    projectName,
+    catalogResources,
+    resetNodes,
+    setEdges,
+    setTool,
+    setProjectId,
+    setProjectLayoutMeta,
+    setLayeredProject,
+    setActiveEnvironment,
+    setCanvasMode,
+    setChatMessages,
+    hasCreatedProject,
+    initialLoadDone,
+    showNotification,
+    showPersistentNotification,
+    clearNotification,
+  });
+
   const activeEnvNodes = useMemo(
     () => resourcesForEnv(nodes, (tool === 'multi' || tool === 'pulumi') ? activeEnv : undefined),
     [nodes, activeEnv, tool],
@@ -241,141 +153,75 @@ export default function App() {
     [activeEnvNodes, edges],
   );
 
-  const buildPersistedState = useCallback(() => ({
-    ...(projectLayoutMeta || {}),
+  const actions = useWorkspaceActions({
     tool,
-    resources: nodes.map(n => ({
-      id: n.id, type: n.type, name: n.name, label: n.label, icon: n.icon,
-      properties: n.properties, file: n.file, line: n.line, x: n.x, y: n.y,
-      connections: edges.filter(e => e.from === n.id).map(e => ({
-        target_id: e.to, field: e.field, label: e.label,
-      })),
-    })),
-  }), [projectLayoutMeta, tool, nodes, edges]);
+    concreteTool,
+    projectId,
+    activeEnv,
+    activeResourceFile,
+    unresolvedHybridEnv,
+    nodes,
+    edges,
+    catalogResources,
+    chatMessages,
+    chatInput,
+    chatLoading,
+    connecting,
+    dragging,
+    lastCmdError,
+    canvasRef,
+    setNodes,
+    setEdges,
+    setSelectedNode,
+    setSelectedEdge,
+    setConnecting,
+    setDragging,
+    setChatMessages,
+    setChatInput,
+    setChatLoading,
+    setSuggestions,
+    setTerminalOutput,
+    setLastCmdError,
+    setFixLoading,
+    showNotification,
+  });
+  const { detectProvider, saveCodeToDisk: saveCodeWithContext } = actions;
 
-  const applyProjectState = useCallback((state: any) => {
-    const meta = extractLayoutMeta(state);
-    const layered = normalizeLayeredProject(meta);
-    setProjectLayoutMeta(meta);
-    setLayeredProject(layered);
-    setActiveEnvironment(current => {
-      if (!layered) return null;
-      if (current && layered.environments.includes(current)) return current;
-      return layered.environments[0];
-    });
-    setCanvasMode(layered ? 'swimlane' : 'freeform');
+  const saveCodeToDisk = useCallback((value: string) => {
+    saveCodeWithContext(value, { setCodeSaving, isSyncing, showNotification });
+  }, [saveCodeWithContext, showNotification]);
 
-    if (state?.resources?.length > 0) {
-      resetNodes(state.resources.map((n: any) => ({
-        id: n.id || `res_${Math.random().toString(36).slice(2)}`,
-        type: n.type, name: n.name,
-        label: n.label || n.type, icon: n.icon || '📦',
-        properties: n.properties || {},
-        file: n.file,
-        line: n.line,
-        x: n.x ?? 80 + Math.random() * 300,
-        y: n.y ?? 80 + Math.random() * 200,
-      })));
-      const restoredEdges: Edge[] = [];
-      for (const n of state.resources) {
-        if (n.connections) {
-          for (const c of n.connections) {
-            restoredEdges.push({
-              id: `${n.id}->${c.target_id}:${c.field}`,
-              from: n.id, to: c.target_id,
-              fromType: n.type,
-              toType: state.resources.find((r: any) => r.id === c.target_id)?.type || '',
-              field: c.field, label: c.label || c.field,
-            });
-          }
-        }
-      }
-      setEdges(restoredEdges);
-    } else {
-      resetNodes([]);
-      setEdges([]);
-    }
-  }, [resetNodes]);
+  const {
+    setImportLoading,
+    setImportPreview,
+    topologyProvider,
+  } = importWorkflow;
 
-  const applyParsedResources = useCallback((resources: Resource[]) => {
-    resetNodes(resources.map((r, i) => {
-      return {
-        ...r,
-        id: r.id || `${r.type}.${r.name || i}`,
-        label: r.label || r.type,
-        icon: r.icon || '📦',
-        properties: r.properties || {},
-        x: r.x ?? 80 + (i % 5) * 200,
-        y: r.y ?? 80 + Math.floor(i / 5) * 130,
-      };
-    }));
-    setEdges([]);
-  }, [resetNodes]);
-
-  // Detect tools and load saved projects on mount
-  useEffect(() => {
-    api.detectTools().then(setDetectedTools).catch(() => {});
-    api.listProjectStates().then(setSavedProjects).catch(() => {});
-    // Restore active project if we had one before reload
-    if (saved.current?.projectId && saved.current?.tool) {
-      hasCreatedProject.current = true;
-      initialLoadDone.current = false;
-      api.loadState(saved.current.projectId).then(state => {
-        applyProjectState(state);
-        const selectedTool = state?.tool || saved.current.tool;
-        const selectedLayered = normalizeLayeredProject(extractLayoutMeta(state));
-        setTool(selectedTool);
-        if (shouldParseResourcesFromDisk(state)) {
-          api.getResources(saved.current.projectId, selectedTool, envForResourceLoad(selectedTool, selectedLayered)).then(applyParsedResources).catch(() => {});
-        }
-      }).catch(() => {});
-    }
-  }, [applyParsedResources, applyProjectState]);
-
-  // Persist active session to localStorage so page reload restores it
-  useEffect(() => {
-    if (tool && projectId) {
-      localStorage.setItem('iac-studio-session', JSON.stringify({ tool, projectId, projectName }));
-    } else {
-      localStorage.removeItem('iac-studio-session');
-    }
-  }, [tool, projectId, projectName]);
-
-  // Auto-save project state whenever canvas changes (debounced)
-  const saveTimer = useRef<ReturnType<typeof setTimeout>>();
-  useEffect(() => {
-    if (!tool || !projectId || !hasCreatedProject.current) return;
-    clearTimeout(saveTimer.current);
-    saveTimer.current = setTimeout(() => {
-      api.saveState(projectId, buildPersistedState()).catch(() => {});
-    }, 2000);
-  }, [buildPersistedState, tool, projectId]);
-
-  // Open a saved project
-  const openProject = useCallback(async (proj: SavedProject) => {
-    setProjectName(proj.name);
-    setProjectId(proj.name);
-    setTool(proj.tool || 'terraform');
-    hasCreatedProject.current = true;
-    try {
-      const state = await api.loadState(proj.name);
-      applyProjectState(state);
-      const selectedTool = state?.tool || proj.tool || 'terraform';
-      const selectedLayered = normalizeLayeredProject(extractLayoutMeta(state));
-      setTool(selectedTool);
-      if (shouldParseResourcesFromDisk(state)) {
-        const parsed = await api.getResources(proj.name, selectedTool, envForResourceLoad(selectedTool, selectedLayered));
-        applyParsedResources(parsed);
-      }
-      showNotification(`Opened project: ${proj.name}`);
-    } catch {
-      // No saved state — start fresh
-      setProjectLayoutMeta(null);
-      setLayeredProject(null);
-      setActiveEnvironment(null);
-      setCanvasMode('freeform');
-    }
-  }, [applyParsedResources, applyProjectState, showNotification]);
+  const projectLifecycle = useProjectLifecycle({
+    savedProject: saved.current,
+    tool,
+    projectId,
+    projectName,
+    projectLayoutMeta,
+    nodes,
+    edges,
+    hasCreatedProject,
+    initialLoadDone,
+    resetNodes,
+    setDetectedTools,
+    setSavedProjects,
+    setProjectName,
+    setProjectId,
+    setTool,
+    setEdges,
+    setChatMessages,
+    setTerminalOutput,
+    setProjectLayoutMeta,
+    setLayeredProject,
+    setActiveEnvironment,
+    setCanvasMode,
+    showNotification,
+  });
 
   useEffect(() => {
     if (tool === 'ansible' && rightTab === 'modules') {
@@ -425,7 +271,7 @@ export default function App() {
       // re-open the project or use the import feature.
       showNotification(`File updated: ${msg.file?.split('/').pop()}`);
     }
-  }, [clearNotification, showNotification, showPersistentNotification, topologyProvider]);
+  }, [clearNotification, setImportLoading, setImportPreview, showNotification, showPersistentNotification, topologyProvider]);
 
   const { connected } = useWebSocket(handleWSMessage);
 
@@ -471,7 +317,7 @@ export default function App() {
         setEdges(prev => prev.filter(e => e.id !== selectedEdge));
         setSelectedEdge(null);
       } else if (selectedNode) {
-        removeNode(selectedNode);
+        actions.removeNode(selectedNode);
       }
     },
     'backspace': () => {
@@ -479,7 +325,7 @@ export default function App() {
         setEdges(prev => prev.filter(e => e.id !== selectedEdge));
         setSelectedEdge(null);
       } else if (selectedNode) {
-        removeNode(selectedNode);
+        actions.removeNode(selectedNode);
       }
     },
     'escape': () => {
@@ -513,8 +359,6 @@ export default function App() {
   // deleting the last resource clears the generated file on disk.
   const syncTimer = useRef<ReturnType<typeof setTimeout>>();
   const pendingSync = useRef<{ projectId: string; tool: string; nodes: Resource[]; edges: Edge[]; env?: string } | null>(null);
-  const hasCreatedProject = useRef(false);
-  const initialLoadDone = useRef(false);
   const syncScope = `${projectId}:${tool || ''}:${activeEnv || ''}`;
   const lastSyncScope = useRef('');
   const flushPendingSync = useCallback(() => {
@@ -557,334 +401,13 @@ export default function App() {
     }, 2000);
   }, [activeEnvEdges, activeEnvNodes, flushPendingSync, projectId, activeEnv, syncScope, tool, unresolvedHybridEnv]);
 
-  // ─── Handlers ───
-
-  const addNode = useCallback((resourceDef: any) => {
-    if (unresolvedHybridEnv) {
-      showNotification(`Environment "${activeEnv}" has no configured IaC tool`, 4000);
-      return;
-    }
-    const node = {
-      id: uid(),
-      type: resourceDef.type,
-      name: resourceDef.type.replace(/^(aws_|google_|azurerm_)/, '').replace(/^compute_|^container_/, ''),
-      label: resourceDef.label,
-      icon: resourceDef.icon,
-      properties: { ...(resourceDef.defaults || {}) },
-      file: activeResourceFile,
-      x: 100 + Math.random() * 280,
-      y: 80 + Math.random() * 180,
-    };
-    setNodes(prev => {
-      // Auto-connect: check if this resource type has ConnectsVia rules
-      const catEntry = catalogResources.find(c => c.type === resourceDef.type);
-      if (catEntry?.connects_via) {
-        const newEdges: Edge[] = [];
-        for (const [field, targetType] of Object.entries(catEntry.connects_via)) {
-          // Find existing nodes of the target type
-          const target = prev.find(n => n.type === targetType);
-          if (target) {
-            newEdges.push({
-              id: edgeId(node.id, target.id, field),
-              from: node.id,
-              to: target.id,
-              fromType: node.type,
-              toType: target.type,
-              field,
-              label: field.replace(/_/g, ' '),
-            });
-          }
-        }
-        if (newEdges.length > 0) {
-          setEdges(prevEdges => [...prevEdges, ...newEdges]);
-        }
-      }
-      return [...prev, node];
-    });
-    setSelectedNode(node.id);
-  }, [activeEnv, activeResourceFile, catalogResources, showNotification, unresolvedHybridEnv]);
-
-  const removeNode = useCallback((id: string) => {
-    setNodes(prev => prev.filter(n => n.id !== id));
-    setEdges(prev => prev.filter(e => e.from !== id && e.to !== id));
-    setSelectedNode(prev => prev === id ? null : prev);
-    setSelectedEdge(prev => {
-      // Clear selected edge if it involved the removed node
-      const edge = edges.find(e => e.id === prev);
-      return edge && (edge.from === id || edge.to === id) ? null : prev;
-    });
-  }, [edges]);
-
-  const updateProp = useCallback((id: string, key: string, value: any) => {
-    setNodes(prev => prev.map(n => n.id === id ? { ...n, properties: { ...n.properties, [key]: value } } : n));
-  }, []);
-
-  const updateName = useCallback((id: string, name: string) => {
-    setNodes(prev => prev.map(n => n.id === id ? { ...n, name } : n));
-  }, []);
-
-  const onMouseDown = (e: React.MouseEvent, nodeId: string) => {
-    e.stopPropagation();
-    const rect = canvasRef.current!.getBoundingClientRect();
-    const node = nodes.find(n => n.id === nodeId)!;
-    setDragging({ id: nodeId, ox: e.clientX - rect.left - node.x, oy: e.clientY - rect.top - node.y });
-    setSelectedNode(nodeId);
-  };
-
-  const onMouseMove = (e: React.MouseEvent) => {
-    // Update connection drag preview
-    if (connecting) {
-      const rect = canvasRef.current!.getBoundingClientRect();
-      setConnecting(prev => prev ? { ...prev, x: e.clientX - rect.left, y: e.clientY - rect.top } : null);
-    }
-    if (!dragging) return;
-    const rect = canvasRef.current!.getBoundingClientRect();
-    const x = Math.max(0, e.clientX - rect.left - dragging.ox);
-    const y = Math.max(0, e.clientY - rect.top - dragging.oy);
-    setNodes(prev => prev.map(n => n.id === dragging.id ? { ...n, x, y } : n));
-  };
-
-  const onMouseUp = () => setDragging(null);
-
-  const handleSelectNode = useCallback((id: string) => {
-    setSelectedNode(id);
-    setSelectedEdge(null);
-  }, []);
-
-  const handleSelectEdge = useCallback((id: string) => {
-    setSelectedEdge(id);
-    setSelectedNode(null);
-  }, []);
-
-  const handleClearCanvasSelection = useCallback(() => {
-    setSelectedNode(null);
-    setSelectedEdge(null);
-  }, []);
-
-  const handleStartConnection = useCallback((nodeId: string, position: { x: number; y: number }) => {
-    setConnecting({ fromId: nodeId, ...position });
-  }, []);
-
-  const handleCancelConnection = useCallback(() => {
-    setConnecting(null);
-  }, []);
-
-  const handleCompleteConnection = useCallback((targetNodeId: string) => {
-    if (!connecting) return;
-    if (connecting.fromId === targetNodeId) {
-      setConnecting(null);
-      return;
-    }
-    const fromNode = nodes.find(n => n.id === connecting.fromId);
-    const toNode = nodes.find(n => n.id === targetNodeId);
-    if (!fromNode || !toNode) {
-      setConnecting(null);
-      return;
-    }
-
-    const catEntry = catalogResources.find(c => c.type === fromNode.type);
-    let field = 'depends_on';
-    if (catEntry?.connects_via) {
-      const match = Object.entries(catEntry.connects_via).find(([, t]) => t === toNode.type);
-      if (match) field = match[0];
-    }
-    const newEdge: Edge = {
-      id: edgeId(connecting.fromId, targetNodeId, field),
-      from: connecting.fromId,
-      to: targetNodeId,
-      fromType: fromNode.type,
-      toType: toNode.type,
-      field,
-      label: field.replace(/_/g, ' '),
-    };
-    setEdges(prev => {
-      if (prev.some(e => e.from === newEdge.from && e.to === newEdge.to && e.field === newEdge.field)) return prev;
-      return [...prev, newEdge];
-    });
-    setConnecting(null);
-  }, [catalogResources, connecting, nodes]);
-
-  // Detect the dominant cloud provider from canvas nodes
-  const detectProvider = useCallback((): string => {
-    const counts: Record<string, number> = { aws: 0, google: 0, azurerm: 0 };
-    nodes.forEach(n => {
-      if (n.type.startsWith('aws_')) counts.aws++;
-      else if (n.type.startsWith('google_')) counts.google++;
-      else if (n.type.startsWith('azurerm_')) counts.azurerm++;
-    });
-    // Also check chat history for provider hints
-    const chatText = chatMessages.map(m => m.text).join(' ').toLowerCase();
-    if (chatText.includes('azure') || chatText.includes('azurerm')) counts.azurerm += 3;
-    if (chatText.includes('gcp') || chatText.includes('google cloud')) counts.google += 3;
-    if (chatText.includes('aws') || chatText.includes('amazon')) counts.aws += 3;
-
-    const max = Math.max(counts.aws, counts.google, counts.azurerm);
-    if (max === 0) return 'aws';
-    if (counts.google === max) return 'google';
-    if (counts.azurerm === max) return 'azurerm';
-    return 'aws';
-  }, [nodes, chatMessages]);
-
   // Fetch suggestions when canvas changes
   useEffect(() => {
     if (!tool) return;
     const provider = detectProvider();
     const canvas = nodes.map(n => ({ type: n.type, name: n.name }));
     api.suggest(tool, provider, canvas).then(setSuggestions).catch(() => setSuggestions([]));
-  }, [nodes, tool, detectProvider]);
-
-  const chatInFlightRef = useRef(false);
-
-  const handleChat = async () => {
-    if (chatLoading || chatInFlightRef.current) return;
-    if (!chatInput.trim() || !tool) return;
-
-    chatInFlightRef.current = true;
-    setChatLoading(true);
-
-    const input = chatInput;
-    setChatInput('');
-    // Append the user turn and a placeholder AI bubble that will be filled in
-    // by the streaming deltas below. Track the assistant bubble by a stable id
-    // assigned before enqueueing state so later patches do not depend on
-    // updater side-effects or a mutable array index.
-    const aiMessageId = `ai-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-    let pendingAiText = '';
-    const updateAiMessageText = (text: string) => {
-      setChatMessages(prev => {
-        const nextAiIndex = prev.findIndex(message => (message as { id?: string }).id === aiMessageId);
-        if (nextAiIndex < 0) return prev;
-        const next = [...prev];
-        next[nextAiIndex] = { ...next[nextAiIndex], text };
-        return next;
-      });
-    };
-
-    setChatMessages(prev => [
-      ...prev,
-      { role: 'user' as const, text: input },
-      { role: 'ai' as const, text: pendingAiText, id: aiMessageId } as (typeof prev)[number],
-    ]);
-
-    try {
-      const provider = detectProvider();
-      const history = chatMessages.map(m => ({ role: m.role === 'ai' ? 'ai' : 'user', content: m.text }));
-      const canvas = nodes.map(n => ({ type: n.type, name: n.name }));
-
-      const result = await api.chatStream(
-        { message: input, tool, provider, history, canvas },
-        (delta: string) => {
-          // Append raw tokens to the live assistant bubble. The server parses
-          // the final JSON in the "complete" event, so we still get clean
-          // message + resources at the end — this just shows progress.
-          pendingAiText += delta;
-          updateAiMessageText(pendingAiText);
-        },
-      );
-
-      // Replace the streamed raw text with the parsed clean message.
-      pendingAiText = result.message;
-      updateAiMessageText(pendingAiText);
-      if (result.suggestions !== undefined) {
-        setSuggestions(normalizeSuggestions(result.suggestions));
-      }
-      if (result.resources) {
-        result.resources.forEach(r => {
-          const meta = catalogResources.find(def => def.type === r.type);
-          addNode({
-            type: r.type,
-            label: meta?.label ?? r.type,
-            icon: meta?.icon ?? '📦',
-            defaults: r.properties,
-          });
-        });
-      }
-    } catch {
-      pendingAiText = 'AI is unavailable. Make sure your provider is reachable.';
-      updateAiMessageText(pendingAiText);
-    } finally {
-      chatInFlightRef.current = false;
-      setChatLoading(false);
-    }
-  };
-
-  const runCmd = (command: string) => {
-    if (!tool) return;
-    if (unresolvedHybridEnv) {
-      setTerminalOutput(prev => [...prev, `Error: environment "${activeEnv}" has no configured IaC tool`]);
-      return;
-    }
-    // apply/destroy require explicit confirmation
-    const needsApproval = command === 'apply' || command === 'destroy';
-    if (needsApproval && !confirm(`Are you sure you want to run "${command}"? This will modify real infrastructure.`)) {
-      return;
-    }
-    setTerminalOutput(prev => [...prev, `$ ${command}`, '']);
-    api.runCommand(projectId, tool, command, {
-      approved: needsApproval,
-      env: activeEnv,
-    }).catch(err => {
-      if (needsApproval && isPolicyBlockedError(err)) {
-        const findings = err.payload?.findings ?? [];
-        const blockingCount = findings.filter(f => f.severity === 'error').length;
-        const summary = summarizePolicyFindings(findings);
-        const summaryLines = summary.split('\n');
-        setTerminalOutput(prev => [
-          ...prev,
-          `Policy blocked ${command}: ${blockingCount} blocking finding${blockingCount === 1 ? '' : 's'}`,
-          ...summaryLines,
-        ]);
-        if (!confirm(`Policy checks blocked "${command}".\n\n${summary}\n\nRun it anyway and acknowledge these findings?`)) {
-          return;
-        }
-        setTerminalOutput(prev => [...prev, `$ ${command} --acknowledged`, '']);
-        api.runCommand(projectId, tool, command, {
-          approved: true,
-          env: activeEnv,
-          acknowledged: true,
-        }).catch(overrideErr => {
-          setTerminalOutput(prev => [...prev, `Error: ${overrideErr.message}`]);
-        });
-        return;
-      }
-      setTerminalOutput(prev => [...prev, `Error: ${err.message}`]);
-    });
-  };
-
-  const closeImportWizard = () => {
-    setShowImportWizard(false);
-    setImportPreview(null);
-    setVisionImages([]);
-    setVisionError(null);
-  };
-
-  const handleBrowseLoaded = useCallback((path: string, entries: FileEntry[], parent: string) => {
-    setBrowsePath(path);
-    setBrowseEntries(entries);
-    setBrowseParent(parent);
-  }, []);
-
-  const loadBrowsePath = useCallback(async (path?: string) => {
-    try {
-      const result = await api.browse(path);
-      handleBrowseLoaded(result.path, result.entries, result.parent);
-    } catch {
-      // Preserve local-only behavior when the backend browse endpoint is unavailable.
-    }
-  }, [handleBrowseLoaded]);
-
-  const startImportBrowse = useCallback(() => {
-    setImportTab('browse');
-    setVisionImages([]);
-    setVisionError(null);
-    setShowImportWizard(true);
-    loadBrowsePath();
-  }, [loadBrowsePath]);
-
-  const startTopologyBuilder = useCallback(() => {
-    setImportTab('topology');
-    setShowImportWizard(true);
-  }, []);
+  }, [detectProvider, nodes, tool]);
 
   const handleDeleteSavedProject = useCallback(async (name: string) => {
     try {
@@ -896,224 +419,49 @@ export default function App() {
     }
   }, [showNotification]);
 
-  const handleGenerateTopology = async () => {
-    const toolKey = detectedTools.find(t => t.available && t.name !== 'Ansible')?.name === 'OpenTofu' ? 'opentofu' : 'terraform';
-
-    if (visionImages.length > 0) {
-      setImportLoading(true);
-      showPersistentNotification('AI is reading your diagram...');
-      try {
-        const result = await api.generateTopologyFromImages({
-          description: topologyDesc,
-          tool: toolKey,
-          provider: topologyProvider,
-          images: visionImages,
-        });
-        if (result.message) {
-          setChatMessages(prev => [...prev, { role: 'ai', text: `Diagram analysis: ${result.message}` }]);
-        }
-        setImportPreview({
-          tool: toolKey,
-          provider: topologyProvider,
-          files: visionImages.map(file => ({ path: file.name, name: file.name, type: file.type, size: file.size })),
-          resources: result.resources || [],
-          edges: [],
-          summary: result.message || 'Infrastructure generated from diagram',
-        });
-      } catch (e: any) {
-        setImportPreview({
-          tool: 'unknown',
-          provider: topologyProvider,
-          files: [],
-          resources: [],
-          edges: [],
-          summary: e.message || 'Diagram analysis failed',
-          warnings: [e.message || 'Diagram analysis failed'],
-        });
-      } finally {
-        setImportLoading(false);
-        clearNotification();
-      }
-      return;
-    }
-
-    if (!topologyDesc.trim()) return;
-    setImportLoading(true);
-    showPersistentNotification('AI is designing your infrastructure...');
-    try {
-      // Fire and forget — result arrives via WebSocket
-      await api.generateTopology(topologyDesc, toolKey, topologyProvider);
-      // Don't setImportLoading(false) here — WebSocket handler does it
-    } catch (e: any) {
-      const message = e?.message || 'Generation failed';
-      setImportPreview({ tool: 'unknown', provider: 'unknown', files: [], resources: [], edges: [], summary: message, warnings: [message] });
-      setImportLoading(false);
-      clearNotification();
-    }
-  };
-
-  const handleImportToCanvas = useCallback(async (preview: ImportResult) => {
-    const selectedTool = preview.tool === 'opentofu' ? 'opentofu' : preview.tool === 'ansible' ? 'ansible' : 'terraform';
-    try {
-      await api.createProject(projectName, selectedTool);
-    } catch (err: unknown) {
-      showNotification(`Import failed: ${errorMessage(err, 'Unable to create project')}`, 5000);
-      return;
-    }
-    setTool(selectedTool);
-    setProjectId(projectName);
-    setProjectLayoutMeta(null);
-    setLayeredProject(null);
-    setActiveEnvironment(null);
-    setCanvasMode('freeform');
-    hasCreatedProject.current = true;
-    initialLoadDone.current = true;
-
-    const catalogByType = new Map(catalogResources.map(resource => [resource.type, resource]));
-    const generatedIdPrefix = `imp_${Date.now()}`;
-    const imported = preview.resources.map((resource, index) => {
-      const id = resource.id || `${generatedIdPrefix}_${index}`;
-      const meta = catalogByType.get(resource.type);
-      const { file: _file, line: _line, ...rest } = resource;
-      return {
-        ...rest,
-        id,
-        x: 80 + (index % 5) * 200,
-        y: 80 + Math.floor(index / 5) * 130,
-        icon: meta?.icon ?? '📦',
-        label: meta?.label ?? resource.type,
-      };
-    });
-    resetNodes(imported);
-
-    const nodeTypeById = new Map(imported.map(resource => [resource.id, resource.type]));
-    const newEdges = preview.edges.flatMap(edge => {
-      const from = edge.from_id;
-      const to = edge.to_id;
-      const fromType = nodeTypeById.get(from);
-      const toType = nodeTypeById.get(to);
-      if (!fromType || !toType) return [];
-      return [{
-        id: edgeId(from, to, edge.field),
-        from,
-        to,
-        fromType,
-        toType,
-        field: edge.field,
-        label: edge.field.replace(/_/g, ' '),
-      }];
-    });
-    setEdges(newEdges);
-
-    setShowImportWizard(false);
-    setImportPreview(null);
-    setVisionImages([]);
-    setVisionError(null);
-    showNotification(`Imported ${preview.resources.length} resources`, 4000);
-  }, [catalogResources, projectName, resetNodes, showNotification]);
-
-  const saveCodeToDisk = useCallback(async (value: string) => {
-    if (!tool || !projectId) return;
-    if (unresolvedHybridEnv) {
-      showNotification(`Save failed: environment "${activeEnv}" has no configured IaC tool`, 5000);
-      return;
-    }
-    if (!value.trim()) {
-      showNotification('Nothing to save yet');
-      return;
-    }
-    setCodeSaving(true);
-    isSyncing.current = true;
-    try {
-      const fileName = concreteTool === 'pulumi' ? 'index.ts' : `main${TOOLS[concreteTool]?.ext || '.tf'}`;
-      await api.syncCodeToDisk(projectId, tool, value, fileName, activeEnv);
-      showNotification(`Saved ${fileName}`);
-    } catch (err: any) {
-      showNotification(`Save failed: ${err.message}`, 5000);
-    } finally {
-      setCodeSaving(false);
-      setTimeout(() => { isSyncing.current = false; }, 1500);
-    }
-  }, [activeEnv, concreteTool, projectId, showNotification, tool, unresolvedHybridEnv]);
-
-  const handleBackToProjectSelect = useCallback(async () => {
-    if (projectId && hasCreatedProject.current) {
-      await api.saveState(projectId, buildPersistedState()).catch(() => {});
-    }
-    api.listProjectStates().then(setSavedProjects).catch(() => {});
-    setTool(null);
-    resetNodes([]);
-    setEdges([]);
-    setChatMessages([]);
-    setTerminalOutput([]);
-    setProjectLayoutMeta(null);
-    setLayeredProject(null);
-    setActiveEnvironment(null);
-    setCanvasMode('freeform');
-    initialLoadDone.current = false;
-    hasCreatedProject.current = false;
-  }, [buildPersistedState, projectId, resetNodes]);
-
   const openAISettings = useCallback(() => {
     api.getAISettings().then(setAiSettings).catch(() => {});
     setShowSettings(true);
   }, []);
 
-  const handleCreateProject = async (selectedTool: string) => {
-    setTool(selectedTool);
-    setProjectLayoutMeta(null);
-    setLayeredProject(null);
-    setActiveEnvironment(null);
-    setCanvasMode('freeform');
-    // Lock the project ID at creation time so renaming the display input
-    // can't silently redirect API calls to a different directory.
-    setProjectId(projectName);
-    hasCreatedProject.current = true;
-    initialLoadDone.current = true; // new projects sync immediately
-    try {
-      await api.createProject(projectName, selectedTool);
-    } catch {
-      // Backend might not be running, continue with local-only mode
-    }
-  };
-
   // ─── Tool Selection ───
   if (!tool) {
+    const iw = importWorkflow;
     return (
       <ProjectLauncher
         savedProjects={savedProjects}
         detectedTools={detectedTools}
         projectName={projectName}
-        showImportWizard={showImportWizard}
-        importTab={importTab}
-        browsePath={browsePath}
-        browseParent={browseParent}
-        browseEntries={browseEntries}
-        importPreview={importPreview}
-        importLoading={importLoading}
-        topologyDesc={topologyDesc}
-        topologyProvider={topologyProvider}
-        visionImages={visionImages}
-        visionError={visionError}
+        showImportWizard={iw.showImportWizard}
+        importTab={iw.importTab}
+        browsePath={iw.browsePath}
+        browseParent={iw.browseParent}
+        browseEntries={iw.browseEntries}
+        importPreview={iw.importPreview}
+        importLoading={iw.importLoading}
+        topologyDesc={iw.topologyDesc}
+        topologyProvider={iw.topologyProvider}
+        visionImages={iw.visionImages}
+        visionError={iw.visionError}
         catalogResources={catalogResources}
         onProjectNameChange={setProjectName}
-        onCreateProject={handleCreateProject}
-        onOpenProject={openProject}
+        onCreateProject={projectLifecycle.handleCreateProject}
+        onOpenProject={projectLifecycle.openProject}
         onRevealProject={(name) => api.revealProject(name).catch(() => {})}
         onDeleteProject={handleDeleteSavedProject}
-        onStartImportBrowse={startImportBrowse}
-        onStartTopology={startTopologyBuilder}
-        onImportTabChange={setImportTab}
-        onBrowseLoaded={handleBrowseLoaded}
-        onImportPreviewChange={setImportPreview}
-        onImportLoadingChange={setImportLoading}
-        onTopologyDescChange={setTopologyDesc}
-        onTopologyProviderChange={setTopologyProvider}
-        onVisionImagesChange={setVisionImages}
-        onVisionErrorChange={setVisionError}
-        onGenerateTopology={handleGenerateTopology}
-        onImportToCanvas={handleImportToCanvas}
-        onCloseImportWizard={closeImportWizard}
+        onStartImportBrowse={iw.startImportBrowse}
+        onStartTopology={iw.startTopologyBuilder}
+        onImportTabChange={iw.setImportTab}
+        onBrowseLoaded={iw.handleBrowseLoaded}
+        onImportPreviewChange={iw.setImportPreview}
+        onImportLoadingChange={iw.setImportLoading}
+        onTopologyDescChange={iw.setTopologyDesc}
+        onTopologyProviderChange={iw.setTopologyProvider}
+        onVisionImagesChange={iw.setVisionImages}
+        onVisionErrorChange={iw.setVisionError}
+        onGenerateTopology={iw.handleGenerateTopology}
+        onImportToCanvas={iw.handleImportToCanvas}
+        onCloseImportWizard={iw.closeImportWizard}
       />
     );
   }
@@ -1124,259 +472,97 @@ export default function App() {
     : (tool === 'multi' && activeEnv ? `environments/${activeEnv}/main${TOOLS[concreteTool]?.ext || '.tf'}` : `main${TOOLS[concreteTool]?.ext || ct.ext}`);
   const codeEditorFilePath = concreteTool === 'pulumi' ? 'index.ts' : `main${TOOLS[concreteTool]?.ext || ct.ext}`;
 
-  // ─── Main UI ───
   return (
-    <div style={S.app} className="iac-app">
-      {/* Notification */}
-      {notification && (
-        <div style={S.notification}>{notification}</div>
-      )}
-
-      <AppHeader
-        tool={tool}
-        toolMeta={ct}
-        projectName={projectName}
-        projectId={projectId}
-        resourceCount={nodes.length}
-        wsConnected={wsConnected}
-        canUndo={canUndo}
-        canRedo={canRedo}
-        onBack={handleBackToProjectSelect}
-        onProjectNameChange={setProjectName}
-        onRevealProject={(id) => api.revealProject(id).catch(() => {})}
-        onUndo={undoNodes}
-        onRedo={redoNodes}
-        onRunCommand={runCmd}
-        onOpenSettings={openAISettings}
-      />
-
-      {/* AI Settings Modal */}
-      {showSettings && (
-        <AISettingsModal
-          settings={aiSettings}
-          onSettingsChange={setAiSettings}
-          onNotify={showNotification}
-          onClose={() => setShowSettings(false)}
-        />
-      )}
-
-      <div style={S.main}>
-        {/* Sidebar — resizable */}
-        <WorkspaceSidebar
-          width={sidebarWidth}
-          activePanel={activePanel}
-          tool={tool}
-          toolMeta={ct}
-          projectName={projectName}
-          provider={detectProvider()}
-          resources={catalogResources}
-          suggestions={suggestions}
-          searchQuery={searchQuery}
-          onActivePanelChange={setActivePanel}
-          onSearchQueryChange={setSearchQuery}
-          onAddResource={addNode}
-          onResourceHover={(resource, position) => {
-            setHoverPos(position);
-            setHoveredResource(resource);
-          }}
-          onResourceHoverEnd={() => setHoveredResource(null)}
-        />
-        {/* Sidebar resize handle */}
-        <div style={{ width: 4, cursor: 'col-resize', background: resizing?.panel === 'sidebar' ? ct.color + '44' : 'transparent', flexShrink: 0, transition: 'background 0.15s' }}
-          onMouseDown={e => setResizing({ panel: 'sidebar', startPos: e.clientX, startSize: sidebarWidth })}
-          onMouseEnter={e => { if (!resizing) (e.currentTarget as any).style.background = 'var(--border-main)'; }}
-          onMouseLeave={e => { if (!resizing) (e.currentTarget as any).style.background = 'transparent'; }} />
-
-        <CanvasPanel
-          canvasRef={canvasRef}
-          nodes={nodes}
-          edges={edges}
-          selectedNodeId={selectedNode}
-          selectedEdgeId={selectedEdge}
-          connecting={connecting}
-          layeredProject={layeredProject}
-          showEnvironmentSelector={showEnvironmentSelector}
-          activeEnvironment={activeEnvironment}
-          canvasMode={canvasMode}
-          toolMeta={ct}
-          onMouseMove={onMouseMove}
-          onDragEnd={onMouseUp}
-          onConnectionCancel={handleCancelConnection}
-          onNodeDragStart={onMouseDown}
-          onStartConnection={handleStartConnection}
-          onCompleteConnection={handleCompleteConnection}
-          onSelectNode={handleSelectNode}
-          onSelectEdge={handleSelectEdge}
-          onClearSelection={handleClearCanvasSelection}
-          onDeleteNode={removeNode}
-          onActiveEnvironmentChange={setActiveEnvironment}
-          onCanvasModeChange={setCanvasMode}
-        />
-
-        {/* Right Panel */}
-        {/* Right panel resize handle */}
-        <div style={{ width: 4, cursor: 'col-resize', background: resizing?.panel === 'right' ? ct.color + '44' : 'transparent', flexShrink: 0, transition: 'background 0.15s' }}
-          onMouseDown={e => setResizing({ panel: 'right', startPos: e.clientX, startSize: rightWidth })}
-          onMouseEnter={e => { if (!resizing) (e.currentTarget as any).style.background = 'var(--border-main)'; }}
-          onMouseLeave={e => { if (!resizing) (e.currentTarget as any).style.background = 'transparent'; }} />
-        <InspectorPanel
-          width={rightWidth}
-          activeTab={rightTab}
-          tool={tool}
-          toolMeta={ct}
-          activeEnv={activeEnv}
-          projectId={projectId}
-          nodes={nodes}
-          edges={edges}
-          selectedNodeId={selectedNode}
-          selectedEdgeId={selectedEdge}
-          syncCode={syncCode}
-          codeFileLabel={codeFileLabel}
-          codeEditorFilePath={codeEditorFilePath}
-          codeSaving={codeSaving}
-          unresolvedHybridEnv={unresolvedHybridEnv}
-          onTabChange={setRightTab}
-          onDeleteEdge={(edgeId) => {
-            setEdges(prev => prev.filter(edge => edge.id !== edgeId));
-            setSelectedEdge(null);
-          }}
-          onSelectEdge={setSelectedEdge}
-          onUpdateNodeName={updateName}
-          onUpdateNodeProp={updateProp}
-          onSyncCodeChange={setSyncCode}
-          onSaveCode={saveCodeToDisk}
-        />
-      </div>
-
-      {/* Bottom: Chat + Terminal */}
-      {/* Bottom panel resize handle */}
-      <div style={{ height: 4, cursor: 'row-resize', background: resizing?.panel === 'bottom' ? ct.color + '44' : 'transparent', flexShrink: 0, transition: 'background 0.15s' }}
-        onMouseDown={e => setResizing({ panel: 'bottom', startPos: e.clientY, startSize: bottomHeight })}
-        onMouseEnter={e => { if (!resizing) (e.currentTarget as any).style.background = 'var(--border-main)'; }}
-        onMouseLeave={e => { if (!resizing) (e.currentTarget as any).style.background = 'transparent'; }} />
-      <div style={{ ...S.bottom, height: bottomHeight }}>
-        <ChatPanel
-          messages={chatMessages}
-          input={chatInput}
-          onInputChange={setChatInput}
-          onSubmit={handleChat}
-          loading={chatLoading}
-          toolColor={ct.color}
-          scrollAnchorRef={chatEndRef}
-        />
-        <TerminalPanel
-          lines={terminalOutput}
-          onClear={() => { setTerminalOutput([]); setLastCmdError(null); }}
-          lastError={lastCmdError}
-          fixLoading={fixLoading}
-          toolColor={ct.color}
-          onFix={lastCmdError ? async () => {
-            setFixLoading(true);
-            try {
-              const provider = detectProvider();
-              const result = await api.analyzePlan({
-                tool: tool!,
-                provider,
-                command: lastCmdError.command,
-                output: lastCmdError.output,
-                exit_code: 1,
-                canvas: nodes.map(n => ({ type: n.type, name: n.name })),
-              });
-              setTerminalOutput(prev => [...prev, '', `✦ AI Diagnosis: ${result.message}`]);
-              if (result.fixes?.length > 0) {
-                setTerminalOutput(prev => [...prev, `✦ Suggested fixes:`]);
-                result.fixes.forEach(fix => {
-                  setTerminalOutput(prev => [...prev, `  → ${fix.resource_type}.${fix.resource_name}: ${fix.field} = "${fix.new_value}" (${fix.reason})`]);
-                  setNodes(prev => prev.map(n => {
-                    if (n.type === fix.resource_type && n.name === fix.resource_name) {
-                      return { ...n, properties: { ...n.properties, [fix.field]: fix.new_value } };
-                    }
-                    return n;
-                  }));
-                });
-                setTerminalOutput(prev => [...prev, `✦ Fixes applied to canvas. Run plan again to verify.`]);
-              }
-              if (result.new_resources?.length > 0) {
-                setTerminalOutput(prev => [...prev, `✦ Adding missing resources:`]);
-                result.new_resources.forEach(r => {
-                  setTerminalOutput(prev => [...prev, `  + ${r.type}.${r.name}`]);
-                  const meta = catalogResources.find(c => c.type === r.type);
-                  addNode({
-                    type: r.type,
-                    label: meta?.label ?? r.type,
-                    icon: meta?.icon ?? '📦',
-                    defaults: r.properties,
-                  });
-                });
-              }
-              setChatMessages(prev => [...prev, { role: 'ai', text: `Plan fix: ${result.message}` }]);
-              setLastCmdError(null);
-            } catch {
-              setTerminalOutput(prev => [...prev, '✦ AI fix analysis failed. Check that Ollama is running.']);
-            }
-            setFixLoading(false);
-          } : undefined}
-        />
-      </div>
-
-      {/* Resource hover tooltip */}
-      {hoveredResource && (
-        <div style={{
-          position: 'fixed', left: hoverPos.x, top: hoverPos.y,
-          background: 'var(--bg-elev-2)', border: '1px solid var(--border-main)', borderRadius: 10,
-          padding: '12px 16px', zIndex: 1000, maxWidth: 300, minWidth: 220,
-          boxShadow: '0 8px 24px rgba(0,0,0,0.5)', pointerEvents: 'none',
-          fontFamily: 'DM Sans',
-        }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
-            <span style={{ fontSize: 20 }}>{hoveredResource.icon}</span>
-            <div>
-              <div style={{ fontSize: 13, fontWeight: 600, color: '#e0e0f0' }}>{hoveredResource.label}</div>
-              <div style={{ fontSize: 10, color: '#666', fontFamily: 'JetBrains Mono' }}>{hoveredResource.type}</div>
-            </div>
-          </div>
-          {hoveredResource.provider && (
-            <div style={{ fontSize: 10, color: '#888', marginBottom: 6 }}>
-              Provider: <span style={{ color: ct.color }}>{hoveredResource.provider}</span>
-            </div>
-          )}
-          {hoveredResource.fields && hoveredResource.fields.length > 0 && (
-            <div style={{ marginBottom: 6 }}>
-              <div style={{ fontSize: 9, color: '#555', textTransform: 'uppercase', letterSpacing: 1, marginBottom: 4, fontFamily: 'JetBrains Mono' }}>Fields</div>
-              {hoveredResource.fields.slice(0, 6).map(f => (
-                <div key={f.name} style={{ fontSize: 11, color: '#999', display: 'flex', gap: 4, lineHeight: 1.6, fontFamily: 'JetBrains Mono' }}>
-                  <span style={{ color: f.required ? '#ef4444' : '#555' }}>{f.required ? '*' : ' '}</span>
-                  <span style={{ color: '#aaa' }}>{f.name}</span>
-                  <span style={{ color: '#555', marginLeft: 'auto' }}>{f.type}</span>
-                </div>
-              ))}
-              {hoveredResource.fields.length > 6 && (
-                <div style={{ fontSize: 10, color: '#444', marginTop: 2 }}>+{hoveredResource.fields.length - 6} more</div>
-              )}
-            </div>
-          )}
-          {hoveredResource.connects_via && Object.keys(hoveredResource.connects_via).length > 0 && (
-            <div>
-              <div style={{ fontSize: 9, color: '#555', textTransform: 'uppercase', letterSpacing: 1, marginBottom: 4, fontFamily: 'JetBrains Mono' }}>Connects To</div>
-              {Object.entries(hoveredResource.connects_via).map(([field, target]) => (
-                <div key={field} style={{ fontSize: 11, color: '#777', fontFamily: 'JetBrains Mono', lineHeight: 1.6 }}>
-                  <span style={{ color: ct.color }}>{field}</span> → <span style={{ color: '#aaa' }}>{target}</span>
-                </div>
-              ))}
-            </div>
-          )}
-          {hoveredResource.defaults && Object.keys(hoveredResource.defaults).length > 0 && (
-            <div style={{ marginTop: 6, paddingTop: 6, borderTop: '1px solid var(--border-soft)' }}>
-              <div style={{ fontSize: 9, color: '#555', textTransform: 'uppercase', letterSpacing: 1, marginBottom: 4, fontFamily: 'JetBrains Mono' }}>Defaults</div>
-              {Object.entries(hoveredResource.defaults).slice(0, 4).map(([k, v]) => (
-                <div key={k} style={{ fontSize: 10, color: '#666', fontFamily: 'JetBrains Mono', lineHeight: 1.5 }}>
-                  {k}: <span style={{ color: '#888' }}>{String(v)}</span>
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
-      )}
-    </div>
+    <WorkspaceShell
+      notification={notification}
+      tool={tool}
+      toolMeta={ct}
+      projectName={projectName}
+      projectId={projectId}
+      nodes={nodes}
+      edges={edges}
+      wsConnected={wsConnected}
+      canUndo={canUndo}
+      canRedo={canRedo}
+      showSettings={showSettings}
+      aiSettings={aiSettings}
+      sidebarWidth={sidebarWidth}
+      rightWidth={rightWidth}
+      bottomHeight={bottomHeight}
+      resizing={resizing}
+      activePanel={activePanel}
+      rightTab={rightTab}
+      searchQuery={searchQuery}
+      provider={detectProvider()}
+      catalogResources={catalogResources}
+      suggestions={suggestions}
+      selectedNode={selectedNode}
+      selectedEdge={selectedEdge}
+      connecting={connecting}
+      layeredProject={layeredProject}
+      showEnvironmentSelector={showEnvironmentSelector}
+      activeEnvironment={activeEnvironment}
+      canvasMode={canvasMode}
+      canvasRef={canvasRef}
+      chatMessages={chatMessages}
+      chatInput={chatInput}
+      chatLoading={chatLoading}
+      chatEndRef={chatEndRef}
+      terminalOutput={terminalOutput}
+      lastCmdError={lastCmdError}
+      fixLoading={fixLoading}
+      syncCode={syncCode}
+      codeFileLabel={codeFileLabel}
+      codeEditorFilePath={codeEditorFilePath}
+      codeSaving={codeSaving}
+      activeEnv={activeEnv}
+      unresolvedHybridEnv={unresolvedHybridEnv}
+      hoveredResource={hoveredResource}
+      hoverPos={hoverPos}
+      onBack={projectLifecycle.handleBackToProjectSelect}
+      onProjectNameChange={setProjectName}
+      onRevealProject={(id) => api.revealProject(id).catch(() => {})}
+      onUndo={undoNodes}
+      onRedo={redoNodes}
+      onRunCommand={actions.runCmd}
+      onOpenSettings={openAISettings}
+      onSettingsChange={setAiSettings}
+      onSettingsNotify={showNotification}
+      onCloseSettings={() => setShowSettings(false)}
+      onResizeStart={setResizing}
+      onActivePanelChange={setActivePanel}
+      onSearchQueryChange={setSearchQuery}
+      onAddResource={actions.addNode}
+      onResourceHover={(resource, position) => {
+        setHoverPos(position);
+        setHoveredResource(resource);
+      }}
+      onResourceHoverEnd={() => setHoveredResource(null)}
+      onMouseMove={actions.onMouseMove}
+      onDragEnd={actions.onMouseUp}
+      onConnectionCancel={actions.handleCancelConnection}
+      onNodeDragStart={actions.onMouseDown}
+      onStartConnection={actions.handleStartConnection}
+      onCompleteConnection={actions.handleCompleteConnection}
+      onSelectNode={actions.handleSelectNode}
+      onSelectEdge={actions.handleSelectEdge}
+      onClearSelection={actions.handleClearCanvasSelection}
+      onDeleteNode={actions.removeNode}
+      onActiveEnvironmentChange={setActiveEnvironment}
+      onCanvasModeChange={setCanvasMode}
+      onRightTabChange={setRightTab}
+      onDeleteEdge={(edgeId) => {
+        setEdges(prev => prev.filter(edge => edge.id !== edgeId));
+        setSelectedEdge(null);
+      }}
+      onUpdateNodeName={actions.updateName}
+      onUpdateNodeProp={actions.updateProp}
+      onSyncCodeChange={setSyncCode}
+      onSaveCode={saveCodeToDisk}
+      onChatInputChange={setChatInput}
+      onChatSubmit={actions.handleChat}
+      onClearTerminal={() => { setTerminalOutput([]); setLastCmdError(null); }}
+      onFixLastError={actions.fixLastError}
+    />
   );
 }

--- a/web/src/app/layered.ts
+++ b/web/src/app/layered.ts
@@ -1,0 +1,85 @@
+import type { Edge } from '../legacy';
+import type { LayeredModule, LayeredProject } from '../types';
+
+export const extractLayoutMeta = (state: any) => {
+  if (!state?.layout) return null;
+  const meta: Record<string, any> = {};
+  for (const key of ['layout', 'blueprint', 'project_name', 'cloud', 'environments', 'environment_tools', 'modules', 'tags']) {
+    if (state[key] !== undefined) meta[key] = state[key];
+  }
+  return meta;
+};
+
+export const normalizeLayeredProject = (state: any): LayeredProject | null => {
+  if (state?.layout !== 'layered-v1') return null;
+  const environments = Array.isArray(state.environments)
+    ? state.environments.filter((env: unknown): env is string => typeof env === 'string' && env.length > 0)
+    : [];
+  if (environments.length === 0) return null;
+  const rawEnvironmentTools = state.environment_tools;
+  let environmentTools: Record<string, string> | undefined;
+  if (
+    rawEnvironmentTools &&
+    typeof rawEnvironmentTools === 'object' &&
+    !Array.isArray(rawEnvironmentTools) &&
+    [Object.prototype, null].includes(Object.getPrototypeOf(rawEnvironmentTools))
+  ) {
+    const normalizedEnvironmentTools = Object.create(null) as Record<string, string>;
+    for (const [env, envTool] of Object.entries(rawEnvironmentTools)) {
+      if (environments.includes(env) && typeof envTool === 'string' && envTool.length > 0) {
+        normalizedEnvironmentTools[env] = envTool;
+      }
+    }
+    if (Object.keys(normalizedEnvironmentTools).length > 0) {
+      environmentTools = normalizedEnvironmentTools;
+    }
+  }
+
+  const rawModules = Array.isArray(state.modules) ? state.modules : [];
+  const modules: LayeredModule[] = rawModules
+    .map((mod: unknown) => {
+      if (typeof mod === 'string') {
+        return { name: mod, path: `modules/${mod}`, environments };
+      }
+      if (mod && typeof mod === 'object') {
+        const candidate = mod as Partial<LayeredModule>;
+        if (!candidate.name) return null;
+        return {
+          name: candidate.name,
+          path: candidate.path || `modules/${candidate.name}`,
+          source: candidate.source,
+          environments: Array.isArray(candidate.environments) && candidate.environments.length > 0
+            ? candidate.environments
+            : environments,
+        };
+      }
+      return null;
+    })
+    .filter((mod): mod is LayeredModule => Boolean(mod?.name));
+
+  if (!modules.some((mod) => mod.name === 'root')) {
+    modules.unshift({ name: 'root', path: 'environments', environments });
+  }
+
+  return { layout: 'layered-v1', environments, environmentTools, modules };
+};
+
+export const resourceEnv = (resource: { file?: string }) => {
+  if (!resource.file) return null;
+  const parts = resource.file.replace(/\\/g, '/').split('/');
+  const envIdx = parts.indexOf('environments');
+  return envIdx >= 0 && parts.length > envIdx + 1 ? parts[envIdx + 1] : null;
+};
+
+export const resourcesForEnv = <T extends { id: string; file?: string }>(resources: T[], env?: string) => {
+  if (!env) return resources;
+  return resources.filter(resource => {
+    const envFromFile = resourceEnv(resource);
+    return envFromFile === env;
+  });
+};
+
+export const edgesForResources = (allEdges: Edge[], resources: { id: string }[]) => {
+  const ids = new Set(resources.map(resource => resource.id));
+  return allEdges.filter(edge => ids.has(edge.from) && ids.has(edge.to));
+};

--- a/web/src/app/types.ts
+++ b/web/src/app/types.ts
@@ -1,0 +1,22 @@
+import type { Resource } from '../api';
+
+export type AppResource = Resource & {
+  x: number;
+  y: number;
+  icon: string;
+  label: string;
+};
+
+export type ChatMessage = {
+  role: string;
+  text: string;
+  id?: string;
+};
+
+export type HistorySetter<T> = (_newState: T | ((_prev: T) => T)) => void;
+
+export type ResizeState = {
+  panel: 'sidebar' | 'right' | 'bottom';
+  startPos: number;
+  startSize: number;
+};

--- a/web/src/app/useImportWorkflow.ts
+++ b/web/src/app/useImportWorkflow.ts
@@ -1,0 +1,234 @@
+import { useCallback, useState, type Dispatch, type MutableRefObject, type SetStateAction } from 'react';
+import { api, type CatalogResource, type FileEntry, type ImportResult } from '../api';
+import { errorMessage } from '../lib/errors';
+import { edgeId, type Edge } from '../legacy';
+import type { LayeredProject } from '../types';
+import type { AppResource, ChatMessage } from './types';
+
+export interface UseImportWorkflowInput {
+  detectedTools: { name: string; available: boolean }[];
+  projectName: string;
+  catalogResources: CatalogResource[];
+  resetNodes: (_nodes: AppResource[]) => void;
+  setEdges: Dispatch<SetStateAction<Edge[]>>;
+  setTool: Dispatch<SetStateAction<string | null>>;
+  setProjectId: Dispatch<SetStateAction<string>>;
+  setProjectLayoutMeta: Dispatch<SetStateAction<Record<string, any> | null>>;
+  setLayeredProject: Dispatch<SetStateAction<LayeredProject | null>>;
+  setActiveEnvironment: Dispatch<SetStateAction<string | null>>;
+  setCanvasMode: Dispatch<SetStateAction<'freeform' | 'swimlane'>>;
+  setChatMessages: Dispatch<SetStateAction<ChatMessage[]>>;
+  hasCreatedProject: MutableRefObject<boolean>;
+  initialLoadDone: MutableRefObject<boolean>;
+  showNotification: (_message: string, _duration?: number) => void;
+  showPersistentNotification: (_message: string) => void;
+  clearNotification: () => void;
+}
+
+export function useImportWorkflow({
+  detectedTools,
+  projectName,
+  catalogResources,
+  resetNodes,
+  setEdges,
+  setTool,
+  setProjectId,
+  setProjectLayoutMeta,
+  setLayeredProject,
+  setActiveEnvironment,
+  setCanvasMode,
+  setChatMessages,
+  hasCreatedProject,
+  initialLoadDone,
+  showNotification,
+  showPersistentNotification,
+  clearNotification,
+}: UseImportWorkflowInput) {
+  const [showImportWizard, setShowImportWizard] = useState(false);
+  const [importTab, setImportTab] = useState<'browse' | 'topology'>('browse');
+  const [browsePath, setBrowsePath] = useState('');
+  const [browseEntries, setBrowseEntries] = useState<FileEntry[]>([]);
+  const [browseParent, setBrowseParent] = useState('');
+  const [importPreview, setImportPreview] = useState<ImportResult | null>(null);
+  const [importLoading, setImportLoading] = useState(false);
+  const [topologyDesc, setTopologyDesc] = useState('');
+  const [topologyProvider, setTopologyProvider] = useState('aws');
+  const [visionImages, setVisionImages] = useState<File[]>([]);
+  const [visionError, setVisionError] = useState<string | null>(null);
+
+  const closeImportWizard = useCallback(() => {
+    setShowImportWizard(false);
+    setImportPreview(null);
+    setVisionImages([]);
+    setVisionError(null);
+  }, []);
+
+  const handleBrowseLoaded = useCallback((path: string, entries: FileEntry[], parent: string) => {
+    setBrowsePath(path);
+    setBrowseEntries(entries);
+    setBrowseParent(parent);
+  }, []);
+
+  const loadBrowsePath = useCallback(async (path?: string) => {
+    try {
+      const result = await api.browse(path);
+      handleBrowseLoaded(result.path, result.entries, result.parent);
+    } catch {
+      // Preserve local-only behavior when the backend browse endpoint is unavailable.
+    }
+  }, [handleBrowseLoaded]);
+
+  const startImportBrowse = useCallback(() => {
+    setImportTab('browse');
+    setVisionImages([]);
+    setVisionError(null);
+    setShowImportWizard(true);
+    loadBrowsePath();
+  }, [loadBrowsePath]);
+
+  const startTopologyBuilder = useCallback(() => {
+    setImportTab('topology');
+    setShowImportWizard(true);
+  }, []);
+
+  const handleGenerateTopology = useCallback(async () => {
+    const toolKey = detectedTools.find(tool => tool.available && tool.name !== 'Ansible')?.name === 'OpenTofu' ? 'opentofu' : 'terraform';
+
+    if (visionImages.length > 0) {
+      setImportLoading(true);
+      showPersistentNotification('AI is reading your diagram...');
+      try {
+        const result = await api.generateTopologyFromImages({
+          description: topologyDesc,
+          tool: toolKey,
+          provider: topologyProvider,
+          images: visionImages,
+        });
+        if (result.message) {
+          setChatMessages(prev => [...prev, { role: 'ai', text: `Diagram analysis: ${result.message}` }]);
+        }
+        setImportPreview({
+          tool: toolKey,
+          provider: topologyProvider,
+          files: visionImages.map(file => ({ path: file.name, name: file.name, type: file.type, size: file.size })),
+          resources: result.resources || [],
+          edges: [],
+          summary: result.message || 'Infrastructure generated from diagram',
+        });
+      } catch (err: any) {
+        setImportPreview({
+          tool: 'unknown',
+          provider: topologyProvider,
+          files: [],
+          resources: [],
+          edges: [],
+          summary: err.message || 'Diagram analysis failed',
+          warnings: [err.message || 'Diagram analysis failed'],
+        });
+      } finally {
+        setImportLoading(false);
+        clearNotification();
+      }
+      return;
+    }
+
+    if (!topologyDesc.trim()) return;
+    setImportLoading(true);
+    showPersistentNotification('AI is designing your infrastructure...');
+    try {
+      await api.generateTopology(topologyDesc, toolKey, topologyProvider);
+    } catch (err: any) {
+      const message = err?.message || 'Generation failed';
+      setImportPreview({ tool: 'unknown', provider: 'unknown', files: [], resources: [], edges: [], summary: message, warnings: [message] });
+      setImportLoading(false);
+      clearNotification();
+    }
+  }, [clearNotification, detectedTools, setChatMessages, showPersistentNotification, topologyDesc, topologyProvider, visionImages]);
+
+  const handleImportToCanvas = useCallback(async (preview: ImportResult) => {
+    const selectedTool = preview.tool === 'opentofu' ? 'opentofu' : preview.tool === 'ansible' ? 'ansible' : 'terraform';
+    try {
+      await api.createProject(projectName, selectedTool);
+    } catch (err: unknown) {
+      showNotification(`Import failed: ${errorMessage(err, 'Unable to create project')}`, 5000);
+      return;
+    }
+    setTool(selectedTool);
+    setProjectId(projectName);
+    setProjectLayoutMeta(null);
+    setLayeredProject(null);
+    setActiveEnvironment(null);
+    setCanvasMode('freeform');
+    hasCreatedProject.current = true;
+    initialLoadDone.current = true;
+
+    const catalogByType = new Map(catalogResources.map(resource => [resource.type, resource]));
+    const generatedIdPrefix = `imp_${Date.now()}`;
+    const imported = preview.resources.map((resource, index) => {
+      const id = resource.id || `${generatedIdPrefix}_${index}`;
+      const meta = catalogByType.get(resource.type);
+      const { file: _file, line: _line, ...rest } = resource;
+      return {
+        ...rest,
+        id,
+        x: 80 + (index % 5) * 200,
+        y: 80 + Math.floor(index / 5) * 130,
+        icon: meta?.icon ?? '📦',
+        label: meta?.label ?? resource.type,
+      };
+    });
+    resetNodes(imported);
+
+    const nodeTypeById = new Map(imported.map(resource => [resource.id, resource.type]));
+    const newEdges = preview.edges.flatMap(edge => {
+      const from = edge.from_id;
+      const to = edge.to_id;
+      const fromType = nodeTypeById.get(from);
+      const toType = nodeTypeById.get(to);
+      if (!fromType || !toType) return [];
+      return [{
+        id: edgeId(from, to, edge.field),
+        from,
+        to,
+        fromType,
+        toType,
+        field: edge.field,
+        label: edge.field.replace(/_/g, ' '),
+      }];
+    });
+    setEdges(newEdges);
+
+    setShowImportWizard(false);
+    setImportPreview(null);
+    setVisionImages([]);
+    setVisionError(null);
+    showNotification(`Imported ${preview.resources.length} resources`, 4000);
+  }, [catalogResources, hasCreatedProject, initialLoadDone, projectName, resetNodes, setActiveEnvironment, setCanvasMode, setEdges, setLayeredProject, setProjectId, setProjectLayoutMeta, setTool, showNotification]);
+
+  return {
+    showImportWizard,
+    importTab,
+    browsePath,
+    browseEntries,
+    browseParent,
+    importPreview,
+    importLoading,
+    topologyDesc,
+    topologyProvider,
+    visionImages,
+    visionError,
+    setImportTab,
+    setImportPreview,
+    setImportLoading,
+    setTopologyDesc,
+    setTopologyProvider,
+    setVisionImages,
+    setVisionError,
+    handleBrowseLoaded,
+    startImportBrowse,
+    startTopologyBuilder,
+    handleGenerateTopology,
+    handleImportToCanvas,
+    closeImportWizard,
+  };
+}

--- a/web/src/app/useProjectLifecycle.ts
+++ b/web/src/app/useProjectLifecycle.ts
@@ -1,0 +1,237 @@
+import { useCallback, useEffect, useRef, type Dispatch, type MutableRefObject, type SetStateAction } from 'react';
+import { api, type Resource, type ToolInfo } from '../api';
+import type { SavedProject } from '../components/ProjectLauncher';
+import type { CanvasMode } from '../components/Canvas';
+import { envForResourceLoad, shouldParseResourcesFromDisk } from '../projectLoad';
+import type { Edge } from '../legacy';
+import type { LayeredProject } from '../types';
+import { extractLayoutMeta, normalizeLayeredProject } from './layered';
+import type { AppResource, ChatMessage } from './types';
+
+interface UseProjectLifecycleInput {
+  savedProject: any;
+  tool: string | null;
+  projectId: string;
+  projectName: string;
+  projectLayoutMeta: Record<string, any> | null;
+  nodes: AppResource[];
+  edges: Edge[];
+  hasCreatedProject: MutableRefObject<boolean>;
+  initialLoadDone: MutableRefObject<boolean>;
+  resetNodes: (_nodes: AppResource[]) => void;
+  setDetectedTools: Dispatch<SetStateAction<ToolInfo[]>>;
+  setSavedProjects: Dispatch<SetStateAction<SavedProject[]>>;
+  setProjectName: Dispatch<SetStateAction<string>>;
+  setProjectId: Dispatch<SetStateAction<string>>;
+  setTool: Dispatch<SetStateAction<string | null>>;
+  setEdges: Dispatch<SetStateAction<Edge[]>>;
+  setChatMessages: Dispatch<SetStateAction<ChatMessage[]>>;
+  setTerminalOutput: Dispatch<SetStateAction<string[]>>;
+  setProjectLayoutMeta: Dispatch<SetStateAction<Record<string, any> | null>>;
+  setLayeredProject: Dispatch<SetStateAction<LayeredProject | null>>;
+  setActiveEnvironment: Dispatch<SetStateAction<string | null>>;
+  setCanvasMode: Dispatch<SetStateAction<CanvasMode>>;
+  showNotification: (_message: string, _duration?: number) => void;
+}
+
+export function useProjectLifecycle({
+  savedProject,
+  tool,
+  projectId,
+  projectName,
+  projectLayoutMeta,
+  nodes,
+  edges,
+  hasCreatedProject,
+  initialLoadDone,
+  resetNodes,
+  setDetectedTools,
+  setSavedProjects,
+  setProjectName,
+  setProjectId,
+  setTool,
+  setEdges,
+  setChatMessages,
+  setTerminalOutput,
+  setProjectLayoutMeta,
+  setLayeredProject,
+  setActiveEnvironment,
+  setCanvasMode,
+  showNotification,
+}: UseProjectLifecycleInput) {
+  const buildPersistedState = useCallback(() => ({
+    ...(projectLayoutMeta || {}),
+    tool,
+    resources: nodes.map(node => ({
+      id: node.id,
+      type: node.type,
+      name: node.name,
+      label: node.label,
+      icon: node.icon,
+      properties: node.properties,
+      file: node.file,
+      line: node.line,
+      x: node.x,
+      y: node.y,
+      connections: edges.filter(edge => edge.from === node.id).map(edge => ({
+        target_id: edge.to,
+        field: edge.field,
+        label: edge.label,
+      })),
+    })),
+  }), [edges, nodes, projectLayoutMeta, tool]);
+
+  const applyProjectState = useCallback((state: any) => {
+    const meta = extractLayoutMeta(state);
+    const layered = normalizeLayeredProject(meta);
+    setProjectLayoutMeta(meta);
+    setLayeredProject(layered);
+    setActiveEnvironment(current => {
+      if (!layered) return null;
+      if (current && layered.environments.includes(current)) return current;
+      return layered.environments[0];
+    });
+    setCanvasMode(layered ? 'swimlane' : 'freeform');
+
+    if (state?.resources?.length > 0) {
+      resetNodes(state.resources.map((resource: any) => ({
+        id: resource.id || `res_${Math.random().toString(36).slice(2)}`,
+        type: resource.type,
+        name: resource.name,
+        label: resource.label || resource.type,
+        icon: resource.icon || '📦',
+        properties: resource.properties || {},
+        file: resource.file,
+        line: resource.line,
+        x: resource.x ?? 80 + Math.random() * 300,
+        y: resource.y ?? 80 + Math.random() * 200,
+      })));
+      const restoredEdges: Edge[] = [];
+      for (const resource of state.resources) {
+        for (const connection of resource.connections || []) {
+          restoredEdges.push({
+            id: `${resource.id}->${connection.target_id}:${connection.field}`,
+            from: resource.id,
+            to: connection.target_id,
+            fromType: resource.type,
+            toType: state.resources.find((candidate: any) => candidate.id === connection.target_id)?.type || '',
+            field: connection.field,
+            label: connection.label || connection.field,
+          });
+        }
+      }
+      setEdges(restoredEdges);
+    } else {
+      resetNodes([]);
+      setEdges([]);
+    }
+  }, [resetNodes, setActiveEnvironment, setCanvasMode, setEdges, setLayeredProject, setProjectLayoutMeta]);
+
+  const applyParsedResources = useCallback((resources: Resource[]) => {
+    resetNodes(resources.map((resource, index) => ({
+      ...resource,
+      id: resource.id || `${resource.type}.${resource.name || index}`,
+      label: resource.label || resource.type,
+      icon: resource.icon || '📦',
+      properties: resource.properties || {},
+      x: resource.x ?? 80 + (index % 5) * 200,
+      y: resource.y ?? 80 + Math.floor(index / 5) * 130,
+    })));
+    setEdges([]);
+  }, [resetNodes, setEdges]);
+
+  useEffect(() => {
+    api.detectTools().then(setDetectedTools).catch(() => {});
+    api.listProjectStates().then(setSavedProjects).catch(() => {});
+    if (savedProject?.projectId && savedProject?.tool) {
+      hasCreatedProject.current = true;
+      initialLoadDone.current = false;
+      api.loadState(savedProject.projectId).then(state => {
+        applyProjectState(state);
+        const selectedTool = state?.tool || savedProject.tool;
+        const selectedLayered = normalizeLayeredProject(extractLayoutMeta(state));
+        setTool(selectedTool);
+        if (shouldParseResourcesFromDisk(state)) {
+          api.getResources(savedProject.projectId, selectedTool, envForResourceLoad(selectedTool, selectedLayered)).then(applyParsedResources).catch(() => {});
+        }
+      }).catch(() => {});
+    }
+  }, [applyParsedResources, applyProjectState, hasCreatedProject, initialLoadDone, savedProject, setDetectedTools, setSavedProjects, setTool]);
+
+  useEffect(() => {
+    if (tool && projectId) {
+      localStorage.setItem('iac-studio-session', JSON.stringify({ tool, projectId, projectName }));
+    } else {
+      localStorage.removeItem('iac-studio-session');
+    }
+  }, [projectId, projectName, tool]);
+
+  const saveTimer = useRef<ReturnType<typeof setTimeout>>();
+  useEffect(() => {
+    if (!tool || !projectId || !hasCreatedProject.current) return;
+    clearTimeout(saveTimer.current);
+    saveTimer.current = setTimeout(() => {
+      api.saveState(projectId, buildPersistedState()).catch(() => {});
+    }, 2000);
+  }, [buildPersistedState, hasCreatedProject, projectId, tool]);
+
+  const openProject = useCallback(async (project: SavedProject) => {
+    setProjectName(project.name);
+    setProjectId(project.name);
+    setTool(project.tool || 'terraform');
+    hasCreatedProject.current = true;
+    try {
+      const state = await api.loadState(project.name);
+      applyProjectState(state);
+      const selectedTool = state?.tool || project.tool || 'terraform';
+      const selectedLayered = normalizeLayeredProject(extractLayoutMeta(state));
+      setTool(selectedTool);
+      if (shouldParseResourcesFromDisk(state)) {
+        const parsed = await api.getResources(project.name, selectedTool, envForResourceLoad(selectedTool, selectedLayered));
+        applyParsedResources(parsed);
+      }
+      showNotification(`Opened project: ${project.name}`);
+    } catch {
+      setProjectLayoutMeta(null);
+      setLayeredProject(null);
+      setActiveEnvironment(null);
+      setCanvasMode('freeform');
+    }
+  }, [applyParsedResources, applyProjectState, hasCreatedProject, setActiveEnvironment, setCanvasMode, setLayeredProject, setProjectId, setProjectLayoutMeta, setProjectName, setTool, showNotification]);
+
+  const handleBackToProjectSelect = useCallback(async () => {
+    if (projectId && hasCreatedProject.current) {
+      await api.saveState(projectId, buildPersistedState()).catch(() => {});
+    }
+    api.listProjectStates().then(setSavedProjects).catch(() => {});
+    setTool(null);
+    resetNodes([]);
+    setEdges([]);
+    setChatMessages([]);
+    setTerminalOutput([]);
+    setProjectLayoutMeta(null);
+    setLayeredProject(null);
+    setActiveEnvironment(null);
+    setCanvasMode('freeform');
+    initialLoadDone.current = false;
+    hasCreatedProject.current = false;
+  }, [buildPersistedState, hasCreatedProject, initialLoadDone, projectId, resetNodes, setActiveEnvironment, setCanvasMode, setChatMessages, setEdges, setLayeredProject, setProjectLayoutMeta, setSavedProjects, setTerminalOutput, setTool]);
+
+  const handleCreateProject = useCallback(async (selectedTool: string) => {
+    setTool(selectedTool);
+    setProjectLayoutMeta(null);
+    setLayeredProject(null);
+    setActiveEnvironment(null);
+    setCanvasMode('freeform');
+    setProjectId(projectName);
+    hasCreatedProject.current = true;
+    initialLoadDone.current = true;
+    try {
+      await api.createProject(projectName, selectedTool);
+    } catch {
+      // Backend might not be running, continue with local-only mode.
+    }
+  }, [hasCreatedProject, initialLoadDone, projectName, setActiveEnvironment, setCanvasMode, setLayeredProject, setProjectId, setProjectLayoutMeta, setTool]);
+
+  return { openProject, handleBackToProjectSelect, handleCreateProject };
+}

--- a/web/src/app/useWorkspaceActions.ts
+++ b/web/src/app/useWorkspaceActions.ts
@@ -1,0 +1,457 @@
+import { useCallback, useRef, type Dispatch, type MouseEvent, type MutableRefObject, type RefObject, type SetStateAction } from 'react';
+import { api, ApiError, normalizeSuggestions, type CatalogResource, type PolicyFinding, type Suggestion } from '../api';
+import {
+  TOOLS,
+  edgeId,
+  uid,
+  type Edge,
+} from '../legacy';
+import type { AppResource, ChatMessage, HistorySetter } from './types';
+
+const summarizePolicyFindings = (findings: PolicyFinding[]) => {
+  if (findings.length === 0) return 'No finding details were returned.';
+  const shown = findings.slice(0, 5).map((finding, index) => {
+    const target = finding.resource ? ` on ${finding.resource}` : '';
+    return `${index + 1}. [${finding.engine}] ${finding.policy_id}${target}: ${finding.message}`;
+  });
+  if (findings.length > shown.length) {
+    shown.push(`...and ${findings.length - shown.length} more.`);
+  }
+  return shown.join('\n');
+};
+
+const isPolicyBlockedError = (err: unknown): err is ApiError => (
+  err instanceof ApiError && err.status === 409 && err.payload?.error === 'policy_blocked'
+);
+
+export interface UseWorkspaceActionsInput {
+  tool: string | null;
+  concreteTool: string;
+  projectId: string;
+  activeEnv: string | null;
+  activeResourceFile?: string;
+  unresolvedHybridEnv: boolean;
+  nodes: AppResource[];
+  edges: Edge[];
+  catalogResources: CatalogResource[];
+  chatMessages: ChatMessage[];
+  chatInput: string;
+  chatLoading: boolean;
+  connecting: { fromId: string; x: number; y: number } | null;
+  dragging: { id: string; ox: number; oy: number } | null;
+  lastCmdError: { command: string; output: string } | null;
+  canvasRef: RefObject<HTMLElement>;
+  setNodes: HistorySetter<AppResource[]>;
+  setEdges: Dispatch<SetStateAction<Edge[]>>;
+  setSelectedNode: Dispatch<SetStateAction<string | null>>;
+  setSelectedEdge: Dispatch<SetStateAction<string | null>>;
+  setConnecting: Dispatch<SetStateAction<{ fromId: string; x: number; y: number } | null>>;
+  setDragging: Dispatch<SetStateAction<{ id: string; ox: number; oy: number } | null>>;
+  setChatMessages: Dispatch<SetStateAction<ChatMessage[]>>;
+  setChatInput: Dispatch<SetStateAction<string>>;
+  setChatLoading: Dispatch<SetStateAction<boolean>>;
+  setSuggestions: Dispatch<SetStateAction<Suggestion[]>>;
+  setTerminalOutput: Dispatch<SetStateAction<string[]>>;
+  setLastCmdError: Dispatch<SetStateAction<{ command: string; output: string } | null>>;
+  setFixLoading: Dispatch<SetStateAction<boolean>>;
+  showNotification: (_message: string, _duration?: number) => void;
+}
+
+export function useWorkspaceActions({
+  tool,
+  concreteTool,
+  projectId,
+  activeEnv,
+  activeResourceFile,
+  unresolvedHybridEnv,
+  nodes,
+  edges,
+  catalogResources,
+  chatMessages,
+  chatInput,
+  chatLoading,
+  connecting,
+  dragging,
+  lastCmdError,
+  canvasRef,
+  setNodes,
+  setEdges,
+  setSelectedNode,
+  setSelectedEdge,
+  setConnecting,
+  setDragging,
+  setChatMessages,
+  setChatInput,
+  setChatLoading,
+  setSuggestions,
+  setTerminalOutput,
+  setLastCmdError,
+  setFixLoading,
+  showNotification,
+}: UseWorkspaceActionsInput) {
+  const chatInFlightRef = useRef(false);
+
+  const addNode = useCallback((resourceDef: any) => {
+    if (unresolvedHybridEnv) {
+      showNotification(`Environment "${activeEnv}" has no configured IaC tool`, 4000);
+      return;
+    }
+    const node: AppResource = {
+      id: uid(),
+      type: resourceDef.type,
+      name: resourceDef.type.replace(/^(aws_|google_|azurerm_)/, '').replace(/^compute_|^container_/, ''),
+      label: resourceDef.label,
+      icon: resourceDef.icon,
+      properties: { ...(resourceDef.defaults || {}) },
+      file: activeResourceFile,
+      x: 100 + Math.random() * 280,
+      y: 80 + Math.random() * 180,
+    };
+    setNodes(prev => {
+      const catEntry = catalogResources.find(resource => resource.type === resourceDef.type);
+      if (catEntry?.connects_via) {
+        const newEdges: Edge[] = [];
+        for (const [field, targetType] of Object.entries(catEntry.connects_via)) {
+          const target = prev.find(resource => resource.type === targetType);
+          if (target) {
+            newEdges.push({
+              id: edgeId(node.id, target.id, field),
+              from: node.id,
+              to: target.id,
+              fromType: node.type,
+              toType: target.type,
+              field,
+              label: field.replace(/_/g, ' '),
+            });
+          }
+        }
+        if (newEdges.length > 0) {
+          setEdges(prevEdges => [...prevEdges, ...newEdges]);
+        }
+      }
+      return [...prev, node];
+    });
+    setSelectedNode(node.id);
+  }, [activeEnv, activeResourceFile, catalogResources, setEdges, setNodes, setSelectedNode, showNotification, unresolvedHybridEnv]);
+
+  const removeNode = useCallback((id: string) => {
+    setNodes(prev => prev.filter(node => node.id !== id));
+    setEdges(prev => prev.filter(edge => edge.from !== id && edge.to !== id));
+    setSelectedNode(prev => prev === id ? null : prev);
+    setSelectedEdge(prev => {
+      const edge = edges.find(candidate => candidate.id === prev);
+      return edge && (edge.from === id || edge.to === id) ? null : prev;
+    });
+  }, [edges, setEdges, setNodes, setSelectedEdge, setSelectedNode]);
+
+  const updateProp = useCallback((id: string, key: string, value: any) => {
+    setNodes(prev => prev.map(node => node.id === id ? { ...node, properties: { ...node.properties, [key]: value } } : node));
+  }, [setNodes]);
+
+  const updateName = useCallback((id: string, name: string) => {
+    setNodes(prev => prev.map(node => node.id === id ? { ...node, name } : node));
+  }, [setNodes]);
+
+  const onMouseDown = useCallback((event: MouseEvent, nodeId: string) => {
+    event.stopPropagation();
+    const rect = canvasRef.current!.getBoundingClientRect();
+    const node = nodes.find(candidate => candidate.id === nodeId)!;
+    setDragging({ id: nodeId, ox: event.clientX - rect.left - node.x, oy: event.clientY - rect.top - node.y });
+    setSelectedNode(nodeId);
+  }, [canvasRef, nodes, setDragging, setSelectedNode]);
+
+  const onMouseMove = useCallback((event: MouseEvent) => {
+    if (connecting) {
+      const rect = canvasRef.current!.getBoundingClientRect();
+      setConnecting(prev => prev ? { ...prev, x: event.clientX - rect.left, y: event.clientY - rect.top } : null);
+    }
+    if (!dragging) return;
+    const rect = canvasRef.current!.getBoundingClientRect();
+    const x = Math.max(0, event.clientX - rect.left - dragging.ox);
+    const y = Math.max(0, event.clientY - rect.top - dragging.oy);
+    setNodes(prev => prev.map(node => node.id === dragging.id ? { ...node, x, y } : node));
+  }, [canvasRef, connecting, dragging, setConnecting, setNodes]);
+
+  const onMouseUp = useCallback(() => setDragging(null), [setDragging]);
+
+  const handleSelectNode = useCallback((id: string) => {
+    setSelectedNode(id);
+    setSelectedEdge(null);
+  }, [setSelectedEdge, setSelectedNode]);
+
+  const handleSelectEdge = useCallback((id: string) => {
+    setSelectedEdge(id);
+    setSelectedNode(null);
+  }, [setSelectedEdge, setSelectedNode]);
+
+  const handleClearCanvasSelection = useCallback(() => {
+    setSelectedNode(null);
+    setSelectedEdge(null);
+  }, [setSelectedEdge, setSelectedNode]);
+
+  const handleStartConnection = useCallback((nodeId: string, position: { x: number; y: number }) => {
+    setConnecting({ fromId: nodeId, ...position });
+  }, [setConnecting]);
+
+  const handleCancelConnection = useCallback(() => {
+    setConnecting(null);
+  }, [setConnecting]);
+
+  const handleCompleteConnection = useCallback((targetNodeId: string) => {
+    if (!connecting) return;
+    if (connecting.fromId === targetNodeId) {
+      setConnecting(null);
+      return;
+    }
+    const fromNode = nodes.find(node => node.id === connecting.fromId);
+    const toNode = nodes.find(node => node.id === targetNodeId);
+    if (!fromNode || !toNode) {
+      setConnecting(null);
+      return;
+    }
+
+    const catEntry = catalogResources.find(resource => resource.type === fromNode.type);
+    let field = 'depends_on';
+    if (catEntry?.connects_via) {
+      const match = Object.entries(catEntry.connects_via).find(([, targetType]) => targetType === toNode.type);
+      if (match) field = match[0];
+    }
+    const newEdge: Edge = {
+      id: edgeId(connecting.fromId, targetNodeId, field),
+      from: connecting.fromId,
+      to: targetNodeId,
+      fromType: fromNode.type,
+      toType: toNode.type,
+      field,
+      label: field.replace(/_/g, ' '),
+    };
+    setEdges(prev => {
+      if (prev.some(edge => edge.from === newEdge.from && edge.to === newEdge.to && edge.field === newEdge.field)) return prev;
+      return [...prev, newEdge];
+    });
+    setConnecting(null);
+  }, [catalogResources, connecting, nodes, setConnecting, setEdges]);
+
+  const detectProvider = useCallback((): string => {
+    const counts: Record<string, number> = { aws: 0, google: 0, azurerm: 0 };
+    nodes.forEach(node => {
+      if (node.type.startsWith('aws_')) counts.aws++;
+      else if (node.type.startsWith('google_')) counts.google++;
+      else if (node.type.startsWith('azurerm_')) counts.azurerm++;
+    });
+    const chatText = chatMessages.map(message => message.text).join(' ').toLowerCase();
+    if (chatText.includes('azure') || chatText.includes('azurerm')) counts.azurerm += 3;
+    if (chatText.includes('gcp') || chatText.includes('google cloud')) counts.google += 3;
+    if (chatText.includes('aws') || chatText.includes('amazon')) counts.aws += 3;
+
+    const max = Math.max(counts.aws, counts.google, counts.azurerm);
+    if (max === 0) return 'aws';
+    if (counts.google === max) return 'google';
+    if (counts.azurerm === max) return 'azurerm';
+    return 'aws';
+  }, [chatMessages, nodes]);
+
+  const handleChat = useCallback(async () => {
+    if (chatLoading || chatInFlightRef.current) return;
+    if (!chatInput.trim() || !tool) return;
+
+    chatInFlightRef.current = true;
+    setChatLoading(true);
+
+    const input = chatInput;
+    setChatInput('');
+    const aiMessageId = `ai-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    let pendingAiText = '';
+    const updateAiMessageText = (text: string) => {
+      setChatMessages(prev => {
+        const nextAiIndex = prev.findIndex(message => message.id === aiMessageId);
+        if (nextAiIndex < 0) return prev;
+        const next = [...prev];
+        next[nextAiIndex] = { ...next[nextAiIndex], text };
+        return next;
+      });
+    };
+
+    setChatMessages(prev => [
+      ...prev,
+      { role: 'user' as const, text: input },
+      { role: 'ai' as const, text: pendingAiText, id: aiMessageId },
+    ]);
+
+    try {
+      const provider = detectProvider();
+      const history = chatMessages.map(message => ({ role: message.role === 'ai' ? 'ai' : 'user', content: message.text }));
+      const canvas = nodes.map(node => ({ type: node.type, name: node.name }));
+
+      const result = await api.chatStream(
+        { message: input, tool, provider, history, canvas },
+        (delta: string) => {
+          pendingAiText += delta;
+          updateAiMessageText(pendingAiText);
+        },
+      );
+
+      pendingAiText = result.message;
+      updateAiMessageText(pendingAiText);
+      if (result.suggestions !== undefined) {
+        setSuggestions(normalizeSuggestions(result.suggestions));
+      }
+      if (result.resources) {
+        result.resources.forEach(resource => {
+          const meta = catalogResources.find(definition => definition.type === resource.type);
+          addNode({
+            type: resource.type,
+            label: meta?.label ?? resource.type,
+            icon: meta?.icon ?? '📦',
+            defaults: resource.properties,
+          });
+        });
+      }
+    } catch {
+      pendingAiText = 'AI is unavailable. Make sure your provider is reachable.';
+      updateAiMessageText(pendingAiText);
+    } finally {
+      chatInFlightRef.current = false;
+      setChatLoading(false);
+    }
+  }, [addNode, catalogResources, chatInput, chatLoading, chatMessages, detectProvider, nodes, setChatInput, setChatLoading, setChatMessages, setSuggestions, tool]);
+
+  const runCmd = useCallback((command: string) => {
+    if (!tool) return;
+    if (unresolvedHybridEnv) {
+      setTerminalOutput(prev => [...prev, `Error: environment "${activeEnv}" has no configured IaC tool`]);
+      return;
+    }
+    const needsApproval = command === 'apply' || command === 'destroy';
+    if (needsApproval && !confirm(`Are you sure you want to run "${command}"? This will modify real infrastructure.`)) {
+      return;
+    }
+    setTerminalOutput(prev => [...prev, `$ ${command}`, '']);
+    api.runCommand(projectId, tool, command, {
+      approved: needsApproval,
+      env: activeEnv,
+    }).catch(err => {
+      if (needsApproval && isPolicyBlockedError(err)) {
+        const findings = err.payload?.findings ?? [];
+        const blockingCount = findings.filter(finding => finding.severity === 'error').length;
+        const summary = summarizePolicyFindings(findings);
+        const summaryLines = summary.split('\n');
+        setTerminalOutput(prev => [
+          ...prev,
+          `Policy blocked ${command}: ${blockingCount} blocking finding${blockingCount === 1 ? '' : 's'}`,
+          ...summaryLines,
+        ]);
+        if (!confirm(`Policy checks blocked "${command}".\n\n${summary}\n\nRun it anyway and acknowledge these findings?`)) {
+          return;
+        }
+        setTerminalOutput(prev => [...prev, `$ ${command} --acknowledged`, '']);
+        api.runCommand(projectId, tool, command, {
+          approved: true,
+          env: activeEnv,
+          acknowledged: true,
+        }).catch(overrideErr => {
+          setTerminalOutput(prev => [...prev, `Error: ${overrideErr.message}`]);
+        });
+        return;
+      }
+      setTerminalOutput(prev => [...prev, `Error: ${err.message}`]);
+    });
+  }, [activeEnv, projectId, setTerminalOutput, tool, unresolvedHybridEnv]);
+
+  const fixLastError = useCallback(async () => {
+    if (!lastCmdError || !tool) return;
+    setFixLoading(true);
+    try {
+      const provider = detectProvider();
+      const result = await api.analyzePlan({
+        tool,
+        provider,
+        command: lastCmdError.command,
+        output: lastCmdError.output,
+        exit_code: 1,
+        canvas: nodes.map(node => ({ type: node.type, name: node.name })),
+      });
+      setTerminalOutput(prev => [...prev, '', `✦ AI Diagnosis: ${result.message}`]);
+      if (result.fixes?.length > 0) {
+        setTerminalOutput(prev => [...prev, '✦ Suggested fixes:']);
+        result.fixes.forEach(fix => {
+          setTerminalOutput(prev => [...prev, `  → ${fix.resource_type}.${fix.resource_name}: ${fix.field} = "${fix.new_value}" (${fix.reason})`]);
+          setNodes(prev => prev.map(node => {
+            if (node.type === fix.resource_type && node.name === fix.resource_name) {
+              return { ...node, properties: { ...node.properties, [fix.field]: fix.new_value } };
+            }
+            return node;
+          }));
+        });
+        setTerminalOutput(prev => [...prev, '✦ Fixes applied to canvas. Run plan again to verify.']);
+      }
+      if (result.new_resources?.length > 0) {
+        setTerminalOutput(prev => [...prev, '✦ Adding missing resources:']);
+        result.new_resources.forEach(resource => {
+          setTerminalOutput(prev => [...prev, `  + ${resource.type}.${resource.name}`]);
+          const meta = catalogResources.find(candidate => candidate.type === resource.type);
+          addNode({
+            type: resource.type,
+            label: meta?.label ?? resource.type,
+            icon: meta?.icon ?? '📦',
+            defaults: resource.properties,
+          });
+        });
+      }
+      setChatMessages(prev => [...prev, { role: 'ai', text: `Plan fix: ${result.message}` }]);
+      setLastCmdError(null);
+    } catch {
+      setTerminalOutput(prev => [...prev, '✦ AI fix analysis failed. Check that Ollama is running.']);
+    }
+    setFixLoading(false);
+  }, [addNode, catalogResources, detectProvider, lastCmdError, nodes, setChatMessages, setFixLoading, setLastCmdError, setNodes, setTerminalOutput, tool]);
+
+  const saveCodeToDisk = useCallback(async (value: string, context: {
+    setCodeSaving: Dispatch<SetStateAction<boolean>>;
+    isSyncing: MutableRefObject<boolean>;
+    showNotification: (_message: string, _duration?: number) => void;
+  }) => {
+    if (!tool || !projectId) return;
+    if (unresolvedHybridEnv) {
+      context.showNotification(`Save failed: environment "${activeEnv}" has no configured IaC tool`, 5000);
+      return;
+    }
+    if (!value.trim()) {
+      context.showNotification('Nothing to save yet');
+      return;
+    }
+    context.setCodeSaving(true);
+    context.isSyncing.current = true;
+    try {
+      const fileName = concreteTool === 'pulumi' ? 'index.ts' : `main${TOOLS[concreteTool]?.ext || '.tf'}`;
+      await api.syncCodeToDisk(projectId, tool, value, fileName, activeEnv);
+      context.showNotification(`Saved ${fileName}`);
+    } catch (err: any) {
+      context.showNotification(`Save failed: ${err.message}`, 5000);
+    } finally {
+      context.setCodeSaving(false);
+      setTimeout(() => { context.isSyncing.current = false; }, 1500);
+    }
+  }, [activeEnv, concreteTool, projectId, tool, unresolvedHybridEnv]);
+
+  return {
+    addNode,
+    removeNode,
+    updateProp,
+    updateName,
+    onMouseDown,
+    onMouseMove,
+    onMouseUp,
+    handleSelectNode,
+    handleSelectEdge,
+    handleClearCanvasSelection,
+    handleStartConnection,
+    handleCancelConnection,
+    handleCompleteConnection,
+    detectProvider,
+    handleChat,
+    runCmd,
+    fixLastError,
+    saveCodeToDisk,
+  };
+}

--- a/web/src/components/ResourceTooltip/ResourceTooltip.tsx
+++ b/web/src/components/ResourceTooltip/ResourceTooltip.tsx
@@ -1,0 +1,67 @@
+import type { CatalogResource } from '../../api';
+
+export interface ResourceTooltipProps {
+  resource: CatalogResource;
+  position: { x: number; y: number };
+  toolColor: string;
+}
+
+export function ResourceTooltip({ resource, position, toolColor }: ResourceTooltipProps) {
+  return (
+    <div style={{
+      position: 'fixed', left: position.x, top: position.y,
+      background: 'var(--bg-elev-2)', border: '1px solid var(--border-main)', borderRadius: 10,
+      padding: '12px 16px', zIndex: 1000, maxWidth: 300, minWidth: 220,
+      boxShadow: '0 8px 24px rgba(0,0,0,0.5)', pointerEvents: 'none',
+      fontFamily: 'DM Sans',
+    }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+        <span style={{ fontSize: 20 }}>{resource.icon}</span>
+        <div>
+          <div style={{ fontSize: 13, fontWeight: 600, color: '#e0e0f0' }}>{resource.label}</div>
+          <div style={{ fontSize: 10, color: '#666', fontFamily: 'JetBrains Mono' }}>{resource.type}</div>
+        </div>
+      </div>
+      {resource.provider && (
+        <div style={{ fontSize: 10, color: '#888', marginBottom: 6 }}>
+          Provider: <span style={{ color: toolColor }}>{resource.provider}</span>
+        </div>
+      )}
+      {resource.fields && resource.fields.length > 0 && (
+        <div style={{ marginBottom: 6 }}>
+          <div style={{ fontSize: 9, color: '#555', textTransform: 'uppercase', letterSpacing: 1, marginBottom: 4, fontFamily: 'JetBrains Mono' }}>Fields</div>
+          {resource.fields.slice(0, 6).map(field => (
+            <div key={field.name} style={{ fontSize: 11, color: '#999', display: 'flex', gap: 4, lineHeight: 1.6, fontFamily: 'JetBrains Mono' }}>
+              <span style={{ color: field.required ? '#ef4444' : '#555' }}>{field.required ? '*' : ' '}</span>
+              <span style={{ color: '#aaa' }}>{field.name}</span>
+              <span style={{ color: '#555', marginLeft: 'auto' }}>{field.type}</span>
+            </div>
+          ))}
+          {resource.fields.length > 6 && (
+            <div style={{ fontSize: 10, color: '#444', marginTop: 2 }}>+{resource.fields.length - 6} more</div>
+          )}
+        </div>
+      )}
+      {resource.connects_via && Object.keys(resource.connects_via).length > 0 && (
+        <div>
+          <div style={{ fontSize: 9, color: '#555', textTransform: 'uppercase', letterSpacing: 1, marginBottom: 4, fontFamily: 'JetBrains Mono' }}>Connects To</div>
+          {Object.entries(resource.connects_via).map(([field, target]) => (
+            <div key={field} style={{ fontSize: 11, color: '#777', fontFamily: 'JetBrains Mono', lineHeight: 1.6 }}>
+              <span style={{ color: toolColor }}>{field}</span> {'->'} <span style={{ color: '#aaa' }}>{target}</span>
+            </div>
+          ))}
+        </div>
+      )}
+      {resource.defaults && Object.keys(resource.defaults).length > 0 && (
+        <div style={{ marginTop: 6, paddingTop: 6, borderTop: '1px solid var(--border-soft)' }}>
+          <div style={{ fontSize: 9, color: '#555', textTransform: 'uppercase', letterSpacing: 1, marginBottom: 4, fontFamily: 'JetBrains Mono' }}>Defaults</div>
+          {Object.entries(resource.defaults).slice(0, 4).map(([key, value]) => (
+            <div key={key} style={{ fontSize: 10, color: '#666', fontFamily: 'JetBrains Mono', lineHeight: 1.5 }}>
+              {key}: <span style={{ color: '#888' }}>{String(value)}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/ResourceTooltip/index.tsx
+++ b/web/src/components/ResourceTooltip/index.tsx
@@ -1,0 +1,2 @@
+export { ResourceTooltip } from './ResourceTooltip';
+export type { ResourceTooltipProps } from './ResourceTooltip';

--- a/web/src/components/Workspace/ResizeHandle.tsx
+++ b/web/src/components/Workspace/ResizeHandle.tsx
@@ -1,0 +1,36 @@
+import type { ResizeState } from '../../app/types';
+
+interface ResizeHandleProps {
+  direction: 'col' | 'row';
+  panel: ResizeState['panel'];
+  activePanel?: string;
+  color: string;
+  startSize: number;
+  onResizeStart: (_state: ResizeState) => void;
+}
+
+export function ResizeHandle({
+  direction,
+  panel,
+  activePanel,
+  color,
+  startSize,
+  onResizeStart,
+}: ResizeHandleProps) {
+  const isRow = direction === 'row';
+  return (
+    <div
+      style={{
+        width: isRow ? undefined : 4,
+        height: isRow ? 4 : undefined,
+        cursor: isRow ? 'row-resize' : 'col-resize',
+        background: activePanel === panel ? color + '44' : 'transparent',
+        flexShrink: 0,
+        transition: 'background 0.15s',
+      }}
+      onMouseDown={event => onResizeStart({ panel, startPos: isRow ? event.clientY : event.clientX, startSize })}
+      onMouseEnter={event => { if (!activePanel) event.currentTarget.style.background = 'var(--border-main)'; }}
+      onMouseLeave={event => { if (!activePanel) event.currentTarget.style.background = 'transparent'; }}
+    />
+  );
+}

--- a/web/src/components/Workspace/WorkspaceShell.tsx
+++ b/web/src/components/Workspace/WorkspaceShell.tsx
@@ -1,0 +1,344 @@
+import type { Dispatch, MouseEvent, RefObject, SetStateAction } from 'react';
+import type { AISettingsConfig } from '../AISettings';
+import { AISettingsModal } from '../AISettings';
+import { AppHeader } from '../AppHeader';
+import { CanvasPanel, type CanvasMode } from '../Canvas';
+import { ChatPanel } from '../Chat';
+import { InspectorPanel, type RightPanelTab } from '../Inspector';
+import { ResourceTooltip } from '../ResourceTooltip';
+import { WorkspaceSidebar, type SidebarPanel } from '../Sidebar';
+import { TerminalPanel } from '../Terminal';
+import type { CatalogResource, Suggestion } from '../../api';
+import type { Edge } from '../../legacy';
+import { S } from '../../styles';
+import type { LayeredProject } from '../../types';
+import type { AppResource, ChatMessage, ResizeState } from '../../app/types';
+import { ResizeHandle } from './ResizeHandle';
+
+interface ToolMeta {
+  color: string;
+  ext: string;
+}
+
+export interface WorkspaceShellProps {
+  notification: string | null;
+  tool: string;
+  toolMeta: ToolMeta;
+  projectName: string;
+  projectId: string;
+  nodes: AppResource[];
+  edges: Edge[];
+  wsConnected: boolean;
+  canUndo: boolean;
+  canRedo: boolean;
+  showSettings: boolean;
+  aiSettings: AISettingsConfig;
+  sidebarWidth: number;
+  rightWidth: number;
+  bottomHeight: number;
+  resizing: ResizeState | null;
+  activePanel: SidebarPanel;
+  rightTab: RightPanelTab;
+  searchQuery: string;
+  provider: string;
+  catalogResources: CatalogResource[];
+  suggestions: Suggestion[];
+  selectedNode: string | null;
+  selectedEdge: string | null;
+  connecting: { fromId: string; x: number; y: number } | null;
+  layeredProject: LayeredProject | null;
+  showEnvironmentSelector: boolean;
+  activeEnvironment: string | null;
+  canvasMode: CanvasMode;
+  canvasRef: RefObject<HTMLElement>;
+  chatMessages: ChatMessage[];
+  chatInput: string;
+  chatLoading: boolean;
+  chatEndRef: RefObject<HTMLDivElement>;
+  terminalOutput: string[];
+  lastCmdError: { command: string; output: string } | null;
+  fixLoading: boolean;
+  syncCode: string;
+  codeFileLabel: string;
+  codeEditorFilePath: string;
+  codeSaving: boolean;
+  activeEnv: string | null;
+  unresolvedHybridEnv: boolean;
+  hoveredResource: CatalogResource | null;
+  hoverPos: { x: number; y: number };
+  onBack: () => void;
+  onProjectNameChange: (_name: string) => void;
+  onRevealProject: (_projectId: string) => void;
+  onUndo: () => void;
+  onRedo: () => void;
+  onRunCommand: (_command: string) => void;
+  onOpenSettings: () => void;
+  onSettingsChange: Dispatch<SetStateAction<AISettingsConfig>>;
+  onSettingsNotify: (_message: string, _duration?: number) => void;
+  onCloseSettings: () => void;
+  onResizeStart: (_state: ResizeState) => void;
+  onActivePanelChange: (_panel: SidebarPanel) => void;
+  onSearchQueryChange: (_query: string) => void;
+  onAddResource: (_resource: CatalogResource) => void;
+  onResourceHover: (_resource: CatalogResource, _position: { x: number; y: number }) => void;
+  onResourceHoverEnd: () => void;
+  onMouseMove: (_event: MouseEvent) => void;
+  onDragEnd: () => void;
+  onConnectionCancel: () => void;
+  onNodeDragStart: (_event: MouseEvent, _nodeId: string) => void;
+  onStartConnection: (_nodeId: string, _position: { x: number; y: number }) => void;
+  onCompleteConnection: (_targetNodeId: string) => void;
+  onSelectNode: (_nodeId: string) => void;
+  onSelectEdge: (_edgeId: string) => void;
+  onClearSelection: () => void;
+  onDeleteNode: (_nodeId: string) => void;
+  onActiveEnvironmentChange: (_env: string) => void;
+  onCanvasModeChange: (_mode: CanvasMode) => void;
+  onRightTabChange: (_tab: RightPanelTab) => void;
+  onDeleteEdge: (_edgeId: string) => void;
+  onUpdateNodeName: (_nodeId: string, _name: string) => void;
+  onUpdateNodeProp: (_nodeId: string, _key: string, _value: any) => void;
+  onSyncCodeChange: (_value: string) => void;
+  onSaveCode: (_value: string) => void;
+  onChatInputChange: (_value: string) => void;
+  onChatSubmit: () => void;
+  onClearTerminal: () => void;
+  onFixLastError?: () => void;
+}
+
+export function WorkspaceShell({
+  notification,
+  tool,
+  toolMeta,
+  projectName,
+  projectId,
+  nodes,
+  edges,
+  wsConnected,
+  canUndo,
+  canRedo,
+  showSettings,
+  aiSettings,
+  sidebarWidth,
+  rightWidth,
+  bottomHeight,
+  resizing,
+  activePanel,
+  rightTab,
+  searchQuery,
+  provider,
+  catalogResources,
+  suggestions,
+  selectedNode,
+  selectedEdge,
+  connecting,
+  layeredProject,
+  showEnvironmentSelector,
+  activeEnvironment,
+  canvasMode,
+  canvasRef,
+  chatMessages,
+  chatInput,
+  chatLoading,
+  chatEndRef,
+  terminalOutput,
+  lastCmdError,
+  fixLoading,
+  syncCode,
+  codeFileLabel,
+  codeEditorFilePath,
+  codeSaving,
+  activeEnv,
+  unresolvedHybridEnv,
+  hoveredResource,
+  hoverPos,
+  onBack,
+  onProjectNameChange,
+  onRevealProject,
+  onUndo,
+  onRedo,
+  onRunCommand,
+  onOpenSettings,
+  onSettingsChange,
+  onSettingsNotify,
+  onCloseSettings,
+  onResizeStart,
+  onActivePanelChange,
+  onSearchQueryChange,
+  onAddResource,
+  onResourceHover,
+  onResourceHoverEnd,
+  onMouseMove,
+  onDragEnd,
+  onConnectionCancel,
+  onNodeDragStart,
+  onStartConnection,
+  onCompleteConnection,
+  onSelectNode,
+  onSelectEdge,
+  onClearSelection,
+  onDeleteNode,
+  onActiveEnvironmentChange,
+  onCanvasModeChange,
+  onRightTabChange,
+  onDeleteEdge,
+  onUpdateNodeName,
+  onUpdateNodeProp,
+  onSyncCodeChange,
+  onSaveCode,
+  onChatInputChange,
+  onChatSubmit,
+  onClearTerminal,
+  onFixLastError,
+}: WorkspaceShellProps) {
+  return (
+    <div style={S.app} className="iac-app">
+      {notification && <div style={S.notification}>{notification}</div>}
+
+      <AppHeader
+        tool={tool}
+        toolMeta={toolMeta}
+        projectName={projectName}
+        projectId={projectId}
+        resourceCount={nodes.length}
+        wsConnected={wsConnected}
+        canUndo={canUndo}
+        canRedo={canRedo}
+        onBack={onBack}
+        onProjectNameChange={onProjectNameChange}
+        onRevealProject={onRevealProject}
+        onUndo={onUndo}
+        onRedo={onRedo}
+        onRunCommand={onRunCommand}
+        onOpenSettings={onOpenSettings}
+      />
+
+      {showSettings && (
+        <AISettingsModal
+          settings={aiSettings}
+          onSettingsChange={onSettingsChange}
+          onNotify={onSettingsNotify}
+          onClose={onCloseSettings}
+        />
+      )}
+
+      <div style={S.main}>
+        <WorkspaceSidebar
+          width={sidebarWidth}
+          activePanel={activePanel}
+          tool={tool}
+          toolMeta={toolMeta}
+          projectName={projectName}
+          provider={provider}
+          resources={catalogResources}
+          suggestions={suggestions}
+          searchQuery={searchQuery}
+          onActivePanelChange={onActivePanelChange}
+          onSearchQueryChange={onSearchQueryChange}
+          onAddResource={onAddResource}
+          onResourceHover={onResourceHover}
+          onResourceHoverEnd={onResourceHoverEnd}
+        />
+        <ResizeHandle
+          direction="col"
+          panel="sidebar"
+          activePanel={resizing?.panel}
+          color={toolMeta.color}
+          startSize={sidebarWidth}
+          onResizeStart={onResizeStart}
+        />
+
+        <CanvasPanel
+          canvasRef={canvasRef}
+          nodes={nodes}
+          edges={edges}
+          selectedNodeId={selectedNode}
+          selectedEdgeId={selectedEdge}
+          connecting={connecting}
+          layeredProject={layeredProject}
+          showEnvironmentSelector={showEnvironmentSelector}
+          activeEnvironment={activeEnvironment}
+          canvasMode={canvasMode}
+          toolMeta={toolMeta}
+          onMouseMove={onMouseMove}
+          onDragEnd={onDragEnd}
+          onConnectionCancel={onConnectionCancel}
+          onNodeDragStart={onNodeDragStart}
+          onStartConnection={onStartConnection}
+          onCompleteConnection={onCompleteConnection}
+          onSelectNode={onSelectNode}
+          onSelectEdge={onSelectEdge}
+          onClearSelection={onClearSelection}
+          onDeleteNode={onDeleteNode}
+          onActiveEnvironmentChange={onActiveEnvironmentChange}
+          onCanvasModeChange={onCanvasModeChange}
+        />
+
+        <ResizeHandle
+          direction="col"
+          panel="right"
+          activePanel={resizing?.panel}
+          color={toolMeta.color}
+          startSize={rightWidth}
+          onResizeStart={onResizeStart}
+        />
+        <InspectorPanel
+          width={rightWidth}
+          activeTab={rightTab}
+          tool={tool}
+          toolMeta={toolMeta}
+          activeEnv={activeEnv}
+          projectId={projectId}
+          nodes={nodes}
+          edges={edges}
+          selectedNodeId={selectedNode}
+          selectedEdgeId={selectedEdge}
+          syncCode={syncCode}
+          codeFileLabel={codeFileLabel}
+          codeEditorFilePath={codeEditorFilePath}
+          codeSaving={codeSaving}
+          unresolvedHybridEnv={unresolvedHybridEnv}
+          onTabChange={onRightTabChange}
+          onDeleteEdge={onDeleteEdge}
+          onSelectEdge={onSelectEdge}
+          onUpdateNodeName={onUpdateNodeName}
+          onUpdateNodeProp={onUpdateNodeProp}
+          onSyncCodeChange={onSyncCodeChange}
+          onSaveCode={onSaveCode}
+        />
+      </div>
+
+      <ResizeHandle
+        direction="row"
+        panel="bottom"
+        activePanel={resizing?.panel}
+        color={toolMeta.color}
+        startSize={bottomHeight}
+        onResizeStart={onResizeStart}
+      />
+      <div style={{ ...S.bottom, height: bottomHeight }}>
+        <ChatPanel
+          messages={chatMessages}
+          input={chatInput}
+          onInputChange={onChatInputChange}
+          onSubmit={onChatSubmit}
+          loading={chatLoading}
+          toolColor={toolMeta.color}
+          scrollAnchorRef={chatEndRef}
+        />
+        <TerminalPanel
+          lines={terminalOutput}
+          onClear={onClearTerminal}
+          lastError={lastCmdError}
+          fixLoading={fixLoading}
+          toolColor={toolMeta.color}
+          onFix={lastCmdError ? onFixLastError : undefined}
+        />
+      </div>
+
+      {hoveredResource && (
+        <ResourceTooltip resource={hoveredResource} position={hoverPos} toolColor={toolMeta.color} />
+      )}
+    </div>
+  );
+}

--- a/web/src/components/Workspace/index.tsx
+++ b/web/src/components/Workspace/index.tsx
@@ -1,0 +1,2 @@
+export { WorkspaceShell } from './WorkspaceShell';
+export type { WorkspaceShellProps } from './WorkspaceShell';


### PR DESCRIPTION
## Summary
- Extract layered project helpers, import flow, project lifecycle, workspace actions, and workspace shell rendering out of App.tsx.
- Keep App.tsx as the orchestration layer while preserving the mounted UI panels and existing workflows.
- Move layered helper tests to import from app/layered.

## Issue #22 acceptance
- web/src/App.tsx: 568 lines, under the < 600 line target.
- Existing frontend integration remains mounted through WorkspaceShell.

Closes #22

## Validation
- npm test -- --run
- npm run build
- npm run lint (passes with existing warnings only)
- git diff --check