### PR TITLE
Add drift suppression rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ start the local server for you.
 | **AI Topology Builder** | Describe an architecture in plain text, AI generates everything |
 | **AI Plan Fix** | When terraform plan fails, AI diagnoses and auto-fixes the issue |
 | **Security Scanner** | Graph-based checks: CIS, SOC2, HIPAA, OWASP compliance |
-| **Drift Monitor** | Run Terraform/OpenTofu state drift checks from the right panel with classified findings |
+| **Drift Monitor** | Run Terraform/OpenTofu state drift checks with classified findings and explicit suppression rules |
 | **Multi-Format Export** | Export to Pulumi TypeScript, CDK Python, CloudFormation |
 | **Smart Suggestions** | AI predicts your next resource based on IaC best practices |
 | **Import Projects** | Browse filesystem, scan existing .tf/.yml files, auto-detect topology |

--- a/docs/index.html
+++ b/docs/index.html
@@ -405,10 +405,24 @@ iac-studio</code></pre>
             <p>
               Open the Drift tab in the right panel to compare Terraform/OpenTofu state against
               code when state is present. IaC Studio classifies each finding and recommends
-              whether to investigate, codify, import, or revert. Export converts the current
-              topology into alternate formats such as Pulumi TypeScript, CDK Python, and
-              CloudFormation where supported.
+              whether to investigate, codify, import, or revert. Known provider noise can be
+              muted with explicit <code>drift.suppressions</code> rules in
+              <code>.iac-studio.json</code>; suppressed findings remain visible in the Drift tab
+              but no longer count as active findings. Export converts the current topology into
+              alternate formats such as Pulumi TypeScript, CDK Python, and CloudFormation where supported.
             </p>
+            <pre><code>{
+  "drift": {
+    "suppressions": [
+      {
+        "address": "aws_s3_bucket.logs",
+        "path": "tags",
+        "classification": "legitimate_config_change",
+        "reason": "provider-managed owner tag"
+      }
+    ]
+  }
+}</code></pre>
           </div>
         </section>
 

--- a/internal/api/drift_test.go
+++ b/internal/api/drift_test.go
@@ -75,6 +75,97 @@ resource "aws_security_group" "web" {
 	}
 }
 
