### PR TITLE
Add classified drift findings foundation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -398,9 +398,10 @@ iac-studio</code></pre>
           <div class="workflow">
             <h3>Detect drift and export</h3>
             <p>
-              Drift detection compares state against code when Terraform state is present. Export converts
-              the current topology into alternate formats such as Pulumi TypeScript, CDK Python, and
-              CloudFormation where supported.
+              Drift detection compares Terraform/OpenTofu state against code when state is present,
+              classifies each finding, and recommends whether to investigate, codify, import, or
+              revert. Export converts the current topology into alternate formats such as Pulumi
+              TypeScript, CDK Python, and CloudFormation where supported.
             </p>
           </div>
         </section>
@@ -735,8 +736,8 @@ ANTHROPIC_MODEL=claude-opus-4-7 \
                 </tr>
                 <tr>
                   <td>Modules, drift, export</td>
-                  <td><code>GET /api/projects/{name}/modules</code><br><code>GET /api/registry/modules/search</code><br><code>POST /api/projects/{name}/promote-to-module</code><br><code>GET /api/projects/{name}/drift</code><br><code>GET /api/export/formats</code><br><code>POST /api/export</code></td>
-                  <td>Discover modules, promote resources, detect drift, and export alternate IaC formats.</td>
+                  <td><code>GET /api/projects/{name}/modules</code><br><code>GET /api/registry/modules/search</code><br><code>POST /api/projects/{name}/promote-to-module</code><br><code>GET/POST /api/projects/{name}/drift</code><br><code>GET /api/export/formats</code><br><code>POST /api/export</code></td>
+                  <td>Discover modules, promote resources, detect classified Terraform/OpenTofu state drift, and export alternate IaC formats.</td>
                 </tr>
                 <tr>
                   <td>Realtime</td>

--- a/internal/api/drift_test.go
+++ b/internal/api/drift_test.go
@@ -1,0 +1,95 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestProjectDriftEndpointReturnsClassifiedFindings(t *testing.T) {
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "demo")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "main.tf"), []byte(`
+resource "aws_security_group" "web" {
+  name    = "web"
+  ingress = []
+}
+`), 0o644); err != nil {
+		t.Fatalf("write main.tf: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "terraform.tfstate"), []byte(`{
+		"version": 4,
+		"resources": [{
+			"mode": "managed",
+			"type": "aws_security_group",
+			"name": "web",
+			"instances": [{"attributes": {"name": "web", "ingress": [{"cidr_blocks": ["0.0.0.0/0"]}]}}]
+		}]
+	}`), 0o600); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+
+	srv := httptest.NewServer(fullRouterForTest(t, root))
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/api/projects/demo/drift", "application/json", strings.NewReader(`{"tool":"terraform"}`))
+	if err != nil {
+		t.Fatalf("POST drift: %v", err)
+	}
+	defer closeBody(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("drift status = %d", resp.StatusCode)
+	}
+
+	var payload struct {
+		Findings []struct {
+			Address           string `json:"address"`
+			Path              string `json:"path"`
+			Classification    string `json:"classification"`
+			RecommendedAction string `json:"recommended_action"`
+		} `json:"findings"`
+		Classifications map[string]int `json:"classifications"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode drift response: %v", err)
+	}
+	if len(payload.Findings) == 0 {
+		t.Fatal("expected drift findings")
+	}
+	got := payload.Findings[0]
+	if got.Address != "aws_security_group.web" ||
+		got.Path != "ingress" ||
+		got.Classification != "unauthorized_change" ||
+		got.RecommendedAction != "revert_or_codify_after_review" {
+		t.Fatalf("unexpected finding: %#v", got)
+	}
+	if payload.Classifications["unauthorized_change"] != 1 {
+		t.Fatalf("unexpected classification counts: %#v", payload.Classifications)
+	}
+}
+
+func TestProjectDriftEndpointRejectsUnsupportedTool(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "demo"), 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	srv := httptest.NewServer(fullRouterForTest(t, root))
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/api/projects/demo/drift", "application/json", strings.NewReader(`{"tool":"ansible"}`))
+	if err != nil {
+		t.Fatalf("POST drift: %v", err)
+	}
+	defer closeBody(resp.Body)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("drift status = %d, want 400", resp.StatusCode)
+	}
+	assertResponseBodyContains(t, resp, "Terraform and OpenTofu")
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1949,16 +1949,54 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 
 	driftDetector := drift.New()
 
