### PR TITLE
Add semantic plan classifier gate

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -131,6 +131,7 @@ Supported: OpenAI, Anthropic, Groq, Together, Azure OpenAI, or any OpenAI-compat
 | **Import existing project** | Click "Import Existing Project" → browse to your .tf files |
 | **Connect cloud target** | Open Cloud tab → save/test a named AWS, Azure, or GCP connection → click "Use for runs" |
 | **Run terraform** | Click Init → Plan → Apply in the header |
+| **Review plan risk** | After Plan, read the semantic summary. Risky, destructive, or unknown Terraform/OpenTofu changes require acknowledgement before Apply |
 | **Undo/Redo** | Ctrl+Z / Ctrl+Shift+Z or the ↩↪ buttons |
 | **Delete** | Select a node or connection, press Delete |
 | **Fix errors** | When Plan fails, click "Fix with AI" in the terminal |
@@ -172,6 +173,24 @@ aws sso login --profile platform-dev
 az login
 gcloud auth application-default login
 ```
+
+## Semantic Plan Gate
+
+Terraform and OpenTofu runs save the exact plan artifact as `tfplan`, export it
+to `tfplan.json`, then classify each planned change before apply.
+
+The summary groups changes into:
+
+| Risk | Meaning |
+|------|---------|
+| `safe` | Metadata-only or no-op changes, such as tag refreshes |
+| `risky` | IAM, network exposure, or stateful resource changes that need review |
+| `destructive` | Deletes or replacements that can remove existing infrastructure |
+| `unknown` | Changes the classifier cannot safely explain |
+
+`Apply` uses the saved `tfplan` file. If the classifier finds risky,
+destructive, or unknown changes, IaC Studio shows the reviewer summary and
+requires explicit acknowledgement before continuing.
 
 ## Development Mode
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ start the local server for you.
 | **Smart Suggestions** | AI predicts your next resource based on IaC best practices |
 | **Import Projects** | Browse filesystem, scan existing .tf/.yml files, auto-detect topology |
 | **Cloud Connections** | Save, test, and select named AWS, Azure, or GCP targets before plan/apply |
+| **Semantic Plan Gate** | Classifies Terraform/OpenTofu changes as safe, risky, destructive, or unknown before apply |
 | **Live Code Preview** | Every canvas change updates the code in real time |
 | **Project Persistence** | Auto-save canvas state, restore on reopen |
 | **Undo/Redo** | Ctrl+Z / Ctrl+Shift+Z with 100-step history |
@@ -136,9 +137,10 @@ IaC Studio runs locally and is designed to be secure by default:
 - **Localhost-only binding** — not exposed to the network
 - **CORS/WebSocket origin verification** — only localhost origins accepted
 - **Path traversal protection** — project names validated and sandboxed
-- **Request size limits** — 1MB cap on all endpoints
+- **Request size limits** — 1MB cap on normal JSON endpoints; plan classification accepts larger plan JSON payloads
 - **Execution safety** — command timeouts, process group kill, approval gates
 - **Plan-before-apply** — server-side gate requires successful plan before apply
+- **Semantic plan review** — Terraform/OpenTofu plans are classified before apply; risky, destructive, or unknown changes require explicit acknowledgement
 - **Cloud target checks** — selected Cloud Connections are tested before command execution
 - **Secret redaction** — static credentials are not echoed in API responses, terminal messages, or generated IaC
 - **No telemetry** — zero data collection, no phone-home

--- a/docs/index.html
+++ b/docs/index.html
@@ -39,6 +39,7 @@
           <a href="#interface">Interface Tour</a>
           <a href="#workflows">Core Workflows</a>
           <a href="#cloud-connections">Cloud Connections</a>
+          <a href="#semantic-plan-gate">Semantic Plan Gate</a>
           <a href="#ai">AI Setup</a>
           <a href="#policy-security">Policy and Security</a>
           <a href="#api-reference">API Reference</a>
@@ -526,6 +527,43 @@ gcloud config set project my-platform-dev</code></pre>
           </div>
         </section>
 
+        <section id="semantic-plan-gate" class="doc-section" data-title="semantic plan classifier apply gate safe risky destructive unknown terraform opentofu">
+          <h2>Semantic Plan Gate</h2>
+          <p>
+            Terraform and OpenTofu plans are saved as <code>tfplan</code>, exported to
+            <code>tfplan.json</code>, and classified before apply. The goal is to turn a long
+            raw plan into a reviewer summary that explains what needs attention before real
+            infrastructure changes run.
+          </p>
+
+          <div class="feature-grid compact">
+            <article>
+              <h3>Safe</h3>
+              <p>Metadata-only or no-op changes, such as tag, label, annotation, or description updates.</p>
+            </article>
+            <article>
+              <h3>Risky</h3>
+              <p>IAM, network exposure, or stateful resource changes that can alter access, reachability, durability, or spend.</p>
+            </article>
+            <article>
+              <h3>Destructive</h3>
+              <p>Deletes and replacements. Stateful replacements call out backup, snapshot, retention, and restore review.</p>
+            </article>
+            <article>
+              <h3>Unknown</h3>
+              <p>Unsupported actions, missing plan JSON, or changes that do not match a known safe pattern.</p>
+            </article>
+          </div>
+
+          <h3>Apply behavior</h3>
+          <ol class="steps">
+            <li><strong>Run Plan.</strong> IaC Studio writes the plan artifact and classifier JSON for the active project or environment.</li>
+            <li><strong>Read the summary.</strong> The terminal shows counts and the highest-priority reviewer focus items.</li>
+            <li><strong>Apply uses the saved plan.</strong> Terraform/OpenTofu apply consumes <code>tfplan</code>, so the reviewed artifact is the one being applied.</li>
+            <li><strong>Acknowledge risk when needed.</strong> Risky, destructive, or unknown summaries block apply until the request includes <code>risk_acknowledged:true</code>.</li>
+          </ol>
+        </section>
+
         <section id="ai" class="doc-section" data-title="ai setup ollama openai anthropic models settings environment variables">
           <h2>AI Setup</h2>
           <p>
@@ -621,7 +659,7 @@ ANTHROPIC_MODEL=claude-opus-4-7 \
             </article>
             <article>
               <h3>Plan-before-apply</h3>
-              <p>Apply is gated by a successful plan and can be blocked by policy findings unless explicitly acknowledged.</p>
+              <p>Apply is gated by a successful plan, semantic risk review, and policy findings unless explicitly acknowledged.</p>
             </article>
             <article>
               <h3>Command control</h3>
@@ -672,8 +710,8 @@ ANTHROPIC_MODEL=claude-opus-4-7 \
                 </tr>
                 <tr>
                   <td>Commands</td>
-                  <td><code>POST /api/projects/{name}/run</code><br><code>POST /api/projects/{name}/kill</code></td>
-                  <td>Run init, plan, apply, and stop active processes. Optional <code>connection_id</code> attaches a selected cloud target.</td>
+                  <td><code>POST /api/projects/{name}/run</code><br><code>POST /api/projects/{name}/kill</code><br><code>POST /api/projects/{name}/plan/classify</code></td>
+                  <td>Run init, plan, apply, stop active processes, and classify Terraform/OpenTofu plan JSON. Optional <code>connection_id</code> attaches a selected cloud target.</td>
                 </tr>
                 <tr>
                   <td>Cloud connections</td>

--- a/internal/api/plan_classification.go
+++ b/internal/api/plan_classification.go
@@ -1,0 +1,116 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	iacplan "github.com/iac-studio/iac-studio/internal/plan"
+)
+
+const (
+	savedPlanJSONFile          = "tfplan.json"
+	maxPlanClassifyRequestBody = 10 << 20
+)
+
+type planClassifyRequest struct {
+	PlanJSON json.RawMessage `json:"plan_json,omitempty"`
+	PlanText string          `json:"plan_text,omitempty"`
+	Tool     string          `json:"tool,omitempty"`
+	Env      string          `json:"env,omitempty"`
+}
+
+func registerPlanClassificationRoutes(mux *http.ServeMux, projectsDir string) {
+	mux.HandleFunc("POST /api/projects/{name}/plan/classify", func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, maxPlanClassifyRequestBody)
+		name := r.PathValue("name")
+		projectPath, err := safeProjectPath(projectsDir, name)
+		if err != nil {
+			http.Error(w, err.Error(), 400)
+			return
+		}
+
+		var req planClassifyRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+			http.Error(w, "invalid request body: "+err.Error(), 400)
+			return
+		}
+
+		tool := effectiveProjectTool(projectPath, req.Tool, req.Env)
+		if tool == "multi" {
+			http.Error(w, hybridToolResolutionMessage("env is required when classifying plans for hybrid projects", req.Env), 400)
+			return
+		}
+		workDir := projectPath
+		if req.Env != "" {
+			subPath, subErr := safeSubdir(projectPath, "environments", req.Env)
+			if subErr != nil {
+				http.Error(w, "invalid env: "+subErr.Error(), 400)
+				return
+			}
+			workDir = subPath
+		}
+
+		classification := classifyPlanRequest(workDir, req)
+		_ = json.NewEncoder(w).Encode(classification)
+	})
+}
+
+func classifyPlanRequest(workDir string, req planClassifyRequest) *iacplan.ClassificationResult {
+	parser := iacplan.New()
+	if len(req.PlanJSON) > 0 {
+		result, err := parser.ClassifyFullPlan(string(req.PlanJSON))
+		if err != nil {
+			return iacplan.UnknownClassification("posted plan JSON could not be parsed")
+		}
+		return result
+	}
+	if strings.TrimSpace(req.PlanText) != "" {
+		parsed, err := parser.ParseStreamOutput(req.PlanText)
+		if err != nil {
+			return iacplan.UnknownClassification("posted plan text could not be parsed")
+		}
+		if len(parsed.Changes) == 0 && strings.Contains(req.PlanText, "to add") {
+			return iacplan.UnknownClassification("posted plan text lacks machine-readable resource changes")
+		}
+		return parser.Classify(parsed)
+	}
+	return classifySavedPlan(workDir)
+}
+
+func classifySavedPlan(workDir string) *iacplan.ClassificationResult {
+	data, err := os.ReadFile(filepath.Join(workDir, savedPlanJSONFile))
+	if err != nil {
+		return iacplan.UnknownClassification("saved plan JSON is unavailable; run plan before applying")
+	}
+	result, err := iacplan.New().ClassifyFullPlan(string(data))
+	if err != nil {
+		return iacplan.UnknownClassification("saved plan JSON could not be parsed; rerun plan before applying")
+	}
+	return result
+}
+
+func planSupportsSemanticClassification(tool string) bool {
+	return tool == "terraform" || tool == "opentofu"
+}
+
+func commandProducesPlan(command string) bool {
+	return command == "plan" || command == "preview" || command == "check"
+}
+
+func appendPlanClassificationOutput(output string, classification *iacplan.ClassificationResult) string {
+	if classification == nil {
+		return output
+	}
+	output = strings.TrimRight(output, "\n")
+	if output != "" {
+		output += "\n\n"
+	}
+	output += "--- Semantic Plan Classifier ---\n"
+	output += classification.Markdown
+	return output + "\n"
+}

--- a/internal/api/plan_classification_test.go
+++ b/internal/api/plan_classification_test.go
@@ -1,0 +1,106 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPlanClassificationEndpointClassifiesPostedPlanJSON(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "demo"), 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	srv := httptest.NewServer(fullRouterForTest(t, root))
+	defer srv.Close()
+
+	body := `{
+		"tool": "terraform",
+		"plan_json": {
+			"resource_changes": [{
+				"address": "aws_security_group.web",
+				"type": "aws_security_group",
+				"name": "web",
+				"change": {
+					"actions": ["update"],
+					"before": {"ingress": []},
+					"after": {"ingress": [{"cidr_blocks": ["0.0.0.0/0"]}]}
+				}
+			}]
+		}
+	}`
+
+	resp, err := http.Post(srv.URL+"/api/projects/demo/plan/classify", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST classify: %v", err)
+	}
+	defer closeBody(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("classify status = %d", resp.StatusCode)
+	}
+
+	var payload struct {
+		Summary struct {
+			Risky                  int  `json:"risky"`
+			RequiresAcknowledgment bool `json:"requires_acknowledgment"`
+		} `json:"summary"`
+		Changes []struct {
+			Address string `json:"address"`
+			Risk    string `json:"risk"`
+		} `json:"changes"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if payload.Summary.Risky != 1 || !payload.Summary.RequiresAcknowledgment {
+		t.Fatalf("unexpected summary: %#v", payload.Summary)
+	}
+	if len(payload.Changes) != 1 || payload.Changes[0].Risk != "risky" {
+		t.Fatalf("unexpected changes: %#v", payload.Changes)
+	}
+}
+
+func TestApplyGateBlocksUnacknowledgedPlanRisk(t *testing.T) {
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "demo")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	t.Cleanup(func() { invalidatePlan(projectDir) })
+	recordPlan(projectDir)
+	if err := os.WriteFile(filepath.Join(projectDir, savedPlanJSONFile), []byte(`{
+		"resource_changes": [{
+			"address": "aws_db_instance.primary",
+			"type": "aws_db_instance",
+			"name": "primary",
+			"change": {
+				"actions": ["delete", "create"],
+				"before": {"identifier": "prod-db"},
+				"after": {"identifier": "prod-db"}
+			}
+		}]
+	}`), 0o600); err != nil {
+		t.Fatalf("write plan json: %v", err)
+	}
+
+	srv := httptest.NewServer(fullRouterForTest(t, root))
+	defer srv.Close()
+
+	resp, err := http.Post(
+		srv.URL+"/api/projects/demo/run",
+		"application/json",
+		strings.NewReader(`{"tool":"terraform","command":"apply","approved":true}`),
+	)
+	if err != nil {
+		t.Fatalf("POST run apply: %v", err)
+	}
+	defer closeBody(resp.Body)
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("apply status = %d, want 409", resp.StatusCode)
+	}
+	assertResponseBodyContains(t, resp, "plan_risk_blocked", "destructive", "aws_db_instance.primary")
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -26,6 +26,7 @@ import (
 	"github.com/iac-studio/iac-studio/internal/generator"
 	"github.com/iac-studio/iac-studio/internal/importer"
 	"github.com/iac-studio/iac-studio/internal/parser"
+	iacplan "github.com/iac-studio/iac-studio/internal/plan"
 	"github.com/iac-studio/iac-studio/internal/project"
 	pulumigen "github.com/iac-studio/iac-studio/internal/pulumi"
 	"github.com/iac-studio/iac-studio/internal/registry"
@@ -1093,6 +1094,12 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 			// is telling us they've read the findings and still want to
 			// proceed. Logged server-side so the override is audit-trailable.
 			Acknowledged bool `json:"acknowledged"`
+			// RiskAcknowledged explicitly overrides the semantic plan risk
+			// gate after the caller has reviewed risky, destructive, or
+			// unknown changes. Kept separate from policy acknowledgement so
+			// the audit trail can distinguish plan semantics from policy
+			// violations.
+			RiskAcknowledged bool `json:"risk_acknowledged"`
 			// Env names the environment subdirectory to execute in for
 			// layered-v1 projects (environments/<env>/...). Empty runs
 			// commands at the project root (flat layout). Validated as a
@@ -1181,6 +1188,25 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 				})
 				return
 			}
