### PR TITLE
Add drift remediation proposals

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ start the local server for you.
 | **AI Topology Builder** | Describe an architecture in plain text, AI generates everything |
 | **AI Plan Fix** | When terraform plan fails, AI diagnoses and auto-fixes the issue |
 | **Security Scanner** | Graph-based checks: CIS, SOC2, HIPAA, OWASP compliance |
-| **Drift Monitor** | Run Terraform/OpenTofu state drift checks with classified findings and explicit suppression rules |
+| **Drift Monitor** | Run Terraform/OpenTofu state drift checks with classified findings, suppression rules, and draft codify/revert PR payloads |
 | **Multi-Format Export** | Export to Pulumi TypeScript, CDK Python, CloudFormation |
 | **Smart Suggestions** | AI predicts your next resource based on IaC best practices |
 | **Import Projects** | Browse filesystem, scan existing .tf/.yml files, auto-detect topology |

--- a/docs/index.html
+++ b/docs/index.html
@@ -408,8 +408,10 @@ iac-studio</code></pre>
               whether to investigate, codify, import, or revert. Known provider noise can be
               muted with explicit <code>drift.suppressions</code> rules in
               <code>.iac-studio.json</code>; suppressed findings remain visible in the Drift tab
-              but no longer count as active findings. Export converts the current topology into
-              alternate formats such as Pulumi TypeScript, CDK Python, and CloudFormation where supported.
+              but no longer count as active findings. From active findings, the Drift tab can draft
+              codify or revert PR metadata with branch names, commit messages, review notes, source
+              locations, and validation steps. Export converts the current topology into alternate
+              formats such as Pulumi TypeScript, CDK Python, and CloudFormation where supported.
             </p>
             <pre><code>{
   "drift": {
@@ -756,8 +758,8 @@ ANTHROPIC_MODEL=claude-opus-4-7 \
                 </tr>
                 <tr>
                   <td>Modules, drift, export</td>
-                  <td><code>GET /api/projects/{name}/modules</code><br><code>GET /api/registry/modules/search</code><br><code>POST /api/projects/{name}/promote-to-module</code><br><code>GET/POST /api/projects/{name}/drift</code><br><code>GET /api/export/formats</code><br><code>POST /api/export</code></td>
-                  <td>Discover modules, promote resources, detect classified Terraform/OpenTofu state drift, and export alternate IaC formats.</td>
+                  <td><code>GET /api/projects/{name}/modules</code><br><code>GET /api/registry/modules/search</code><br><code>POST /api/projects/{name}/promote-to-module</code><br><code>GET/POST /api/projects/{name}/drift</code><br><code>POST /api/projects/{name}/drift/remediation</code><br><code>GET /api/export/formats</code><br><code>POST /api/export</code></td>
+                  <td>Discover modules, promote resources, detect classified Terraform/OpenTofu state drift, draft codify/revert remediation PR payloads, and export alternate IaC formats.</td>
                 </tr>
                 <tr>
                   <td>Realtime</td>

--- a/internal/api/drift_test.go
+++ b/internal/api/drift_test.go
@@ -184,3 +184,84 @@ func TestProjectDriftEndpointRejectsUnsupportedTool(t *testing.T) {
 	}
 	assertResponseBodyContains(t, resp, "Terraform and OpenTofu")
 }
+
+func TestProjectDriftRemediationEndpointReturnsDraftProposal(t *testing.T) {
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "demo")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "main.tf"), []byte(`
+resource "aws_security_group" "web" {
+  name    = "web"
+  ingress = []
+}
+`), 0o644); err != nil {
+		t.Fatalf("write main.tf: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "terraform.tfstate"), []byte(`{
+		"version": 4,
+		"resources": [{
+			"mode": "managed",
+			"type": "aws_security_group",
+			"name": "web",
+			"instances": [{"attributes": {"name": "web", "ingress": [{"cidr_blocks": ["0.0.0.0/0"]}]}}]
+		}]
+	}`), 0o600); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+
+	srv := httptest.NewServer(fullRouterForTest(t, root))
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/api/projects/demo/drift/remediation", "application/json", strings.NewReader(`{"tool":"terraform","mode":"revert"}`))
+	if err != nil {
+		t.Fatalf("POST drift remediation: %v", err)
+	}
+	defer closeBody(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("drift remediation status = %d", resp.StatusCode)
+	}
+
+	var payload struct {
+		Mode          string `json:"mode"`
+		Title         string `json:"title"`
+		Branch        string `json:"branch"`
+		CommitMessage string `json:"commit_message"`
+		Body          string `json:"body"`
+		FileChanges   []struct {
+			Path    string `json:"path"`
+			Line    int    `json:"line"`
+			Action  string `json:"action"`
+			Address string `json:"address"`
+			Field   string `json:"field"`
+		} `json:"file_changes"`
+		Warnings []string `json:"warnings"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode drift remediation response: %v", err)
+	}
+	if payload.Mode != "revert" ||
+		payload.Title != "Revert unauthorized drift for demo" ||
+		payload.Branch != "iac-studio-drift-revert-demo" ||
+		payload.CommitMessage != "Document drift revert for demo" {
+		t.Fatalf("unexpected proposal metadata: %#v", payload)
+	}
+	if len(payload.FileChanges) != 1 {
+		t.Fatalf("file changes = %d, want 1", len(payload.FileChanges))
+	}
+	change := payload.FileChanges[0]
+	if change.Path != "main.tf" ||
+		change.Line != 2 ||
+		change.Action != "revert" ||
+		change.Address != "aws_security_group.web" ||
+		change.Field != "ingress" {
+		t.Fatalf("unexpected remediation change: %#v", change)
+	}
+	if !strings.Contains(payload.Body, "Run drift again") {
+		t.Fatalf("proposal body should include validation guidance: %s", payload.Body)
+	}
+	if !strings.Contains(strings.Join(payload.Warnings, "\n"), "provider-side change") {
+		t.Fatalf("proposal should warn about provider-side revert: %#v", payload.Warnings)
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -401,6 +401,95 @@ func hybridToolResolutionMessage(missingEnvMessage, env string) string {
 	return fmt.Sprintf("unresolved hybrid tool for env %q; check .iac-studio.json environment_tools", env)
 }
 
+type projectDriftRequest struct {
+	Tool string
+	Env  string
+}
+
+type projectDriftRun struct {
+	Report    *drift.DriftReport
+	Resources []parser.Resource
+	WorkDir   string
+	Tool      string
+	Env       string
+}
+
+func runProjectDrift(projectsDir, name string, req projectDriftRequest, detector *drift.Detector) (*projectDriftRun, int, string) {
+	projectPath, err := safeProjectPath(projectsDir, name)
+	if err != nil {
+		return nil, http.StatusBadRequest, err.Error()
+	}
+
+	tool := effectiveProjectTool(projectPath, req.Tool, req.Env)
+	if tool == "multi" {
+		return nil, http.StatusBadRequest, hybridToolResolutionMessage("env is required when detecting drift for hybrid projects", req.Env)
+	}
+	if tool != "terraform" && tool != "opentofu" {
+		return nil, http.StatusBadRequest, "drift detection currently supports Terraform and OpenTofu state"
+	}
+
+	workDir := projectPath
+	if req.Env != "" {
+		subPath, subErr := safeSubdir(projectPath, "environments", req.Env)
+		if subErr != nil {
+			return nil, http.StatusBadRequest, "invalid env: " + subErr.Error()
+		}
+		workDir = subPath
+	}
+
+	p := parser.ForTool(tool)
+	resources, err := p.ParseDir(workDir)
+	if err != nil {
+		return nil, http.StatusInternalServerError, err.Error()
+	}
+	codeResources := make(map[string]map[string]interface{})
+	for _, res := range resources {
+		codeResources[res.Type+"."+res.Name] = res.Properties
+	}
+
+	var suppressions []drift.SuppressionRule
+	if descriptor, descriptorErr := readProjectToolDescriptor(projectPath); descriptorErr == nil {
+		suppressions = descriptor.Drift.Suppressions
+	}
+	report, err := detector.DetectWithOptions(workDir, codeResources, drift.DetectOptions{
+		Env:          req.Env,
+		Suppressions: suppressions,
+	})
+	if err != nil {
+		return nil, http.StatusInternalServerError, err.Error()
+	}
+	return &projectDriftRun{
+		Report:    report,
+		Resources: resources,
+		WorkDir:   workDir,
+		Tool:      tool,
+		Env:       req.Env,
+	}, http.StatusOK, ""
+}
+
+func driftResourceLocations(workDir string, resources []parser.Resource) map[string]drift.ResourceLocation {
+	locations := make(map[string]drift.ResourceLocation, len(resources))
+	for _, res := range resources {
+		addr := res.Type + "." + res.Name
+		locations[addr] = drift.ResourceLocation{
+			File: relativeSourcePath(workDir, res.File),
+			Line: res.Line,
+		}
+	}
+	return locations
+}
+
+func relativeSourcePath(root, path string) string {
+	if strings.TrimSpace(path) == "" {
+		return ""
+	}
+	rel, err := filepath.Rel(root, path)
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return filepath.ToSlash(filepath.Base(path))
+	}
+	return filepath.ToSlash(rel)
+}
+
 func parseProjectResources(projectPath, tool, env string) ([]parser.Resource, error) {
 	if tool == "multi" {
 		if env == "" {
@@ -1954,11 +2043,6 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 
 	handleDrift := func(w http.ResponseWriter, r *http.Request) {
 		name := r.PathValue("name")
-		projectPath, err := safeProjectPath(projectsDir, name)
-		if err != nil {
-			http.Error(w, err.Error(), 400)
-			return
-		}
 
 		limitBody(w, r)
 		var req struct {
@@ -1978,53 +2062,60 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 			req.Env = r.URL.Query().Get("env")
 		}
 
-		tool := effectiveProjectTool(projectPath, req.Tool, req.Env)
-		if tool == "multi" {
-			http.Error(w, hybridToolResolutionMessage("env is required when detecting drift for hybrid projects", req.Env), 400)
+		run, status, message := runProjectDrift(projectsDir, name, projectDriftRequest{
+			Tool: req.Tool,
+			Env:  req.Env,
+		}, driftDetector)
+		if run == nil {
+			http.Error(w, message, status)
 			return
 		}
-		if tool != "terraform" && tool != "opentofu" {
-			http.Error(w, "drift detection currently supports Terraform and OpenTofu state", 400)
-			return
-		}
-
-		workDir := projectPath
-		if req.Env != "" {
-			subPath, subErr := safeSubdir(projectPath, "environments", req.Env)
-			if subErr != nil {
-				http.Error(w, "invalid env: "+subErr.Error(), 400)
-				return
-			}
-			workDir = subPath
-		}
-
-		p := parser.ForTool(tool)
-		resources, err := p.ParseDir(workDir)
-		if err != nil {
-			http.Error(w, err.Error(), 500)
-			return
-		}
-		// Build code resource index
-		codeResources := make(map[string]map[string]interface{})
-		for _, res := range resources {
-			codeResources[res.Type+"."+res.Name] = res.Properties
-		}
-		var suppressions []drift.SuppressionRule
-		if descriptor, descriptorErr := readProjectToolDescriptor(projectPath); descriptorErr == nil {
-			suppressions = descriptor.Drift.Suppressions
-		}
-		report, err := driftDetector.DetectWithOptions(workDir, codeResources, drift.DetectOptions{
-			Env:          req.Env,
-			Suppressions: suppressions,
-		})
-		if err != nil {
-			http.Error(w, err.Error(), 500)
-			return
-		}
-		_ = json.NewEncoder(w).Encode(report)
+		_ = json.NewEncoder(w).Encode(run.Report)
 	}
 	mux.HandleFunc("GET /api/projects/{name}/drift", handleDrift)
 	mux.HandleFunc("POST /api/projects/{name}/drift", handleDrift)
+
+	mux.HandleFunc("POST /api/projects/{name}/drift/remediation", func(w http.ResponseWriter, r *http.Request) {
+		name := r.PathValue("name")
+		limitBody(w, r)
+		var req struct {
+			Tool string `json:"tool,omitempty"`
+			Env  string `json:"env,omitempty"`
+			Mode string `json:"mode"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+			http.Error(w, "invalid request body: "+err.Error(), 400)
+			return
+		}
+		if req.Tool == "" {
+			req.Tool = r.URL.Query().Get("tool")
+		}
+		if req.Env == "" {
+			req.Env = r.URL.Query().Get("env")
+		}
+
+		run, status, message := runProjectDrift(projectsDir, name, projectDriftRequest{
+			Tool: req.Tool,
+			Env:  req.Env,
+		}, driftDetector)
+		if run == nil {
+			http.Error(w, message, status)
+			return
+		}
+		proposal, err := drift.BuildRemediationProposal(drift.RemediationInput{
+			ProjectName: name,
+			Tool:        run.Tool,
+			Env:         run.Env,
+			Mode:        req.Mode,
+			Findings:    run.Report.Findings,
+			Locations:   driftResourceLocations(run.WorkDir, run.Resources),
+		})
+		if err != nil {
+			http.Error(w, err.Error(), 400)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(proposal)
+	})
 
 	// ─── Multi-Format Export ───
 

--- a/internal/drift/remediation.go
+++ b/internal/drift/remediation.go
@@ -1,0 +1,283 @@
+package drift
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const (
+	RemediationModeCodify = "codify"
+	RemediationModeRevert = "revert"
+)
+
+// ResourceLocation points a finding back to source code when the parser can
+// identify the resource block that produced it.
+type ResourceLocation struct {
+	File string `json:"file,omitempty"`
+	Line int    `json:"line,omitempty"`
+}
+
+// RemediationInput is the provider-neutral input for building a drift PR draft.
+type RemediationInput struct {
+	ProjectName string
+	Tool        string
+	Env         string
+	Mode        string
+	Findings    []DriftFinding
+	Locations   map[string]ResourceLocation
+}
+
+// RemediationFileChange describes the file or runbook change a PR should carry.
+type RemediationFileChange struct {
+	Path    string `json:"path,omitempty"`
+	Line    int    `json:"line,omitempty"`
+	Action  string `json:"action"`
+	Address string `json:"address"`
+	Field   string `json:"field,omitempty"`
+	Summary string `json:"summary"`
+	Before  string `json:"before,omitempty"`
+	After   string `json:"after,omitempty"`
+}
+
+// RemediationProposal is a PR-ready remediation draft. It intentionally avoids
+// mutating source or cloud resources; later provider integrations can convert
+// these file-change notes into exact patches or apply runbooks.
+type RemediationProposal struct {
+	Mode          string                  `json:"mode"`
+	Title         string                  `json:"title"`
+	Branch        string                  `json:"branch"`
+	CommitMessage string                  `json:"commit_message"`
+	Body          string                  `json:"body"`
+	Findings      []DriftFinding          `json:"findings"`
+	FileChanges   []RemediationFileChange `json:"file_changes"`
+	Warnings      []string                `json:"warnings,omitempty"`
+}
+
+// BuildRemediationProposal converts active drift findings into a conservative
+// PR draft. Codify means "accept the observed state into IaC"; revert means
+// "bring live infrastructure back to the IaC value."
+func BuildRemediationProposal(input RemediationInput) (RemediationProposal, error) {
+	mode := strings.TrimSpace(strings.ToLower(input.Mode))
+	if mode != RemediationModeCodify && mode != RemediationModeRevert {
+		return RemediationProposal{}, errors.New("remediation mode must be codify or revert")
+	}
+
+	projectName := strings.TrimSpace(input.ProjectName)
+	if projectName == "" {
+		projectName = "project"
+	}
+	tool := strings.TrimSpace(input.Tool)
+	if tool == "" {
+		tool = "terraform"
+	}
+
+	proposal := RemediationProposal{
+		Mode:          mode,
+		Title:         remediationTitle(mode, projectName),
+		Branch:        remediationBranch(mode, projectName, input.Env),
+		CommitMessage: remediationCommitMessage(mode, projectName),
+	}
+
+	var skippedLegitimate int
+	for _, finding := range input.Findings {
+		if finding.Suppressed {
+			continue
+		}
+		if mode == RemediationModeRevert && finding.Classification == ClassificationLegitimateConfigChange {
+			skippedLegitimate++
+			continue
+		}
+		change, warnings := remediationChange(mode, finding, input.Locations[finding.Address])
+		proposal.Findings = append(proposal.Findings, finding)
+		proposal.FileChanges = append(proposal.FileChanges, change)
+		proposal.Warnings = append(proposal.Warnings, warnings...)
+	}
+
+	if skippedLegitimate > 0 {
+		proposal.Warnings = append(proposal.Warnings,
+			fmt.Sprintf("%d legitimate configuration change finding(s) were left out of the revert draft; codify is usually the safer workflow for those.", skippedLegitimate))
+	}
+	if len(proposal.Findings) == 0 {
+		proposal.Warnings = append(proposal.Warnings, "No active drift findings matched this remediation mode.")
+	}
+	if mode == RemediationModeRevert {
+		proposal.Warnings = append(proposal.Warnings, "Revert drafts do not edit IaC files; they document the provider-side change needed to bring live infrastructure back to code.")
+	}
+
+	proposal.Body = remediationBody(projectName, tool, input.Env, proposal)
+	return proposal, nil
+}
+
+func remediationTitle(mode, projectName string) string {
+	switch mode {
+	case RemediationModeCodify:
+		return fmt.Sprintf("Codify drift for %s", projectName)
+	case RemediationModeRevert:
+		return fmt.Sprintf("Revert unauthorized drift for %s", projectName)
+	default:
+		return fmt.Sprintf("Resolve drift for %s", projectName)
+	}
+}
+
+func remediationBranch(mode, projectName, env string) string {
+	parts := []string{"iac-studio", "drift", mode, slug(projectName)}
+	if strings.TrimSpace(env) != "" {
+		parts = append(parts, slug(env))
+	}
+	return strings.Join(parts, "-")
+}
+
+func remediationCommitMessage(mode, projectName string) string {
+	switch mode {
+	case RemediationModeCodify:
+		return fmt.Sprintf("Codify drift for %s", projectName)
+	case RemediationModeRevert:
+		return fmt.Sprintf("Document drift revert for %s", projectName)
+	default:
+		return fmt.Sprintf("Resolve drift for %s", projectName)
+	}
+}
+
+func remediationChange(mode string, finding DriftFinding, location ResourceLocation) (RemediationFileChange, []string) {
+	change := RemediationFileChange{
+		Path:    location.File,
+		Line:    location.Line,
+		Address: finding.Address,
+		Field:   finding.Path,
+	}
+	var warnings []string
+	if change.Path == "" {
+		change.Path = "manual-remediation.md"
+		warnings = append(warnings, fmt.Sprintf("No source file location was available for %s; the draft includes manual remediation notes.", finding.Address))
+	}
+
+	switch mode {
+	case RemediationModeCodify:
+		change.Action = "codify"
+		change.Before = formatRemediationValue(finding.ExpectedValue)
+		change.After = formatRemediationValue(finding.CurrentValue)
+		switch finding.Status {
+		case "drifted":
+			change.Summary = fmt.Sprintf("Update %s %s to the current state value.", finding.Address, fallbackField(finding.Path))
+			if finding.Classification == ClassificationUnauthorizedChange {
+				warnings = append(warnings, fmt.Sprintf("%s is classified as unauthorized drift; review ownership before accepting it into code.", finding.Address))
+			}
+		case "unmanaged":
+			change.Action = "manual"
+			change.Summary = fmt.Sprintf("Import or add unmanaged resource %s to IaC after ownership review.", finding.Address)
+		case "missing":
+			change.Action = "manual"
+			change.Summary = fmt.Sprintf("Apply or import %s so state and code agree; codifying is not enough for missing state.", finding.Address)
+		default:
+			change.Action = "manual"
+			change.Summary = fmt.Sprintf("Review %s and update IaC if the drift is intentional.", finding.Address)
+		}
+	case RemediationModeRevert:
+		change.Action = "revert"
+		change.Before = formatRemediationValue(finding.CurrentValue)
+		change.After = formatRemediationValue(finding.ExpectedValue)
+		switch finding.Status {
+		case "drifted":
+			change.Summary = fmt.Sprintf("Restore live %s %s to the value declared in code.", finding.Address, fallbackField(finding.Path))
+		case "unmanaged":
+			change.Action = "manual"
+			change.Summary = fmt.Sprintf("Remove unmanaged resource %s or import it intentionally after review.", finding.Address)
+		case "missing":
+			change.Action = "manual"
+			change.Summary = fmt.Sprintf("Recreate or import %s because it exists in code but is missing from state.", finding.Address)
+		default:
+			change.Action = "manual"
+			change.Summary = fmt.Sprintf("Review %s and choose a provider-side revert action.", finding.Address)
+		}
+	}
+	return change, warnings
+}
+
+func remediationBody(projectName, tool, env string, proposal RemediationProposal) string {
+	var b strings.Builder
+	b.WriteString("## Summary\n")
+	b.WriteString(fmt.Sprintf("- Project: `%s`\n", projectName))
+	b.WriteString(fmt.Sprintf("- Tool: `%s`\n", tool))
+	if strings.TrimSpace(env) != "" {
+		b.WriteString(fmt.Sprintf("- Environment: `%s`\n", env))
+	}
+	b.WriteString(fmt.Sprintf("- Mode: `%s`\n", proposal.Mode))
+	b.WriteString(fmt.Sprintf("- Findings: `%d`\n\n", len(proposal.Findings)))
+
+	b.WriteString("## Proposed remediation\n")
+	if len(proposal.FileChanges) == 0 {
+		b.WriteString("- No file or runbook changes were generated.\n")
+	}
+	for _, change := range proposal.FileChanges {
+		location := change.Path
+		if change.Line > 0 {
+			location = fmt.Sprintf("%s:%d", change.Path, change.Line)
+		}
+		if location == "" {
+			location = "manual remediation"
+		}
+		b.WriteString(fmt.Sprintf("- `%s` `%s`: %s", change.Action, change.Address, change.Summary))
+		if change.Field != "" {
+			b.WriteString(fmt.Sprintf(" Field: `%s`.", change.Field))
+		}
+		b.WriteString(fmt.Sprintf(" Location: `%s`.\n", location))
+	}
+
+	if len(proposal.Warnings) > 0 {
+		b.WriteString("\n## Review notes\n")
+		for _, warning := range proposal.Warnings {
+			b.WriteString(fmt.Sprintf("- %s\n", warning))
+		}
+	}
+
+	b.WriteString("\n## Validation\n")
+	b.WriteString("- Run plan/classification before applying any remediation.\n")
+	b.WriteString("- Run drift again after the change to confirm the findings are resolved.\n")
+	return b.String()
+}
+
+func formatRemediationValue(value interface{}) string {
+	if value == nil {
+		return "not set"
+	}
+	if s, ok := value.(string); ok {
+		return s
+	}
+	data, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Sprintf("%v", value)
+	}
+	return string(data)
+}
+
+func fallbackField(path string) string {
+	if strings.TrimSpace(path) == "" {
+		return "configuration"
+	}
+	return path
+}
+
+func slug(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	var out strings.Builder
+	lastDash := false
+	for _, r := range value {
+		keep := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')
+		if keep {
+			out.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if !lastDash {
+			out.WriteByte('-')
+			lastDash = true
+		}
+	}
+	s := strings.Trim(out.String(), "-")
+	if s == "" {
+		return "project"
+	}
+	return s
+}

--- a/internal/drift/remediation_test.go
+++ b/internal/drift/remediation_test.go
@@ -1,0 +1,119 @@
+package drift
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildCodifyRemediationProposal(t *testing.T) {
+	proposal, err := BuildRemediationProposal(RemediationInput{
+		ProjectName: "demo",
+		Tool:        "terraform",
+		Env:         "dev",
+		Mode:        RemediationModeCodify,
+		Findings: []DriftFinding{
+			{
+				Address:           "aws_s3_bucket.logs",
+				Type:              "aws_s3_bucket",
+				Name:              "logs",
+				Status:            "drifted",
+				Path:              "tags",
+				ExpectedValue:     map[string]interface{}{"Owner": "platform"},
+				CurrentValue:      map[string]interface{}{"Owner": "data"},
+				Classification:    ClassificationLegitimateConfigChange,
+				RecommendedAction: ActionCodifyOrAccept,
+				Reason:            "Only metadata fields drifted.",
+			},
+		},
+		Locations: map[string]ResourceLocation{
+			"aws_s3_bucket.logs": {File: "main.tf", Line: 2},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildRemediationProposal: %v", err)
+	}
+
+	if proposal.Title != "Codify drift for demo" {
+		t.Fatalf("title = %q", proposal.Title)
+	}
+	if proposal.Branch != "iac-studio-drift-codify-demo-dev" {
+		t.Fatalf("branch = %q", proposal.Branch)
+	}
+	if len(proposal.FileChanges) != 1 {
+		t.Fatalf("file changes = %d, want 1", len(proposal.FileChanges))
+	}
+	change := proposal.FileChanges[0]
+	if change.Action != "codify" || change.Path != "main.tf" || change.Line != 2 {
+		t.Fatalf("unexpected change metadata: %#v", change)
+	}
+	if change.Before != `{"Owner":"platform"}` || change.After != `{"Owner":"data"}` {
+		t.Fatalf("unexpected before/after: %#v", change)
+	}
+	if !strings.Contains(proposal.Body, "Run drift again") {
+		t.Fatalf("body should include validation guidance: %s", proposal.Body)
+	}
+}
+
+func TestBuildRevertRemediationProposalSkipsLegitimateDrift(t *testing.T) {
+	proposal, err := BuildRemediationProposal(RemediationInput{
+		ProjectName: "demo",
+		Tool:        "opentofu",
+		Mode:        RemediationModeRevert,
+		Findings: []DriftFinding{
+			{
+				Address:           "aws_s3_bucket.logs",
+				Type:              "aws_s3_bucket",
+				Name:              "logs",
+				Status:            "drifted",
+				Path:              "tags",
+				Classification:    ClassificationLegitimateConfigChange,
+				RecommendedAction: ActionCodifyOrAccept,
+				Reason:            "Only metadata fields drifted.",
+			},
+			{
+				Address:           "aws_security_group.web",
+				Type:              "aws_security_group",
+				Name:              "web",
+				Status:            "drifted",
+				Path:              "ingress",
+				ExpectedValue:     []interface{}{},
+				CurrentValue:      []interface{}{map[string]interface{}{"cidr_blocks": []interface{}{"0.0.0.0/0"}}},
+				Classification:    ClassificationUnauthorizedChange,
+				RecommendedAction: ActionRevertOrCodifyAfterReview,
+				Reason:            "Network drift can change reachability.",
+			},
+		},
+		Locations: map[string]ResourceLocation{
+			"aws_security_group.web": {File: "network.tf", Line: 12},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildRemediationProposal: %v", err)
+	}
+
+	if proposal.Mode != RemediationModeRevert {
+		t.Fatalf("mode = %q", proposal.Mode)
+	}
+	if len(proposal.Findings) != 1 || proposal.Findings[0].Address != "aws_security_group.web" {
+		t.Fatalf("unexpected findings: %#v", proposal.Findings)
+	}
+	if len(proposal.Warnings) < 2 {
+		t.Fatalf("expected skip and revert warnings, got %#v", proposal.Warnings)
+	}
+	if !strings.Contains(strings.Join(proposal.Warnings, "\n"), "legitimate configuration change") {
+		t.Fatalf("expected legitimate drift skip warning: %#v", proposal.Warnings)
+	}
+	if !strings.Contains(proposal.Body, "provider-side change") {
+		t.Fatalf("body should explain provider-side revert: %s", proposal.Body)
+	}
+}
+
+func TestBuildRemediationProposalRejectsUnknownMode(t *testing.T) {
+	_, err := BuildRemediationProposal(RemediationInput{
+		ProjectName: "demo",
+		Mode:        "delete-everything",
+	})
+	if err == nil {
+		t.Fatal("expected unknown mode error")
+	}
+}

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -260,6 +260,39 @@ describe('api.runDrift', () => {
   });
 });
 
+describe('api.createDriftRemediation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('posts remediation mode with tool and environment', async () => {
+    const response = {
+      mode: 'revert',
+      title: 'Revert unauthorized drift for demo',
+      branch: 'iac-studio-drift-revert-demo-dev',
+      commit_message: 'Document drift revert for demo',
+      body: '## Summary',
+      findings: [],
+      file_changes: [],
+    };
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(response), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(api.createDriftRemediation('demo', { tool: 'terraform', env: 'dev', mode: 'revert' })).resolves.toEqual(response);
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/projects/demo/drift/remediation', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tool: 'terraform', env: 'dev', mode: 'revert' }),
+    });
+  });
+});
+
 describe('api.suggest', () => {
   afterEach(() => {
     vi.unstubAllGlobals();

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -225,6 +225,30 @@ export interface DriftReport {
   summary: string;
 }
 
+export type DriftRemediationMode = 'codify' | 'revert';
+
+export interface DriftRemediationFileChange {
+  path?: string;
+  line?: number;
+  action: string;
+  address: string;
+  field?: string;
+  summary: string;
+  before?: string;
+  after?: string;
+}
+
+export interface DriftRemediationProposal {
+  mode: DriftRemediationMode;
+  title: string;
+  branch: string;
+  commit_message: string;
+  body: string;
+  findings: DriftFinding[];
+  file_changes: DriftRemediationFileChange[];
+  warnings?: string[];
+}
+
 // Checks res.ok and throws with the backend's error message instead of
 // letting callers hit an opaque JSON parse failure on text/plain errors.
 async function check(res: Response): Promise<Response> {
@@ -482,6 +506,15 @@ export const api = {
 
   async runDrift(projectName: string, req: { tool?: string; env?: string } = {}): Promise<DriftReport> {
     const res = await fetch(`${BASE}/api/projects/${projectName}/drift`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(req),
+    });
+    return (await check(res)).json();
+  },
+
+  async createDriftRemediation(projectName: string, req: { tool?: string; env?: string; mode: DriftRemediationMode }): Promise<DriftRemediationProposal> {
+    const res = await fetch(`${BASE}/api/projects/${projectName}/drift/remediation`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(req),

--- a/web/src/components/DriftPanel/DriftPanel.test.tsx
+++ b/web/src/components/DriftPanel/DriftPanel.test.tsx
@@ -110,6 +110,74 @@ describe('DriftPanel', () => {
     expect(await screen.findByText('Revert unauthorized drift for demo')).toBeInTheDocument();
     expect(screen.getByText('branch iac-studio-drift-revert-demo-dev')).toBeInTheDocument();
     expect(screen.getByText('Restore live aws_security_group.web ingress to the value declared in code.')).toBeInTheDocument();
+    expect(screen.getByText('Revert drafts do not edit IaC files.')).toBeInTheDocument();
+  });
+
+  it('shows all warnings and a +N overflow note when there are more than 3 file changes', async () => {
+    const changes = Array.from({ length: 5 }, (_, i) => ({
+      path: `main.tf`,
+      line: i + 1,
+      action: 'revert',
+      address: `aws_instance.host${i}`,
+      field: 'ami',
+      summary: `Restore host${i} ami.`,
+    }));
+    const client = {
+      runDrift: vi.fn().mockResolvedValue({
+        has_state: true,
+        state_path: '/tmp/demo/terraform.tfstate',
+        drifted: [],
+        findings: changes.map((c) => ({
+          address: c.address,
+          type: 'aws_instance',
+          name: c.address.split('.')[1],
+          status: 'drifted',
+          path: 'ami',
+          expected_value: 'ami-old',
+          current_value: 'ami-new',
+          classification: 'unauthorized_change',
+          recommended_action: 'revert_or_codify_after_review',
+          reason: 'AMI drift.',
+        })),
+        missing: [],
+        unmanaged: [],
+        in_sync: 0,
+        total: 5,
+        classifications: { unauthorized_change: 5 },
+        summary: '5 resources: 0 in sync, 5 drifted, 0 missing from state, 0 unmanaged',
+      }),
+      createDriftRemediation: vi.fn().mockResolvedValue({
+        mode: 'revert',
+        title: 'Revert unauthorized drift for demo',
+        branch: 'iac-studio-drift-revert-demo',
+        commit_message: 'Document drift revert for demo',
+        body: '## Summary',
+        findings: [],
+        file_changes: changes,
+        warnings: ['Revert drafts do not edit IaC files.', 'Review network changes carefully.'],
+      }),
+    };
+
+    render(<DriftPanel projectName="demo" tool="terraform" client={client} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Run drift' }));
+    expect(await screen.findByText('aws_instance.host0')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Draft revert PR' }));
+
+    await waitFor(() => {
+      expect(client.createDriftRemediation).toHaveBeenCalled();
+    });
+
+    // Only first 3 changes shown, with an overflow indicator
+    expect((await screen.findAllByText('aws_instance.host0')).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('aws_instance.host1').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('aws_instance.host2').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('+2 more changes — see PR description')).toBeInTheDocument();
+
+    // Both warnings are visible
+    expect(screen.getByText('Revert drafts do not edit IaC files.')).toBeInTheDocument();
+    expect(screen.getByText('Review network changes carefully.')).toBeInTheDocument();
   });
 
   it('shows a no-state result without fabricating findings', async () => {

--- a/web/src/components/DriftPanel/DriftPanel.test.tsx
+++ b/web/src/components/DriftPanel/DriftPanel.test.tsx
@@ -49,6 +49,69 @@ describe('DriftPanel', () => {
     expect(screen.getByText('["0.0.0.0/0"]')).toBeInTheDocument();
   });
 
+  it('drafts a remediation PR proposal for active findings', async () => {
+    const client = {
+      runDrift: vi.fn().mockResolvedValue({
+        has_state: true,
+        state_path: '/tmp/demo/terraform.tfstate',
+        drifted: [],
+        findings: [
+          {
+            address: 'aws_security_group.web',
+            type: 'aws_security_group',
+            name: 'web',
+            status: 'drifted',
+            path: 'ingress',
+            expected_value: [],
+            current_value: [{ cidr_blocks: ['0.0.0.0/0'] }],
+            classification: 'unauthorized_change',
+            recommended_action: 'revert_or_codify_after_review',
+            reason: 'Network drift can change reachability.',
+          },
+        ],
+        missing: [],
+        unmanaged: [],
+        in_sync: 0,
+        total: 1,
+        classifications: { unauthorized_change: 1 },
+        summary: '1 resources: 0 in sync, 1 drifted, 0 missing from state, 0 unmanaged',
+      }),
+      createDriftRemediation: vi.fn().mockResolvedValue({
+        mode: 'revert',
+        title: 'Revert unauthorized drift for demo',
+        branch: 'iac-studio-drift-revert-demo-dev',
+        commit_message: 'Document drift revert for demo',
+        body: '## Summary',
+        findings: [],
+        file_changes: [
+          {
+            path: 'main.tf',
+            line: 2,
+            action: 'revert',
+            address: 'aws_security_group.web',
+            field: 'ingress',
+            summary: 'Restore live aws_security_group.web ingress to the value declared in code.',
+          },
+        ],
+        warnings: ['Revert drafts do not edit IaC files.'],
+      }),
+    };
+
+    render(<DriftPanel projectName="demo" tool="terraform" env="dev" client={client} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Run drift' }));
+    expect(await screen.findByText('aws_security_group.web')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Draft revert PR' }));
+
+    await waitFor(() => {
+      expect(client.createDriftRemediation).toHaveBeenCalledWith('demo', { tool: 'terraform', env: 'dev', mode: 'revert' });
+    });
+    expect(await screen.findByText('Revert unauthorized drift for demo')).toBeInTheDocument();
+    expect(screen.getByText('branch iac-studio-drift-revert-demo-dev')).toBeInTheDocument();
+    expect(screen.getByText('Restore live aws_security_group.web ingress to the value declared in code.')).toBeInTheDocument();
+  });
+
   it('shows a no-state result without fabricating findings', async () => {
     const client = {
       runDrift: vi.fn().mockResolvedValue({

--- a/web/src/components/DriftPanel/DriftPanel.tsx
+++ b/web/src/components/DriftPanel/DriftPanel.tsx
@@ -255,12 +255,19 @@ export function DriftPanel({
                   )}
                 </div>
               ))}
+              {proposal.file_changes.length > 3 && (
+                <div className="text-[10px] text-muted-foreground">
+                  +{proposal.file_changes.length - 3} more change{proposal.file_changes.length - 3 !== 1 ? 's' : ''} — see PR description
+                </div>
+              )}
             </div>
           )}
 
           {proposal.warnings && proposal.warnings.length > 0 && (
-            <div className="mt-3 rounded border border-amber-500/30 bg-amber-500/10 px-2 py-2 text-xs leading-5 text-amber-200">
-              {proposal.warnings[0]}
+            <div className="mt-3 space-y-1 rounded border border-amber-500/30 bg-amber-500/10 px-2 py-2 text-xs leading-5 text-amber-200">
+              {proposal.warnings.map((warning, i) => (
+                <div key={i}>{warning}</div>
+              ))}
             </div>
           )}
         </section>

--- a/web/src/components/DriftPanel/DriftPanel.tsx
+++ b/web/src/components/DriftPanel/DriftPanel.tsx
@@ -1,14 +1,20 @@
 import { useMemo, useState } from 'react';
-import { AlertCircle, GitCompareArrows, Play } from 'lucide-react';
+import { AlertCircle, GitCompareArrows, GitPullRequest, Play, RotateCcw } from 'lucide-react';
 
-import { api, type DriftFinding, type DriftReport } from '../../api';
+import {
+  api,
+  type DriftFinding,
+  type DriftRemediationMode,
+  type DriftRemediationProposal,
+  type DriftReport,
+} from '../../api';
 import { Button } from '../ui/button';
 
 export interface DriftPanelProps {
   projectName: string;
   tool?: string;
   env?: string;
-  client?: Pick<typeof api, 'runDrift'>;
+  client?: Pick<typeof api, 'runDrift'> & Partial<Pick<typeof api, 'createDriftRemediation'>>;
 }
 
 const SUPPORTED_TOOLS = new Set(['terraform', 'opentofu']);
@@ -66,18 +72,24 @@ export function DriftPanel({
   client = api,
 }: DriftPanelProps) {
   const [running, setRunning] = useState(false);
+  const [draftingMode, setDraftingMode] = useState<DriftRemediationMode | null>(null);
   const [report, setReport] = useState<DriftReport | null>(null);
+  const [proposal, setProposal] = useState<DriftRemediationProposal | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [proposalError, setProposalError] = useState<string | null>(null);
   const supported = SUPPORTED_TOOLS.has(tool);
   const findings = useMemo(() => normalizeFindings(report), [report]);
   const suppressedFindings = useMemo(() => normalizeSuppressedFindings(report), [report]);
   const classifications = useMemo(() => normalizeClassifications(report), [report]);
+  const canDraftRemediation = supported && findings.length > 0 && Boolean(client.createDriftRemediation);
 
   const run = async () => {
     if (!supported) return;
     setRunning(true);
     setError(null);
+    setProposalError(null);
     setReport(null);
+    setProposal(null);
     try {
       const req: { tool: string; env?: string } = { tool };
       if (env) req.env = env;
@@ -87,6 +99,23 @@ export function DriftPanel({
       setError(String(err));
     } finally {
       setRunning(false);
+    }
+  };
+
+  const draftRemediation = async (mode: DriftRemediationMode) => {
+    if (!canDraftRemediation || !client.createDriftRemediation) return;
+    setDraftingMode(mode);
+    setProposalError(null);
+    setProposal(null);
+    try {
+      const req: { tool: string; env?: string; mode: DriftRemediationMode } = { tool, mode };
+      if (env) req.env = env;
+      const response = await client.createDriftRemediation(projectName, req);
+      setProposal(response);
+    } catch (err) {
+      setProposalError(String(err));
+    } finally {
+      setDraftingMode(null);
     }
   };
 
@@ -154,6 +183,84 @@ export function DriftPanel({
                   {formatLabel(classification)} {count}
                 </span>
               ))}
+            </div>
+          )}
+          {findings.length > 0 && (
+            <div className="mt-3 grid grid-cols-2 gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => draftRemediation('codify')}
+                disabled={!canDraftRemediation || draftingMode !== null}
+              >
+                <GitPullRequest className="h-3.5 w-3.5" />
+                {draftingMode === 'codify' ? 'Drafting...' : 'Draft codify PR'}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => draftRemediation('revert')}
+                disabled={!canDraftRemediation || draftingMode !== null}
+              >
+                <RotateCcw className="h-3.5 w-3.5" />
+                {draftingMode === 'revert' ? 'Drafting...' : 'Draft revert PR'}
+              </Button>
+            </div>
+          )}
+        </section>
+      )}
+
+      {proposalError && (
+        <div className="flex items-start gap-2 rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+          <AlertCircle className="mt-0.5 h-3.5 w-3.5 flex-shrink-0" />
+          <span>{proposalError}</span>
+        </div>
+      )}
+
+      {proposal && (
+        <section className="rounded-md border border-primary/30 bg-primary/10 px-3 py-3">
+          <div className="flex items-start gap-2">
+            <GitPullRequest className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-primary" />
+            <div className="min-w-0 flex-1">
+              <div className="truncate text-xs font-semibold text-foreground">{proposal.title}</div>
+              <div className="mt-1 truncate font-mono text-[10px] text-muted-foreground">
+                branch {proposal.branch}
+              </div>
+              <div className="mt-1 truncate font-mono text-[10px] text-muted-foreground">
+                commit {proposal.commit_message}
+              </div>
+            </div>
+          </div>
+
+          {proposal.file_changes.length > 0 && (
+            <div className="mt-3 space-y-2">
+              {proposal.file_changes.slice(0, 3).map((change, index) => (
+                <div
+                  key={`${change.address}-${change.field ?? change.action}-${index}`}
+                  className="rounded border border-border bg-background/70 px-2 py-2"
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="truncate text-xs font-semibold text-foreground">{change.address}</span>
+                    <span className="flex-shrink-0 rounded border border-border px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest text-muted-foreground">
+                      {change.action}
+                    </span>
+                  </div>
+                  <div className="mt-1 text-xs leading-5 text-muted-foreground">{change.summary}</div>
+                  {(change.path || change.field) && (
+                    <div className="mt-1 truncate font-mono text-[10px] text-muted-foreground">
+                      {change.path ?? 'manual'}{change.line ? `:${change.line}` : ''}{change.field ? ` / ${change.field}` : ''}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+
+          {proposal.warnings && proposal.warnings.length > 0 && (
+            <div className="mt-3 rounded border border-amber-500/30 bg-amber-500/10 px-2 py-2 text-xs leading-5 text-amber-200">
+              {proposal.warnings[0]}
             </div>
           )}
         </section>


### PR DESCRIPTION
## Summary
- Add provider-neutral drift remediation proposal generation for codify and revert workflows.
- Add `POST /api/projects/{name}/drift/remediation`, reusing the server-side drift detector and suppression handling.
- Surface draft codify/revert PR metadata in the Drift panel, including branch, commit, source location, warnings, and file/runbook notes.
- Document the new drift remediation draft workflow.

Part of #44.

## Validation
- `GOCACHE=/private/tmp/iacstudio-go-cache go test ./...`
- `npm -C web test -- --run`
- `npm -C web run build`
- `npm -C web run lint` (passes with existing 14 warnings)
- `git diff --check`