+func TestProjectDriftEndpointAppliesConfiguredSuppressions(t *testing.T) {
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "demo")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, ".iac-studio.json"), []byte(`{
+  "tool": "terraform",
+  "drift": {
+    "suppressions": [
+      {
+        "address": "aws_s3_bucket.logs",
+        "path": "tags",
+        "classification": "legitimate_config_change",
+        "reason": "provider-managed owner tag"
+      }
+    ]
+  }
+}`), 0o644); err != nil {
+		t.Fatalf("write project metadata: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "main.tf"), []byte(`
+resource "aws_s3_bucket" "logs" {
+  bucket = "logs"
+  tags = {
+    Owner = "platform"
+  }
+}
+`), 0o644); err != nil {
+		t.Fatalf("write main.tf: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "terraform.tfstate"), []byte(`{
+		"version": 4,
+		"resources": [{
+			"mode": "managed",
+			"type": "aws_s3_bucket",
+			"name": "logs",
+			"instances": [{"attributes": {"bucket": "logs", "tags": {"Owner": "legacy"}}}]
+		}]
+	}`), 0o600); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+
+	srv := httptest.NewServer(fullRouterForTest(t, root))
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/api/projects/demo/drift", "application/json", strings.NewReader(`{"tool":"terraform"}`))
+	if err != nil {
+		t.Fatalf("POST drift: %v", err)
+	}
+	defer closeBody(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("drift status = %d", resp.StatusCode)
+	}
+
+	var payload struct {
+		Findings           []json.RawMessage `json:"findings"`
+		SuppressedFindings []struct {
+			Address           string `json:"address"`
+			Path              string `json:"path"`
+			Suppressed        bool   `json:"suppressed"`
+			SuppressionReason string `json:"suppression_reason"`
+		} `json:"suppressed_findings"`
+		Suppressed      int            `json:"suppressed"`
+		Classifications map[string]int `json:"classifications"`
+		Summary         string         `json:"summary"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode drift response: %v", err)
+	}
+	if len(payload.Findings) != 0 {
+		t.Fatalf("active findings = %d, want 0", len(payload.Findings))
+	}
+	if payload.Suppressed != 1 || len(payload.SuppressedFindings) != 1 {
+		t.Fatalf("suppressed = %d/%d, want 1/1", payload.Suppressed, len(payload.SuppressedFindings))
+	}
+	suppressed := payload.SuppressedFindings[0]
+	if suppressed.Address != "aws_s3_bucket.logs" ||
+		suppressed.Path != "tags" ||
+		!suppressed.Suppressed ||
+		suppressed.SuppressionReason != "provider-managed owner tag" {
+		t.Fatalf("unexpected suppressed finding: %#v", suppressed)
+	}
+	if payload.Classifications["legitimate_config_change"] != 0 {
+		t.Fatalf("suppressed findings should not increment active classification counts: %#v", payload.Classifications)
+	}
+	if !strings.Contains(payload.Summary, "1 suppressed") {
+		t.Fatalf("summary should include suppressed count: %s", payload.Summary)
+	}
+}
+
 func TestProjectDriftEndpointRejectsUnsupportedTool(t *testing.T) {
 	root := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(root, "demo"), 0o755); err != nil {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -337,6 +337,9 @@ type projectToolDescriptor struct {
 	Tool             string            `json:"tool"`
 	Environments     []string          `json:"environments"`
 	EnvironmentTools map[string]string `json:"environment_tools"`
+	Drift            struct {
+		Suppressions []drift.SuppressionRule `json:"suppressions"`
+	} `json:"drift"`
 }
 
 func readProjectToolDescriptor(projectPath string) (projectToolDescriptor, error) {
@@ -2006,7 +2009,14 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 		for _, res := range resources {
 			codeResources[res.Type+"."+res.Name] = res.Properties
 		}
-		report, err := driftDetector.Detect(workDir, codeResources)
+		var suppressions []drift.SuppressionRule
+		if descriptor, descriptorErr := readProjectToolDescriptor(projectPath); descriptorErr == nil {
+			suppressions = descriptor.Drift.Suppressions
+		}
+		report, err := driftDetector.DetectWithOptions(workDir, codeResources, drift.DetectOptions{
+			Env:          req.Env,
+			Suppressions: suppressions,
+		})
 		if err != nil {
 			http.Error(w, err.Error(), 500)
 			return

--- a/internal/drift/drift.go
+++ b/internal/drift/drift.go
@@ -30,16 +30,18 @@ const (
 
 // DriftReport describes differences between code and deployed state.
 type DriftReport struct {
-	HasState        bool              `json:"has_state"`
-	StatePath       string            `json:"state_path"`
-	Drifted         []DriftedResource `json:"drifted"`
-	Findings        []DriftFinding    `json:"findings"`
-	Missing         []string          `json:"missing"`   // in code but not in state
-	Unmanaged       []string          `json:"unmanaged"` // in state but not in code
-	InSync          int               `json:"in_sync"`   // resources matching
-	Total           int               `json:"total"`
-	Classifications map[string]int    `json:"classifications,omitempty"`
-	Summary         string            `json:"summary"`
+	HasState           bool              `json:"has_state"`
+	StatePath          string            `json:"state_path"`
+	Drifted            []DriftedResource `json:"drifted"`
+	Findings           []DriftFinding    `json:"findings"`
+	SuppressedFindings []DriftFinding    `json:"suppressed_findings"`
+	Suppressed         int               `json:"suppressed"`
+	Missing            []string          `json:"missing"`   // in code but not in state
+	Unmanaged          []string          `json:"unmanaged"` // in state but not in code
+	InSync             int               `json:"in_sync"`   // resources matching
+	Total              int               `json:"total"`
+	Classifications    map[string]int    `json:"classifications,omitempty"`
+	Summary            string            `json:"summary"`
 }
 
 // DriftedResource is a resource where state differs from code.
@@ -75,6 +77,28 @@ type DriftFinding struct {
 	Classification    string      `json:"classification"`
 	RecommendedAction string      `json:"recommended_action"`
 	Reason            string      `json:"reason"`
+	Suppressed        bool        `json:"suppressed,omitempty"`
+	SuppressionReason string      `json:"suppression_reason,omitempty"`
+}
+
+// SuppressionRule mutes known-noise drift findings. Every non-empty selector
+// must match a finding. Keep rules explicit: an entirely empty rule never
+// matches, so a malformed config cannot accidentally hide all drift.
+type SuppressionRule struct {
+	Address        string `json:"address,omitempty"`
+	Type           string `json:"type,omitempty"`
+	Name           string `json:"name,omitempty"`
+	Status         string `json:"status,omitempty"`
+	Path           string `json:"path,omitempty"`
+	Classification string `json:"classification,omitempty"`
+	Env            string `json:"env,omitempty"`
+	Reason         string `json:"reason,omitempty"`
+}
+
+// DetectOptions controls optional drift post-processing.
+type DetectOptions struct {
+	Env          string
+	Suppressions []SuppressionRule
 }
 
 // tfState represents the minimal Terraform state file structure we need.
@@ -96,7 +120,17 @@ type tfStateInstance struct {
 
 // Detect compares terraform.tfstate with the parsed code resources.
 func (d *Detector) Detect(projectDir string, codeResources map[string]map[string]interface{}) (*DriftReport, error) {
-	report := &DriftReport{Findings: []DriftFinding{}, Classifications: map[string]int{}}
+	return d.DetectWithOptions(projectDir, codeResources, DetectOptions{})
+}
+
+// DetectWithOptions compares terraform.tfstate with parsed code resources and
+// applies caller-supplied suppression rules to known-noise findings.
+func (d *Detector) DetectWithOptions(projectDir string, codeResources map[string]map[string]interface{}, opts DetectOptions) (*DriftReport, error) {
+	report := &DriftReport{
+		Findings:           []DriftFinding{},
+		SuppressedFindings: []DriftFinding{},
+		Classifications:    map[string]int{},
+	}
 
 	// Find state file
 	statePaths := []string{
@@ -160,7 +194,7 @@ func (d *Detector) Detect(projectDir string, codeResources map[string]map[string
 				Address: resource.Address, Type: resource.Type, Name: resource.Name,
 				Status: resource.Status, Classification: resource.Classification,
 				RecommendedAction: resource.RecommendedAction, Reason: resource.Reason,
-			})
+			}, opts)
 			continue
 		}
 
@@ -191,7 +225,7 @@ func (d *Detector) Detect(projectDir string, codeResources map[string]map[string
 					Address: addr, Type: resType, Name: resName, Status: "drifted",
 					Path: change.Path, ExpectedValue: change.CodeValue, CurrentValue: change.LiveValue,
 					Classification: classification, RecommendedAction: action, Reason: reason,
-				})
+				}, opts)
 			}
 		} else {
 			report.InSync++
@@ -218,7 +252,7 @@ func (d *Detector) Detect(projectDir string, codeResources map[string]map[string
 				Address: resource.Address, Type: resource.Type, Name: resource.Name,
 				Status: resource.Status, Classification: resource.Classification,
 				RecommendedAction: resource.RecommendedAction, Reason: resource.Reason,
-			})
+			}, opts)
 		}
 	}
 