-	mux.HandleFunc("POST /api/projects/{name}/drift", func(w http.ResponseWriter, r *http.Request) {
+	handleDrift := func(w http.ResponseWriter, r *http.Request) {
 		name := r.PathValue("name")
-		tool := r.URL.Query().Get("tool")
 		projectPath, err := safeProjectPath(projectsDir, name)
 		if err != nil {
 			http.Error(w, err.Error(), 400)
 			return
 		}
+
+		limitBody(w, r)
+		var req struct {
+			Tool string `json:"tool,omitempty"`
+			Env  string `json:"env,omitempty"`
+		}
+		if r.Method == http.MethodPost {
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+				http.Error(w, "invalid request body: "+err.Error(), 400)
+				return
+			}
+		}
+		if req.Tool == "" {
+			req.Tool = r.URL.Query().Get("tool")
+		}
+		if req.Env == "" {
+			req.Env = r.URL.Query().Get("env")
+		}
+
+		tool := effectiveProjectTool(projectPath, req.Tool, req.Env)
+		if tool == "multi" {
+			http.Error(w, hybridToolResolutionMessage("env is required when detecting drift for hybrid projects", req.Env), 400)
+			return
+		}
+		if tool != "terraform" && tool != "opentofu" {
+			http.Error(w, "drift detection currently supports Terraform and OpenTofu state", 400)
+			return
+		}
+
+		workDir := projectPath
+		if req.Env != "" {
+			subPath, subErr := safeSubdir(projectPath, "environments", req.Env)
+			if subErr != nil {
+				http.Error(w, "invalid env: "+subErr.Error(), 400)
+				return
+			}
+			workDir = subPath
+		}
+
 		p := parser.ForTool(tool)
-		resources, err := p.ParseDir(projectPath)
+		resources, err := p.ParseDir(workDir)
 		if err != nil {
 			http.Error(w, err.Error(), 500)
 			return
@@ -1968,13 +2006,15 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 		for _, res := range resources {
 			codeResources[res.Type+"."+res.Name] = res.Properties
 		}
-		report, err := driftDetector.Detect(projectPath, codeResources)
+		report, err := driftDetector.Detect(workDir, codeResources)
 		if err != nil {
 			http.Error(w, err.Error(), 500)
 			return
 		}
 		_ = json.NewEncoder(w).Encode(report)
-	})
+	}
+	mux.HandleFunc("GET /api/projects/{name}/drift", handleDrift)
+	mux.HandleFunc("POST /api/projects/{name}/drift", handleDrift)
 
 	// ─── Multi-Format Export ───
 

--- a/internal/drift/drift.go
+++ b/internal/drift/drift.go
@@ -15,25 +15,43 @@ func New() *Detector {
 	return &Detector{}
 }
 
+const (
+	ClassificationLegitimateConfigChange = "legitimate_config_change"
+	ClassificationUnauthorizedChange     = "unauthorized_change"
+	ClassificationMissingFromState       = "missing_from_state"
+	ClassificationUnknown                = "unknown"
+
+	ActionCodifyOrAccept            = "codify_or_accept"
+	ActionImportOrApply             = "import_or_apply"
+	ActionInvestigate               = "investigate"
+	ActionReviewImportOrRemove      = "review_import_or_remove"
+	ActionRevertOrCodifyAfterReview = "revert_or_codify_after_review"
+)
+
 // DriftReport describes differences between code and deployed state.
 type DriftReport struct {
-	HasState    bool           `json:"has_state"`
-	StatePath   string         `json:"state_path"`
-	Drifted     []DriftedResource `json:"drifted"`
-	Missing     []string       `json:"missing"`       // in code but not in state
-	Unmanaged   []string       `json:"unmanaged"`     // in state but not in code
-	InSync      int            `json:"in_sync"`       // resources matching
-	Total       int            `json:"total"`
-	Summary     string         `json:"summary"`
+	HasState        bool              `json:"has_state"`
+	StatePath       string            `json:"state_path"`
+	Drifted         []DriftedResource `json:"drifted"`
+	Findings        []DriftFinding    `json:"findings"`
+	Missing         []string          `json:"missing"`   // in code but not in state
+	Unmanaged       []string          `json:"unmanaged"` // in state but not in code
+	InSync          int               `json:"in_sync"`   // resources matching
+	Total           int               `json:"total"`
+	Classifications map[string]int    `json:"classifications,omitempty"`
+	Summary         string            `json:"summary"`
 }
 
 // DriftedResource is a resource where state differs from code.
 type DriftedResource struct {
-	Address  string       `json:"address"`
-	Type     string       `json:"type"`
-	Name     string       `json:"name"`
-	Changes  []DriftField `json:"changes"`
-	Status   string       `json:"status"` // drifted | missing | unmanaged
+	Address           string       `json:"address"`
+	Type              string       `json:"type"`
+	Name              string       `json:"name"`
+	Changes           []DriftField `json:"changes"`
+	Status            string       `json:"status"` // drifted | missing | unmanaged
+	Classification    string       `json:"classification,omitempty"`
+	RecommendedAction string       `json:"recommended_action,omitempty"`
+	Reason            string       `json:"reason,omitempty"`
 }
 
 // DriftField is a single attribute that drifted.