+			if planSupportsSemanticClassification(effectiveTool) {
+				classification := classifySavedPlan(runPath)
+				if req.Command == "destroy" {
+					classification = iacplan.UnknownClassification("destroy does not consume the saved apply plan; review the destructive command separately")
+				}
+				if classification.Summary.RequiresAcknowledgment && !req.RiskAcknowledged {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusConflict)
+					_ = json.NewEncoder(w).Encode(map[string]any{
+						"error":          "plan_risk_blocked",
+						"detail":         "semantic plan classifier found risky, destructive, or unknown changes — re-submit with risk_acknowledged:true to proceed",
+						"classification": classification,
+					})
+					return
+				}
+				if req.RiskAcknowledged {
+					log.Printf("apply gate: semantic plan risk acknowledged by client for %s (command=%s tool=%s)", name, req.Command, effectiveTool)
+				}
+			}
 			if !req.Acknowledged {
 				// Walk every available engine against the project so we can
 				// surface blocking findings before the apply runs. On any
@@ -1202,24 +1228,53 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 			}
 		}
 
+		if commandProducesPlan(req.Command) {
+			invalidatePlan(runPath)
+			if planSupportsSemanticClassification(effectiveTool) {
+				_ = os.Remove(filepath.Join(runPath, savedPlanJSONFile))
+			}
+		}
+
 		// Execute in background. Use context.Background() — not r.Context() —
 		// because the HTTP handler returns 202 immediately, which would cancel
 		// a request-scoped context and kill the command. SafeRunner applies its
 		// own per-command timeout (init=5m, plan=10m, apply=30m).
 		go func() {
 			result, err := run.ExecuteWithEnv(context.Background(), runPath, effectiveTool, req.Command, req.Env, commandEnv)
+			var classification *iacplan.ClassificationResult
 			// Only record a successful plan — failed/cancelled plans don't count.
 			// 'preview' is Pulumi's equivalent of terraform plan; without it
 			// here, a pulumi up following a successful preview would be
 			// blocked with 'plan_required'. runPath reflects any env rebase
 			// so dev + prod track their plan state
 			// independently.
-			if err == nil && (req.Command == "plan" || req.Command == "preview" || req.Command == "check") {
+			if err == nil && commandProducesPlan(req.Command) {
+				if planSupportsSemanticClassification(effectiveTool) {
+					exported, exportErr := run.ExportSavedPlanJSON(context.Background(), runPath, effectiveTool, commandEnv)
+					if exportErr != nil {
+						classification = iacplan.UnknownClassification("saved plan JSON export failed; rerun plan before applying")
+						_ = os.Remove(filepath.Join(runPath, savedPlanJSONFile))
+					} else if classified, classifyErr := iacplan.New().ClassifyFullPlan(exported.Output); classifyErr != nil {
+						classification = iacplan.UnknownClassification("saved plan JSON could not be classified; rerun plan before applying")
+						_ = os.Remove(filepath.Join(runPath, savedPlanJSONFile))
+					} else if writeErr := os.WriteFile(filepath.Join(runPath, savedPlanJSONFile), []byte(exported.Output), 0600); writeErr != nil {
+						classification = iacplan.UnknownClassification("saved plan JSON could not be written; rerun plan before applying")
+						_ = os.Remove(filepath.Join(runPath, savedPlanJSONFile))
+					} else {
+						classification = classified
+					}
+					if result != nil {
+						result.Output = appendPlanClassificationOutput(result.Output, classification)
+					}
+				}
 				recordPlan(runPath)
 			}
 			msg := map[string]interface{}{
 				"type":    "terminal",
 				"project": name,
+			}
+			if classification != nil {
+				msg["plan_classification"] = classification
 			}
 			if connectionSummary.ID != "" {
 				msg["connection"] = map[string]string{
@@ -1954,6 +2009,10 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 
 	// Policy engines — builtin + OPA (embedded) + Conftest + Sentinel (shell-out).
 	registerPolicyRoutes(mux, projectsDir)
+
+	// Semantic plan classifier — turns Terraform/OpenTofu plan JSON into
+	// safe/risky/destructive/unknown reviewer summaries.
+	registerPlanClassificationRoutes(mux, projectsDir)
 
 	// Security scanner plugins — graph + Checkov + Trivy + Terrascan + KICS.
 	registerScannerRoutes(mux, projectsDir)

--- a/internal/plan/classifier.go
+++ b/internal/plan/classifier.go
@@ -1,0 +1,385 @@
+package plan
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// RiskLevel is the apply-gate severity assigned to a planned change.
+type RiskLevel string
+
+const (
+	RiskSafe        RiskLevel = "safe"
+	RiskRisky       RiskLevel = "risky"
+	RiskDestructive RiskLevel = "destructive"
+	RiskUnknown     RiskLevel = "unknown"
+)
+
+// ClassifiedChange is the reviewer-facing interpretation of one planned
+// resource change.
+type ClassifiedChange struct {
+	Address       string        `json:"address"`
+	Type          string        `json:"type"`
+	Name          string        `json:"name"`
+	Provider      string        `json:"provider,omitempty"`
+	Action        string        `json:"action"`
+	Risk          RiskLevel     `json:"risk"`
+	Categories    []string      `json:"categories"`
+	Reason        string        `json:"reason"`
+	ReviewerFocus []string      `json:"reviewer_focus"`
+	FieldChanges  []FieldChange `json:"field_changes,omitempty"`
+}
+
+// ClassificationSummary is the compact result used by the UI and apply gate.
+type ClassificationSummary struct {
+	Safe                   int    `json:"safe"`
+	Risky                  int    `json:"risky"`
+	Destructive            int    `json:"destructive"`
+	Unknown                int    `json:"unknown"`
+	Total                  int    `json:"total"`
+	RequiresAcknowledgment bool   `json:"requires_acknowledgment"`
+	Text                   string `json:"text"`
+}
+
+// ClassificationResult is the full semantic plan classifier response.
+type ClassificationResult struct {
+	Summary  ClassificationSummary `json:"summary"`
+	Changes  []ClassifiedChange    `json:"changes"`
+	Markdown string                `json:"markdown,omitempty"`
+}
+
+// ClassifyFullPlan parses `terraform show -json tfplan` output and classifies it.
+func (p *Parser) ClassifyFullPlan(jsonOutput string) (*ClassificationResult, error) {
+	parsed, err := p.ParseFullPlan(jsonOutput)
+	if err != nil {
+		return nil, err
+	}
+	return p.Classify(parsed), nil
+}
+
+// Classify translates parsed plan changes into a reviewer-facing risk summary.
+func (p *Parser) Classify(result *PlanResult) *ClassificationResult {
+	if result == nil {
+		return UnknownClassification("no plan result was available")
+	}
+	classified := make([]ClassifiedChange, 0, len(result.Changes))
+	for _, change := range result.Changes {
+		classified = append(classified, classifyChange(change))
+	}
+
+	summary := ClassificationSummary{Total: len(classified)}
+	for _, change := range classified {
+		switch change.Risk {
+		case RiskSafe:
+			summary.Safe++
+		case RiskRisky:
+			summary.Risky++
+		case RiskDestructive:
+			summary.Destructive++
+		default:
+			summary.Unknown++
+		}
+	}
+	summary.RequiresAcknowledgment = summary.Risky > 0 || summary.Destructive > 0 || summary.Unknown > 0
+	summary.Text = formatSummaryText(summary)
+
+	res := &ClassificationResult{
+		Summary: summary,
+		Changes: classified,
+	}
+	res.Markdown = formatClassificationMarkdown(res)
+	return res
+}
+
+// UnknownClassification returns a blocking classifier result for cases where
+// the plan cannot be inspected. The apply gate uses this fail-closed path.
+func UnknownClassification(reason string) *ClassificationResult {
+	if strings.TrimSpace(reason) == "" {
+		reason = "plan could not be classified"
+	}
+	result := &ClassificationResult{
+		Summary: ClassificationSummary{
+			Unknown:                1,
+			Total:                  1,
+			RequiresAcknowledgment: true,
+			Text:                   "Semantic plan: 1 unknown change",
+		},
+		Changes: []ClassifiedChange{{
+			Address:       "(plan)",
+			Action:        "unknown",
+			Risk:          RiskUnknown,
+			Categories:    []string{"unknown"},
+			Reason:        reason,
+			ReviewerFocus: []string{"Inspect the saved plan output before applying."},
+		}},
+	}
+	result.Markdown = formatClassificationMarkdown(result)
+	return result
+}
+
+func classifyChange(change ResourceChange) ClassifiedChange {
+	out := ClassifiedChange{
+		Address:      change.Address,
+		Type:         change.Type,
+		Name:         change.Name,
+		Provider:     change.Provider,
+		Action:       change.Action,
+		FieldChanges: change.FieldChanges,
+	}
+
+	switch change.Action {
+	case "no-op", "read":
+		out.Risk = RiskSafe
+		out.Categories = []string{"safe_noise"}
+		out.Reason = "No infrastructure mutation is planned."
+		out.ReviewerFocus = []string{"Confirm the plan contains no create, update, replace, or delete action for this resource."}
+		return out
+	case "delete", "replace":
+		out.Risk = RiskDestructive
+		out.Categories = []string{"destructive"}
+		if isStatefulResource(change.Type) {
+			out.Categories = append(out.Categories, "data")
+			out.Reason = fmt.Sprintf("%s %s can remove or recreate stateful data.", actionLabel(change.Action), change.Type)
+			out.ReviewerFocus = []string{"Verify backups, snapshots, retention policy, and restore steps before approving."}
+		} else {
+			out.Reason = fmt.Sprintf("%s %s can remove existing infrastructure.", actionLabel(change.Action), change.Type)
+			out.ReviewerFocus = []string{"Confirm the resource is intentionally removed and downstream dependencies are understood."}
+		}
+		return out
+	case "update":
+		if isMetadataOnlyUpdate(change.FieldChanges) {
+			out.Risk = RiskSafe
+			out.Categories = []string{"safe_noise"}
+			out.Reason = "Only metadata fields such as tags or description changed."
+			out.ReviewerFocus = []string{"Confirm tag and description values match the owning team's conventions."}
+			return out
+		}
+	case "create":
+		// Fall through to resource-sensitive rules below. A generic create
+		// remains unknown because cost, IAM, and network blast radius depend
+		// on provider-specific defaults.
+	default:
+		out.Risk = RiskUnknown
+		out.Categories = []string{"unknown"}
+		out.Reason = fmt.Sprintf("Action %q is not recognized by the semantic classifier.", change.Action)
+		out.ReviewerFocus = []string{"Inspect the raw plan and provider documentation before approving."}
+		return out
+	}
+
+	switch {
+	case isIAMResource(change.Type):
+		out.Risk = RiskRisky
+		out.Categories = []string{"identity"}
+		out.Reason = "IAM changes can expand permissions or trust relationships."
+		out.ReviewerFocus = []string{"Review newly granted actions, principals, conditions, and assume-role paths."}
+	case isNetworkExposureResource(change.Type) || containsPublicCIDR(change.After):
+		out.Risk = RiskRisky
+		out.Categories = []string{"network_exposure"}
+		if containsPublicCIDR(change.After) {
+			out.Reason = "The planned network configuration includes public CIDR exposure."
+			out.ReviewerFocus = []string{"Check 0.0.0.0/0 or ::/0 rules, ports, protocols, and source restrictions."}
+		} else {
+			out.Reason = "Network boundary changes can alter service reachability."
+			out.ReviewerFocus = []string{"Review ingress, egress, route, firewall, listener, and peering changes."}
+		}
+	case isStatefulResource(change.Type):
+		out.Risk = RiskRisky
+		out.Categories = []string{"data", "cost_sensitive"}
+		out.Reason = "Stateful data resources can affect durability, availability, or spend."
+		out.ReviewerFocus = []string{"Review storage class, deletion protection, encryption, retention, and size changes."}
+	default:
+		out.Risk = RiskUnknown
+		out.Categories = []string{"unknown"}
+		out.Reason = "This change does not match a known safe pattern."
+		out.ReviewerFocus = []string{"Inspect provider defaults, cost impact, and dependency changes before applying."}
+	}
+	return out
+}
+
+func isMetadataOnlyUpdate(changes []FieldChange) bool {
+	if len(changes) == 0 {
+		return false
+	}
+	for _, change := range changes {
+		root := strings.Split(change.Path, ".")[0]
+		switch root {
+		case "tags", "tags_all", "description", "labels", "annotations":
+			continue
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func isIAMResource(resourceType string) bool {
+	t := strings.ToLower(resourceType)
+	return strings.Contains(t, "_iam_") ||
+		strings.Contains(t, "iam") ||
+		strings.Contains(t, "role_assignment") ||
+		strings.Contains(t, "role_binding") ||
+		strings.Contains(t, "service_account")
+}
+
+func isNetworkExposureResource(resourceType string) bool {
+	t := strings.ToLower(resourceType)
+	needles := []string{
+		"security_group",
+		"firewall",
+		"network_acl",
+		"network_security_group",
+		"route",
+		"listener",
+		"load_balancer",
+		"target_group",
+		"vpc_peering",
+		"internet_gateway",
+	}
+	for _, needle := range needles {
+		if strings.Contains(t, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func isStatefulResource(resourceType string) bool {
+	t := strings.ToLower(resourceType)
+	needles := []string{
+		"db_instance",
+		"db_cluster",
+		"rds",
+		"dynamodb",
+		"s3_bucket",
+		"storage_bucket",
+		"sql_database",
+		"postgresql",
+		"mysql",
+		"disk",
+		"volume",
+		"snapshot",
+		"redis",
+		"elasticache",
+		"backup",
+	}
+	for _, needle := range needles {
+		if strings.Contains(t, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsPublicCIDR(value any) bool {
+	switch v := value.(type) {
+	case nil:
+		return false
+	case string:
+		return v == "0.0.0.0/0" || v == "::/0"
+	case []any:
+		for _, item := range v {
+			if containsPublicCIDR(item) {
+				return true
+			}
+		}
+	case map[string]interface{}:
+		for _, item := range v {
+			if containsPublicCIDR(item) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func actionLabel(action string) string {
+	switch action {
+	case "replace":
+		return "Replacing"
+	case "delete":
+		return "Deleting"
+	case "create":
+		return "Creating"
+	case "update":
+		return "Updating"
+	default:
+		return "Changing"
+	}
+}
+
+func formatSummaryText(summary ClassificationSummary) string {
+	if summary.Total == 0 {
+		return "Semantic plan: no infrastructure changes"
+	}
+	parts := []string{}
+	if summary.Safe > 0 {
+		parts = append(parts, fmt.Sprintf("%d safe", summary.Safe))
+	}
+	if summary.Risky > 0 {
+		parts = append(parts, fmt.Sprintf("%d risky", summary.Risky))
+	}
+	if summary.Destructive > 0 {
+		parts = append(parts, fmt.Sprintf("%d destructive", summary.Destructive))
+	}
+	if summary.Unknown > 0 {
+		parts = append(parts, fmt.Sprintf("%d unknown", summary.Unknown))
+	}
+	return "Semantic plan: " + strings.Join(parts, " · ")
+}
+
+func formatClassificationMarkdown(result *ClassificationResult) string {
+	if result == nil {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString(result.Summary.Text)
+	if result.Summary.RequiresAcknowledgment {
+		b.WriteString("\n\nAcknowledgement required before apply.")
+	}
+	if len(result.Changes) == 0 {
+		return b.String()
+	}
+
+	b.WriteString("\n\n")
+	changes := append([]ClassifiedChange(nil), result.Changes...)
+	sort.SliceStable(changes, func(i, j int) bool {
+		left, right := riskRank(changes[i].Risk), riskRank(changes[j].Risk)
+		if left != right {
+			return left > right
+		}
+		return changes[i].Address < changes[j].Address
+	})
+	limit := len(changes)
+	if limit > 8 {
+		limit = 8
+	}
+	for i := 0; i < limit; i++ {
+		change := changes[i]
+		b.WriteString(fmt.Sprintf("- [%s] %s `%s`: %s", strings.ToUpper(string(change.Risk)), change.Action, change.Address, change.Reason))
+		if len(change.ReviewerFocus) > 0 {
+			b.WriteString(" Focus: ")
+			b.WriteString(strings.Join(change.ReviewerFocus, " "))
+		}
+		b.WriteString("\n")
+	}
+	if len(changes) > limit {
+		b.WriteString(fmt.Sprintf("- ...and %d more change(s)\n", len(changes)-limit))
+	}
+	return strings.TrimSpace(b.String())
+}
+
+func riskRank(risk RiskLevel) int {
+	switch risk {
+	case RiskDestructive:
+		return 4
+	case RiskRisky:
+		return 3
+	case RiskUnknown:
+		return 2
+	case RiskSafe:
+		return 1
+	default:
+		return 0
+	}
+}

--- a/internal/plan/classifier_test.go
+++ b/internal/plan/classifier_test.go
@@ -1,0 +1,189 @@
+package plan
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestClassifySafeTagUpdate(t *testing.T) {
+	result := classifyPlanJSON(t, `{
+		"resource_changes": [{
+			"address": "aws_s3_bucket.logs",
+			"type": "aws_s3_bucket",
+			"name": "logs",
+			"provider_name": "registry.terraform.io/hashicorp/aws",
+			"change": {
+				"actions": ["update"],
+				"before": {"tags": {"Owner": "platform"}},
+				"after": {"tags": {"Owner": "sre"}}
+			}
+		}]
+	}`)
+
+	assertSummary(t, result, RiskSafe, 1)
+	if result.Summary.RequiresAcknowledgment {
+		t.Fatal("safe tag-only update should not require acknowledgement")
+	}
+	assertReasonContains(t, result, "metadata")
+}
+
+func TestClassifySecurityGroupPublicIngressRisky(t *testing.T) {
+	result := classifyPlanJSON(t, `{
+		"resource_changes": [{
+			"address": "aws_security_group.web",
+			"type": "aws_security_group",
+			"name": "web",
+			"change": {
+				"actions": ["update"],
+				"before": {"ingress": []},
+				"after": {"ingress": [{"from_port": 22, "to_port": 22, "cidr_blocks": ["0.0.0.0/0"]}]}
+			}
+		}]
+	}`)
+
+	assertSummary(t, result, RiskRisky, 1)
+	assertRequiresAcknowledgment(t, result)
+	assertCategory(t, result.Changes[0], "network_exposure")
+	assertReasonContains(t, result, "public CIDR")
+}
+
+func TestClassifyIAMExpansionRisky(t *testing.T) {
+	result := classifyPlanJSON(t, `{
+		"resource_changes": [{
+			"address": "aws_iam_policy.analytics",
+			"type": "aws_iam_policy",
+			"name": "analytics",
+			"change": {
+				"actions": ["update"],
+				"before": {"policy": "{\"Statement\":[]}"},
+				"after": {"policy": "{\"Statement\":[{\"Action\":\"s3:ListBucket\",\"Resource\":\"*\"}]}"}
+			}
+		}]
+	}`)
+
+	assertSummary(t, result, RiskRisky, 1)
+	assertRequiresAcknowledgment(t, result)
+	assertCategory(t, result.Changes[0], "identity")
+	assertReasonContains(t, result, "permissions")
+}
+
+func TestClassifyRDSReplacementDestructive(t *testing.T) {
+	result := classifyPlanJSON(t, `{
+		"resource_changes": [{
+			"address": "aws_db_instance.primary",
+			"type": "aws_db_instance",
+			"name": "primary",
+			"change": {
+				"actions": ["delete", "create"],
+				"before": {"identifier": "prod-db", "allocated_storage": 100},
+				"after": {"identifier": "prod-db", "allocated_storage": 500}
+			}
+		}]
+	}`)
+
+	assertSummary(t, result, RiskDestructive, 1)
+	assertRequiresAcknowledgment(t, result)
+	assertCategory(t, result.Changes[0], "data")
+	assertReasonContains(t, result, "stateful data")
+}
+
+func TestClassifyDeleteDestructive(t *testing.T) {
+	result := classifyPlanJSON(t, `{
+		"resource_changes": [{
+			"address": "aws_lambda_function.worker",
+			"type": "aws_lambda_function",
+			"name": "worker",
+			"change": {
+				"actions": ["delete"],
+				"before": {"function_name": "worker"},
+				"after": null
+			}
+		}]
+	}`)
+
+	assertSummary(t, result, RiskDestructive, 1)
+	assertRequiresAcknowledgment(t, result)
+	assertReasonContains(t, result, "remove existing infrastructure")
+}
+
+func TestClassifyUnknownAction(t *testing.T) {
+	result := classifyPlanJSON(t, `{
+		"resource_changes": [{
+			"address": "example_service.main",
+			"type": "example_service",
+			"name": "main",
+			"change": {
+				"actions": ["rotate"],
+				"before": {"name": "main"},
+				"after": {"name": "main"}
+			}
+		}]
+	}`)
+
+	assertSummary(t, result, RiskUnknown, 1)
+	assertRequiresAcknowledgment(t, result)
+	assertReasonContains(t, result, "not recognized")
+}
+
+func classifyPlanJSON(t *testing.T, data string) *ClassificationResult {
+	t.Helper()
+	result, err := New().ClassifyFullPlan(data)
+	if err != nil {
+		t.Fatalf("classify plan JSON: %v", err)
+	}
+	return result
+}
+
+func assertSummary(t *testing.T, result *ClassificationResult, risk RiskLevel, want int) {
+	t.Helper()
+	if result.Summary.Total != want {
+		t.Fatalf("summary total = %d, want %d", result.Summary.Total, want)
+	}
+	var got int
+	switch risk {
+	case RiskSafe:
+		got = result.Summary.Safe
+	case RiskRisky:
+		got = result.Summary.Risky
+	case RiskDestructive:
+		got = result.Summary.Destructive
+	case RiskUnknown:
+		got = result.Summary.Unknown
+	}
+	if got != want {
+		t.Fatalf("summary %s = %d, want %d: %#v", risk, got, want, result.Summary)
+	}
+	if len(result.Changes) != want {
+		t.Fatalf("changes = %d, want %d", len(result.Changes), want)
+	}
+	if result.Changes[0].Risk != risk {
+		t.Fatalf("risk = %s, want %s", result.Changes[0].Risk, risk)
+	}
+}
+
+func assertRequiresAcknowledgment(t *testing.T, result *ClassificationResult) {
+	t.Helper()
+	if !result.Summary.RequiresAcknowledgment {
+		t.Fatalf("expected acknowledgement requirement: %#v", result.Summary)
+	}
+}
+
+func assertCategory(t *testing.T, change ClassifiedChange, want string) {
+	t.Helper()
+	for _, category := range change.Categories {
+		if category == want {
+			return
+		}
+	}
+	t.Fatalf("categories %v do not contain %q", change.Categories, want)
+}
+
+func assertReasonContains(t *testing.T, result *ClassificationResult, want string) {
+	t.Helper()
+	if len(result.Changes) == 0 {
+		t.Fatal("no changes returned")
+	}
+	if !strings.Contains(result.Changes[0].Reason, want) {
+		t.Fatalf("reason %q does not contain %q", result.Changes[0].Reason, want)
+	}
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -106,9 +106,9 @@ func (r *Runner) terraformArgs(command, binary string) []string {
 	case "init":
 		return []string{binary, "init"}
 	case "plan":
-		return []string{binary, "plan", "-no-color"}
+		return []string{binary, "plan", "-out=tfplan", "-no-color"}
 	case "apply":
-		return []string{binary, "apply", "-auto-approve", "-no-color"}
+		return []string{binary, "apply", "-no-color", "tfplan"}
 	case "destroy":
 		return []string{binary, "destroy", "-auto-approve", "-no-color"}
 	case "validate":

--- a/internal/runner/safe_runner.go
+++ b/internal/runner/safe_runner.go
@@ -301,7 +301,7 @@ func (sr *SafeRunner) ExportSavedPlanJSON(ctx context.Context, projectDir, tool 
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	binary := "terraform"
+	var binary string
 	switch tool {
 	case "terraform":
 		binary = "terraform"

--- a/internal/runner/safe_runner.go
+++ b/internal/runner/safe_runner.go
@@ -293,6 +293,71 @@ func (sr *SafeRunner) ExecutePlanJSON(ctx context.Context, projectDir, tool stri
 	return result, nil
 }
 
+// ExportSavedPlanJSON renders the saved Terraform/OpenTofu plan file created
+// by `plan -out=tfplan` into full JSON (`show -json tfplan`). The result is
+// used by policy engines and the semantic apply gate.
+func (sr *SafeRunner) ExportSavedPlanJSON(ctx context.Context, projectDir, tool string, extraEnv map[string]string) (*ExecutionResult, error) {
+	timeout := sr.defaults.PlanTimeout
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	binary := "terraform"
+	switch tool {
+	case "terraform":
+		binary = "terraform"
+	case "opentofu":
+		binary = "tofu"
+	default:
+		return nil, fmt.Errorf("saved plan JSON export is not supported for %s", tool)
+	}
+
+	cmd := exec.CommandContext(ctx, binary, "show", "-json", "tfplan")
+	cmd.Dir = projectDir
+	if len(extraEnv) > 0 {
+		cmd.Env = mergeEnv(os.Environ(), extraEnv)
+	}
+	configureCommandCancel(cmd)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &limitedWriter{buf: &stdout, limit: sr.defaults.MaxOutputBytes}
+	cmd.Stderr = &limitedWriter{buf: &stderr, limit: sr.defaults.MaxOutputBytes}
+
+	start := time.Now()
+	err := cmd.Run()
+
+	result := &ExecutionResult{
+		ID:       fmt.Sprintf("plan-show-json-%d", time.Now().UnixNano()),
+		Output:   stdout.String(),
+		Duration: time.Since(start),
+	}
+	if stderr.Len() > 0 {
+		result.Output += "\n" + stderr.String()
+	}
+	if lw, ok := cmd.Stdout.(*limitedWriter); ok && lw.truncated {
+		result.Truncated = true
+		result.Output += "\n\n--- OUTPUT TRUNCATED (exceeded limit) ---"
+	}
+
+	switch {
+	case ctx.Err() == context.DeadlineExceeded:
+		result.Status = "timed_out"
+		return result, fmt.Errorf("command timed out after %v", timeout)
+	case ctx.Err() == context.Canceled:
+		result.Status = "cancelled"
+		return result, fmt.Errorf("command was cancelled")
+	case err != nil:
+		result.Status = "failed"
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			result.ExitCode = exitErr.ExitCode()
+		}
+		return result, err
+	default:
+		result.Status = "completed"
+		result.ExitCode = 0
+		return result, nil
+	}
+}
+
 // RequiresApproval returns true if the command needs plan review first.
 // Covers both the Terraform/Ansible vocabulary ("apply", "destroy")
 // and Pulumi's native verbs ("up", "refresh") so every state-mutating

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -149,6 +149,52 @@ describe('api.runCommand', () => {
     });
   });
 
+  it('preserves structured plan_risk_blocked errors for the UI override flow', async () => {
+    const payload = {
+      error: 'plan_risk_blocked',
+      detail: 'semantic plan classifier found risky changes',
+      classification: {
+        summary: {
+          safe: 0,
+          risky: 1,
+          destructive: 0,
+          unknown: 0,
+          total: 1,
+          requires_acknowledgment: true,
+          text: 'Semantic plan: 1 risky',
+        },
+        changes: [{
+          address: 'aws_security_group.web',
+          action: 'update',
+          risk: 'risky',
+          categories: ['network_exposure'],
+          reason: 'public CIDR exposure',
+          reviewer_focus: ['Check ingress.'],
+        }],
+      },
+    };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(payload), {
+        status: 409,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    ));
+
+    let caught: unknown;
+    try {
+      await api.runCommand('demo', 'terraform', 'apply', { approved: true, env: 'dev' });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(ApiError);
+    expect(caught).toMatchObject({
+      name: 'ApiError',
+      status: 409,
+      payload,
+    });
+  });
+
   it('sends the selected cloud connection when running commands', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ status: 'running' }), {
@@ -169,6 +215,7 @@ describe('api.runCommand', () => {
         approved: false,
         env: 'dev',
         acknowledged: false,
+        risk_acknowledged: false,
         connection_id: 'conn_1',
       }),
     });

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -6,6 +6,7 @@ export interface ApiErrorPayload {
   error?: string;
   detail?: string;
   findings?: PolicyFinding[];
+  classification?: PlanClassification;
 }
 
 export class ApiError extends Error {
@@ -136,6 +137,45 @@ export interface CloudConnectionTestResult {
   summary: string;
   connection: CloudConnection;
   checks: { name: string; status: 'pass' | 'warn' | 'error'; message: string }[];
+}
+
+export type PlanRiskLevel = 'safe' | 'risky' | 'destructive' | 'unknown';
+
+export interface PlanFieldChange {
+  path: string;
+  old_value?: unknown;
+  new_value?: unknown;
+  sensitive?: boolean;
+  computed?: boolean;
+}
+
+export interface PlanClassifiedChange {
+  address: string;
+  type?: string;
+  name?: string;
+  provider?: string;
+  action: string;
+  risk: PlanRiskLevel;
+  categories: string[];
+  reason: string;
+  reviewer_focus: string[];
+  field_changes?: PlanFieldChange[];
+}
+
+export interface PlanClassificationSummary {
+  safe: number;
+  risky: number;
+  destructive: number;
+  unknown: number;
+  total: number;
+  requires_acknowledgment: boolean;
+  text: string;
+}
+
+export interface PlanClassification {
+  summary: PlanClassificationSummary;
+  changes: PlanClassifiedChange[];
+  markdown?: string;
 }
 
 // Checks res.ok and throws with the backend's error message instead of
@@ -366,7 +406,7 @@ export const api = {
     projectName: string,
     tool: string,
     command: string,
-    opts: { approved?: boolean; env?: string; acknowledged?: boolean; connectionId?: string | null } = {},
+    opts: { approved?: boolean; env?: string; acknowledged?: boolean; riskAcknowledged?: boolean; connectionId?: string | null } = {},
   ): Promise<{ status: string; connection?: CloudConnection }> {
     const res = await fetch(`${BASE}/api/projects/${projectName}/run`, {
       method: 'POST',
@@ -377,8 +417,18 @@ export const api = {
         approved: opts.approved ?? false,
         env: opts.env,
         acknowledged: opts.acknowledged ?? false,
+        risk_acknowledged: opts.riskAcknowledged ?? false,
         connection_id: opts.connectionId || undefined,
       }),
+    });
+    return (await check(res)).json();
+  },
+
+  async classifyPlan(projectName: string, req: { tool?: string; env?: string; plan_json?: unknown; plan_text?: string } = {}): Promise<PlanClassification> {
+    const res = await fetch(`${BASE}/api/projects/${projectName}/plan/classify`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(req),
     });
     return (await check(res)).json();
   },

--- a/web/src/app/useWorkspaceActions.ts
+++ b/web/src/app/useWorkspaceActions.ts
@@ -1,5 +1,5 @@
 import { useCallback, useRef, type Dispatch, type MouseEvent, type MutableRefObject, type RefObject, type SetStateAction } from 'react';
-import { api, ApiError, normalizeSuggestions, type CatalogResource, type CloudConnection, type PolicyFinding, type Suggestion } from '../api';
+import { api, ApiError, normalizeSuggestions, type CatalogResource, type CloudConnection, type PlanClassification, type PolicyFinding, type Suggestion } from '../api';
 import {
   TOOLS,
   edgeId,
@@ -22,6 +22,28 @@ const summarizePolicyFindings = (findings: PolicyFinding[]) => {
 
 const isPolicyBlockedError = (err: unknown): err is ApiError => (
   err instanceof ApiError && err.status === 409 && err.payload?.error === 'policy_blocked'
+);
+
+const summarizePlanClassification = (classification?: PlanClassification) => {
+  if (!classification) return 'No classifier details were returned.';
+  const lines = [classification.summary.text];
+  const priority = { destructive: 4, risky: 3, unknown: 2, safe: 1 } as const;
+  const changes = [...classification.changes]
+    .sort((a, b) => priority[b.risk] - priority[a.risk])
+    .slice(0, 5)
+    .map((change, index) => {
+      const focus = change.reviewer_focus?.length ? ` Focus: ${change.reviewer_focus.join(' ')}` : '';
+      return `${index + 1}. [${change.risk}] ${change.action} ${change.address}: ${change.reason}${focus}`;
+    });
+  lines.push(...changes);
+  if (classification.changes.length > changes.length) {
+    lines.push(`...and ${classification.changes.length - changes.length} more.`);
+  }
+  return lines.join('\n');
+};
+
+const isPlanRiskBlockedError = (err: unknown): err is ApiError => (
+  err instanceof ApiError && err.status === 409 && err.payload?.error === 'plan_risk_blocked'
 );
 
 export interface UseWorkspaceActionsInput {
@@ -330,33 +352,64 @@ export function useWorkspaceActions({
     }
     const connectionLabel = selectedCloudConnection ? ` --connection ${selectedCloudConnection.name}` : '';
     setTerminalOutput(prev => [...prev, `$ ${command}${connectionLabel}`, '']);
+
+    const handlePolicyBlock = (err: ApiError, riskAcknowledged: boolean) => {
+      const findings = err.payload?.findings ?? [];
+      const blockingCount = findings.filter(finding => finding.severity === 'error').length;
+      const summary = summarizePolicyFindings(findings);
+      const summaryLines = summary.split('\n');
+      setTerminalOutput(prev => [
+        ...prev,
+        `Policy blocked ${command}: ${blockingCount} blocking finding${blockingCount === 1 ? '' : 's'}`,
+        ...summaryLines,
+      ]);
+      if (!confirm(`Policy checks blocked "${command}".\n\n${summary}\n\nRun it anyway and acknowledge these findings?`)) {
+        return;
+      }
+      setTerminalOutput(prev => [...prev, `$ ${command} --acknowledged${connectionLabel}`, '']);
+      api.runCommand(projectId, tool, command, {
+        approved: true,
+        env: activeEnv,
+        acknowledged: true,
+        riskAcknowledged,
+        connectionId: selectedCloudConnection?.id,
+      }).catch(overrideErr => {
+        setTerminalOutput(prev => [...prev, `Error: ${overrideErr.message}`]);
+      });
+    };
+
     api.runCommand(projectId, tool, command, {
       approved: needsApproval,
       env: activeEnv,
       connectionId: selectedCloudConnection?.id,
     }).catch(err => {
-      if (needsApproval && isPolicyBlockedError(err)) {
-        const findings = err.payload?.findings ?? [];
-        const blockingCount = findings.filter(finding => finding.severity === 'error').length;
-        const summary = summarizePolicyFindings(findings);
-        const summaryLines = summary.split('\n');
+      if (needsApproval && isPlanRiskBlockedError(err)) {
+        const summary = summarizePlanClassification(err.payload?.classification);
         setTerminalOutput(prev => [
           ...prev,
-          `Policy blocked ${command}: ${blockingCount} blocking finding${blockingCount === 1 ? '' : 's'}`,
-          ...summaryLines,
+          `Semantic plan gate blocked ${command}:`,
+          ...summary.split('\n'),
         ]);
-        if (!confirm(`Policy checks blocked "${command}".\n\n${summary}\n\nRun it anyway and acknowledge these findings?`)) {
+        if (!confirm(`Semantic plan review flagged "${command}".\n\n${summary}\n\nRun it anyway and acknowledge this risk?`)) {
           return;
         }
-        setTerminalOutput(prev => [...prev, `$ ${command} --acknowledged${connectionLabel}`, '']);
+        setTerminalOutput(prev => [...prev, `$ ${command} --risk-acknowledged${connectionLabel}`, '']);
         api.runCommand(projectId, tool, command, {
           approved: true,
           env: activeEnv,
-          acknowledged: true,
+          riskAcknowledged: true,
           connectionId: selectedCloudConnection?.id,
         }).catch(overrideErr => {
+          if (needsApproval && isPolicyBlockedError(overrideErr)) {
+            handlePolicyBlock(overrideErr, true);
+            return;
+          }
           setTerminalOutput(prev => [...prev, `Error: ${overrideErr.message}`]);
         });
+        return;
+      }
+      if (needsApproval && isPolicyBlockedError(err)) {
+        handlePolicyBlock(err, false);
         return;
       }
       setTerminalOutput(prev => [...prev, `Error: ${err.message}`]);

--- a/web/src/useWebSocket.ts
+++ b/web/src/useWebSocket.ts
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useCallback, useState } from 'react';
 
+import type { PlanClassification } from './api';
+
 export interface WSMessage {
   type: 'file_changed' | 'terminal' | 'error' | 'ai_progress' | 'ai_topology_result';
   project?: string;
@@ -10,6 +12,7 @@ export interface WSMessage {
   status?: string;
   message?: string;
   resources?: any[];
+  plan_classification?: PlanClassification;
 }
 
 export function useWebSocket(onMessage: (msg: WSMessage) => void) {


### PR DESCRIPTION
## Summary
- add a deterministic Terraform/OpenTofu semantic plan classifier with safe/risky/destructive/unknown summaries
- save Terraform/OpenTofu plans as `tfplan`, export `tfplan.json`, and apply the saved plan artifact
- block apply on risky/destructive/unknown classifier results until `risk_acknowledged:true`
- add UI acknowledgement handling, API endpoint, tests, and docs

Refs #43

## Validation
- `GOCACHE=/private/tmp/iacstudio-go-cache go test ./...`
- `npm test -- --run`
- `npm run build`
- `npm run lint` (passes with existing warnings)
- `git diff --check`