### PR TITLE
Add cloud connections foundation

### DIFF
--- a/internal/api/cloud_connections_test.go
+++ b/internal/api/cloud_connections_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -26,7 +27,7 @@ func TestCloudConnectionRoutesRedactSecrets(t *testing.T) {
 	if err != nil {
 		t.Fatalf("POST connection: %v", err)
 	}
-	defer resp.Body.Close()
+	defer closeBody(resp.Body)
 	if resp.StatusCode != http.StatusCreated {
 		t.Fatalf("create should 201, got %d", resp.StatusCode)
 	}
@@ -50,7 +51,7 @@ func TestCloudConnectionRoutesRedactSecrets(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET connections: %v", err)
 	}
-	defer resp.Body.Close()
+	defer closeBody(resp.Body)
 	var raw bytes.Buffer
 	if _, err := raw.ReadFrom(resp.Body); err != nil {
 		t.Fatalf("read list: %v", err)
@@ -73,7 +74,7 @@ func TestCloudConnectionTestReportsMissingFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("POST connection: %v", err)
 	}
-	defer resp.Body.Close()
+	defer closeBody(resp.Body)
 	var created struct {
 		ID string `json:"id"`
 	}
@@ -85,7 +86,7 @@ func TestCloudConnectionTestReportsMissingFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("POST test: %v", err)
 	}