@@ -43,16 +61,32 @@ type DriftField struct {
 	LiveValue interface{} `json:"live_value"`
 }
 
+// DriftFinding is a single reviewer-facing drift item. The names use
+// expected/current so future cloud reads can reuse the same API shape even
+// though the first implementation compares HCL against Terraform state.
+type DriftFinding struct {
+	Address           string      `json:"address"`
+	Type              string      `json:"type"`
+	Name              string      `json:"name"`
+	Status            string      `json:"status"` // drifted | missing | unmanaged
+	Path              string      `json:"path,omitempty"`
+	ExpectedValue     interface{} `json:"expected_value,omitempty"`
+	CurrentValue      interface{} `json:"current_value,omitempty"`
+	Classification    string      `json:"classification"`
+	RecommendedAction string      `json:"recommended_action"`
+	Reason            string      `json:"reason"`
+}
+
 // tfState represents the minimal Terraform state file structure we need.
 type tfState struct {
-	Version   int `json:"version"`
+	Version   int               `json:"version"`
 	Resources []tfStateResource `json:"resources"`
 }
 
 type tfStateResource struct {
-	Mode      string `json:"mode"` // "managed" or "data"
-	Type      string `json:"type"`
-	Name      string `json:"name"`
+	Mode      string            `json:"mode"` // "managed" or "data"
+	Type      string            `json:"type"`
+	Name      string            `json:"name"`
 	Instances []tfStateInstance `json:"instances"`
 }
 
