### PR TITLE
Add drift monitor panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ start the local server for you.
 | **AI Topology Builder** | Describe an architecture in plain text, AI generates everything |
 | **AI Plan Fix** | When terraform plan fails, AI diagnoses and auto-fixes the issue |
 | **Security Scanner** | Graph-based checks: CIS, SOC2, HIPAA, OWASP compliance |
-| **Drift Detection** | Compare terraform.tfstate against code, find what changed |
+| **Drift Monitor** | Run Terraform/OpenTofu state drift checks from the right panel with classified findings |
 | **Multi-Format Export** | Export to Pulumi TypeScript, CDK Python, CloudFormation |
 | **Smart Suggestions** | AI predicts your next resource based on IaC best practices |
 | **Import Projects** | Browse filesystem, scan existing .tf/.yml files, auto-detect topology |

--- a/docs/index.html
+++ b/docs/index.html
@@ -316,6 +316,11 @@ iac-studio</code></pre>
                   <td>Review violations, acknowledge allowed exceptions, block unsafe apply attempts.</td>
                 </tr>
                 <tr>
+                  <td>Drift Monitor</td>
+                  <td>Terraform/OpenTofu state drift checks.</td>
+                  <td>Run drift from the right panel, review classified findings, and choose whether to investigate, codify, import, or revert.</td>
+                </tr>
+                <tr>
                   <td>Scan Panel</td>
                   <td>Security scanner controls and findings.</td>
                   <td>Run scanners, map findings to compliance frameworks, generate CI workflow snippets.</td>
@@ -398,10 +403,11 @@ iac-studio</code></pre>
           <div class="workflow">
             <h3>Detect drift and export</h3>
             <p>
-              Drift detection compares Terraform/OpenTofu state against code when state is present,
-              classifies each finding, and recommends whether to investigate, codify, import, or
-              revert. Export converts the current topology into alternate formats such as Pulumi
-              TypeScript, CDK Python, and CloudFormation where supported.
+              Open the Drift tab in the right panel to compare Terraform/OpenTofu state against
+              code when state is present. IaC Studio classifies each finding and recommends
+              whether to investigate, codify, import, or revert. Export converts the current
+              topology into alternate formats such as Pulumi TypeScript, CDK Python, and
+              CloudFormation where supported.
             </p>
           </div>
         </section>

--- a/web/src/components/DriftPanel/DriftPanel.test.tsx
+++ b/web/src/components/DriftPanel/DriftPanel.test.tsx
@@ -73,6 +73,19 @@ describe('DriftPanel', () => {
     expect(screen.getByText('0 findings')).toBeInTheDocument();
   });
 