@@ -226,13 +260,71 @@ func (d *Detector) Detect(projectDir string, codeResources map[string]map[string
 	driftCount := len(report.Drifted)
 	report.Summary = fmt.Sprintf("%d resources: %d in sync, %d drifted, %d missing from state, %d unmanaged",
 		report.Total, report.InSync, driftCount-len(report.Missing)-len(report.Unmanaged), len(report.Missing), len(report.Unmanaged))
+	if report.Suppressed > 0 {
+		report.Summary += fmt.Sprintf(", %d suppressed", report.Suppressed)
+	}
 
 	return report, nil
 }
 
-func (r *DriftReport) addFinding(f DriftFinding) {
+func (r *DriftReport) addFinding(f DriftFinding, opts DetectOptions) {
+	if reason, ok := suppressionReason(f, opts); ok {
+		f.Suppressed = true
+		f.SuppressionReason = reason
+		r.SuppressedFindings = append(r.SuppressedFindings, f)
+		r.Suppressed++
+		return
+	}
 	r.Findings = append(r.Findings, f)
 	r.Classifications[f.Classification]++
+}
+
+func suppressionReason(f DriftFinding, opts DetectOptions) (string, bool) {
+	for _, rule := range opts.Suppressions {
+		if !rule.matches(f, opts.Env) {
+			continue
+		}
+		if strings.TrimSpace(rule.Reason) != "" {
+			return strings.TrimSpace(rule.Reason), true
+		}
+		return "suppressed by drift rule", true
+	}
+	return "", false
+}
+
+func (r SuppressionRule) matches(f DriftFinding, env string) bool {
+	hasSelector := false
+	for _, value := range []string{r.Address, r.Type, r.Name, r.Status, r.Path, r.Classification, r.Env} {
+		if strings.TrimSpace(value) != "" {
+			hasSelector = true
+			break
+		}
+	}
+	if !hasSelector {
+		return false
+	}
+	if r.Env != "" && r.Env != env {
+		return false
+	}
+	if r.Address != "" && r.Address != f.Address {
+		return false
+	}
+	if r.Type != "" && r.Type != f.Type {
+		return false
+	}
+	if r.Name != "" && r.Name != f.Name {
+		return false
+	}
+	if r.Status != "" && r.Status != f.Status {
+		return false
+	}
+	if r.Path != "" && r.Path != f.Path {
+		return false
+	}
+	if r.Classification != "" && r.Classification != f.Classification {
+		return false
+	}
+	return true
 }
 
 func classifyResourceDrift(resourceType string, changes []DriftField) (classification, action, reason string) {

--- a/internal/drift/drift_test.go
+++ b/internal/drift/drift_test.go
@@ -3,6 +3,7 @@ package drift
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -79,6 +80,82 @@ func TestDetectReportsMissingAndUnmanagedResources(t *testing.T) {
 	requireFinding(t, report, "aws_instance.manual", "", ClassificationUnauthorizedChange, ActionReviewImportOrRemove)
 	if len(report.Missing) != 1 || len(report.Unmanaged) != 1 {
 		t.Fatalf("missing/unmanaged = %#v/%#v", report.Missing, report.Unmanaged)
+	}
+}
+
+func TestDetectSuppressesKnownNoiseByAddressPathAndClassification(t *testing.T) {
+	dir := t.TempDir()
+	writeState(t, dir, `{
+		"version": 4,
+		"resources": [{
+			"mode": "managed",
+			"type": "aws_s3_bucket",
+			"name": "logs",
+			"instances": [{"attributes": {"tags": {"Owner": "old"}}}]
+		}]
+	}`)
+
+	report, err := New().DetectWithOptions(dir, map[string]map[string]interface{}{
+		"aws_s3_bucket.logs": {"tags": map[string]interface{}{"Owner": "platform"}},
+	}, DetectOptions{
+		Suppressions: []SuppressionRule{{
+			Address:        "aws_s3_bucket.logs",
+			Path:           "tags",
+			Classification: ClassificationLegitimateConfigChange,
+			Reason:         "provider-managed owner tag",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("detect drift: %v", err)
+	}
+
+	if len(report.Findings) != 0 {
+		t.Fatalf("active findings = %#v, want none", report.Findings)
+	}
+	if report.Suppressed != 1 || len(report.SuppressedFindings) != 1 {
+		t.Fatalf("suppressed = %d/%d, want 1/1", report.Suppressed, len(report.SuppressedFindings))
+	}
+	suppressed := report.SuppressedFindings[0]
+	if !suppressed.Suppressed || suppressed.SuppressionReason != "provider-managed owner tag" {
+		t.Fatalf("suppressed finding metadata = %#v", suppressed)
+	}
+	if report.Classifications[ClassificationLegitimateConfigChange] != 0 {
+		t.Fatalf("classification counts should exclude suppressed findings: %#v", report.Classifications)
+	}
+	if !strings.Contains(report.Summary, "1 suppressed") {
+		t.Fatalf("summary should include suppressed count: %s", report.Summary)
+	}
+}
+
+func TestDetectKeepsFindingsWhenSuppressionDoesNotMatch(t *testing.T) {
+	dir := t.TempDir()
+	writeState(t, dir, `{
+		"version": 4,
+		"resources": [{
+			"mode": "managed",
+			"type": "aws_security_group",
+			"name": "web",
+			"instances": [{"attributes": {"ingress": [{"cidr_blocks": ["0.0.0.0/0"]}]}}]
+		}]
+	}`)
+
+	report, err := New().DetectWithOptions(dir, map[string]map[string]interface{}{
+		"aws_security_group.web": {"ingress": []interface{}{}},
+	}, DetectOptions{
+		Suppressions: []SuppressionRule{{
+			Address:        "aws_security_group.web",
+			Path:           "tags",
+			Classification: ClassificationUnauthorizedChange,
+			Reason:         "wrong path should not match",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("detect drift: %v", err)
+	}
+
+	requireFinding(t, report, "aws_security_group.web", "ingress", ClassificationUnauthorizedChange, ActionRevertOrCodifyAfterReview)
+	if report.Suppressed != 0 || len(report.SuppressedFindings) != 0 {
+		t.Fatalf("suppressed = %d/%d, want 0/0", report.Suppressed, len(report.SuppressedFindings))
 	}
 }
 

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -22,6 +22,7 @@ type State struct {
 	Environments []string          `json:"environments,omitempty"`
 	EnvTools     map[string]string `json:"environment_tools,omitempty"`
 	Modules      json.RawMessage   `json:"modules,omitempty"`
+	Drift        json.RawMessage   `json:"drift,omitempty"`
 	Tags         map[string]string `json:"tags,omitempty"`
 	CreatedAt    time.Time         `json:"created_at"`
 	UpdatedAt    time.Time         `json:"updated_at"`

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -20,6 +20,7 @@ func TestLoadAndSavePreservesLayeredMetadata(t *testing.T) {
   "environments": ["dev", "prod"],
   "environment_tools": {"dev": "pulumi", "prod": "terraform"},
   "modules": ["networking", "compute"],
+  "drift": {"suppressions": [{"address": "aws_s3_bucket.logs", "path": "tags"}]},
   "tags": {"ManagedBy": "iac-studio"}
 }`)
 	if err := os.WriteFile(filepath.Join(projectDir, ".iac-studio.json"), initial, 0o644); err != nil {
@@ -46,6 +47,9 @@ func TestLoadAndSavePreservesLayeredMetadata(t *testing.T) {
 	if !bytes.Contains(state.Modules, []byte(`"networking"`)) {
 		t.Fatalf("expected raw module metadata to be preserved, got %s", string(state.Modules))
 	}
+	if !bytes.Contains(state.Drift, []byte(`"aws_s3_bucket.logs"`)) {
+		t.Fatalf("expected raw drift metadata to be preserved, got %s", string(state.Drift))
+	}
 
 	state.Resources = []Node{{ID: "aws_vpc.main", Type: "aws_vpc", Name: "main"}}
 	if err := manager.Save("demo", state); err != nil {
@@ -60,6 +64,8 @@ func TestLoadAndSavePreservesLayeredMetadata(t *testing.T) {
 		[]byte(`"environments": [`),
 		[]byte(`"environment_tools": {`),
 		[]byte(`"networking"`),
+		[]byte(`"drift": {`),
+		[]byte(`"aws_s3_bucket.logs"`),
 		[]byte(`"tags": {`),
 	} {
 		if !bytes.Contains(saved, needle) {

--- a/web/src/App.test.ts
+++ b/web/src/App.test.ts
@@ -1,6 +1,33 @@
 import { describe, expect, it } from 'vitest';
 
-import { normalizeLayeredProject, resourcesForEnv } from './app/layered';
+import { extractLayoutMeta, normalizeLayeredProject, resourcesForEnv } from './app/layered';
+
+describe('extractLayoutMeta', () => {
+  it('preserves drift suppression metadata for flat projects', () => {
+    expect(extractLayoutMeta({
+      drift: {
+        suppressions: [
+          {
+            address: 'aws_s3_bucket.logs',
+            path: 'tags',
+            reason: 'provider-managed owner tag',
+          },
+        ],
+      },
+      resources: [],
+    })).toEqual({
+      drift: {
+        suppressions: [
+          {
+            address: 'aws_s3_bucket.logs',
+            path: 'tags',
+            reason: 'provider-managed owner tag',
+          },
+        ],
+      },
+    });
+  });
+});
 
 describe('normalizeLayeredProject', () => {
   it('drops empty or invalid environment tool maps', () => {

--- a/web/src/App.test.ts
+++ b/web/src/App.test.ts
@@ -3,6 +3,11 @@ import { describe, expect, it } from 'vitest';
 import { extractLayoutMeta, normalizeLayeredProject, resourcesForEnv } from './app/layered';
 
 describe('extractLayoutMeta', () => {
+  it('returns null for null or undefined input', () => {
+    expect(extractLayoutMeta(null)).toBeNull();
+    expect(extractLayoutMeta(undefined)).toBeNull();
+  });
+
   it('preserves drift suppression metadata for flat projects', () => {
     expect(extractLayoutMeta({
       drift: {

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -233,6 +233,8 @@ describe('api.runDrift', () => {
       state_path: '/tmp/demo/terraform.tfstate',
       drifted: [],
       findings: [],
+      suppressed_findings: [],
+      suppressed: 0,
       missing: [],
       unmanaged: [],
       in_sync: 1,

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -206,6 +206,8 @@ export interface DriftFinding {
   classification: string;
   recommended_action: string;
   reason: string;
+  suppressed?: boolean;
+  suppression_reason?: string;
 }
 
 export interface DriftReport {
@@ -213,6 +215,8 @@ export interface DriftReport {
   state_path: string;
   drifted: DriftResource[];
   findings: DriftFinding[];
+  suppressed_findings?: DriftFinding[];
+  suppressed?: number;
   missing: string[];
   unmanaged: string[];
   in_sync: number;

--- a/web/src/app/layered.ts
+++ b/web/src/app/layered.ts
@@ -2,12 +2,11 @@ import type { Edge } from '../legacy';
 import type { LayeredModule, LayeredProject } from '../types';
 
 export const extractLayoutMeta = (state: any) => {
-  if (!state?.layout) return null;
   const meta: Record<string, any> = {};
-  for (const key of ['layout', 'blueprint', 'project_name', 'cloud', 'environments', 'environment_tools', 'modules', 'tags']) {
+  for (const key of ['layout', 'blueprint', 'project_name', 'cloud', 'environments', 'environment_tools', 'modules', 'tags', 'drift']) {
     if (state[key] !== undefined) meta[key] = state[key];
   }
-  return meta;
+  return Object.keys(meta).length > 0 ? meta : null;
 };
 
 export const normalizeLayeredProject = (state: any): LayeredProject | null => {

--- a/web/src/app/layered.ts
+++ b/web/src/app/layered.ts
@@ -2,6 +2,7 @@ import type { Edge } from '../legacy';
 import type { LayeredModule, LayeredProject } from '../types';
 
 export const extractLayoutMeta = (state: any) => {
+  if (!state) return null;
   const meta: Record<string, any> = {};
   for (const key of ['layout', 'blueprint', 'project_name', 'cloud', 'environments', 'environment_tools', 'modules', 'tags', 'drift']) {
     if (state[key] !== undefined) meta[key] = state[key];

--- a/web/src/components/DriftPanel/DriftPanel.test.tsx
+++ b/web/src/components/DriftPanel/DriftPanel.test.tsx
@@ -73,6 +73,48 @@ describe('DriftPanel', () => {
     expect(screen.getByText('0 findings')).toBeInTheDocument();
   });
 
+  it('renders suppressed findings as muted known-noise items', async () => {
+    const client = {
+      runDrift: vi.fn().mockResolvedValue({
+        has_state: true,
+        state_path: '/tmp/demo/terraform.tfstate',
+        drifted: [],
+        findings: [],
+        suppressed_findings: [
+          {
+            address: 'aws_s3_bucket.logs',
+            type: 'aws_s3_bucket',
+            name: 'logs',
+            status: 'drifted',
+            path: 'tags',
+            classification: 'legitimate_config_change',
+            recommended_action: 'codify_or_accept',
+            reason: 'Only metadata fields drifted.',
+            suppressed: true,
+            suppression_reason: 'provider-managed owner tag',
+          },
+        ],
+        suppressed: 1,
+        missing: [],
+        unmanaged: [],
+        in_sync: 1,
+        total: 1,
+        classifications: {},
+        summary: '1 resources: 1 in sync, 0 drifted, 0 missing from state, 0 unmanaged, 1 suppressed',
+      }),
+    };
+
+    render(<DriftPanel projectName="demo" client={client} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Run drift' }));
+
+    expect(await screen.findByText('No active drift findings.')).toBeInTheDocument();
+    expect(screen.getByText('1 suppressed')).toBeInTheDocument();
+    expect(screen.getByText('Suppressed')).toBeInTheDocument();
+    expect(screen.getByText('aws_s3_bucket.logs')).toBeInTheDocument();
+    expect(screen.getByText('provider-managed owner tag')).toBeInTheDocument();
+  });
+
   it('shows the error banner when the API call fails', async () => {
     const client = {
       runDrift: vi.fn().mockRejectedValue(new Error('connection refused')),

--- a/web/src/components/DriftPanel/DriftPanel.tsx
+++ b/web/src/components/DriftPanel/DriftPanel.tsx
@@ -48,6 +48,10 @@ function normalizeFindings(report: DriftReport | null): DriftFinding[] {
   return Array.isArray(report?.findings) ? report.findings : [];
 }
 
+function normalizeSuppressedFindings(report: DriftReport | null): DriftFinding[] {
+  return Array.isArray(report?.suppressed_findings) ? report.suppressed_findings : [];
+}
+
 function normalizeClassifications(report: DriftReport | null): [string, number][] {
   if (!report?.classifications) return [];
   return Object.entries(report.classifications)
@@ -66,6 +70,7 @@ export function DriftPanel({
   const [error, setError] = useState<string | null>(null);
   const supported = SUPPORTED_TOOLS.has(tool);
   const findings = useMemo(() => normalizeFindings(report), [report]);
+  const suppressedFindings = useMemo(() => normalizeSuppressedFindings(report), [report]);
   const classifications = useMemo(() => normalizeClassifications(report), [report]);
 
   const run = async () => {
@@ -128,9 +133,16 @@ export function DriftPanel({
                 </div>
               )}
             </div>
-            <span className={`rounded border px-2 py-0.5 font-mono text-[10px] font-bold uppercase tracking-widest ${findings.length > 0 ? 'border-amber-500/30 bg-amber-500/10 text-amber-300' : 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300'}`}>
-              {findings.length} finding{findings.length === 1 ? '' : 's'}
-            </span>
+            <div className="flex flex-shrink-0 flex-col items-end gap-1">
+              <span className={`rounded border px-2 py-0.5 font-mono text-[10px] font-bold uppercase tracking-widest ${findings.length > 0 ? 'border-amber-500/30 bg-amber-500/10 text-amber-300' : 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300'}`}>
+                {findings.length} finding{findings.length === 1 ? '' : 's'}
+              </span>
+              {suppressedFindings.length > 0 && (
+                <span className="rounded border border-border bg-background/70 px-2 py-0.5 font-mono text-[10px] font-bold uppercase tracking-widest text-muted-foreground">
+                  {suppressedFindings.length} suppressed
+                </span>
+              )}
+            </div>
           </div>
           {classifications.length > 0 && (
             <div className="mt-3 flex flex-wrap gap-2">
@@ -156,7 +168,7 @@ export function DriftPanel({
 
         {report && findings.length === 0 && (
           <div className="rounded-md border border-border bg-card px-3 py-8 text-center text-xs text-muted-foreground">
-            {report.has_state ? 'No drift findings.' : 'No state file was found for this project.'}
+            {report.has_state ? 'No active drift findings.' : 'No state file was found for this project.'}
           </div>
         )}
 
@@ -214,6 +226,46 @@ export function DriftPanel({
               </article>
             ))}
           </div>
+        )}
+
+        {suppressedFindings.length > 0 && (
+          <section className="mt-4">
+            <div className="mb-2 text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+              Suppressed
+            </div>
+            <div className="space-y-3">
+              {suppressedFindings.map((finding, index) => (
+                <article
+                  key={`suppressed-${finding.address}-${finding.path ?? finding.status}-${index}`}
+                  className="rounded-md border border-border bg-card/50 p-3 opacity-75"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="truncate text-xs font-semibold text-foreground">
+                        {finding.address}
+                      </div>
+                      <div className="mt-1 flex flex-wrap gap-2 text-[10px] font-mono uppercase tracking-widest text-muted-foreground">
+                        <span>{finding.status}</span>
+                        {finding.path && <span>{finding.path}</span>}
+                      </div>
+                    </div>
+                    <span className={`flex-shrink-0 rounded border px-2 py-0.5 font-mono text-[10px] font-bold uppercase tracking-widest ${classificationStyle(finding.classification)}`}>
+                      {formatLabel(finding.classification)}
+                    </span>
+                  </div>
+
+                  <div className="mt-3 rounded border border-border bg-background/50 px-2 py-2">
+                    <div className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+                      Suppression reason
+                    </div>
+                    <div className="mt-1 text-xs text-foreground">
+                      {finding.suppression_reason || 'suppressed by drift rule'}
+                    </div>
+                  </div>
+                </article>
+              ))}
+            </div>
+          </section>
         )}
       </div>
     </div>


### PR DESCRIPTION
Refs #44. Summary: adds explicit drift suppression rules under .iac-studio.json, separates active findings from suppressed known-noise findings in the API, preserves drift metadata through project state load/save, and renders suppressed findings in the Drift Monitor. Validation: npm -C web test -- --run; npm -C web run build; npm -C web run lint; GOCACHE=/private/tmp/iacstudio-go-cache go test ./...; git diff --check.