@@ -62,7 +96,7 @@ type tfStateInstance struct {
 
 // Detect compares terraform.tfstate with the parsed code resources.
 func (d *Detector) Detect(projectDir string, codeResources map[string]map[string]interface{}) (*DriftReport, error) {
-	report := &DriftReport{}
+	report := &DriftReport{Classifications: map[string]int{}}
 
 	// Find state file
 	statePaths := []string{
@@ -115,8 +149,17 @@ func (d *Detector) Detect(projectDir string, codeResources map[string]map[string
 		stateAttrs, inState := stateIndex[addr]
 		if !inState {
 			report.Missing = append(report.Missing, addr)
-			report.Drifted = append(report.Drifted, DriftedResource{
+			resource := DriftedResource{
 				Address: addr, Type: resType, Name: resName, Status: "missing",
+				Classification:    ClassificationMissingFromState,
+				RecommendedAction: ActionImportOrApply,
+				Reason:            "Resource exists in code but is not present in Terraform state.",
+			}
+			report.Drifted = append(report.Drifted, resource)
+			report.addFinding(DriftFinding{
+				Address: resource.Address, Type: resource.Type, Name: resource.Name,
+				Status: resource.Status, Classification: resource.Classification,
+				RecommendedAction: resource.RecommendedAction, Reason: resource.Reason,
 			})
 			continue
 		}
@@ -137,10 +180,19 @@ func (d *Detector) Detect(projectDir string, codeResources map[string]map[string
 		}
 
 		if len(changes) > 0 {
+			classification, action, reason := classifyResourceDrift(resType, changes)
 			report.Drifted = append(report.Drifted, DriftedResource{
 				Address: addr, Type: resType, Name: resName,
 				Changes: changes, Status: "drifted",
+				Classification: classification, RecommendedAction: action, Reason: reason,
 			})
+			for _, change := range changes {
+				report.addFinding(DriftFinding{
+					Address: addr, Type: resType, Name: resName, Status: "drifted",
+					Path: change.Path, ExpectedValue: change.CodeValue, CurrentValue: change.LiveValue,
+					Classification: classification, RecommendedAction: action, Reason: reason,
+				})
+			}
 		} else {
 			report.InSync++
 		}
@@ -155,8 +207,17 @@ func (d *Detector) Detect(projectDir string, codeResources map[string]map[string
 			if len(parts) == 2 {
 				resType, resName = parts[0], parts[1]
 			}
-			report.Drifted = append(report.Drifted, DriftedResource{
+			resource := DriftedResource{
 				Address: addr, Type: resType, Name: resName, Status: "unmanaged",
+				Classification:    ClassificationUnauthorizedChange,
+				RecommendedAction: ActionReviewImportOrRemove,
+				Reason:            "Resource exists in Terraform state but not in code.",
+			}
+			report.Drifted = append(report.Drifted, resource)
+			report.addFinding(DriftFinding{
+				Address: resource.Address, Type: resource.Type, Name: resource.Name,
+				Status: resource.Status, Classification: resource.Classification,
+				RecommendedAction: resource.RecommendedAction, Reason: resource.Reason,
 			})
 		}
 	}
@@ -167,4 +228,97 @@ func (d *Detector) Detect(projectDir string, codeResources map[string]map[string
 		report.Total, report.InSync, driftCount-len(report.Missing)-len(report.Unmanaged), len(report.Missing), len(report.Unmanaged))
 
 	return report, nil
+}
+
+func (r *DriftReport) addFinding(f DriftFinding) {
+	r.Findings = append(r.Findings, f)
+	if r.Classifications == nil {
+		r.Classifications = map[string]int{}
+	}
+	r.Classifications[f.Classification]++
+}
+
+func classifyResourceDrift(resourceType string, changes []DriftField) (classification, action, reason string) {
+	if len(changes) == 0 {
+		return ClassificationUnknown, ActionInvestigate, "No field-level drift details were available."
+	}
+	if isMetadataOnlyDrift(changes) {
+		return ClassificationLegitimateConfigChange, ActionCodifyOrAccept, "Only metadata fields drifted."
+	}
+	switch {
+	case isIdentityResource(resourceType):
+		return ClassificationUnauthorizedChange, ActionRevertOrCodifyAfterReview, "Identity drift can expand permissions or trust boundaries."
+	case isNetworkResource(resourceType):
+		return ClassificationUnauthorizedChange, ActionRevertOrCodifyAfterReview, "Network drift can change reachability or public exposure."
+	case isStatefulResource(resourceType):
+		return ClassificationUnauthorizedChange, ActionRevertOrCodifyAfterReview, "Stateful drift can affect durability, availability, or spend."
+	default:
+		return ClassificationUnknown, ActionInvestigate, "Drift does not match a known low-risk pattern."
+	}
+}
+
+func isMetadataOnlyDrift(changes []DriftField) bool {
+	for _, change := range changes {
+		root := strings.Split(change.Path, ".")[0]
+		switch root {
+		case "tags", "labels", "annotations", "description":
+			continue
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func isIdentityResource(resourceType string) bool {
+	t := strings.ToLower(resourceType)
+	return strings.Contains(t, "_iam_") ||
+		strings.Contains(t, "iam") ||
+		strings.Contains(t, "role_assignment") ||
+		strings.Contains(t, "role_binding") ||
+		strings.Contains(t, "service_account")
+}
+
+func isNetworkResource(resourceType string) bool {
+	t := strings.ToLower(resourceType)
+	needles := []string{
+		"security_group",
+		"firewall",
+		"network_acl",
+		"network_security_group",
+		"route",
+		"listener",
+		"load_balancer",
+		"vpc_peering",
+		"internet_gateway",
+	}
+	for _, needle := range needles {
+		if strings.Contains(t, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func isStatefulResource(resourceType string) bool {
+	t := strings.ToLower(resourceType)
+	needles := []string{
+		"db_instance",
+		"db_cluster",
+		"rds",
+		"dynamodb",
+		"s3_bucket",
+		"storage_bucket",
+		"sql_database",
+		"disk",
+		"volume",
+		"redis",
+		"elasticache",
+	}
+	for _, needle := range needles {
+		if strings.Contains(t, needle) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/drift/drift.go
+++ b/internal/drift/drift.go
@@ -96,7 +96,7 @@ type tfStateInstance struct {
 
 // Detect compares terraform.tfstate with the parsed code resources.
 func (d *Detector) Detect(projectDir string, codeResources map[string]map[string]interface{}) (*DriftReport, error) {
-	report := &DriftReport{Classifications: map[string]int{}}
+	report := &DriftReport{Findings: []DriftFinding{}, Classifications: map[string]int{}}
 
 	// Find state file
 	statePaths := []string{
@@ -232,9 +232,6 @@ func (d *Detector) Detect(projectDir string, codeResources map[string]map[string
 
 func (r *DriftReport) addFinding(f DriftFinding) {
 	r.Findings = append(r.Findings, f)
-	if r.Classifications == nil {
-		r.Classifications = map[string]int{}
-	}
 	r.Classifications[f.Classification]++
 }
 

--- a/internal/drift/drift_test.go
+++ b/internal/drift/drift_test.go
@@ -1,0 +1,104 @@
+package drift
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDetectClassifiesMetadataDriftAsLegitimate(t *testing.T) {
+	dir := t.TempDir()
+	writeState(t, dir, `{
+		"version": 4,
+		"resources": [{
+			"mode": "managed",
+			"type": "aws_s3_bucket",
+			"name": "logs",
+			"instances": [{"attributes": {"tags": {"Owner": "old"}}}]
+		}]
+	}`)
+
+	report, err := New().Detect(dir, map[string]map[string]interface{}{
+		"aws_s3_bucket.logs": {"tags": map[string]interface{}{"Owner": "platform"}},
+	})
+	if err != nil {
+		t.Fatalf("detect drift: %v", err)
+	}
+
+	requireFinding(t, report, "aws_s3_bucket.logs", "tags", ClassificationLegitimateConfigChange, ActionCodifyOrAccept)
+	if report.Classifications[ClassificationLegitimateConfigChange] != 1 {
+		t.Fatalf("classification counts = %#v", report.Classifications)
+	}
+}
+
+func TestDetectClassifiesSecurityGroupDriftAsUnauthorized(t *testing.T) {
+	dir := t.TempDir()
+	writeState(t, dir, `{
+		"version": 4,
+		"resources": [{
+			"mode": "managed",
+			"type": "aws_security_group",
+			"name": "web",
+			"instances": [{"attributes": {"ingress": [{"cidr_blocks": ["0.0.0.0/0"]}]}}]
+		}]
+	}`)
+
+	report, err := New().Detect(dir, map[string]map[string]interface{}{
+		"aws_security_group.web": {"ingress": []interface{}{}},
+	})
+	if err != nil {
+		t.Fatalf("detect drift: %v", err)
+	}
+
+	requireFinding(t, report, "aws_security_group.web", "ingress", ClassificationUnauthorizedChange, ActionRevertOrCodifyAfterReview)
+	if report.Findings[0].ExpectedValue == nil || report.Findings[0].CurrentValue == nil {
+		t.Fatalf("finding should include expected/current values: %#v", report.Findings[0])
+	}
+}
+
+func TestDetectReportsMissingAndUnmanagedResources(t *testing.T) {
+	dir := t.TempDir()
+	writeState(t, dir, `{
+		"version": 4,
+		"resources": [{
+			"mode": "managed",
+			"type": "aws_instance",
+			"name": "manual",
+			"instances": [{"attributes": {"instance_type": "t3.micro"}}]
+		}]
+	}`)
+
+	report, err := New().Detect(dir, map[string]map[string]interface{}{
+		"aws_s3_bucket.logs": {"bucket": "logs"},
+	})
+	if err != nil {
+		t.Fatalf("detect drift: %v", err)
+	}
+
+	requireFinding(t, report, "aws_s3_bucket.logs", "", ClassificationMissingFromState, ActionImportOrApply)
+	requireFinding(t, report, "aws_instance.manual", "", ClassificationUnauthorizedChange, ActionReviewImportOrRemove)
+	if len(report.Missing) != 1 || len(report.Unmanaged) != 1 {
+		t.Fatalf("missing/unmanaged = %#v/%#v", report.Missing, report.Unmanaged)
+	}
+}
+
+func writeState(t *testing.T, dir, state string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "terraform.tfstate"), []byte(state), 0o600); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+}
+
+func requireFinding(t *testing.T, report *DriftReport, address, path, classification, action string) {
+	t.Helper()
+	for _, finding := range report.Findings {
+		if finding.Address == address &&
+			finding.Path == path &&
+			finding.Classification == classification &&
+			finding.RecommendedAction == action {
+			return
+		}
+	}
+	t.Fatalf("finding not found: address=%s path=%s classification=%s action=%s report=%#v",
+		address, path, classification, action, report.Findings)
+}

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -222,6 +222,42 @@ describe('api.runCommand', () => {
   });
 });
 
+describe('api.runDrift', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('posts tool and environment to the drift endpoint', async () => {
+    const response = {
+      has_state: true,
+      state_path: '/tmp/demo/terraform.tfstate',
+      drifted: [],
+      findings: [],
+      missing: [],
+      unmanaged: [],
+      in_sync: 1,
+      total: 1,
+      classifications: {},
+      summary: '1 resources: 1 in sync, 0 drifted, 0 missing from state, 0 unmanaged',
+    };
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(response), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(api.runDrift('demo', { tool: 'terraform', env: 'dev' })).resolves.toEqual(response);
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/projects/demo/drift', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tool: 'terraform', env: 'dev' }),
+    });
+  });
+});
+
 describe('api.suggest', () => {
   afterEach(() => {
     vi.unstubAllGlobals();

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -178,6 +178,49 @@ export interface PlanClassification {
   markdown?: string;
 }
 
+export interface DriftField {
+  path: string;
+  code_value?: unknown;
+  live_value?: unknown;
+}
+
+export interface DriftResource {
+  address: string;
+  type: string;
+  name: string;
+  changes?: DriftField[];
+  status: 'drifted' | 'missing' | 'unmanaged';
+  classification?: string;
+  recommended_action?: string;
+  reason?: string;
+}
+
+export interface DriftFinding {
+  address: string;
+  type: string;
+  name: string;
+  status: 'drifted' | 'missing' | 'unmanaged';
+  path?: string;
+  expected_value?: unknown;
+  current_value?: unknown;
+  classification: string;
+  recommended_action: string;
+  reason: string;
+}
+
+export interface DriftReport {
+  has_state: boolean;
+  state_path: string;
+  drifted: DriftResource[];
+  findings: DriftFinding[];
+  missing: string[];
+  unmanaged: string[];
+  in_sync: number;
+  total: number;
+  classifications?: Record<string, number>;
+  summary: string;
+}
+
 // Checks res.ok and throws with the backend's error message instead of
 // letting callers hit an opaque JSON parse failure on text/plain errors.
 async function check(res: Response): Promise<Response> {
@@ -426,6 +469,15 @@ export const api = {
 
   async classifyPlan(projectName: string, req: { tool?: string; env?: string; plan_json?: unknown; plan_text?: string } = {}): Promise<PlanClassification> {
     const res = await fetch(`${BASE}/api/projects/${projectName}/plan/classify`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(req),
+    });
+    return (await check(res)).json();
+  },
+
+  async runDrift(projectName: string, req: { tool?: string; env?: string } = {}): Promise<DriftReport> {
+    const res = await fetch(`${BASE}/api/projects/${projectName}/drift`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(req),


### PR DESCRIPTION
## Summary
- add classified drift findings to the Terraform/OpenTofu state-backed drift detector
- expose field-level findings with expected/current values, classification, recommended action, and reason
- make `/api/projects/{name}/drift` environment-aware and support GET/POST with explicit Terraform/OpenTofu guardrails
- add TypeScript drift response types/client method and docs updates

Refs #44

## Validation
- `GOCACHE=/private/tmp/iacstudio-go-cache go test ./...`
- `npm test -- --run`
- `npm run build`
- `npm run lint` (passes with existing warnings)
- `git diff --check`