### PR TITLE
Bind cloud connections to run workflows

### DIFF
--- a/internal/api/cloud_connections_test.go
+++ b/internal/api/cloud_connections_test.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -124,6 +126,58 @@ func TestCloudConnectionUpdateMissingConnectionReturns404(t *testing.T) {
 	if resp.StatusCode != http.StatusNotFound {
 		t.Fatalf("missing update should 404, got %d", resp.StatusCode)
 	}
+}
+
+func TestRunWithMissingCloudConnectionReturns404(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "demo"), 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	srv := httptest.NewServer(fullRouterForTest(t, root))
+	defer srv.Close()
+
+	body := `{"tool":"terraform","command":"plan","connection_id":"missing"}`
+	resp, err := http.Post(srv.URL+"/api/projects/demo/run", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST run: %v", err)
+	}
+	defer closeBody(resp.Body)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("run with missing connection should 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestRunWithIncompleteCloudConnectionReturns400(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "demo"), 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	srv := httptest.NewServer(fullRouterForTest(t, root))
+	defer srv.Close()
+
+	createBody := `{"name":"sp","provider":"azure","auth_method":"azure_service_principal","metadata":{"tenant_id":"tenant-1"}}`
+	resp, err := http.Post(srv.URL+"/api/cloud/connections", "application/json", strings.NewReader(createBody))
+	if err != nil {
+		t.Fatalf("POST connection: %v", err)
+	}
+	defer closeBody(resp.Body)
+	var created struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create: %v", err)
+	}
+
+	runBody := `{"tool":"terraform","command":"plan","connection_id":"` + created.ID + `"}`
+	resp, err = http.Post(srv.URL+"/api/projects/demo/run", "application/json", strings.NewReader(runBody))
+	if err != nil {
+		t.Fatalf("POST run: %v", err)
+	}
+	defer closeBody(resp.Body)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("run with incomplete connection should 400, got %d", resp.StatusCode)
+	}
+	assertResponseBodyContains(t, resp, "connection_not_ready", "client_secret")
 }
 
 func routeHasCheck(checks []struct {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1072,6 +1072,8 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 		})
 	})
 