-	defer resp.Body.Close()
+	defer closeBody(resp.Body)
 	var result struct {
 		OK     bool `json:"ok"`
 		Checks []struct {
@@ -119,7 +120,7 @@ func TestCloudConnectionUpdateMissingConnectionReturns404(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PUT missing connection: %v", err)
 	}
-	defer resp.Body.Close()
+	defer closeBody(resp.Body)
 	if resp.StatusCode != http.StatusNotFound {
 		t.Fatalf("missing update should 404, got %d", resp.StatusCode)
 	}
@@ -135,4 +136,8 @@ func routeHasCheck(checks []struct {
 		}
 	}
 	return false
+}
+
+func closeBody(body io.Closer) {
+	_ = body.Close()
 }

--- a/internal/api/cloud_connections_test.go
+++ b/internal/api/cloud_connections_test.go
@@ -1,0 +1,138 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestCloudConnectionRoutesRedactSecrets(t *testing.T) {
+	root := t.TempDir()
+	srv := httptest.NewServer(fullRouterForTest(t, root))
+	defer srv.Close()
+
+	body := `{
+		"name":"prod-admin",
+		"provider":"aws",
+		"auth_method":"aws_static",
+		"region":"us-east-1",
+		"metadata":{"access_key_id":"AKIAEXAMPLE","account_id":"123456789012"},
+		"secrets":{"secret_access_key":"super-secret"}
+	}`
+	resp, err := http.Post(srv.URL+"/api/cloud/connections", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST connection: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create should 201, got %d", resp.StatusCode)
+	}
+
+	var created struct {
+		ID           string            `json:"id"`
+		Metadata     map[string]string `json:"metadata"`
+		SecretFields []string          `json:"secret_fields"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create: %v", err)
+	}
+	if created.ID == "" {
+		t.Fatal("created connection should include id")
+	}
+	if got := created.Metadata["access_key_id"]; got != "AKIAEXAMPLE" {
+		t.Fatalf("public metadata should include access key id, got %q", got)
+	}
+
+	resp, err = http.Get(srv.URL + "/api/cloud/connections")
+	if err != nil {
+		t.Fatalf("GET connections: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var raw bytes.Buffer
+	if _, err := raw.ReadFrom(resp.Body); err != nil {
+		t.Fatalf("read list: %v", err)
+	}
+	if strings.Contains(raw.String(), "super-secret") {
+		t.Fatalf("secret leaked in list response: %s", raw.String())
+	}
+	if !strings.Contains(raw.String(), "secret_access_key") {
+		t.Fatalf("secret field presence should be returned: %s", raw.String())
+	}
+}
+
+func TestCloudConnectionTestReportsMissingFields(t *testing.T) {
+	root := t.TempDir()
+	srv := httptest.NewServer(fullRouterForTest(t, root))
+	defer srv.Close()
+
+	body := `{"name":"sp","provider":"azure","auth_method":"azure_service_principal","metadata":{"tenant_id":"tenant-1"}}`
+	resp, err := http.Post(srv.URL+"/api/cloud/connections", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST connection: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var created struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create: %v", err)
+	}
+
+	resp, err = http.Post(srv.URL+"/api/cloud/connections/"+created.ID+"/test", "application/json", nil)
+	if err != nil {
+		t.Fatalf("POST test: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var result struct {
+		OK     bool `json:"ok"`
+		Checks []struct {
+			Name   string `json:"name"`
+			Status string `json:"status"`
+		} `json:"checks"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode test: %v", err)
+	}
+	if result.OK {
+		t.Fatal("incomplete service principal should not test ok")
+	}
+	if !routeHasCheck(result.Checks, "client_secret", "error") {
+		t.Fatalf("client_secret missing check not found: %#v", result.Checks)
+	}
+}
+
+func TestCloudConnectionUpdateMissingConnectionReturns404(t *testing.T) {
+	root := t.TempDir()
+	srv := httptest.NewServer(fullRouterForTest(t, root))
+	defer srv.Close()
+
+	body := `{"name":"prod-admin","provider":"aws","auth_method":"aws_profile","metadata":{"profile":"default"}}`
+	req, err := http.NewRequest(http.MethodPut, srv.URL+"/api/cloud/connections/missing", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT missing connection: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("missing update should 404, got %d", resp.StatusCode)
+	}
+}
+
+func routeHasCheck(checks []struct {
+	Name   string `json:"name"`
+	Status string `json:"status"`
+}, name string, status string) bool {
+	for _, check := range checks {
+		if check.Name == name && check.Status == status {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/api/cloud_connections_test.go
+++ b/internal/api/cloud_connections_test.go
@@ -26,7 +26,7 @@ func TestCloudConnectionRoutesRedactSecrets(t *testing.T) {
 	if err != nil {
 		t.Fatalf("POST connection: %v", err)
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusCreated {
 		t.Fatalf("create should 201, got %d", resp.StatusCode)
 	}
@@ -50,7 +50,7 @@ func TestCloudConnectionRoutesRedactSecrets(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET connections: %v", err)
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer resp.Body.Close()
 	var raw bytes.Buffer
 	if _, err := raw.ReadFrom(resp.Body); err != nil {
 		t.Fatalf("read list: %v", err)
@@ -73,7 +73,7 @@ func TestCloudConnectionTestReportsMissingFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("POST connection: %v", err)
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer resp.Body.Close()
 	var created struct {
 		ID string `json:"id"`
 	}
@@ -85,7 +85,7 @@ func TestCloudConnectionTestReportsMissingFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("POST test: %v", err)
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer resp.Body.Close()
 	var result struct {
 		OK     bool `json:"ok"`
 		Checks []struct {
@@ -119,7 +119,7 @@ func TestCloudConnectionUpdateMissingConnectionReturns404(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PUT missing connection: %v", err)
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusNotFound {
 		t.Fatalf("missing update should 404, got %d", resp.StatusCode)
 	}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -20,6 +20,7 @@ import (
 	"github.com/iac-studio/iac-studio/internal/ai"
 	"github.com/iac-studio/iac-studio/internal/ai/providers"
 	"github.com/iac-studio/iac-studio/internal/catalog"
+	"github.com/iac-studio/iac-studio/internal/cloudconnections"
 	"github.com/iac-studio/iac-studio/internal/drift"
 	"github.com/iac-studio/iac-studio/internal/exporter"
 	"github.com/iac-studio/iac-studio/internal/generator"
@@ -1408,6 +1409,94 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 	// ─── Project State Persistence ───
 
 	pm := project.NewManager(projectsDir)
+	cloudConnections := cloudconnections.NewManager(projectsDir)
+
+	// Cloud connection broker - stores named cloud targets for later plan/apply,
+	// drift, import, and MCP workflows. Route responses always use public views
+	// so secret values are never echoed back to the browser.
+	mux.HandleFunc("GET /api/cloud/auth-methods", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string][]string{
+			"aws":   cloudconnections.SupportedAuthMethods(cloudconnections.ProviderAWS),
+			"azure": cloudconnections.SupportedAuthMethods(cloudconnections.ProviderAzure),
+			"gcp":   cloudconnections.SupportedAuthMethods(cloudconnections.ProviderGCP),
+		})
+	})
+
+	mux.HandleFunc("GET /api/cloud/connections", func(w http.ResponseWriter, _ *http.Request) {
+		connections, err := cloudConnections.List()
+		if err != nil {
+			http.Error(w, err.Error(), 500)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(connections)
+	})
+
+	mux.HandleFunc("POST /api/cloud/connections", func(w http.ResponseWriter, r *http.Request) {
+		limitBody(w, r)
+		var req cloudconnections.Connection
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid request", 400)
+			return
+		}
+		req.ID = ""
+		connection, err := cloudConnections.Save(req)
+		if err != nil {
+			http.Error(w, err.Error(), 400)
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(connection)
+	})
+
+	mux.HandleFunc("PUT /api/cloud/connections/{id}", func(w http.ResponseWriter, r *http.Request) {
+		limitBody(w, r)
+		id := r.PathValue("id")
+		if _, err := cloudConnections.Get(id); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				http.Error(w, "connection not found", 404)
+				return
+			}
+			http.Error(w, err.Error(), 500)
+			return
+		}
+		var req cloudconnections.Connection
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid request", 400)
+			return
+		}
+		req.ID = id
+		connection, err := cloudConnections.Save(req)
+		if err != nil {
+			http.Error(w, err.Error(), 400)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(connection)
+	})
+
+	mux.HandleFunc("DELETE /api/cloud/connections/{id}", func(w http.ResponseWriter, r *http.Request) {
+		if err := cloudConnections.Delete(r.PathValue("id")); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				http.Error(w, "connection not found", 404)
+				return
+			}
+			http.Error(w, err.Error(), 500)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "deleted"})
+	})
+
+	mux.HandleFunc("POST /api/cloud/connections/{id}/test", func(w http.ResponseWriter, r *http.Request) {
+		result, err := cloudConnections.Test(r.PathValue("id"))
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				http.Error(w, "connection not found", 404)
+				return
+			}
+			http.Error(w, err.Error(), 500)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(result)
+	})
 
 	// List all projects with their saved state
 	mux.HandleFunc("GET /api/projects/states", func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/cloudconnections/connections.go
+++ b/internal/cloudconnections/connections.go
@@ -1,0 +1,433 @@
+package cloudconnections
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	ProviderAWS   = "aws"
+	ProviderAzure = "azure"
+	ProviderGCP   = "gcp"
+)
+
+var providerAuthMethods = map[string][]string{
+	ProviderAWS: {
+		"aws_profile",
+		"aws_sso",
+		"aws_static",
+	},
+	ProviderAzure: {
+		"azure_cli",
+		"azure_service_principal",
+	},
+	ProviderGCP: {
+		"gcp_gcloud",
+		"gcp_service_account",
+	},
+}
+
+var secretFieldsByMethod = map[string][]string{
+	"aws_static":              {"secret_access_key", "session_token"},
+	"azure_service_principal": {"client_secret"},
+	"gcp_service_account":     {"service_account_json"},
+}
+
+var requiredFieldsByMethod = map[string][]string{
+	"aws_profile":             {"profile"},
+	"aws_sso":                 {"profile"},
+	"aws_static":              {"access_key_id", "secret_access_key"},
+	"azure_service_principal": {"tenant_id", "client_id", "client_secret"},
+	"gcp_service_account":     {"project_id", "service_account_json"},
+}
+
+// Connection is the persisted form. Secrets are intentionally isolated from
+// public metadata so route handlers can return redacted PublicConnection views.
+type Connection struct {
+	ID         string            `json:"id"`
+	Name       string            `json:"name"`
+	Provider   string            `json:"provider"`
+	AuthMethod string            `json:"auth_method"`
+	Region     string            `json:"region,omitempty"`
+	Metadata   map[string]string `json:"metadata,omitempty"`
+	Secrets    map[string]string `json:"secrets,omitempty"`
+	CreatedAt  time.Time         `json:"created_at"`
+	UpdatedAt  time.Time         `json:"updated_at"`
+}
+
+type PublicConnection struct {
+	ID           string            `json:"id"`
+	Name         string            `json:"name"`
+	Provider     string            `json:"provider"`
+	AuthMethod   string            `json:"auth_method"`
+	Region       string            `json:"region,omitempty"`
+	Metadata     map[string]string `json:"metadata,omitempty"`
+	SecretFields []string          `json:"secret_fields,omitempty"`
+	CreatedAt    time.Time         `json:"created_at"`
+	UpdatedAt    time.Time         `json:"updated_at"`
+}
+
+type TestResult struct {
+	OK         bool             `json:"ok"`
+	Summary    string           `json:"summary"`
+	Connection PublicConnection `json:"connection"`
+	Checks     []Check          `json:"checks"`
+}
+
+type Check struct {
+	Name    string `json:"name"`
+	Status  string `json:"status"`
+	Message string `json:"message"`
+}
+
+type Manager struct {
+	path string
+	mu   sync.RWMutex
+}
+
+func NewManager(projectsDir string) *Manager {
+	return &Manager{path: filepath.Join(projectsDir, ".iac-studio-connections.json")}
+}
+
+func SupportedAuthMethods(provider string) []string {
+	methods := providerAuthMethods[provider]
+	return slices.Clone(methods)
+}
+
+func (m *Manager) List() ([]PublicConnection, error) {
+	connections, err := m.load()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]PublicConnection, 0, len(connections))
+	for _, connection := range connections {
+		out = append(out, publicConnection(connection))
+	}
+	return out, nil
+}
+
+func (m *Manager) Get(id string) (*Connection, error) {
+	connections, err := m.load()
+	if err != nil {
+		return nil, err
+	}
+	for _, connection := range connections {
+		if connection.ID == id {
+			copy := connection
+			copy.Metadata = cloneMap(connection.Metadata)
+			copy.Secrets = cloneMap(connection.Secrets)
+			return &copy, nil
+		}
+	}
+	return nil, os.ErrNotExist
+}
+
+func (m *Manager) Save(input Connection) (PublicConnection, error) {
+	if err := normalizeAndValidate(&input); err != nil {
+		return PublicConnection{}, err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	connections, err := m.loadUnlocked()
+	if err != nil {
+		return PublicConnection{}, err
+	}
+
+	now := time.Now().UTC()
+	if input.ID == "" {
+		input.ID = newID()
+		input.CreatedAt = now
+	} else {
+		input.CreatedAt = now
+		for _, existing := range connections {
+			if existing.ID == input.ID {
+				input.CreatedAt = existing.CreatedAt
+				input.Secrets = mergeSecrets(existing.Secrets, input.Secrets)
+				break
+			}
+		}
+	}
+	input.UpdatedAt = now
+	input.Metadata = publicMetadata(input.AuthMethod, input.Metadata)
+	input.Secrets = secretMetadata(input.AuthMethod, input.Secrets)
+
+	replaced := false
+	for index, existing := range connections {
+		if existing.ID == input.ID {
+			connections[index] = input
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		connections = append(connections, input)
+	}
+
+	if err := m.saveUnlocked(connections); err != nil {
+		return PublicConnection{}, err
+	}
+	return publicConnection(input), nil
+}
+
+func (m *Manager) Delete(id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	connections, err := m.loadUnlocked()
+	if err != nil {
+		return err
+	}
+	next := connections[:0]
+	found := false
+	for _, connection := range connections {
+		if connection.ID == id {
+			found = true
+			continue
+		}
+		next = append(next, connection)
+	}
+	if !found {
+		return os.ErrNotExist
+	}
+	return m.saveUnlocked(next)
+}
+
+func (m *Manager) Test(id string) (TestResult, error) {
+	connection, err := m.Get(id)
+	if err != nil {
+		return TestResult{}, err
+	}
+	checks := validateReadiness(*connection)
+	ok := true
+	for _, check := range checks {
+		if check.Status == "error" {
+			ok = false
+			break
+		}
+	}
+	summary := "Connection is ready for local IaC workflows."
+	if !ok {
+		summary = "Connection is missing required fields before it can be used."
+	}
+	return TestResult{
+		OK:         ok,
+		Summary:    summary,
+		Connection: publicConnection(*connection),
+		Checks:     checks,
+	}, nil
+}
+
+func (m *Manager) load() ([]Connection, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.loadUnlocked()
+}
+
+func (m *Manager) loadUnlocked() ([]Connection, error) {
+	data, err := os.ReadFile(m.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []Connection{}, nil
+		}
+		return nil, fmt.Errorf("read cloud connections: %w", err)
+	}
+	var connections []Connection
+	if err := json.Unmarshal(data, &connections); err != nil {
+		return nil, fmt.Errorf("parse cloud connections: %w", err)
+	}
+	return connections, nil
+}
+
+func (m *Manager) saveUnlocked(connections []Connection) error {
+	if err := os.MkdirAll(filepath.Dir(m.path), 0o755); err != nil {
+		return fmt.Errorf("create cloud connections directory: %w", err)
+	}
+	data, err := json.MarshalIndent(connections, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal cloud connections: %w", err)
+	}
+	return os.WriteFile(m.path, data, 0o600)
+}
+
+func normalizeAndValidate(connection *Connection) error {
+	connection.ID = strings.TrimSpace(connection.ID)
+	connection.Name = strings.TrimSpace(connection.Name)
+	connection.Provider = strings.TrimSpace(connection.Provider)
+	connection.AuthMethod = strings.TrimSpace(connection.AuthMethod)
+	connection.Region = strings.TrimSpace(connection.Region)
+
+	if connection.Name == "" {
+		return errors.New("connection name is required")
+	}
+	methods := providerAuthMethods[connection.Provider]
+	if len(methods) == 0 {
+		return fmt.Errorf("unsupported cloud provider: %s", connection.Provider)
+	}
+	if !slices.Contains(methods, connection.AuthMethod) {
+		return fmt.Errorf("unsupported auth method %q for provider %q", connection.AuthMethod, connection.Provider)
+	}
+	connection.Metadata = trimMap(connection.Metadata)
+	connection.Secrets = trimMap(connection.Secrets)
+	return nil
+}
+
+func publicConnection(connection Connection) PublicConnection {
+	return PublicConnection{
+		ID:           connection.ID,
+		Name:         connection.Name,
+		Provider:     connection.Provider,
+		AuthMethod:   connection.AuthMethod,
+		Region:       connection.Region,
+		Metadata:     publicMetadata(connection.AuthMethod, connection.Metadata),
+		SecretFields: presentSecretFields(connection.AuthMethod, connection.Secrets),
+		CreatedAt:    connection.CreatedAt,
+		UpdatedAt:    connection.UpdatedAt,
+	}
+}
+
+func publicMetadata(authMethod string, metadata map[string]string) map[string]string {
+	allowed := map[string]bool{
+		"profile":         true,
+		"account_id":      true,
+		"role_arn":        true,
+		"access_key_id":   true,
+		"subscription_id": true,
+		"tenant_id":       true,
+		"client_id":       true,
+		"project_id":      true,
+	}
+	out := map[string]string{}
+	for key, value := range trimMap(metadata) {
+		if allowed[key] && !slices.Contains(secretFieldsByMethod[authMethod], key) {
+			out[key] = value
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func secretMetadata(authMethod string, secrets map[string]string) map[string]string {
+	out := map[string]string{}
+	for _, key := range secretFieldsByMethod[authMethod] {
+		if value := strings.TrimSpace(secrets[key]); value != "" && !isMasked(value) {
+			out[key] = value
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func presentSecretFields(authMethod string, secrets map[string]string) []string {
+	out := []string{}
+	for _, key := range secretFieldsByMethod[authMethod] {
+		if strings.TrimSpace(secrets[key]) != "" {
+			out = append(out, key)
+		}
+	}
+	return out
+}
+
+func mergeSecrets(existing, submitted map[string]string) map[string]string {
+	out := cloneMap(existing)
+	for key, value := range submitted {
+		if value = strings.TrimSpace(value); value != "" && !isMasked(value) {
+			if out == nil {
+				out = map[string]string{}
+			}
+			out[key] = value
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func validateReadiness(connection Connection) []Check {
+	required := requiredFieldsByMethod[connection.AuthMethod]
+	checks := []Check{{
+		Name:    "auth_method",
+		Status:  "pass",
+		Message: fmt.Sprintf("%s is configured for %s", connection.AuthMethod, connection.Provider),
+	}}
+	for _, field := range required {
+		value := connection.Metadata[field]
+		if slices.Contains(secretFieldsByMethod[connection.AuthMethod], field) {
+			value = connection.Secrets[field]
+		}
+		if strings.TrimSpace(value) == "" {
+			checks = append(checks, Check{
+				Name:    field,
+				Status:  "error",
+				Message: fmt.Sprintf("%s is required for %s", field, connection.AuthMethod),
+			})
+		} else {
+			checks = append(checks, Check{
+				Name:    field,
+				Status:  "pass",
+				Message: fmt.Sprintf("%s is present", field),
+			})
+		}
+	}
+	if len(required) == 0 {
+		checks = append(checks, Check{
+			Name:    "local_auth",
+			Status:  "pass",
+			Message: "Uses locally managed cloud CLI credentials.",
+		})
+	}
+	return checks
+}
+
+func trimMap(values map[string]string) map[string]string {
+	out := map[string]string{}
+	for key, value := range values {
+		if key = strings.TrimSpace(key); key != "" {
+			if value = strings.TrimSpace(value); value != "" {
+				out[key] = value
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func cloneMap(values map[string]string) map[string]string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(values))
+	for key, value := range values {
+		out[key] = value
+	}
+	return out
+}
+
+func isMasked(value string) bool {
+	return strings.Contains(value, "*") || strings.Contains(value, "\u2022")
+}
+
+func newID() string {
+	var bytes [8]byte
+	if _, err := rand.Read(bytes[:]); err != nil {
+		return fmt.Sprintf("conn_%d", time.Now().UnixNano())
+	}
+	return "conn_" + hex.EncodeToString(bytes[:])
+}

--- a/internal/cloudconnections/connections.go
+++ b/internal/cloudconnections/connections.go
@@ -257,7 +257,60 @@ func (m *Manager) saveUnlocked(connections []Connection) error {
 	if err != nil {
 		return fmt.Errorf("marshal cloud connections: %w", err)
 	}
-	return os.WriteFile(m.path, data, 0o600)
+	if err := writeFileAtomic(m.path, data, 0o600); err != nil {
+		return fmt.Errorf("write cloud connections: %w", err)
+	}
+	return nil
+}
+
+func writeFileAtomic(path string, data []byte, mode os.FileMode) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+
+	tmpFile, err := os.CreateTemp(dir, filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmpFile.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if _, err := tmpFile.Write(data); err != nil {
+		_ = tmpFile.Close()
+		return err
+	}
+	if err := tmpFile.Chmod(mode); err != nil {
+		_ = tmpFile.Close()
+		return err
+	}
+	if err := tmpFile.Sync(); err != nil {
+		_ = tmpFile.Close()
+		return err
+	}
+	if err := tmpFile.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return err
+	}
+	cleanup = false
+	syncDirBestEffort(dir)
+	return nil
+}
+
+func syncDirBestEffort(dir string) {
+	handle, err := os.Open(dir)
+	if err != nil {
+		return
+	}
+	defer func() { _ = handle.Close() }()
+	_ = handle.Sync()
 }
 
 func normalizeAndValidate(connection *Connection) error {
@@ -421,7 +474,16 @@ func cloneMap(values map[string]string) map[string]string {
 }
 
 func isMasked(value string) bool {
-	return strings.Contains(value, "*") || strings.Contains(value, "\u2022")
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return false
+	}
+	for _, r := range value {
+		if r != '*' && r != '\u2022' {
+			return false
+		}
+	}
+	return true
 }
 
 func newID() string {

--- a/internal/cloudconnections/connections_test.go
+++ b/internal/cloudconnections/connections_test.go
@@ -1,0 +1,140 @@
+package cloudconnections
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestManagerRedactsStaticSecrets(t *testing.T) {
+	manager := NewManager(t.TempDir())
+
+	created, err := manager.Save(Connection{
+		Name:       "prod-admin",
+		Provider:   ProviderAWS,
+		AuthMethod: "aws_static",
+		Region:     "us-east-1",
+		Metadata: map[string]string{
+			"access_key_id": "AKIAEXAMPLE",
+			"account_id":    "123456789012",
+		},
+		Secrets: map[string]string{
+			"secret_access_key": "super-secret",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if got := created.Metadata["access_key_id"]; got != "AKIAEXAMPLE" {
+		t.Fatalf("access key id should be public metadata, got %q", got)
+	}
+	if slices.Contains(created.SecretFields, "secret_access_key") == false {
+		t.Fatalf("secret field presence should be exposed without value: %#v", created.SecretFields)
+	}
+
+	listed, err := manager.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(listed) != 1 {
+		t.Fatalf("expected one connection, got %d", len(listed))
+	}
+	if _, leaked := listed[0].Metadata["secret_access_key"]; leaked {
+		t.Fatal("secret_access_key leaked into public metadata")
+	}
+
+	data, err := os.ReadFile(filepath.Join(filepath.Dir(manager.path), ".iac-studio-connections.json"))
+	if err != nil {
+		t.Fatalf("read persisted file: %v", err)
+	}
+	if !contains(string(data), "super-secret") {
+		t.Fatal("expected secret to persist for later runner use")
+	}
+}
+
+func TestManagerKeepsExistingSecretOnMaskedUpdate(t *testing.T) {
+	manager := NewManager(t.TempDir())
+
+	created, err := manager.Save(Connection{
+		Name:       "prod-admin",
+		Provider:   ProviderAWS,
+		AuthMethod: "aws_static",
+		Metadata:   map[string]string{"access_key_id": "AKIAEXAMPLE"},
+		Secrets:    map[string]string{"secret_access_key": "old-secret"},
+	})
+	if err != nil {
+		t.Fatalf("Save create: %v", err)
+	}
+
+	if _, err := manager.Save(Connection{
+		ID:         created.ID,
+		Name:       "prod-admin-renamed",
+		Provider:   ProviderAWS,
+		AuthMethod: "aws_static",
+		Metadata:   map[string]string{"access_key_id": "AKIAEXAMPLE"},
+		Secrets:    map[string]string{"secret_access_key": "********"},
+	}); err != nil {
+		t.Fatalf("Save update: %v", err)
+	}
+
+	stored, err := manager.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got := stored.Secrets["secret_access_key"]; got != "old-secret" {
+		t.Fatalf("masked update should keep old secret, got %q", got)
+	}
+}
+
+func TestManagerTestReportsMissingRequiredFields(t *testing.T) {
+	manager := NewManager(t.TempDir())
+
+	created, err := manager.Save(Connection{
+		Name:       "incomplete-sp",
+		Provider:   ProviderAzure,
+		AuthMethod: "azure_service_principal",
+		Metadata:   map[string]string{"tenant_id": "tenant-1"},
+	})
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	result, err := manager.Test(created.ID)
+	if err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+	if result.OK {
+		t.Fatal("incomplete service principal should not be ready")
+	}
+	if !hasCheck(result.Checks, "client_id", "error") || !hasCheck(result.Checks, "client_secret", "error") {
+		t.Fatalf("missing required fields were not reported: %#v", result.Checks)
+	}
+}
+
+func TestManagerRejectsUnsupportedAuthMethod(t *testing.T) {
+	manager := NewManager(t.TempDir())
+
+	_, err := manager.Save(Connection{
+		Name:       "bad",
+		Provider:   ProviderAWS,
+		AuthMethod: "azure_cli",
+	})
+	if err == nil {
+		t.Fatal("expected unsupported auth method error")
+	}
+}
+
+func contains(text, want string) bool {
+	return strings.Contains(text, want)
+}
+
+func hasCheck(checks []Check, name string, status string) bool {
+	for _, check := range checks {
+		if check.Name == name && check.Status == status {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cloudconnections/connections_test.go
+++ b/internal/cloudconnections/connections_test.go
@@ -88,6 +88,71 @@ func TestManagerKeepsExistingSecretOnMaskedUpdate(t *testing.T) {
 	}
 }
 
+func TestManagerPersistsSecretContainingMaskCharacters(t *testing.T) {
+	manager := NewManager(t.TempDir())
+
+	created, err := manager.Save(Connection{
+		Name:       "prod-admin",
+		Provider:   ProviderAWS,
+		AuthMethod: "aws_static",
+		Metadata:   map[string]string{"access_key_id": "AKIAEXAMPLE"},
+		Secrets:    map[string]string{"secret_access_key": "old-secret"},
+	})
+	if err != nil {
+		t.Fatalf("Save create: %v", err)
+	}
+
+	want := "{\"private_key\":\"abc*def\u2022ghi\"}"
+	if _, err := manager.Save(Connection{
+		ID:         created.ID,
+		Name:       "prod-admin",
+		Provider:   ProviderAWS,
+		AuthMethod: "aws_static",
+		Metadata:   map[string]string{"access_key_id": "AKIAEXAMPLE"},
+		Secrets:    map[string]string{"secret_access_key": want},
+	}); err != nil {
+		t.Fatalf("Save update: %v", err)
+	}
+
+	stored, err := manager.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got := stored.Secrets["secret_access_key"]; got != want {
+		t.Fatalf("secret containing mask characters should persist, got %q", got)
+	}
+}
+
+func TestManagerSaveUsesAtomicFileModeAndCleansTempFiles(t *testing.T) {
+	dir := t.TempDir()
+	manager := NewManager(dir)
+
+	if _, err := manager.Save(Connection{
+		Name:       "prod-admin",
+		Provider:   ProviderAWS,
+		AuthMethod: "aws_profile",
+		Metadata:   map[string]string{"profile": "default"},
+	}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	info, err := os.Stat(manager.path)
+	if err != nil {
+		t.Fatalf("stat persisted file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("connection file mode should be 0600, got %o", got)
+	}
+
+	tmpFiles, err := filepath.Glob(filepath.Join(dir, ".iac-studio-connections.json.*.tmp"))
+	if err != nil {
+		t.Fatalf("glob temp files: %v", err)
+	}
+	if len(tmpFiles) != 0 {
+		t.Fatalf("atomic temp files should be cleaned up: %#v", tmpFiles)
+	}
+}
+
 func TestManagerTestReportsMissingRequiredFields(t *testing.T) {
 	manager := NewManager(t.TempDir())
 
@@ -123,6 +188,31 @@ func TestManagerRejectsUnsupportedAuthMethod(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected unsupported auth method error")
+	}
+}
+
+func TestIsMaskedRequiresOnlyMaskCharacters(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "empty", value: "", want: false},
+		{name: "stars", value: "********", want: true},
+		{name: "bullets", value: "\u2022\u2022\u2022\u2022", want: true},
+		{name: "mixed masks", value: "***\u2022\u2022", want: true},
+		{name: "trimmed masks", value: "  ********  ", want: true},
+		{name: "embedded star", value: "abc*def", want: false},
+		{name: "embedded bullet", value: "abc\u2022def", want: false},
+		{name: "json credential", value: `{"private_key":"abc*def"}`, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isMasked(tt.value); got != tt.want {
+				t.Fatalf("isMasked(%q) = %t, want %t", tt.value, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -37,6 +37,79 @@ describe('api.generateTopologyFromImages', () => {
   });
 });
 
+describe('api.cloudConnections', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('creates cloud connections with provider metadata and secrets', async () => {
+    const response = {
+      id: 'conn_1',
+      name: 'prod-admin',
+      provider: 'aws',
+      auth_method: 'aws_static',
+      metadata: { access_key_id: 'AKIAEXAMPLE' },
+      secret_fields: ['secret_access_key'],
+    };
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(response), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(api.createCloudConnection({
+      name: 'prod-admin',
+      provider: 'aws',
+      auth_method: 'aws_static',
+      region: 'us-east-1',
+      metadata: { access_key_id: 'AKIAEXAMPLE' },
+      secrets: { secret_access_key: 'super-secret' },
+    })).resolves.toEqual(response);
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/cloud/connections', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'prod-admin',
+        provider: 'aws',
+        auth_method: 'aws_static',
+        region: 'us-east-1',
+        metadata: { access_key_id: 'AKIAEXAMPLE' },
+        secrets: { secret_access_key: 'super-secret' },
+      }),
+    });
+  });
+
+  it('tests cloud connections through the scoped test endpoint', async () => {
+    const response = {
+      ok: true,
+      summary: 'Connection is ready for local IaC workflows.',
+      connection: {
+        id: 'conn_1',
+        name: 'prod-admin',
+        provider: 'aws',
+        auth_method: 'aws_profile',
+      },
+      checks: [{ name: 'auth_method', status: 'pass', message: 'configured' }],
+    };
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(response), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(api.testCloudConnection('conn_1')).resolves.toEqual(response);
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/cloud/connections/conn_1/test', {
+      method: 'POST',
+    });
+  });
+});
+
 describe('api.runCommand', () => {
   afterEach(() => {
     vi.unstubAllGlobals();

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -98,6 +98,46 @@ export interface CatalogResource {
   connects_via?: Record<string, string>;
 }
 
+export type CloudProvider = 'aws' | 'azure' | 'gcp';
+
+export type CloudAuthMethod =
+  | 'aws_profile'
+  | 'aws_sso'
+  | 'aws_static'
+  | 'azure_cli'
+  | 'azure_service_principal'
+  | 'gcp_gcloud'
+  | 'gcp_service_account';
+
+export interface CloudConnection {
+  id: string;
+  name: string;
+  provider: CloudProvider;
+  auth_method: CloudAuthMethod;
+  region?: string;
+  metadata?: Record<string, string>;
+  secret_fields?: string[];
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface CloudConnectionInput {
+  id?: string;
+  name: string;
+  provider: CloudProvider;
+  auth_method: CloudAuthMethod;
+  region?: string;
+  metadata?: Record<string, string>;
+  secrets?: Record<string, string>;
+}
+
+export interface CloudConnectionTestResult {
+  ok: boolean;
+  summary: string;
+  connection: CloudConnection;
+  checks: { name: string; status: 'pass' | 'warn' | 'error'; message: string }[];
+}
+
 // Checks res.ok and throws with the backend's error message instead of
 // letting callers hit an opaque JSON parse failure on text/plain errors.
 async function check(res: Response): Promise<Response> {
@@ -117,6 +157,39 @@ async function check(res: Response): Promise<Response> {
 }
 
 export const api = {
+  async listCloudConnections(): Promise<CloudConnection[]> {
+    const res = await fetch(`${BASE}/api/cloud/connections`);
+    return (await check(res)).json();
+  },
+
+  async createCloudConnection(input: CloudConnectionInput): Promise<CloudConnection> {
+    const res = await fetch(`${BASE}/api/cloud/connections`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    });
+    return (await check(res)).json();
+  },
+
+  async updateCloudConnection(id: string, input: CloudConnectionInput): Promise<CloudConnection> {
+    const res = await fetch(`${BASE}/api/cloud/connections/${encodeURIComponent(id)}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    });
+    return (await check(res)).json();
+  },
+
+  async deleteCloudConnection(id: string): Promise<{ status: string }> {
+    const res = await fetch(`${BASE}/api/cloud/connections/${encodeURIComponent(id)}`, { method: 'DELETE' });
+    return (await check(res)).json();
+  },
+
+  async testCloudConnection(id: string): Promise<CloudConnectionTestResult> {
+    const res = await fetch(`${BASE}/api/cloud/connections/${encodeURIComponent(id)}/test`, { method: 'POST' });
+    return (await check(res)).json();
+  },
+
   // Fetch resource catalog for a tool (optionally filtered by provider)
   async getCatalog(tool: string, provider?: string): Promise<{ tool: string; resources: CatalogResource[] }> {
     const params = new URLSearchParams({ tool });

--- a/web/src/components/CloudConnections/CloudConnectionsPanel.test.tsx
+++ b/web/src/components/CloudConnections/CloudConnectionsPanel.test.tsx
@@ -127,6 +127,7 @@ describe('CloudConnectionsPanel', () => {
       expect(client.testCloudConnection).toHaveBeenCalledWith('conn_1');
     });
     expect(await screen.findByText(/client_secret is required/)).toBeInTheDocument();
+    expect(screen.getByLabelText('Connection test failed')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Delete sp' }));
     await waitFor(() => {

--- a/web/src/components/CloudConnections/CloudConnectionsPanel.test.tsx
+++ b/web/src/components/CloudConnections/CloudConnectionsPanel.test.tsx
@@ -1,0 +1,136 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { CloudConnection, CloudConnectionInput, CloudConnectionTestResult } from '../../api';
+import { CloudConnectionsPanel } from './CloudConnectionsPanel';
+
+function makeClient(initial: CloudConnection[] = []) {
+  let connections = [...initial];
+  return {
+    listCloudConnections: vi.fn(async () => connections),
+    createCloudConnection: vi.fn(async (input: CloudConnectionInput) => {
+      const connection: CloudConnection = {
+        id: 'conn_1',
+        name: input.name,
+        provider: input.provider,
+        auth_method: input.auth_method,
+        region: input.region,
+        metadata: input.metadata,
+        secret_fields: input.secrets && Object.keys(input.secrets).length > 0 ? Object.keys(input.secrets) : undefined,
+      };
+      connections = [connection];
+      return connection;
+    }),
+    updateCloudConnection: vi.fn(async (id: string, input: CloudConnectionInput) => {
+      const connection: CloudConnection = {
+        id,
+        name: input.name,
+        provider: input.provider,
+        auth_method: input.auth_method,
+        region: input.region,
+        metadata: input.metadata,
+        secret_fields: initial.find(item => item.id === id)?.secret_fields,
+      };
+      connections = connections.map(item => item.id === id ? connection : item);
+      return connection;
+    }),
+    deleteCloudConnection: vi.fn(async (id: string) => {
+      connections = connections.filter(item => item.id !== id);
+      return { status: 'deleted' };
+    }),
+    testCloudConnection: vi.fn(async (id: string): Promise<CloudConnectionTestResult> => ({
+      ok: false,
+      summary: 'Connection is missing required fields before it can be used.',
+      connection: connections.find(item => item.id === id)!,
+      checks: [
+        { name: 'client_secret', status: 'error', message: 'client_secret is required for azure_service_principal' },
+      ],
+    })),
+  };
+}
+
+describe('CloudConnectionsPanel', () => {
+  it('creates an AWS profile connection and refreshes the list', async () => {
+    const client = makeClient();
+    render(<CloudConnectionsPanel client={client} />);
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'prod-admin' } });
+    fireEvent.change(screen.getByLabelText('Region'), { target: { value: 'us-east-1' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save connection' }));
+
+    await waitFor(() => {
+      expect(client.createCloudConnection).toHaveBeenCalledWith(expect.objectContaining({
+        name: 'prod-admin',
+        provider: 'aws',
+        auth_method: 'aws_profile',
+        region: 'us-east-1',
+        metadata: { profile: 'default' },
+        secrets: {},
+      }));
+    });
+    await waitFor(() => {
+      expect(screen.getByText('prod-admin')).toBeInTheDocument();
+    });
+  });
+
+  it('does not render stored secret values when editing', async () => {
+    const client = makeClient([
+      {
+        id: 'conn_1',
+        name: 'break-glass',
+        provider: 'aws',
+        auth_method: 'aws_static',
+        metadata: { access_key_id: 'AKIAEXAMPLE' },
+        secret_fields: ['secret_access_key'],
+      },
+    ]);
+    render(<CloudConnectionsPanel client={client} />);
+
+    await screen.findByText('break-glass');
+    fireEvent.click(screen.getByText('break-glass'));
+
+    expect(screen.getByLabelText('Secret access key')).toHaveValue('');
+    expect(screen.getByPlaceholderText('Stored secret; leave blank to keep it')).toBeInTheDocument();
+  });
+
+  it('preserves draft identity fields when switching providers', async () => {
+    const client = makeClient();
+    render(<CloudConnectionsPanel client={client} />);
+
+    await screen.findByText('0 connections');
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'prod-admin' } });
+    fireEvent.change(screen.getByLabelText('Region'), { target: { value: 'us-east-1' } });
+    fireEvent.change(screen.getByLabelText('Provider'), { target: { value: 'azure' } });
+
+    expect(screen.getByLabelText('Name')).toHaveValue('prod-admin');
+    expect(screen.getByLabelText('Region')).toHaveValue('us-east-1');
+    expect(screen.getByLabelText('Auth')).toHaveValue('azure_cli');
+  });
+
+  it('runs connection tests and deletes connections', async () => {
+    const client = makeClient([
+      {
+        id: 'conn_1',
+        name: 'sp',
+        provider: 'azure',
+        auth_method: 'azure_service_principal',
+        metadata: { tenant_id: 'tenant-1' },
+      },
+    ]);
+    render(<CloudConnectionsPanel client={client} />);
+
+    await screen.findByText('sp');
+    fireEvent.click(screen.getByRole('button', { name: 'Test' }));
+
+    await waitFor(() => {
+      expect(client.testCloudConnection).toHaveBeenCalledWith('conn_1');
+    });
+    expect(await screen.findByText(/client_secret is required/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete sp' }));
+    await waitFor(() => {
+      expect(client.deleteCloudConnection).toHaveBeenCalledWith('conn_1');
+    });
+  });
+});

--- a/web/src/components/CloudConnections/CloudConnectionsPanel.tsx
+++ b/web/src/components/CloudConnections/CloudConnectionsPanel.tsx
@@ -1,0 +1,363 @@
+import { useEffect, useMemo, useState } from 'react';
+import { CheckCircle2, CloudCog, PlugZap, Trash2 } from 'lucide-react';
+
+import {
+  api,
+  type CloudAuthMethod,
+  type CloudConnection,
+  type CloudConnectionInput,
+  type CloudConnectionTestResult,
+  type CloudProvider,
+} from '../../api';
+import { Button } from '../ui/button';
+
+type CloudClient = Pick<
+  typeof api,
+  'listCloudConnections' |
+  'createCloudConnection' |
+  'updateCloudConnection' |
+  'deleteCloudConnection' |
+  'testCloudConnection'
+>;
+
+export interface CloudConnectionsPanelProps {
+  client?: CloudClient;
+}
+
+const providerMethods: Record<CloudProvider, { key: CloudAuthMethod; label: string }[]> = {
+  aws: [
+    { key: 'aws_profile', label: 'AWS profile' },
+    { key: 'aws_sso', label: 'AWS SSO profile' },
+    { key: 'aws_static', label: 'Static key fallback' },
+  ],
+  azure: [
+    { key: 'azure_cli', label: 'Azure CLI' },
+    { key: 'azure_service_principal', label: 'Service principal' },
+  ],
+  gcp: [
+    { key: 'gcp_gcloud', label: 'gcloud auth' },
+    { key: 'gcp_service_account', label: 'Service account JSON' },
+  ],
+};
+
+const metadataFields: Record<CloudAuthMethod, { key: string; label: string; secret?: boolean; multiline?: boolean }[]> = {
+  aws_profile: [
+    { key: 'profile', label: 'Profile' },
+    { key: 'account_id', label: 'Account ID' },
+    { key: 'role_arn', label: 'Role ARN' },
+  ],
+  aws_sso: [
+    { key: 'profile', label: 'SSO profile' },
+    { key: 'account_id', label: 'Account ID' },
+    { key: 'role_arn', label: 'Role ARN' },
+  ],
+  aws_static: [
+    { key: 'access_key_id', label: 'Access key ID' },
+    { key: 'secret_access_key', label: 'Secret access key', secret: true },
+    { key: 'session_token', label: 'Session token', secret: true, multiline: true },
+    { key: 'account_id', label: 'Account ID' },
+    { key: 'role_arn', label: 'Role ARN' },
+  ],
+  azure_cli: [
+    { key: 'subscription_id', label: 'Subscription ID' },
+    { key: 'tenant_id', label: 'Tenant ID' },
+  ],
+  azure_service_principal: [
+    { key: 'tenant_id', label: 'Tenant ID' },
+    { key: 'subscription_id', label: 'Subscription ID' },
+    { key: 'client_id', label: 'Client ID' },
+    { key: 'client_secret', label: 'Client secret', secret: true },
+  ],
+  gcp_gcloud: [
+    { key: 'project_id', label: 'Project ID' },
+  ],
+  gcp_service_account: [
+    { key: 'project_id', label: 'Project ID' },
+    { key: 'service_account_json', label: 'Service account JSON', secret: true, multiline: true },
+  ],
+};
+
+const defaultInput = (): CloudConnectionInput => ({
+  name: '',
+  provider: 'aws',
+  auth_method: 'aws_profile',
+  region: '',
+  metadata: { profile: 'default' },
+  secrets: {},
+});
+
+function splitFields(input: CloudConnectionInput) {
+  const metadata: Record<string, string> = {};
+  const secrets: Record<string, string> = {};
+  for (const field of metadataFields[input.auth_method]) {
+    const value = field.secret ? input.secrets?.[field.key] : input.metadata?.[field.key];
+    if (value?.trim()) {
+      if (field.secret) secrets[field.key] = value.trim();
+      else metadata[field.key] = value.trim();
+    }
+  }
+  return { metadata, secrets };
+}
+
+function fromConnection(connection: CloudConnection): CloudConnectionInput {
+  return {
+    id: connection.id,
+    name: connection.name,
+    provider: connection.provider,
+    auth_method: connection.auth_method,
+    region: connection.region || '',
+    metadata: { ...(connection.metadata || {}) },
+    secrets: {},
+  };
+}
+
+export function CloudConnectionsPanel({ client = api }: CloudConnectionsPanelProps) {
+  const [connections, setConnections] = useState<CloudConnection[]>([]);
+  const [form, setForm] = useState<CloudConnectionInput>(defaultInput);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [testingId, setTestingId] = useState<string | null>(null);
+  const [testResult, setTestResult] = useState<CloudConnectionTestResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const selected = useMemo(
+    () => connections.find(connection => connection.id === form.id),
+    [connections, form.id],
+  );
+
+  const load = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      setConnections(await client.listCloudConnections());
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const updateField = (key: string, value: string, secret?: boolean) => {
+    setForm(current => ({
+      ...current,
+      [secret ? 'secrets' : 'metadata']: {
+        ...(secret ? current.secrets : current.metadata),
+        [key]: value,
+      },
+    }));
+  };
+
+  const save = async () => {
+    setSaving(true);
+    setError(null);
+    const { metadata, secrets } = splitFields(form);
+    const payload: CloudConnectionInput = {
+      ...form,
+      region: form.region?.trim(),
+      metadata,
+      secrets,
+    };
+    try {
+      const saved = form.id
+        ? await client.updateCloudConnection(form.id, payload)
+        : await client.createCloudConnection(payload);
+      setForm(fromConnection(saved));
+      setTestResult(null);
+      await load();
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const remove = async (id: string) => {
+    setError(null);
+    try {
+      await client.deleteCloudConnection(id);
+      if (form.id === id) setForm(defaultInput());
+      if (testResult?.connection.id === id) setTestResult(null);
+      await load();
+    } catch (err) {
+      setError(String(err));
+    }
+  };
+
+  const test = async (id: string) => {
+    setTestingId(id);
+    setError(null);
+    try {
+      setTestResult(await client.testCloudConnection(id));
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setTestingId(null);
+    }
+  };
+
+  return (
+    <div className="flex h-full flex-col gap-3 bg-background p-4">
+      <header className="flex items-center gap-3">
+        <CloudCog className="h-4 w-4 text-primary" />
+        <h2 className="text-sm font-semibold uppercase tracking-widest text-foreground">
+          Cloud Connections
+        </h2>
+        <Button size="sm" variant="outline" className="ml-auto" onClick={() => setForm(defaultInput())}>
+          New
+        </Button>
+      </header>
+
+      {error && (
+        <div className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+          {error}
+        </div>
+      )}
+
+      <section className="grid gap-2">
+        <label className="grid gap-1 text-xs text-muted-foreground">
+          Name
+          <input
+            className="rounded-md border border-border bg-card px-3 py-2 text-sm text-foreground outline-none focus:border-primary"
+            value={form.name}
+            onChange={event => setForm(current => ({ ...current, name: event.target.value }))}
+            placeholder="prod-admin"
+          />
+        </label>
+
+        <div className="grid grid-cols-2 gap-2">
+          <label className="grid gap-1 text-xs text-muted-foreground">
+            Provider
+            <select
+              className="rounded-md border border-border bg-card px-3 py-2 text-sm text-foreground outline-none focus:border-primary"
+              value={form.provider}
+              onChange={event => {
+                const provider = event.target.value as CloudProvider;
+                setForm(current => ({
+                  ...current,
+                  id: undefined,
+                  provider,
+                  auth_method: providerMethods[provider][0].key,
+                  metadata: {},
+                  secrets: {},
+                }));
+              }}
+            >
+              <option value="aws">AWS</option>
+              <option value="azure">Azure</option>
+              <option value="gcp">GCP</option>
+            </select>
+          </label>
+
+          <label className="grid gap-1 text-xs text-muted-foreground">
+            Auth
+            <select
+              className="rounded-md border border-border bg-card px-3 py-2 text-sm text-foreground outline-none focus:border-primary"
+              value={form.auth_method}
+              onChange={event => setForm(current => ({ ...current, auth_method: event.target.value as CloudAuthMethod, metadata: {}, secrets: {} }))}
+            >
+              {providerMethods[form.provider].map(method => (
+                <option key={method.key} value={method.key}>{method.label}</option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        <label className="grid gap-1 text-xs text-muted-foreground">
+          Region
+          <input
+            className="rounded-md border border-border bg-card px-3 py-2 text-sm text-foreground outline-none focus:border-primary"
+            value={form.region || ''}
+            onChange={event => setForm(current => ({ ...current, region: event.target.value }))}
+            placeholder={form.provider === 'aws' ? 'us-east-1' : form.provider === 'azure' ? 'eastus' : 'us-central1'}
+          />
+        </label>
+
+        {metadataFields[form.auth_method].map(field => {
+          const value = field.secret ? form.secrets?.[field.key] || '' : form.metadata?.[field.key] || '';
+          const stored = selected?.secret_fields?.includes(field.key);
+          const className = 'rounded-md border border-border bg-card px-3 py-2 text-sm text-foreground outline-none focus:border-primary';
+          return (
+            <label key={field.key} className="grid gap-1 text-xs text-muted-foreground">
+              {field.label}
+              {field.multiline ? (
+                <textarea
+                  className={`${className} min-h-20 resize-none font-mono text-xs`}
+                  value={value}
+                  onChange={event => updateField(field.key, event.target.value, field.secret)}
+                  placeholder={stored ? 'Stored secret; leave blank to keep it' : undefined}
+                />
+              ) : (
+                <input
+                  className={className}
+                  type={field.secret ? 'password' : 'text'}
+                  value={value}
+                  onChange={event => updateField(field.key, event.target.value, field.secret)}
+                  placeholder={stored ? 'Stored secret; leave blank to keep it' : undefined}
+                />
+              )}
+            </label>
+          );
+        })}
+
+        <Button onClick={save} disabled={saving || !form.name.trim()}>
+          {saving ? 'Saving...' : form.id ? 'Update connection' : 'Save connection'}
+        </Button>
+      </section>
+
+      <section className="min-h-0 flex-1 overflow-y-auto border-t border-border pt-3">
+        <div className="mb-2 flex items-center justify-between text-xs text-muted-foreground">
+          <span>{loading ? 'Loading...' : `${connections.length} connection${connections.length === 1 ? '' : 's'}`}</span>
+        </div>
+        <div className="grid gap-2">
+          {connections.map(connection => (
+            <div key={connection.id} className="rounded-md border border-border bg-card p-3">
+              <button
+                type="button"
+                className="mb-2 flex w-full items-center gap-2 text-left"
+                onClick={() => {
+                  setForm(fromConnection(connection));
+                  setTestResult(null);
+                }}
+              >
+                <PlugZap className="h-3.5 w-3.5 text-primary" />
+                <span className="min-w-0 flex-1 truncate text-sm font-semibold text-foreground">{connection.name}</span>
+                <span className="rounded bg-primary/10 px-2 py-0.5 font-mono text-[10px] uppercase text-primary">{connection.provider}</span>
+              </button>
+              <div className="mb-3 font-mono text-[11px] text-muted-foreground">
+                {connection.auth_method}{connection.region ? ` / ${connection.region}` : ''}
+              </div>
+              <div className="flex gap-2">
+                <Button size="sm" variant="outline" onClick={() => test(connection.id)} disabled={testingId === connection.id}>
+                  {testingId === connection.id ? 'Testing...' : 'Test'}
+                </Button>
+                <Button size="sm" variant="ghost" onClick={() => remove(connection.id)} aria-label={`Delete ${connection.name}`}>
+                  <Trash2 className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {testResult && (
+        <section className={`rounded-md border px-3 py-2 text-xs ${testResult.ok ? 'border-primary/40 bg-primary/10' : 'border-destructive/50 bg-destructive/10'}`}>
+          <div className="mb-2 flex items-center gap-2 font-semibold text-foreground">
+            <CheckCircle2 className="h-3.5 w-3.5" />
+            {testResult.summary}
+          </div>
+          <div className="grid gap-1 font-mono text-[11px]">
+            {testResult.checks.map(check => (
+              <div key={check.name} className={check.status === 'error' ? 'text-destructive' : 'text-muted-foreground'}>
+                {check.status.toUpperCase()} {check.name}: {check.message}
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/CloudConnections/CloudConnectionsPanel.tsx
+++ b/web/src/components/CloudConnections/CloudConnectionsPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { CheckCircle2, CloudCog, PlugZap, Trash2 } from 'lucide-react';
+import { CheckCircle2, CloudCog, PlugZap, Trash2, XCircle } from 'lucide-react';
 
 import {
   api,
@@ -346,7 +346,11 @@ export function CloudConnectionsPanel({ client = api }: CloudConnectionsPanelPro
       {testResult && (
         <section className={`rounded-md border px-3 py-2 text-xs ${testResult.ok ? 'border-primary/40 bg-primary/10' : 'border-destructive/50 bg-destructive/10'}`}>
           <div className="mb-2 flex items-center gap-2 font-semibold text-foreground">
-            <CheckCircle2 className="h-3.5 w-3.5" />
+            {testResult.ok ? (
+              <CheckCircle2 className="h-3.5 w-3.5 text-primary" aria-label="Connection test passed" />
+            ) : (
+              <XCircle className="h-3.5 w-3.5 text-destructive" aria-label="Connection test failed" />
+            )}
             {testResult.summary}
           </div>
           <div className="grid gap-1 font-mono text-[11px]">

--- a/web/src/components/CloudConnections/index.tsx
+++ b/web/src/components/CloudConnections/index.tsx
@@ -1,0 +1,1 @@
+export { CloudConnectionsPanel } from './CloudConnectionsPanel';

--- a/web/src/components/Inspector/InspectorPanel.test.tsx
+++ b/web/src/components/Inspector/InspectorPanel.test.tsx
@@ -18,6 +18,12 @@ vi.mock('../CodeEditor', () => ({
   ),
 }));
 
+vi.mock('../CloudConnections', () => ({
+  CloudConnectionsPanel: () => (
+    <div>Cloud connections panel</div>
+  ),
+}));
+
 vi.mock('../PolicyStudio', () => ({
   PolicyStudioPanel: ({ projectName, tool, env }: any) => (
     <div>Policy panel {projectName} {tool} {env}</div>
@@ -193,8 +199,15 @@ describe('InspectorPanel', () => {
   it('renders tool tabs and mounted panels', () => {
     renderInspector({ activeTab: 'modules' });
 
+    expect(screen.getByRole('button', { name: 'Cloud' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Modules' })).toBeInTheDocument();
     expect(screen.getByText('Module registry vpc')).toBeInTheDocument();
+  });
+
+  it('renders the cloud connections tab', () => {
+    renderInspector({ activeTab: 'cloud' });
+
+    expect(screen.getByText('Cloud connections panel')).toBeInTheDocument();
   });
 
   it('guards unresolved hybrid environments', () => {

--- a/web/src/components/Inspector/index.tsx
+++ b/web/src/components/Inspector/index.tsx
@@ -1,12 +1,13 @@
 import type { Resource } from '../../api';
 import type { Edge } from '../../legacy';
 import { S } from '../../styles';
+import { CloudConnectionsPanel } from '../CloudConnections';
 import { CodeEditor } from '../CodeEditor';
 import { ModuleRegistryPanel } from '../ModuleRegistry';
 import { PolicyStudioPanel } from '../PolicyStudio';
 import { ScanPanel } from '../ScanPanel';
 
-export type RightPanelTab = 'inspect' | 'policy' | 'scan' | 'modules';
+export type RightPanelTab = 'inspect' | 'cloud' | 'policy' | 'scan' | 'modules';
 
 export interface InspectorResource extends Resource {
   icon: string;
@@ -93,6 +94,7 @@ export function InspectorPanel({
 
   const tabs: { key: RightPanelTab; label: string }[] = [
     { key: 'inspect', label: selected || selectedEdge ? 'Inspect' : 'Code' },
+    { key: 'cloud', label: 'Cloud' },
     { key: 'policy', label: 'Policy' },
     { key: 'scan', label: 'Scan' },
     ...(tool === 'ansible' ? [] : [{ key: 'modules' as const, label: 'Modules' }]),
@@ -247,6 +249,12 @@ export function InspectorPanel({
             </div>
           </div>
         </>
+      )}
+
+      {activeTab === 'cloud' && (
+        <div style={{ flex: 1, minHeight: 0 }}>
+          <CloudConnectionsPanel />
+        </div>
       )}
 
       {activeTab === 'policy' && (


### PR DESCRIPTION
## Summary
- add a redacted cloud connection broker for AWS, Azure, and GCP auth profiles
- expose CRUD/test endpoints for future deploy, drift, import, and MCP workflows
- mount a Cloud tab in the right rail for managing and testing connections

Refs #42

## Validation
- GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/cloudconnections ./internal/api
- npm test -- --run
- npm run build
- npm run lint (0 errors, existing warnings)
- git diff --check