+  it('shows the error banner when the API call fails', async () => {
+    const client = {
+      runDrift: vi.fn().mockRejectedValue(new Error('connection refused')),
+    };
+
+    render(<DriftPanel projectName="demo" tool="terraform" client={client} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Run drift' }));
+
+    expect(await screen.findByText('Error: connection refused')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Run drift' })).not.toBeDisabled();
+  });
+
   it('disables drift for tools the backend does not support yet', () => {
     const client = { runDrift: vi.fn() };
 

--- a/web/src/components/DriftPanel/DriftPanel.test.tsx
+++ b/web/src/components/DriftPanel/DriftPanel.test.tsx
@@ -1,0 +1,85 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { DriftPanel } from './DriftPanel';
+
+describe('DriftPanel', () => {
+  it('runs drift with tool and environment and renders classified findings', async () => {
+    const client = {
+      runDrift: vi.fn().mockResolvedValue({
+        has_state: true,
+        state_path: '/tmp/demo/environments/dev/terraform.tfstate',
+        drifted: [],
+        findings: [
+          {
+            address: 'aws_security_group.web',
+            type: 'aws_security_group',
+            name: 'web',
+            status: 'drifted',
+            path: 'ingress.0.cidr_blocks',
+            expected_value: ['10.0.0.0/8'],
+            current_value: ['0.0.0.0/0'],
+            classification: 'unauthorized_change',
+            recommended_action: 'revert_or_codify_after_review',
+            reason: 'Security group ingress widened outside code.',
+          },
+        ],
+        missing: [],
+        unmanaged: [],
+        in_sync: 4,
+        total: 5,
+        classifications: { unauthorized_change: 1 },
+        summary: '5 resources: 4 in sync, 1 drifted, 0 missing from state, 0 unmanaged',
+      }),
+    };
+
+    render(<DriftPanel projectName="demo" tool="terraform" env="dev" client={client} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Run drift' }));
+
+    await waitFor(() => {
+      expect(client.runDrift).toHaveBeenCalledWith('demo', { tool: 'terraform', env: 'dev' });
+    });
+
+    expect(screen.getByText('aws_security_group.web')).toBeInTheDocument();
+    expect(screen.getByText('unauthorized change')).toBeInTheDocument();
+    expect(screen.getByText('revert or codify after review')).toBeInTheDocument();
+    expect(screen.getByText('Security group ingress widened outside code.')).toBeInTheDocument();
+    expect(screen.getByText('["10.0.0.0/8"]')).toBeInTheDocument();
+    expect(screen.getByText('["0.0.0.0/0"]')).toBeInTheDocument();
+  });
+
+  it('shows a no-state result without fabricating findings', async () => {
+    const client = {
+      runDrift: vi.fn().mockResolvedValue({
+        has_state: false,
+        state_path: '',
+        drifted: [],
+        findings: [],
+        missing: [],
+        unmanaged: [],
+        in_sync: 0,
+        total: 0,
+        classifications: {},
+        summary: 'No state file found',
+      }),
+    };
+
+    render(<DriftPanel projectName="demo" client={client} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Run drift' }));
+
+    expect(await screen.findByText('No state file was found for this project.')).toBeInTheDocument();
+    expect(screen.getByText('0 findings')).toBeInTheDocument();
+  });
+
+  it('disables drift for tools the backend does not support yet', () => {
+    const client = { runDrift: vi.fn() };
+
+    render(<DriftPanel projectName="demo" tool="ansible" client={client} />);
+
+    expect(screen.getByRole('button', { name: 'Run drift' })).toBeDisabled();
+    expect(screen.getByText('Drift detection currently supports Terraform and OpenTofu projects.')).toBeInTheDocument();
+    expect(client.runDrift).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/components/DriftPanel/DriftPanel.tsx
+++ b/web/src/components/DriftPanel/DriftPanel.tsx
@@ -1,0 +1,221 @@
+import { useMemo, useState } from 'react';
+import { AlertCircle, GitCompareArrows, Play } from 'lucide-react';
+
+import { api, type DriftFinding, type DriftReport } from '../../api';
+import { Button } from '../ui/button';
+
+export interface DriftPanelProps {
+  projectName: string;
+  tool?: string;
+  env?: string;
+  client?: Pick<typeof api, 'runDrift'>;
+}
+
+const SUPPORTED_TOOLS = new Set(['terraform', 'opentofu']);
+
+const CLASSIFICATION_STYLES: Record<string, string> = {
+  legitimate: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300',
+  legitimate_config_change: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300',
+  unauthorized: 'border-destructive/40 bg-destructive/10 text-destructive',
+  unauthorized_change: 'border-destructive/40 bg-destructive/10 text-destructive',
+  unmanaged: 'border-amber-500/30 bg-amber-500/10 text-amber-300',
+  missing: 'border-amber-500/30 bg-amber-500/10 text-amber-300',
+  missing_from_state: 'border-amber-500/30 bg-amber-500/10 text-amber-300',
+  unknown: 'border-border bg-card text-muted-foreground',
+};
+
+function formatValue(value: unknown): string {
+  if (value === undefined) return 'not set';
+  if (value === null) return 'null';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function classificationStyle(classification: string): string {
+  return CLASSIFICATION_STYLES[classification.toLowerCase()] ?? CLASSIFICATION_STYLES.unknown;
+}
+
+function formatLabel(value: string): string {
+  return value.replace(/_/g, ' ');
+}
+
+function normalizeFindings(report: DriftReport | null): DriftFinding[] {
+  return Array.isArray(report?.findings) ? report.findings : [];
+}
+
+function normalizeClassifications(report: DriftReport | null): [string, number][] {
+  if (!report?.classifications) return [];
+  return Object.entries(report.classifications)
+    .filter(([, count]) => count > 0)
+    .sort(([left], [right]) => left.localeCompare(right));
+}
+
+export function DriftPanel({
+  projectName,
+  tool = 'terraform',
+  env,
+  client = api,
+}: DriftPanelProps) {
+  const [running, setRunning] = useState(false);
+  const [report, setReport] = useState<DriftReport | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const supported = SUPPORTED_TOOLS.has(tool);
+  const findings = useMemo(() => normalizeFindings(report), [report]);
+  const classifications = useMemo(() => normalizeClassifications(report), [report]);
+
+  const run = async () => {
+    if (!supported) return;
+    setRunning(true);
+    setError(null);
+    setReport(null);
+    try {
+      const req: { tool: string; env?: string } = { tool };
+      if (env) req.env = env;
+      const response = await client.runDrift(projectName, req);
+      setReport(response);
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  return (
+    <div className="flex h-full flex-col gap-3 bg-background p-4">
+      <header className="flex items-center gap-3">
+        <GitCompareArrows className="h-4 w-4 text-primary" />
+        <h2 className="text-sm font-semibold uppercase tracking-widest text-foreground">
+          Drift Monitor
+        </h2>
+        <Button
+          size="sm"
+          className="ml-auto"
+          onClick={run}
+          disabled={running || !supported}
+        >
+          <Play className="h-3.5 w-3.5" />
+          {running ? 'Checking...' : 'Run drift'}
+        </Button>
+      </header>
+
+      {!supported && (
+        <div className="flex items-start gap-2 rounded-md border border-border bg-card px-3 py-2 text-xs text-muted-foreground">
+          <AlertCircle className="mt-0.5 h-3.5 w-3.5 flex-shrink-0" />
+          <span>Drift detection currently supports Terraform and OpenTofu projects.</span>
+        </div>
+      )}
+
+      {error && (
+        <div className="flex items-start gap-2 rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+          <AlertCircle className="mt-0.5 h-3.5 w-3.5 flex-shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      {report && (
+        <section className="rounded-md border border-border bg-card px-3 py-3">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <div className="text-xs font-mono text-muted-foreground">{report.summary}</div>
+              {report.state_path && (
+                <div className="mt-1 truncate text-[10px] font-mono text-muted-foreground">
+                  state {report.state_path}
+                </div>
+              )}
+            </div>
+            <span className={`rounded border px-2 py-0.5 font-mono text-[10px] font-bold uppercase tracking-widest ${findings.length > 0 ? 'border-amber-500/30 bg-amber-500/10 text-amber-300' : 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300'}`}>
+              {findings.length} finding{findings.length === 1 ? '' : 's'}
+            </span>
+          </div>
+          {classifications.length > 0 && (
+            <div className="mt-3 flex flex-wrap gap-2">
+              {classifications.map(([classification, count]) => (
+                <span
+                  key={classification}
+                  className={`rounded border px-2 py-1 font-mono text-[10px] uppercase tracking-widest ${classificationStyle(classification)}`}
+                >
+                  {formatLabel(classification)} {count}
+                </span>
+              ))}
+            </div>
+          )}
+        </section>
+      )}
+
+      <div className="flex-1 overflow-y-auto">
+        {!report && (
+          <div className="rounded-md border border-dashed border-border bg-card/40 px-3 py-8 text-center text-xs text-muted-foreground">
+            Run drift to compare Terraform/OpenTofu state against the current code.
+          </div>
+        )}
+
+        {report && findings.length === 0 && (
+          <div className="rounded-md border border-border bg-card px-3 py-8 text-center text-xs text-muted-foreground">
+            {report.has_state ? 'No drift findings.' : 'No state file was found for this project.'}
+          </div>
+        )}
+
+        {findings.length > 0 && (
+          <div className="space-y-3">
+            {findings.map((finding, index) => (
+              <article
+                key={`${finding.address}-${finding.path ?? finding.status}-${index}`}
+                className="rounded-md border border-border bg-card p-3"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="truncate text-xs font-semibold text-foreground">
+                      {finding.address}
+                    </div>
+                    <div className="mt-1 flex flex-wrap gap-2 text-[10px] font-mono uppercase tracking-widest text-muted-foreground">
+                      <span>{finding.status}</span>
+                      {finding.path && <span>{finding.path}</span>}
+                    </div>
+                  </div>
+                  <span className={`flex-shrink-0 rounded border px-2 py-0.5 font-mono text-[10px] font-bold uppercase tracking-widest ${classificationStyle(finding.classification)}`}>
+                    {formatLabel(finding.classification)}
+                  </span>
+                </div>
+
+                <p className="mt-3 text-xs leading-5 text-muted-foreground">{finding.reason}</p>
+
+                <div className="mt-3 rounded border border-border bg-background/60 px-2 py-2">
+                  <div className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+                    Recommended action
+                  </div>
+                  <div className="mt-1 text-xs text-foreground">{formatLabel(finding.recommended_action)}</div>
+                </div>
+
+                {finding.path && (
+                  <div className="mt-3 grid gap-2 text-xs">
+                    <div className="rounded border border-border bg-background/60 px-2 py-2">
+                      <div className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+                        Code
+                      </div>
+                      <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-[11px] text-foreground">
+                        {formatValue(finding.expected_value)}
+                      </pre>
+                    </div>
+                    <div className="rounded border border-border bg-background/60 px-2 py-2">
+                      <div className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+                        State
+                      </div>
+                      <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-[11px] text-foreground">
+                        {formatValue(finding.current_value)}
+                      </pre>
+                    </div>
+                  </div>
+                )}
+              </article>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/DriftPanel/index.tsx
+++ b/web/src/components/DriftPanel/index.tsx
@@ -1,0 +1,2 @@
+export { DriftPanel } from './DriftPanel';
+export type { DriftPanelProps } from './DriftPanel';

--- a/web/src/components/Inspector/InspectorPanel.test.tsx
+++ b/web/src/components/Inspector/InspectorPanel.test.tsx
@@ -36,6 +36,12 @@ vi.mock('../ScanPanel', () => ({
   ),
 }));
 
+vi.mock('../DriftPanel', () => ({
+  DriftPanel: ({ projectName, tool, env }: any) => (
+    <div>Drift panel {projectName} {tool} {env}</div>
+  ),
+}));
+
 vi.mock('../ModuleRegistry', () => ({
   ModuleRegistryPanel: ({ initialQuery }: any) => (
     <div>Module registry {initialQuery}</div>
@@ -200,8 +206,15 @@ describe('InspectorPanel', () => {
     renderInspector({ activeTab: 'modules' });
 
     expect(screen.getByRole('button', { name: 'Cloud' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Drift' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Modules' })).toBeInTheDocument();
     expect(screen.getByText('Module registry vpc')).toBeInTheDocument();
+  });
+
+  it('renders the drift tab with tool and environment context', () => {
+    renderInspector({ activeTab: 'drift', activeEnv: 'dev' });
+
+    expect(screen.getByText('Drift panel demo terraform dev')).toBeInTheDocument();
   });
 
   it('renders the cloud connections tab', () => {

--- a/web/src/components/Inspector/index.tsx
+++ b/web/src/components/Inspector/index.tsx
@@ -3,11 +3,12 @@ import type { Edge } from '../../legacy';
 import { S } from '../../styles';
 import { CloudConnectionsPanel } from '../CloudConnections';
 import { CodeEditor } from '../CodeEditor';
+import { DriftPanel } from '../DriftPanel';
 import { ModuleRegistryPanel } from '../ModuleRegistry';
 import { PolicyStudioPanel } from '../PolicyStudio';
 import { ScanPanel } from '../ScanPanel';
 
-export type RightPanelTab = 'inspect' | 'cloud' | 'policy' | 'scan' | 'modules';
+export type RightPanelTab = 'inspect' | 'cloud' | 'drift' | 'policy' | 'scan' | 'modules';
 
 export interface InspectorResource extends Resource {
   icon: string;
@@ -99,6 +100,7 @@ export function InspectorPanel({
   const tabs: { key: RightPanelTab; label: string }[] = [
     { key: 'inspect', label: selected || selectedEdge ? 'Inspect' : 'Code' },
     { key: 'cloud', label: 'Cloud' },
+    { key: 'drift', label: 'Drift' },
     { key: 'policy', label: 'Policy' },
     { key: 'scan', label: 'Scan' },
     ...(tool === 'ansible' ? [] : [{ key: 'modules' as const, label: 'Modules' }]),
@@ -272,6 +274,18 @@ export function InspectorPanel({
             </div>
           ) : (
             <PolicyStudioPanel projectName={projectId} tool={tool} env={activeEnv || undefined} />
+          )}
+        </div>
+      )}
+
+      {activeTab === 'drift' && (
+        <div style={{ flex: 1, minHeight: 0 }}>
+          {unresolvedHybridEnv ? (
+            <div style={{ padding: 16, color: 'var(--text-muted)', fontSize: 13 }}>
+              Environment "{activeEnv}" has no configured IaC tool in .iac-studio.json.
+            </div>
+          ) : (
+            <DriftPanel projectName={projectId} tool={tool} env={activeEnv || undefined} />
           )}
         </div>
       )}


### PR DESCRIPTION
Refs #44. Summary: adds a Drift tab to the right inspector, runs Terraform/OpenTofu drift checks with active tool/env context, renders classified findings with state/code values, and documents the workflow. Validation: npm -C web test -- --run; npm -C web run build; npm -C web run lint; GOCACHE=/private/tmp/iacstudio-go-cache go test ./...; git diff --check.