+	cloudConnections := cloudconnections.NewManager(projectsDir)
+
 	// Run IaC command (init, plan, apply)
 	mux.HandleFunc("POST /api/projects/{name}/run", func(w http.ResponseWriter, r *http.Request) {
 		name := r.PathValue("name")
@@ -1095,7 +1097,8 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 			// layered-v1 projects (environments/<env>/...). Empty runs
 			// commands at the project root (flat layout). Validated as a
 			// safe path segment so a bad value can't traverse.
-			Env string `json:"env,omitempty"`
+			Env          string `json:"env,omitempty"`
+			ConnectionID string `json:"connection_id,omitempty"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			http.Error(w, "invalid request", 400)
@@ -1121,6 +1124,37 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 				return
 			}
 			runPath = subPath
+		}
+
+		var commandEnv map[string]string
+		var connectionSummary cloudconnections.PublicConnection
+		if req.ConnectionID != "" {
+			connection, connErr := cloudConnections.Get(req.ConnectionID)
+			if connErr != nil {
+				if errors.Is(connErr, os.ErrNotExist) {
+					http.Error(w, "connection not found", 404)
+					return
+				}
+				http.Error(w, connErr.Error(), 500)
+				return
+			}
+			testResult, testErr := cloudConnections.Test(req.ConnectionID)
+			if testErr != nil {
+				http.Error(w, testErr.Error(), 500)
+				return
+			}
+			if !testResult.OK {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"error":  "connection_not_ready",
+					"detail": testResult.Summary,
+					"checks": testResult.Checks,
+				})
+				return
+			}
+			commandEnv = cloudconnections.CommandEnvironment(*connection)
+			connectionSummary = testResult.Connection
 		}
 
 		// Block apply/destroy unless:
@@ -1173,7 +1207,7 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 		// a request-scoped context and kill the command. SafeRunner applies its
 		// own per-command timeout (init=5m, plan=10m, apply=30m).
 		go func() {
-			result, err := run.Execute(context.Background(), runPath, effectiveTool, req.Command, req.Env)
+			result, err := run.ExecuteWithEnv(context.Background(), runPath, effectiveTool, req.Command, req.Env, commandEnv)
 			// Only record a successful plan — failed/cancelled plans don't count.
 			// 'preview' is Pulumi's equivalent of terraform plan; without it
 			// here, a pulumi up following a successful preview would be
@@ -1186,6 +1220,13 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 			msg := map[string]interface{}{
 				"type":    "terminal",
 				"project": name,
+			}
+			if connectionSummary.ID != "" {
+				msg["connection"] = map[string]string{
+					"id":       connectionSummary.ID,
+					"name":     connectionSummary.Name,
+					"provider": connectionSummary.Provider,
+				}
 			}
 			if result != nil {
 				msg["output"] = result.Output
@@ -1200,7 +1241,11 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 		}()
 
 		w.WriteHeader(http.StatusAccepted)
-		_ = json.NewEncoder(w).Encode(map[string]string{"status": "running"})
+		response := map[string]any{"status": "running"}
+		if connectionSummary.ID != "" {
+			response["connection"] = connectionSummary
+		}
+		_ = json.NewEncoder(w).Encode(response)
 	})
 
 	// Kill a running command
@@ -1409,7 +1454,6 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 	// ─── Project State Persistence ───
 
 	pm := project.NewManager(projectsDir)
-	cloudConnections := cloudconnections.NewManager(projectsDir)
 
 	// Cloud connection broker - stores named cloud targets for later plan/apply,
 	// drift, import, and MCP workflows. Route responses always use public views

--- a/internal/cloudconnections/connections.go
+++ b/internal/cloudconnections/connections.go
@@ -103,6 +103,65 @@ func SupportedAuthMethods(provider string) []string {
 	return slices.Clone(methods)
 }
 
+// CommandEnvironment translates a saved connection into process environment
+// variables understood by Terraform/OpenTofu, Pulumi, and cloud CLIs. It never
+// returns display text, so callers can attach it to command execution without
+// echoing secrets back to the terminal or websocket payloads.
+func CommandEnvironment(connection Connection) map[string]string {
+	env := map[string]string{}
+	set := func(key, value string) {
+		if value = strings.TrimSpace(value); value != "" {
+			env[key] = value
+		}
+	}
+
+	switch connection.AuthMethod {
+	case "aws_profile", "aws_sso":
+		set("AWS_PROFILE", connection.Metadata["profile"])
+		set("AWS_SDK_LOAD_CONFIG", "1")
+	case "aws_static":
+		set("AWS_ACCESS_KEY_ID", connection.Metadata["access_key_id"])
+		set("AWS_SECRET_ACCESS_KEY", connection.Secrets["secret_access_key"])
+		set("AWS_SESSION_TOKEN", connection.Secrets["session_token"])
+	case "azure_cli":
+		set("ARM_SUBSCRIPTION_ID", connection.Metadata["subscription_id"])
+		set("ARM_TENANT_ID", connection.Metadata["tenant_id"])
+	case "azure_service_principal":
+		set("ARM_SUBSCRIPTION_ID", connection.Metadata["subscription_id"])
+		set("ARM_TENANT_ID", connection.Metadata["tenant_id"])
+		set("ARM_CLIENT_ID", connection.Metadata["client_id"])
+		set("ARM_CLIENT_SECRET", connection.Secrets["client_secret"])
+	case "gcp_gcloud":
+		setGCPProject(env, connection.Metadata["project_id"])
+	case "gcp_service_account":
+		setGCPProject(env, connection.Metadata["project_id"])
+		set("GOOGLE_CREDENTIALS", connection.Secrets["service_account_json"])
+	}
+
+	switch connection.Provider {
+	case ProviderAWS:
+		set("AWS_REGION", connection.Region)
+		set("AWS_DEFAULT_REGION", connection.Region)
+	case ProviderGCP:
+		set("CLOUDSDK_COMPUTE_REGION", connection.Region)
+		set("GOOGLE_REGION", connection.Region)
+	}
+
+	if len(env) == 0 {
+		return nil
+	}
+	return env
+}
+
+func setGCPProject(env map[string]string, projectID string) {
+	if projectID = strings.TrimSpace(projectID); projectID == "" {
+		return
+	}
+	env["GOOGLE_PROJECT"] = projectID
+	env["GOOGLE_CLOUD_PROJECT"] = projectID
+	env["CLOUDSDK_CORE_PROJECT"] = projectID
+}
+
 func (m *Manager) List() ([]PublicConnection, error) {
 	connections, err := m.load()
 	if err != nil {

--- a/internal/cloudconnections/connections_test.go
+++ b/internal/cloudconnections/connections_test.go
@@ -191,6 +191,86 @@ func TestManagerRejectsUnsupportedAuthMethod(t *testing.T) {
 	}
 }
 
+func TestCommandEnvironmentAWSProfile(t *testing.T) {
+	env := CommandEnvironment(Connection{
+		Provider:   ProviderAWS,
+		AuthMethod: "aws_profile",
+		Region:     "us-east-1",
+		Metadata:   map[string]string{"profile": "prod-admin"},
+	})
+
+	if env["AWS_PROFILE"] != "prod-admin" {
+		t.Fatalf("AWS_PROFILE not set from profile: %#v", env)
+	}
+	if env["AWS_SDK_LOAD_CONFIG"] != "1" {
+		t.Fatalf("AWS_SDK_LOAD_CONFIG should be enabled for profile auth: %#v", env)
+	}
+	if env["AWS_REGION"] != "us-east-1" || env["AWS_DEFAULT_REGION"] != "us-east-1" {
+		t.Fatalf("AWS region env not set: %#v", env)
+	}
+}
+
+func TestCommandEnvironmentAWSStatic(t *testing.T) {
+	env := CommandEnvironment(Connection{
+		Provider:   ProviderAWS,
+		AuthMethod: "aws_static",
+		Region:     "us-west-2",
+		Metadata:   map[string]string{"access_key_id": "AKIAEXAMPLE"},
+		Secrets: map[string]string{
+			"secret_access_key": "secret-value",
+			"session_token":     "session-value",
+		},
+	})
+
+	if env["AWS_ACCESS_KEY_ID"] != "AKIAEXAMPLE" ||
+		env["AWS_SECRET_ACCESS_KEY"] != "secret-value" ||
+		env["AWS_SESSION_TOKEN"] != "session-value" {
+		t.Fatalf("AWS static credential env not set: %#v", env)
+	}
+}
+
+func TestCommandEnvironmentAzureServicePrincipal(t *testing.T) {
+	env := CommandEnvironment(Connection{
+		Provider:   ProviderAzure,
+		AuthMethod: "azure_service_principal",
+		Metadata: map[string]string{
+			"subscription_id": "sub-1",
+			"tenant_id":       "tenant-1",
+			"client_id":       "client-1",
+		},
+		Secrets: map[string]string{"client_secret": "secret-value"},
+	})
+
+	if env["ARM_SUBSCRIPTION_ID"] != "sub-1" ||
+		env["ARM_TENANT_ID"] != "tenant-1" ||
+		env["ARM_CLIENT_ID"] != "client-1" ||
+		env["ARM_CLIENT_SECRET"] != "secret-value" {
+		t.Fatalf("Azure service principal env not set: %#v", env)
+	}
+}
+
+func TestCommandEnvironmentGCPServiceAccount(t *testing.T) {
+	env := CommandEnvironment(Connection{
+		Provider:   ProviderGCP,
+		AuthMethod: "gcp_service_account",
+		Region:     "us-central1",
+		Metadata:   map[string]string{"project_id": "prod-project"},
+		Secrets:    map[string]string{"service_account_json": `{"type":"service_account"}`},
+	})
+
+	if env["GOOGLE_PROJECT"] != "prod-project" ||
+		env["GOOGLE_CLOUD_PROJECT"] != "prod-project" ||
+		env["CLOUDSDK_CORE_PROJECT"] != "prod-project" {
+		t.Fatalf("GCP project env not set: %#v", env)
+	}
+	if env["GOOGLE_CREDENTIALS"] != `{"type":"service_account"}` {
+		t.Fatalf("GCP credentials env not set: %#v", env)
+	}
+	if env["GOOGLE_REGION"] != "us-central1" || env["CLOUDSDK_COMPUTE_REGION"] != "us-central1" {
+		t.Fatalf("GCP region env not set: %#v", env)
+	}
+}
+
 func TestIsMaskedRequiresOnlyMaskCharacters(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -98,8 +99,8 @@ func TestBuildArgs_Pulumi(t *testing.T) {
 		// server-side approval gate handles that instead).
 		wantHasYes bool
 	}{
-		{"init", "npm", false},     // npm install, not pulumi stack init
-		{"plan", "pulumi", false},  // preview
+		{"init", "npm", false},    // npm install, not pulumi stack init
+		{"plan", "pulumi", false}, // preview
 		{"preview", "pulumi", false},
 		{"apply", "pulumi", true},
 		{"up", "pulumi", true},
@@ -201,5 +202,37 @@ func TestRequiresApproval_CoversPulumiUp(t *testing.T) {
 		if got := sr.RequiresApproval(cmd); got != want {
 			t.Errorf("RequiresApproval(%q) = %v, want %v", cmd, got, want)
 		}
+	}
+}
+
+func TestMergeEnvOverridesBase(t *testing.T) {
+	got := mergeEnv(
+		[]string{"PATH=/usr/bin", "AWS_PROFILE=default", "BROKEN", "EMPTYKEY"},
+		map[string]string{
+			"AWS_PROFILE":   "prod-admin",
+			"AWS_REGION":    "us-east-1",
+			"GOOGLE_REGION": "",
+		},
+	)
+
+	values := map[string]string{}
+	for _, entry := range got {
+		key, value, ok := strings.Cut(entry, "=")
+		if !ok {
+			t.Fatalf("env entry missing separator: %q", entry)
+		}
+		values[key] = value
+	}
+	if values["PATH"] != "/usr/bin" {
+		t.Fatalf("PATH should be preserved: %#v", values)
+	}
+	if values["AWS_PROFILE"] != "prod-admin" {
+		t.Fatalf("AWS_PROFILE should be overridden: %#v", values)
+	}
+	if values["AWS_REGION"] != "us-east-1" {
+		t.Fatalf("AWS_REGION should be added: %#v", values)
+	}
+	if values["GOOGLE_REGION"] != "" {
+		t.Fatalf("empty override value should be preserved: %#v", values)
 	}
 }

--- a/internal/runner/safe_runner.go
+++ b/internal/runner/safe_runner.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 	"sync"
@@ -84,6 +85,12 @@ func NewSafeRunner(config SafetyConfig) *SafeRunner {
 // `--stack <env>`. Empty env runs in projectDir's own workspace
 // (flat layouts).
 func (sr *SafeRunner) Execute(ctx context.Context, projectDir, tool, command, env string) (*ExecutionResult, error) {
+	return sr.ExecuteWithEnv(ctx, projectDir, tool, command, env, nil)
+}
+
+// ExecuteWithEnv runs a command with additional environment variables. Values
+// in extraEnv override the inherited process environment for this command only.
+func (sr *SafeRunner) ExecuteWithEnv(ctx context.Context, projectDir, tool, command, env string, extraEnv map[string]string) (*ExecutionResult, error) {
 	// Project-level lock — prevent concurrent executions on the same project
 	// which would cause terraform state lock contention and corruption.
 	sr.mu.Lock()
@@ -127,6 +134,9 @@ func (sr *SafeRunner) Execute(ctx context.Context, projectDir, tool, command, en
 
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
 	cmd.Dir = projectDir
+	if len(extraEnv) > 0 {
+		cmd.Env = mergeEnv(os.Environ(), extraEnv)
+	}
 
 	configureCommandCancel(cmd)
 
@@ -180,6 +190,35 @@ func (sr *SafeRunner) Execute(ctx context.Context, projectDir, tool, command, en
 		result.ExitCode = 0
 		return result, nil
 	}
+}
+
+func mergeEnv(base []string, overrides map[string]string) []string {
+	values := map[string]string{}
+	order := make([]string, 0, len(base)+len(overrides))
+	for _, entry := range base {
+		key, value, ok := strings.Cut(entry, "=")
+		if !ok || key == "" {
+			continue
+		}
+		if _, exists := values[key]; !exists {
+			order = append(order, key)
+		}
+		values[key] = value
+	}
+	for key, value := range overrides {
+		if strings.TrimSpace(key) == "" {
+			continue
+		}
+		if _, exists := values[key]; !exists {
+			order = append(order, key)
+		}
+		values[key] = value
+	}
+	out := make([]string, 0, len(order))
+	for _, key := range order {
+		out = append(out, key+"="+values[key])
+	}
+	return out
 }
 
 // Kill cancels a running execution for a project (the kill switch).

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
-import { api, Resource, ToolInfo, CatalogResource, Suggestion } from './api';
+import { api, Resource, ToolInfo, CatalogResource, Suggestion, type CloudConnection } from './api';
 import { useWebSocket, WSMessage } from './useWebSocket';
 import { useHistory } from './useHistory';
 import { useKeyboardShortcuts } from './useKeyboardShortcuts';
@@ -57,6 +57,7 @@ export default function App() {
   const [layeredProject, setLayeredProject] = useState<LayeredProject | null>(null);
   const [activeEnvironment, setActiveEnvironment] = useState<string | null>(null);
   const [canvasMode, setCanvasMode] = useState<CanvasMode>('freeform');
+  const [selectedCloudConnection, setSelectedCloudConnection] = useState<CloudConnection | null>(null);
 
   const [terminalOutput, setTerminalOutput] = useState<string[]>([]);
   const [dragging, setDragging] = useState<{ id: string; ox: number; oy: number } | null>(null);
@@ -158,6 +159,7 @@ export default function App() {
     concreteTool,
     projectId,
     activeEnv,
+    selectedCloudConnection,
     activeResourceFile,
     unresolvedHybridEnv,
     nodes,
@@ -516,6 +518,7 @@ export default function App() {
       codeEditorFilePath={codeEditorFilePath}
       codeSaving={codeSaving}
       activeEnv={activeEnv}
+      selectedCloudConnection={selectedCloudConnection}
       unresolvedHybridEnv={unresolvedHybridEnv}
       hoveredResource={hoveredResource}
       hoverPos={hoverPos}
@@ -549,6 +552,7 @@ export default function App() {
       onClearSelection={actions.handleClearCanvasSelection}
       onDeleteNode={actions.removeNode}
       onActiveEnvironmentChange={setActiveEnvironment}
+      onCloudConnectionSelect={setSelectedCloudConnection}
       onCanvasModeChange={setCanvasMode}
       onRightTabChange={setRightTab}
       onDeleteEdge={(edgeId) => {

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -148,6 +148,31 @@ describe('api.runCommand', () => {
       payload,
     });
   });
+
+  it('sends the selected cloud connection when running commands', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ status: 'running' }), {
+        status: 202,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await api.runCommand('demo', 'terraform', 'plan', { connectionId: 'conn_1', env: 'dev' });
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/projects/demo/run', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        tool: 'terraform',
+        command: 'plan',
+        approved: false,
+        env: 'dev',
+        acknowledged: false,
+        connection_id: 'conn_1',
+      }),
+    });
+  });
 });
 
 describe('api.suggest', () => {

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -366,8 +366,8 @@ export const api = {
     projectName: string,
     tool: string,
     command: string,
-    opts: { approved?: boolean; env?: string; acknowledged?: boolean } = {},
-  ): Promise<{ status: string }> {
+    opts: { approved?: boolean; env?: string; acknowledged?: boolean; connectionId?: string | null } = {},
+  ): Promise<{ status: string; connection?: CloudConnection }> {
     const res = await fetch(`${BASE}/api/projects/${projectName}/run`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -377,6 +377,7 @@ export const api = {
         approved: opts.approved ?? false,
         env: opts.env,
         acknowledged: opts.acknowledged ?? false,
+        connection_id: opts.connectionId || undefined,
       }),
     });
     return (await check(res)).json();

--- a/web/src/app/useWorkspaceActions.ts
+++ b/web/src/app/useWorkspaceActions.ts
@@ -1,5 +1,5 @@
 import { useCallback, useRef, type Dispatch, type MouseEvent, type MutableRefObject, type RefObject, type SetStateAction } from 'react';
-import { api, ApiError, normalizeSuggestions, type CatalogResource, type PolicyFinding, type Suggestion } from '../api';
+import { api, ApiError, normalizeSuggestions, type CatalogResource, type CloudConnection, type PolicyFinding, type Suggestion } from '../api';
 import {
   TOOLS,
   edgeId,
@@ -29,6 +29,7 @@ export interface UseWorkspaceActionsInput {
   concreteTool: string;
   projectId: string;
   activeEnv: string | null;
+  selectedCloudConnection: CloudConnection | null;
   activeResourceFile?: string;
   unresolvedHybridEnv: boolean;
   nodes: AppResource[];
@@ -62,6 +63,7 @@ export function useWorkspaceActions({
   concreteTool,
   projectId,
   activeEnv,
+  selectedCloudConnection,
   activeResourceFile,
   unresolvedHybridEnv,
   nodes,
@@ -326,10 +328,12 @@ export function useWorkspaceActions({
     if (needsApproval && !confirm(`Are you sure you want to run "${command}"? This will modify real infrastructure.`)) {
       return;
     }
-    setTerminalOutput(prev => [...prev, `$ ${command}`, '']);
+    const connectionLabel = selectedCloudConnection ? ` --connection ${selectedCloudConnection.name}` : '';
+    setTerminalOutput(prev => [...prev, `$ ${command}${connectionLabel}`, '']);
     api.runCommand(projectId, tool, command, {
       approved: needsApproval,
       env: activeEnv,
+      connectionId: selectedCloudConnection?.id,
     }).catch(err => {
       if (needsApproval && isPolicyBlockedError(err)) {
         const findings = err.payload?.findings ?? [];
@@ -344,11 +348,12 @@ export function useWorkspaceActions({
         if (!confirm(`Policy checks blocked "${command}".\n\n${summary}\n\nRun it anyway and acknowledge these findings?`)) {
           return;
         }
-        setTerminalOutput(prev => [...prev, `$ ${command} --acknowledged`, '']);
+        setTerminalOutput(prev => [...prev, `$ ${command} --acknowledged${connectionLabel}`, '']);
         api.runCommand(projectId, tool, command, {
           approved: true,
           env: activeEnv,
           acknowledged: true,
+          connectionId: selectedCloudConnection?.id,
         }).catch(overrideErr => {
           setTerminalOutput(prev => [...prev, `Error: ${overrideErr.message}`]);
         });
@@ -356,7 +361,7 @@ export function useWorkspaceActions({
       }
       setTerminalOutput(prev => [...prev, `Error: ${err.message}`]);
     });
-  }, [activeEnv, projectId, setTerminalOutput, tool, unresolvedHybridEnv]);
+  }, [activeEnv, projectId, selectedCloudConnection, setTerminalOutput, tool, unresolvedHybridEnv]);
 
   const fixLastError = useCallback(async () => {
     if (!lastCmdError || !tool) return;

--- a/web/src/components/AppHeader/AppHeader.tsx
+++ b/web/src/components/AppHeader/AppHeader.tsx
@@ -1,5 +1,6 @@
 import { UIButton } from '../../ui';
 import { S } from '../../styles';
+import type { CloudConnection } from '../../api';
 
 export interface AppHeaderTool {
   color: string;
@@ -16,6 +17,7 @@ export interface AppHeaderProps {
   wsConnected: boolean;
   canUndo: boolean;
   canRedo: boolean;
+  selectedCloudConnection?: CloudConnection | null;
   onBack: () => void | Promise<void>;
   onProjectNameChange: (_name: string) => void;
   onRevealProject: (_projectId: string) => void;
@@ -34,6 +36,7 @@ export function AppHeader({
   wsConnected,
   canUndo,
   canRedo,
+  selectedCloudConnection,
   onBack,
   onProjectNameChange,
   onRevealProject,
@@ -72,6 +75,21 @@ export function AppHeader({
       </div>
       <div style={S.hRight}>
         <span style={S.count}>{resourceCount} resource{resourceCount !== 1 ? 's' : ''}</span>
+        {selectedCloudConnection && (
+          <span
+            style={{
+              ...S.count,
+              color: toolMeta.color,
+              maxWidth: 220,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+            title={`${selectedCloudConnection.name} (${selectedCloudConnection.provider}${selectedCloudConnection.region ? ` / ${selectedCloudConnection.region}` : ''})`}
+          >
+            CLOUD {selectedCloudConnection.name}
+          </span>
+        )}
         <button
           style={{ ...S.cmd, background: 'var(--bg-elev-2)', color: canUndo ? 'var(--text-main)' : '#4b5551' }}
           onClick={onUndo}

--- a/web/src/components/CloudConnections/CloudConnectionsPanel.test.tsx
+++ b/web/src/components/CloudConnections/CloudConnectionsPanel.test.tsx
@@ -93,6 +93,52 @@ describe('CloudConnectionsPanel', () => {
     expect(screen.getByPlaceholderText('Stored secret; leave blank to keep it')).toBeInTheDocument();
   });
 
+  it('selects a connection as the run target', async () => {
+    const connection: CloudConnection = {
+      id: 'conn_1',
+      name: 'prod-admin',
+      provider: 'aws',
+      auth_method: 'aws_profile',
+      metadata: { profile: 'prod-admin' },
+    };
+    const client = makeClient([connection]);
+    const onConnectionSelected = vi.fn();
+    render(<CloudConnectionsPanel client={client} onConnectionSelected={onConnectionSelected} />);
+
+    await screen.findByText('prod-admin');
+    fireEvent.click(screen.getByRole('button', { name: 'Use for runs' }));
+
+    expect(onConnectionSelected).toHaveBeenCalledWith(connection);
+  });
+
+  it('clears the selected run target when it is deleted', async () => {
+    const client = makeClient([
+      {
+        id: 'conn_1',
+        name: 'prod-admin',
+        provider: 'aws',
+        auth_method: 'aws_profile',
+        metadata: { profile: 'prod-admin' },
+      },
+    ]);
+    const onConnectionSelected = vi.fn();
+    render(
+      <CloudConnectionsPanel
+        client={client}
+        selectedConnectionId="conn_1"
+        onConnectionSelected={onConnectionSelected}
+      />,
+    );
+
+    await screen.findByText('Run target: prod-admin');
+    fireEvent.click(screen.getByRole('button', { name: 'Delete prod-admin' }));
+
+    expect(onConnectionSelected).toHaveBeenCalledWith(null);
+    await waitFor(() => {
+      expect(client.deleteCloudConnection).toHaveBeenCalledWith('conn_1');
+    });
+  });
+
   it('preserves draft identity fields when switching providers', async () => {
     const client = makeClient();
     render(<CloudConnectionsPanel client={client} />);

--- a/web/src/components/CloudConnections/CloudConnectionsPanel.tsx
+++ b/web/src/components/CloudConnections/CloudConnectionsPanel.tsx
@@ -22,6 +22,8 @@ type CloudClient = Pick<
 
 export interface CloudConnectionsPanelProps {
   client?: CloudClient;
+  selectedConnectionId?: string | null;
+  onConnectionSelected?: (_connection: CloudConnection | null) => void;
 }
 
 const providerMethods: Record<CloudProvider, { key: CloudAuthMethod; label: string }[]> = {
@@ -111,7 +113,11 @@ function fromConnection(connection: CloudConnection): CloudConnectionInput {
   };
 }
 
-export function CloudConnectionsPanel({ client = api }: CloudConnectionsPanelProps) {
+export function CloudConnectionsPanel({
+  client = api,
+  selectedConnectionId = null,
+  onConnectionSelected,
+}: CloudConnectionsPanelProps) {
   const [connections, setConnections] = useState<CloudConnection[]>([]);
   const [form, setForm] = useState<CloudConnectionInput>(defaultInput);
   const [loading, setLoading] = useState(false);
@@ -141,6 +147,13 @@ export function CloudConnectionsPanel({ client = api }: CloudConnectionsPanelPro
     load();
   }, []);
 
+  useEffect(() => {
+    if (!selectedConnectionId || connections.length === 0) return;
+    if (!connections.some(connection => connection.id === selectedConnectionId)) {
+      onConnectionSelected?.(null);
+    }
+  }, [connections, onConnectionSelected, selectedConnectionId]);
+
   const updateField = (key: string, value: string, secret?: boolean) => {
     setForm(current => ({
       ...current,
@@ -166,6 +179,7 @@ export function CloudConnectionsPanel({ client = api }: CloudConnectionsPanelPro
         ? await client.updateCloudConnection(form.id, payload)
         : await client.createCloudConnection(payload);
       setForm(fromConnection(saved));
+      if (selectedConnectionId === saved.id) onConnectionSelected?.(saved);
       setTestResult(null);
       await load();
     } catch (err) {
@@ -210,6 +224,12 @@ export function CloudConnectionsPanel({ client = api }: CloudConnectionsPanelPro
           New
         </Button>
       </header>
+
+      {selectedConnectionId && (
+        <div className="rounded-md border border-primary/40 bg-primary/10 px-3 py-2 text-xs text-foreground">
+          Run target: {connections.find(connection => connection.id === selectedConnectionId)?.name || 'selected connection'}
+        </div>
+      )}
 
       {error && (
         <div className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-xs text-destructive">
@@ -331,10 +351,26 @@ export function CloudConnectionsPanel({ client = api }: CloudConnectionsPanelPro
                 {connection.auth_method}{connection.region ? ` / ${connection.region}` : ''}
               </div>
               <div className="flex gap-2">
+                <Button
+                  size="sm"
+                  variant={selectedConnectionId === connection.id ? 'default' : 'outline'}
+                  onClick={() => onConnectionSelected?.(connection)}
+                  disabled={!onConnectionSelected || selectedConnectionId === connection.id}
+                >
+                  {selectedConnectionId === connection.id ? 'Selected' : 'Use for runs'}
+                </Button>
                 <Button size="sm" variant="outline" onClick={() => test(connection.id)} disabled={testingId === connection.id}>
                   {testingId === connection.id ? 'Testing...' : 'Test'}
                 </Button>
-                <Button size="sm" variant="ghost" onClick={() => remove(connection.id)} aria-label={`Delete ${connection.name}`}>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => {
+                    if (selectedConnectionId === connection.id) onConnectionSelected?.(null);
+                    remove(connection.id);
+                  }}
+                  aria-label={`Delete ${connection.name}`}
+                >
                   <Trash2 className="h-3.5 w-3.5" />
                 </Button>
               </div>

--- a/web/src/components/Inspector/index.tsx
+++ b/web/src/components/Inspector/index.tsx
@@ -1,4 +1,4 @@
-import type { Resource } from '../../api';
+import type { CloudConnection, Resource } from '../../api';
 import type { Edge } from '../../legacy';
 import { S } from '../../styles';
 import { CloudConnectionsPanel } from '../CloudConnections';
@@ -35,6 +35,7 @@ export interface InspectorPanelProps {
   codeEditorFilePath: string;
   codeSaving: boolean;
   unresolvedHybridEnv: boolean;
+  selectedCloudConnection?: CloudConnection | null;
   onTabChange: (_tab: RightPanelTab) => void;
   onDeleteEdge: (_edgeId: string) => void;
   onSelectEdge: (_edgeId: string) => void;
@@ -42,6 +43,7 @@ export interface InspectorPanelProps {
   onUpdateNodeProp: (_nodeId: string, _key: string, _value: any) => void;
   onSyncCodeChange: (_value: string) => void;
   onSaveCode: (_value: string) => void;
+  onCloudConnectionSelect?: (_connection: CloudConnection | null) => void;
   onCopyCode?: (_value: string) => void;
 }
 
@@ -67,6 +69,7 @@ export function InspectorPanel({
   codeEditorFilePath,
   codeSaving,
   unresolvedHybridEnv,
+  selectedCloudConnection,
   onTabChange,
   onDeleteEdge,
   onSelectEdge,
@@ -74,6 +77,7 @@ export function InspectorPanel({
   onUpdateNodeProp,
   onSyncCodeChange,
   onSaveCode,
+  onCloudConnectionSelect,
   onCopyCode,
 }: InspectorPanelProps) {
   const selected = nodes.find(node => node.id === selectedNodeId);
@@ -253,7 +257,10 @@ export function InspectorPanel({
 
       {activeTab === 'cloud' && (
         <div style={{ flex: 1, minHeight: 0 }}>
-          <CloudConnectionsPanel />
+          <CloudConnectionsPanel
+            selectedConnectionId={selectedCloudConnection?.id}
+            onConnectionSelected={onCloudConnectionSelect}
+          />
         </div>
       )}
 

--- a/web/src/components/Workspace/WorkspaceShell.tsx
+++ b/web/src/components/Workspace/WorkspaceShell.tsx
@@ -8,7 +8,7 @@ import { InspectorPanel, type RightPanelTab } from '../Inspector';
 import { ResourceTooltip } from '../ResourceTooltip';
 import { WorkspaceSidebar, type SidebarPanel } from '../Sidebar';
 import { TerminalPanel } from '../Terminal';
-import type { CatalogResource, Suggestion } from '../../api';
+import type { CatalogResource, CloudConnection, Suggestion } from '../../api';
 import type { Edge } from '../../legacy';
 import { S } from '../../styles';
 import type { LayeredProject } from '../../types';
@@ -63,6 +63,7 @@ export interface WorkspaceShellProps {
   codeEditorFilePath: string;
   codeSaving: boolean;
   activeEnv: string | null;
+  selectedCloudConnection: CloudConnection | null;
   unresolvedHybridEnv: boolean;
   hoveredResource: CatalogResource | null;
   hoverPos: { x: number; y: number };
@@ -93,6 +94,7 @@ export interface WorkspaceShellProps {
   onClearSelection: () => void;
   onDeleteNode: (_nodeId: string) => void;
   onActiveEnvironmentChange: (_env: string) => void;
+  onCloudConnectionSelect: (_connection: CloudConnection | null) => void;
   onCanvasModeChange: (_mode: CanvasMode) => void;
   onRightTabChange: (_tab: RightPanelTab) => void;
   onDeleteEdge: (_edgeId: string) => void;
@@ -149,6 +151,7 @@ export function WorkspaceShell({
   codeEditorFilePath,
   codeSaving,
   activeEnv,
+  selectedCloudConnection,
   unresolvedHybridEnv,
   hoveredResource,
   hoverPos,
@@ -179,6 +182,7 @@ export function WorkspaceShell({
   onClearSelection,
   onDeleteNode,
   onActiveEnvironmentChange,
+  onCloudConnectionSelect,
   onCanvasModeChange,
   onRightTabChange,
   onDeleteEdge,
@@ -211,6 +215,7 @@ export function WorkspaceShell({
         onRedo={onRedo}
         onRunCommand={onRunCommand}
         onOpenSettings={onOpenSettings}
+        selectedCloudConnection={selectedCloudConnection}
       />
 
       {showSettings && (
@@ -298,6 +303,7 @@ export function WorkspaceShell({
           codeEditorFilePath={codeEditorFilePath}
           codeSaving={codeSaving}
           unresolvedHybridEnv={unresolvedHybridEnv}
+          selectedCloudConnection={selectedCloudConnection}
           onTabChange={onRightTabChange}
           onDeleteEdge={onDeleteEdge}
           onSelectEdge={onSelectEdge}
@@ -305,6 +311,7 @@ export function WorkspaceShell({
           onUpdateNodeProp={onUpdateNodeProp}
           onSyncCodeChange={onSyncCodeChange}
           onSaveCode={onSaveCode}
+          onCloudConnectionSelect={onCloudConnectionSelect}
         />
       </div>
 


### PR DESCRIPTION
## Summary
- let users mark a Cloud Connection as the active run target
- pass selected connection IDs through `runCommand` and `/api/projects/{name}/run`
- translate ready connections into per-command provider environment variables without echoing secrets
- reject missing or incomplete connections before execution

Refs #42

## Validation
- `GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/cloudconnections ./internal/runner ./internal/api`
- `npm test -- --run src/api.test.ts src/components/CloudConnections/CloudConnectionsPanel.test.tsx src/components/AppHeader/AppHeader.test.tsx src/components/Inspector/InspectorPanel.test.tsx`
- `npm run build`
- `npm run lint` (0 errors, existing 14 warnings)
- `git diff --check`