### PR TITLE
Add recovery checkpoint metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ start the local server for you.
 | **AI Plan Fix** | When terraform plan fails, AI diagnoses and auto-fixes the issue |
 | **Security Scanner** | Graph-based checks: CIS, SOC2, HIPAA, OWASP compliance |
 | **Drift Monitor** | Run Terraform/OpenTofu state drift checks with classified findings, suppression rules, draft codify/revert PR payloads, and review artifacts |
+| **Recovery Checkpoints** | Successful apply runs record state/plan metadata and hashes for audit, drift, and future rollback workflows |
 | **Multi-Format Export** | Export to Pulumi TypeScript, CDK Python, CloudFormation |
 | **Smart Suggestions** | AI predicts your next resource based on IaC best practices |
 | **Import Projects** | Browse filesystem, scan existing .tf/.yml files, auto-detect topology |
@@ -93,7 +94,7 @@ Browser (React/TS)                   Go Backend (single binary)
 │ AI Chat + Fix        │              │ AI Bridge (Ollama/OpenAI)   │
 │ Code Preview         │              │ Security Scanner            │
 │ Terminal             │              │ Drift Detector              │
-│ Smart Suggestions    │              │ Multi-Format Exporter       │
+│ Smart Suggestions    │              │ Recovery Checkpoints        │
 │ Import Wizard        │              │ Project State Manager       │
 └─────────────────────┘              │ WebSocket Hub               │
                                      └────────────┬───────────────┘
@@ -103,7 +104,8 @@ Browser (React/TS)                   Go Backend (single binary)
                              ~/iac-projects/   Ollama       terraform/
                              ├── main.tf       (local AI)   tofu/
                              ├── variables.tf               ansible
-                             └── .iac-studio.json (state)
+                             ├── .iac-studio.json (state)
+                             └── .iac-studio/snapshots/
 ```
 
 ## AI Integration
@@ -141,6 +143,7 @@ IaC Studio runs locally and is designed to be secure by default:
 - **Execution safety** — command timeouts, process group kill, approval gates
 - **Plan-before-apply** — server-side gate requires successful plan before apply
 - **Semantic plan review** — Terraform/OpenTofu plans are classified before apply; risky, destructive, or unknown changes require explicit acknowledgement
+- **Recovery checkpoints** — successful apply-style runs write metadata and state/plan hashes under `.iac-studio/snapshots`
 - **Cloud target checks** — selected Cloud Connections are tested before command execution
 - **Secret redaction** — static credentials are not echoed in API responses, terminal messages, or generated IaC
 - **No telemetry** — zero data collection, no phone-home
@@ -202,6 +205,7 @@ All flags have sensible defaults. Just run `iac-studio` and go.
 - [x] Execution safety (timeouts, approval gates, kill switch)
 - [x] Policy engine (15+ built-in guardrails)
 - [x] Cloud Connections for AWS, Azure, and GCP run targets
+- [x] Recovery checkpoint metadata for successful apply runs
 - [x] Cost estimation (30+ resource types)
 - [x] CI/CD pipeline generator (GitHub Actions, GitLab CI)
 - [x] Environment promotion (dev/staging/prod workspaces)

--- a/docs/index.html
+++ b/docs/index.html
@@ -588,6 +588,38 @@ gcloud config set project my-platform-dev</code></pre>
           </ol>
         </section>
 
+        <section id="recovery-checkpoints" class="doc-section" data-title="recovery checkpoints snapshots state metadata rollback apply audit">
+          <h2>Recovery Checkpoints</h2>
+          <p>
+            Every successful apply-style run records a lightweight checkpoint under
+            <code>.iac-studio/snapshots/</code>. Checkpoints store metadata and hashes for the
+            run; they do not copy raw state files or secrets into the browser.
+          </p>
+
+          <div class="feature-grid compact">
+            <article>
+              <h3>What is recorded</h3>
+              <p>Project, tool, environment, command, run directory, timestamp, and detected local state or saved plan hashes.</p>
+            </article>
+            <article>
+              <h3>When it records</h3>
+              <p>Terraform/OpenTofu <code>apply</code>, Pulumi <code>up</code>, and Ansible <code>playbook</code> after the command succeeds.</p>
+            </article>
+            <article>
+              <h3>Why it matters</h3>
+              <p>Drift, incident review, and rollback work need an auditable timeline of what was applied and which reviewed plan/state artifacts existed.</p>
+            </article>
+            <article>
+              <h3>How to view it</h3>
+              <p>Open the Drift panel and load recovery checkpoints for the current project or environment.</p>
+            </article>
+          </div>
+
+          <pre><code>.iac-studio/
+  snapshots/
+    20260610T120000Z-terraform-apply-dev-abc12345.json</code></pre>
+        </section>
+
         <section id="ai" class="doc-section" data-title="ai setup ollama openai anthropic models settings environment variables">
           <h2>AI Setup</h2>
           <p>
@@ -759,8 +791,8 @@ ANTHROPIC_MODEL=claude-opus-4-7 \
                 </tr>
                 <tr>
                   <td>Modules, drift, export</td>
-                  <td><code>GET /api/projects/{name}/modules</code><br><code>GET /api/registry/modules/search</code><br><code>POST /api/projects/{name}/promote-to-module</code><br><code>GET/POST /api/projects/{name}/drift</code><br><code>POST /api/projects/{name}/drift/remediation</code><br><code>POST /api/projects/{name}/drift/remediation/artifacts</code><br><code>GET /api/export/formats</code><br><code>POST /api/export</code></td>
-                  <td>Discover modules, promote resources, detect classified Terraform/OpenTofu state drift, draft codify/revert remediation PR payloads, write remediation review artifacts, and export alternate IaC formats.</td>
+                  <td><code>GET /api/projects/{name}/modules</code><br><code>GET /api/registry/modules/search</code><br><code>POST /api/projects/{name}/promote-to-module</code><br><code>GET /api/projects/{name}/snapshots</code><br><code>GET/POST /api/projects/{name}/drift</code><br><code>POST /api/projects/{name}/drift/remediation</code><br><code>POST /api/projects/{name}/drift/remediation/artifacts</code><br><code>GET /api/export/formats</code><br><code>POST /api/export</code></td>
+                  <td>Discover modules, promote resources, list recovery checkpoints, detect classified Terraform/OpenTofu state drift, draft codify/revert remediation PR payloads, write remediation review artifacts, and export alternate IaC formats.</td>
                 </tr>
                 <tr>
                   <td>Realtime</td>
@@ -791,6 +823,7 @@ Go server
 Local project directory
   main.tf, index.ts, playbooks, modules
   .iac-studio.json
+  .iac-studio/snapshots/*.json
   terraform.tfstate when present</code></pre>
 
           <h3>Repository layout</h3>

--- a/internal/api/plan_classification.go
+++ b/internal/api/plan_classification.go
@@ -102,6 +102,10 @@ func commandProducesPlan(command string) bool {
 	return command == "plan" || command == "preview" || command == "check"
 }
 
+func commandRecordsSnapshot(command string) bool {
+	return command == "apply" || command == "up" || command == "playbook"
+}
+
 func appendPlanClassificationOutput(output string, classification *iacplan.ClassificationResult) string {
 	if classification == nil {
 		return output

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -29,6 +29,7 @@ import (
 	iacplan "github.com/iac-studio/iac-studio/internal/plan"
 	"github.com/iac-studio/iac-studio/internal/project"
 	pulumigen "github.com/iac-studio/iac-studio/internal/pulumi"
+	"github.com/iac-studio/iac-studio/internal/recovery"
 	"github.com/iac-studio/iac-studio/internal/registry"
 	"github.com/iac-studio/iac-studio/internal/runner"
 	"github.com/iac-studio/iac-studio/internal/scaffold"
@@ -93,18 +94,25 @@ func safeProjectPath(projectsDir, name string) (string, error) {
 // Used by the /api/projects/{name}/run endpoint to rebase execution
 // into environments/<env>/ for layered-v1 layouts so the runner finds
 // Pulumi.yaml / main.tf in the right workdir.
+func safePathSegment(seg string) error {
+	if seg == "" || seg == "." || seg == ".." ||
+		strings.ContainsAny(seg, `/\`) ||
+		strings.Contains(seg, "..") {
+		return fmt.Errorf("invalid path segment: %q", seg)
+	}
+	for _, r := range seg {
+		if !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') ||
+			(r >= '0' && r <= '9') || r == '-' || r == '_') {
+			return fmt.Errorf("invalid path segment: %q (only alphanumeric, hyphens, underscores)", seg)
+		}
+	}
+	return nil
+}
+
 func safeSubdir(projectPath string, segments ...string) (string, error) {
 	for _, seg := range segments {
-		if seg == "" || seg == "." || seg == ".." ||
-			strings.ContainsAny(seg, `/\`) ||
-			strings.Contains(seg, "..") {
-			return "", fmt.Errorf("invalid path segment: %q", seg)
-		}
-		for _, r := range seg {
-			if !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') ||
-				(r >= '0' && r <= '9') || r == '-' || r == '_') {
-				return "", fmt.Errorf("invalid path segment: %q (only alphanumeric, hyphens, underscores)", seg)
-			}
+		if err := safePathSegment(seg); err != nil {
+			return "", err
 		}
 	}
 	joined := filepath.Join(append([]string{projectPath}, segments...)...)
@@ -1379,6 +1387,8 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 		go func() {
 			result, err := run.ExecuteWithEnv(context.Background(), runPath, effectiveTool, req.Command, req.Env, commandEnv)
 			var classification *iacplan.ClassificationResult
+			var snapshot *recovery.StateSnapshot
+			var snapshotErr error
 			// Only record a successful plan — failed/cancelled plans don't count.
 			// 'preview' is Pulumi's equivalent of terraform plan; without it
 			// here, a pulumi up following a successful preview would be
@@ -1406,12 +1416,32 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 				}
 				recordPlan(runPath)
 			}
+			if err == nil && commandRecordsSnapshot(req.Command) {
+				recorded, recordErr := recovery.RecordSnapshot(projectRoot, runPath, recovery.SnapshotInput{
+					Project: name,
+					Tool:    effectiveTool,
+					Env:     req.Env,
+					Command: req.Command,
+				}, time.Now().UTC())
+				if recordErr != nil {
+					snapshotErr = recordErr
+					log.Printf("state snapshot: failed to record metadata for %s (command=%s tool=%s): %v", name, req.Command, effectiveTool, recordErr)
+				} else {
+					snapshot = &recorded
+				}
+			}
 			msg := map[string]interface{}{
 				"type":    "terminal",
 				"project": name,
 			}
 			if classification != nil {
 				msg["plan_classification"] = classification
+			}
+			if snapshot != nil {
+				msg["state_snapshot"] = snapshot
+			}
+			if snapshotErr != nil {
+				msg["state_snapshot_error"] = snapshotErr.Error()
 			}
 			if connectionSummary.ID != "" {
 				msg["connection"] = map[string]string{
@@ -2080,6 +2110,39 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 		}
 		report := secScanner.Scan(resources)
 		_ = json.NewEncoder(w).Encode(report)
+	})
+
+	// ─── Recovery Snapshots ───
+
+	mux.HandleFunc("GET /api/projects/{name}/snapshots", func(w http.ResponseWriter, r *http.Request) {
+		name := r.PathValue("name")
+		projectPath, err := safeProjectPath(projectsDir, name)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		env := r.URL.Query().Get("env")
+		if env != "" {
+			if err := safePathSegment(env); err != nil {
+				http.Error(w, "invalid env: "+err.Error(), http.StatusBadRequest)
+				return
+			}
+		}
+		snapshots, err := recovery.ListSnapshots(projectPath)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if env != "" {
+			filtered := snapshots[:0]
+			for _, snapshot := range snapshots {
+				if snapshot.Env == env {
+					filtered = append(filtered, snapshot)
+				}
+			}
+			snapshots = filtered
+		}
+		_ = json.NewEncoder(w).Encode(snapshots)
 	})
 
 	// ─── Drift Detection ───

--- a/internal/api/snapshots_test.go
+++ b/internal/api/snapshots_test.go
@@ -1,0 +1,85 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/iac-studio/iac-studio/internal/recovery"
+)
+
+func TestListSnapshotsFiltersByEnvironment(t *testing.T) {
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "demo")
+	devDir := filepath.Join(projectDir, "environments", "dev")
+	prodDir := filepath.Join(projectDir, "environments", "prod")
+	if err := os.MkdirAll(devDir, 0o755); err != nil {
+		t.Fatalf("mkdir dev env: %v", err)
+	}
+	if err := os.MkdirAll(prodDir, 0o755); err != nil {
+		t.Fatalf("mkdir prod env: %v", err)
+	}
+	if _, err := recovery.RecordSnapshot(projectDir, prodDir, recovery.SnapshotInput{
+		Project: "demo",
+		Tool:    "terraform",
+		Env:     "prod",
+		Command: "apply",
+	}, time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)); err != nil {
+		t.Fatalf("record prod snapshot: %v", err)
+	}
+	if _, err := recovery.RecordSnapshot(projectDir, devDir, recovery.SnapshotInput{
+		Project: "demo",
+		Tool:    "terraform",
+		Env:     "dev",
+		Command: "apply",
+	}, time.Date(2026, 6, 10, 13, 0, 0, 0, time.UTC)); err != nil {
+		t.Fatalf("record dev snapshot: %v", err)
+	}
+
+	srv := httptest.NewServer(fullRouterForTest(t, root))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/projects/demo/snapshots?env=dev")
+	if err != nil {
+		t.Fatalf("GET snapshots: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("snapshots status = %d", resp.StatusCode)
+	}
+
+	var snapshots []recovery.StateSnapshot
+	if err := json.NewDecoder(resp.Body).Decode(&snapshots); err != nil {
+		t.Fatalf("decode snapshots: %v", err)
+	}
+	if len(snapshots) != 1 {
+		t.Fatalf("got %d snapshots, want 1", len(snapshots))
+	}
+	if snapshots[0].Env != "dev" || snapshots[0].WorkDir != "environments/dev" {
+		t.Fatalf("unexpected snapshot: %#v", snapshots[0])
+	}
+}
+
+func TestListSnapshotsRejectsUnsafeEnvironmentFilter(t *testing.T) {
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "demo")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+
+	srv := httptest.NewServer(fullRouterForTest(t, root))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/projects/demo/snapshots?env=../prod")
+	if err != nil {
+		t.Fatalf("GET snapshots: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("unsafe env status = %d, want 400", resp.StatusCode)
+	}
+}

--- a/internal/recovery/snapshots.go
+++ b/internal/recovery/snapshots.go
@@ -236,13 +236,16 @@ func snapshotID(snapshot StateSnapshot) string {
 func slug(value string) string {
 	value = strings.ToLower(strings.TrimSpace(value))
 	var b strings.Builder
+	lastWasHyphen := false
 	for _, r := range value {
 		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
 			b.WriteRune(r)
+			lastWasHyphen = false
 			continue
 		}
-		if b.Len() > 0 {
+		if b.Len() > 0 && !lastWasHyphen {
 			b.WriteByte('-')
+			lastWasHyphen = true
 		}
 	}
 	out := strings.Trim(b.String(), "-")

--- a/internal/recovery/snapshots.go
+++ b/internal/recovery/snapshots.go
@@ -1,0 +1,253 @@
+package recovery
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const snapshotsDir = ".iac-studio/snapshots"
+
+// StateSnapshot is the first recovery primitive: a durable audit record for a
+// successful state-changing run. It stores metadata and hashes, not raw state.
+type StateSnapshot struct {
+	ID        string    `json:"id"`
+	Project   string    `json:"project"`
+	Tool      string    `json:"tool"`
+	Env       string    `json:"env,omitempty"`
+	Command   string    `json:"command"`
+	WorkDir   string    `json:"work_dir"`
+	StatePath string    `json:"state_path,omitempty"`
+	StateSHA  string    `json:"state_sha256,omitempty"`
+	StateSize int64     `json:"state_size,omitempty"`
+	PlanPath  string    `json:"plan_path,omitempty"`
+	PlanSHA   string    `json:"plan_sha256,omitempty"`
+	PlanSize  int64     `json:"plan_size,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
+	Status    string    `json:"status"`
+	Notes     []string  `json:"notes,omitempty"`
+}
+
+type SnapshotInput struct {
+	Project string
+	Tool    string
+	Env     string
+	Command string
+}
+
+func RecordSnapshot(projectRoot, workDir string, input SnapshotInput, now time.Time) (StateSnapshot, error) {
+	snapshot, err := BuildSnapshot(projectRoot, workDir, input, now)
+	if err != nil {
+		return StateSnapshot{}, err
+	}
+	dir := filepath.Join(projectRoot, filepath.FromSlash(snapshotsDir))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return StateSnapshot{}, fmt.Errorf("create snapshots directory: %w", err)
+	}
+	data, err := json.MarshalIndent(snapshot, "", "  ")
+	if err != nil {
+		return StateSnapshot{}, fmt.Errorf("marshal snapshot: %w", err)
+	}
+	path := filepath.Join(dir, snapshot.ID+".json")
+	if err := os.WriteFile(path, append(data, '\n'), 0o644); err != nil {
+		return StateSnapshot{}, fmt.Errorf("write snapshot metadata: %w", err)
+	}
+	return snapshot, nil
+}
+
+func BuildSnapshot(projectRoot, workDir string, input SnapshotInput, now time.Time) (StateSnapshot, error) {
+	if now.IsZero() {
+		now = time.Now().UTC()
+	} else {
+		now = now.UTC()
+	}
+	rootAbs, workAbs, relWorkDir, err := containedWorkDir(projectRoot, workDir)
+	if err != nil {
+		return StateSnapshot{}, err
+	}
+	if input.Project == "" {
+		input.Project = filepath.Base(projectRoot)
+	}
+	snapshot := StateSnapshot{
+		Project:   input.Project,
+		Tool:      input.Tool,
+		Env:       input.Env,
+		Command:   input.Command,
+		WorkDir:   relWorkDir,
+		CreatedAt: now,
+		Status:    "recorded",
+	}
+
+	if file, ok, hashErr := firstExistingHash(rootAbs, workAbs, []string{"terraform.tfstate"}); hashErr != nil {
+		return StateSnapshot{}, hashErr
+	} else if ok {
+		snapshot.StatePath = file.Path
+		snapshot.StateSHA = file.SHA256
+		snapshot.StateSize = file.Size
+	} else {
+		snapshot.Notes = append(snapshot.Notes, stateNote(input.Tool))
+	}
+
+	if file, ok, hashErr := firstExistingHash(rootAbs, workAbs, []string{"tfplan.json", "tfplan"}); hashErr != nil {
+		return StateSnapshot{}, hashErr
+	} else if ok {
+		snapshot.PlanPath = file.Path
+		snapshot.PlanSHA = file.SHA256
+		snapshot.PlanSize = file.Size
+	}
+
+	snapshot.ID = snapshotID(snapshot)
+	return snapshot, nil
+}
+
+func ListSnapshots(projectRoot string) ([]StateSnapshot, error) {
+	dir := filepath.Join(projectRoot, filepath.FromSlash(snapshotsDir))
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []StateSnapshot{}, nil
+		}
+		return nil, fmt.Errorf("read snapshots directory: %w", err)
+	}
+
+	snapshots := make([]StateSnapshot, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || entry.Type()&os.ModeSymlink != 0 || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			return nil, fmt.Errorf("read snapshot %s: %w", entry.Name(), err)
+		}
+		var snapshot StateSnapshot
+		if err := json.Unmarshal(data, &snapshot); err != nil {
+			return nil, fmt.Errorf("parse snapshot %s: %w", entry.Name(), err)
+		}
+		snapshots = append(snapshots, snapshot)
+	}
+
+	sort.SliceStable(snapshots, func(i, j int) bool {
+		return snapshots[i].CreatedAt.After(snapshots[j].CreatedAt)
+	})
+	return snapshots, nil
+}
+
+type hashedFile struct {
+	Path   string
+	SHA256 string
+	Size   int64
+}
+
+func containedWorkDir(projectRoot, workDir string) (string, string, string, error) {
+	rootAbs, err := filepath.Abs(projectRoot)
+	if err != nil {
+		return "", "", "", fmt.Errorf("resolve project root: %w", err)
+	}
+	workAbs, err := filepath.Abs(workDir)
+	if err != nil {
+		return "", "", "", fmt.Errorf("resolve work dir: %w", err)
+	}
+	rel, err := filepath.Rel(rootAbs, workAbs)
+	if err != nil {
+		return "", "", "", fmt.Errorf("relativize work dir: %w", err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return "", "", "", fmt.Errorf("work dir escapes project root")
+	}
+	if rel == "." {
+		rel = ""
+	}
+	return rootAbs, workAbs, filepath.ToSlash(rel), nil
+}
+
+func firstExistingHash(rootAbs, workAbs string, candidates []string) (hashedFile, bool, error) {
+	for _, candidate := range candidates {
+		path := filepath.Join(workAbs, candidate)
+		info, err := os.Lstat(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return hashedFile{}, false, fmt.Errorf("stat %s: %w", candidate, err)
+		}
+		if info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+			continue
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return hashedFile{}, false, fmt.Errorf("read %s: %w", candidate, err)
+		}
+		rel, err := filepath.Rel(rootAbs, path)
+		if err != nil {
+			return hashedFile{}, false, fmt.Errorf("relativize %s: %w", candidate, err)
+		}
+		sum := sha256.Sum256(data)
+		return hashedFile{
+			Path:   filepath.ToSlash(rel),
+			SHA256: hex.EncodeToString(sum[:]),
+			Size:   info.Size(),
+		}, true, nil
+	}
+	return hashedFile{}, false, nil
+}
+
+func stateNote(tool string) string {
+	switch tool {
+	case "pulumi":
+		return "No local Terraform/OpenTofu state file was found; Pulumi state is usually stored in the configured backend."
+	case "ansible":
+		return "No local state file was found; Ansible runs are recorded as operational checkpoints."
+	default:
+		return "No local terraform.tfstate file was found in the run directory."
+	}
+}
+
+func snapshotID(snapshot StateSnapshot) string {
+	env := snapshot.Env
+	if env == "" {
+		env = "root"
+	}
+	fingerprint := sha256.Sum256([]byte(strings.Join([]string{
+		snapshot.Project,
+		snapshot.Tool,
+		snapshot.Command,
+		env,
+		snapshot.WorkDir,
+		snapshot.StateSHA,
+		snapshot.PlanSHA,
+		snapshot.CreatedAt.Format(time.RFC3339Nano),
+	}, "|")))
+	parts := []string{
+		snapshot.CreatedAt.Format("20060102T150405Z"),
+		slug(snapshot.Tool),
+		slug(snapshot.Command),
+		slug(env),
+		hex.EncodeToString(fingerprint[:])[:8],
+	}
+	return strings.Join(parts, "-")
+}
+
+func slug(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	var b strings.Builder
+	for _, r := range value {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteByte('-')
+		}
+	}
+	out := strings.Trim(b.String(), "-")
+	if out == "" {
+		return "unknown"
+	}
+	return out
+}

--- a/internal/recovery/snapshots_test.go
+++ b/internal/recovery/snapshots_test.go
@@ -92,6 +92,20 @@ func TestBuildSnapshotRejectsWorkDirOutsideProject(t *testing.T) {
 	}
 }
 
+func TestSlugCollapsesAdjacentSeparators(t *testing.T) {
+	tests := map[string]string{
+		"apply --auto-approve": "apply-auto-approve",
+		"plan  -out=tfplan":    "plan-out-tfplan",
+		"up --yes":             "up-yes",
+	}
+
+	for input, want := range tests {
+		if got := slug(input); got != want {
+			t.Fatalf("slug(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
 func sha(data []byte) string {
 	sum := sha256.Sum256(data)
 	return hex.EncodeToString(sum[:])

--- a/internal/recovery/snapshots_test.go
+++ b/internal/recovery/snapshots_test.go
@@ -1,0 +1,98 @@
+package recovery
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestRecordSnapshotCapturesStateAndPlanMetadata(t *testing.T) {
+	root := t.TempDir()
+	workDir := filepath.Join(root, "environments", "dev")
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatalf("mkdir work dir: %v", err)
+	}
+	state := []byte(`{"version":4}`)
+	plan := []byte(`{"resource_changes":[]}`)
+	if err := os.WriteFile(filepath.Join(workDir, "terraform.tfstate"), state, 0o644); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workDir, "tfplan.json"), plan, 0o644); err != nil {
+		t.Fatalf("write plan: %v", err)
+	}
+	now := time.Date(2026, 6, 10, 12, 30, 0, 0, time.UTC)
+
+	snapshot, err := RecordSnapshot(root, workDir, SnapshotInput{
+		Project: "demo",
+		Tool:    "terraform",
+		Env:     "dev",
+		Command: "apply",
+	}, now)
+	if err != nil {
+		t.Fatalf("record snapshot: %v", err)
+	}
+
+	if snapshot.Project != "demo" || snapshot.Tool != "terraform" || snapshot.Env != "dev" || snapshot.Command != "apply" {
+		t.Fatalf("unexpected snapshot identity: %#v", snapshot)
+	}
+	if snapshot.WorkDir != "environments/dev" {
+		t.Fatalf("work dir = %q", snapshot.WorkDir)
+	}
+	if snapshot.StatePath != "environments/dev/terraform.tfstate" || snapshot.StateSize != int64(len(state)) {
+		t.Fatalf("state metadata = path %q size %d", snapshot.StatePath, snapshot.StateSize)
+	}
+	if snapshot.StateSHA != sha(state) {
+		t.Fatalf("state sha = %q, want %q", snapshot.StateSHA, sha(state))
+	}
+	if snapshot.PlanPath != "environments/dev/tfplan.json" || snapshot.PlanSHA != sha(plan) {
+		t.Fatalf("plan metadata = path %q sha %q", snapshot.PlanPath, snapshot.PlanSHA)
+	}
+	if snapshot.ID == "" {
+		t.Fatal("snapshot id should be set")
+	}
+	if _, err := os.Stat(filepath.Join(root, ".iac-studio", "snapshots", snapshot.ID+".json")); err != nil {
+		t.Fatalf("snapshot metadata file missing: %v", err)
+	}
+}
+
+func TestListSnapshotsSortsNewestFirst(t *testing.T) {
+	root := t.TempDir()
+	if _, err := RecordSnapshot(root, root, SnapshotInput{Project: "demo", Tool: "terraform", Command: "apply"}, time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)); err != nil {
+		t.Fatalf("record first: %v", err)
+	}
+	if _, err := RecordSnapshot(root, root, SnapshotInput{Project: "demo", Tool: "pulumi", Command: "up"}, time.Date(2026, 6, 10, 13, 0, 0, 0, time.UTC)); err != nil {
+		t.Fatalf("record second: %v", err)
+	}
+
+	snapshots, err := ListSnapshots(root)
+	if err != nil {
+		t.Fatalf("list snapshots: %v", err)
+	}
+	if len(snapshots) != 2 {
+		t.Fatalf("got %d snapshots, want 2", len(snapshots))
+	}
+	if snapshots[0].Tool != "pulumi" || snapshots[1].Tool != "terraform" {
+		t.Fatalf("snapshots not sorted newest first: %#v", snapshots)
+	}
+	if len(snapshots[0].Notes) == 0 {
+		t.Fatal("pulumi snapshot without local state should include a note")
+	}
+}
+
+func TestBuildSnapshotRejectsWorkDirOutsideProject(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+
+	_, err := BuildSnapshot(root, outside, SnapshotInput{Project: "demo", Tool: "terraform", Command: "apply"}, time.Now())
+	if err == nil {
+		t.Fatal("expected work dir escape to fail")
+	}
+}
+
+func sha(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -333,6 +333,39 @@ describe('api.createDriftRemediationArtifacts', () => {
   });
 });
 
+describe('api.listStateSnapshots', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('fetches environment-scoped recovery snapshots', async () => {
+    const response = [{
+      id: '20260610T120000Z-terraform-apply-dev-abc12345',
+      project: 'demo',
+      tool: 'terraform',
+      env: 'dev',
+      command: 'apply',
+      work_dir: 'environments/dev',
+      state_path: 'environments/dev/terraform.tfstate',
+      state_sha256: 'abc123',
+      state_size: 42,
+      created_at: '2026-06-10T12:00:00Z',
+      status: 'recorded',
+    }];
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(response), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(api.listStateSnapshots('demo', 'dev')).resolves.toEqual(response);
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/projects/demo/snapshots?env=dev');
+  });
+});
+
 describe('api.suggest', () => {
   afterEach(() => {
     vi.unstubAllGlobals();

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -264,6 +264,24 @@ export interface DriftRemediationArtifactSet {
   files: DriftRemediationArtifactFile[];
 }
 
+export interface StateSnapshot {
+  id: string;
+  project: string;
+  tool: string;
+  env?: string;
+  command: string;
+  work_dir: string;
+  state_path?: string;
+  state_sha256?: string;
+  state_size?: number;
+  plan_path?: string;
+  plan_sha256?: string;
+  plan_size?: number;
+  created_at: string;
+  status: string;
+  notes?: string[];
+}
+
 // Checks res.ok and throws with the backend's error message instead of
 // letting callers hit an opaque JSON parse failure on text/plain errors.
 async function check(res: Response): Promise<Response> {
@@ -543,6 +561,14 @@ export const api = {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(req),
     });
+    return (await check(res)).json();
+  },
+
+  async listStateSnapshots(projectName: string, env?: string): Promise<StateSnapshot[]> {
+    const params = new URLSearchParams();
+    if (env) params.set('env', env);
+    const query = params.toString();
+    const res = await fetch(`${BASE}/api/projects/${projectName}/snapshots${query ? `?${query}` : ''}`);
     return (await check(res)).json();
   },
 

--- a/web/src/components/DriftPanel/DriftPanel.test.tsx
+++ b/web/src/components/DriftPanel/DriftPanel.test.tsx
@@ -49,6 +49,42 @@ describe('DriftPanel', () => {
     expect(screen.getByText('["0.0.0.0/0"]')).toBeInTheDocument();
   });
 
+  it('loads recovery checkpoints for the active environment', async () => {
+    const client = {
+      runDrift: vi.fn(),
+      listStateSnapshots: vi.fn().mockResolvedValue([
+        {
+          id: '20260610T120000Z-terraform-apply-dev-abc12345',
+          project: 'demo',
+          tool: 'terraform',
+          env: 'dev',
+          command: 'apply',
+          work_dir: 'environments/dev',
+          state_path: 'environments/dev/terraform.tfstate',
+          state_sha256: 'abc1234567890abcdef',
+          state_size: 42,
+          plan_path: 'environments/dev/tfplan.json',
+          plan_sha256: 'def4567890abcdef',
+          plan_size: 21,
+          created_at: '2026-06-10T12:00:00Z',
+          status: 'recorded',
+        },
+      ]),
+    };
+
+    render(<DriftPanel projectName="demo" tool="terraform" env="dev" client={client} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Load' }));
+
+    await waitFor(() => {
+      expect(client.listStateSnapshots).toHaveBeenCalledWith('demo', 'dev');
+    });
+    expect(await screen.findByText('terraform apply')).toBeInTheDocument();
+    expect(screen.getByText(/environments\/dev · 20260610T120000Z-terraform-apply-dev-abc12345/)).toBeInTheDocument();
+    expect(screen.getByText(/state environments\/dev\/terraform\.tfstate abc123456789/)).toBeInTheDocument();
+    expect(screen.getByText(/plan environments\/dev\/tfplan\.json def4567890ab/)).toBeInTheDocument();
+  });
+
   it('drafts a remediation PR proposal for active findings', async () => {
     const client = {
       runDrift: vi.fn().mockResolvedValue({

--- a/web/src/components/DriftPanel/DriftPanel.tsx
+++ b/web/src/components/DriftPanel/DriftPanel.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { AlertCircle, FileText, GitCompareArrows, GitPullRequest, Play, RotateCcw } from 'lucide-react';
+import { AlertCircle, FileText, GitCompareArrows, GitPullRequest, History, Play, RotateCcw } from 'lucide-react';
 
 import {
   api,
@@ -8,6 +8,7 @@ import {
   type DriftRemediationMode,
   type DriftRemediationProposal,
   type DriftReport,
+  type StateSnapshot,
 } from '../../api';
 import { Button } from '../ui/button';
 
@@ -15,7 +16,7 @@ export interface DriftPanelProps {
   projectName: string;
   tool?: string;
   env?: string;
-  client?: Pick<typeof api, 'runDrift'> & Partial<Pick<typeof api, 'createDriftRemediation' | 'createDriftRemediationArtifacts'>>;
+  client?: Pick<typeof api, 'runDrift'> & Partial<Pick<typeof api, 'createDriftRemediation' | 'createDriftRemediationArtifacts' | 'listStateSnapshots'>>;
 }
 
 const SUPPORTED_TOOLS = new Set(['terraform', 'opentofu']);
@@ -66,6 +67,22 @@ function normalizeClassifications(report: DriftReport | null): [string, number][
     .sort(([left], [right]) => left.localeCompare(right));
 }
 
+function shortHash(value?: string): string {
+  if (!value) return '';
+  return value.slice(0, 12);
+}
+
+function formatSnapshotTime(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
 export function DriftPanel({
   projectName,
   tool = 'terraform',
@@ -78,14 +95,19 @@ export function DriftPanel({
   const [report, setReport] = useState<DriftReport | null>(null);
   const [proposal, setProposal] = useState<DriftRemediationProposal | null>(null);
   const [artifacts, setArtifacts] = useState<DriftRemediationArtifactSet | null>(null);
+  const [snapshots, setSnapshots] = useState<StateSnapshot[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [proposalError, setProposalError] = useState<string | null>(null);
   const [artifactError, setArtifactError] = useState<string | null>(null);
+  const [snapshotError, setSnapshotError] = useState<string | null>(null);
+  const [loadingSnapshots, setLoadingSnapshots] = useState(false);
+  const [snapshotsLoaded, setSnapshotsLoaded] = useState(false);
   const supported = SUPPORTED_TOOLS.has(tool);
   const findings = useMemo(() => normalizeFindings(report), [report]);
   const suppressedFindings = useMemo(() => normalizeSuppressedFindings(report), [report]);
   const classifications = useMemo(() => normalizeClassifications(report), [report]);
   const canDraftRemediation = supported && findings.length > 0 && Boolean(client.createDriftRemediation);
+  const canListSnapshots = Boolean(client.listStateSnapshots);
 
   const run = async () => {
     if (!supported) return;
@@ -144,6 +166,21 @@ export function DriftPanel({
     }
   };
 
+  const loadSnapshots = async () => {
+    if (!client.listStateSnapshots) return;
+    setLoadingSnapshots(true);
+    setSnapshotError(null);
+    try {
+      const response = await client.listStateSnapshots(projectName, env);
+      setSnapshots(response);
+      setSnapshotsLoaded(true);
+    } catch (err) {
+      setSnapshotError(String(err));
+    } finally {
+      setLoadingSnapshots(false);
+    }
+  };
+
   return (
     <div className="flex h-full flex-col gap-3 bg-background p-4">
       <header className="flex items-center gap-3">
@@ -174,6 +211,85 @@ export function DriftPanel({
           <AlertCircle className="mt-0.5 h-3.5 w-3.5 flex-shrink-0" />
           <span>{error}</span>
         </div>
+      )}
+
+      {canListSnapshots && (
+        <section className="rounded-md border border-border bg-card px-3 py-3">
+          <div className="flex items-center gap-2">
+            <History className="h-3.5 w-3.5 text-primary" />
+            <div className="min-w-0 flex-1">
+              <div className="text-xs font-semibold uppercase tracking-widest text-foreground">
+                Recovery checkpoints
+              </div>
+              <div className="mt-1 truncate text-[10px] text-muted-foreground">
+                Successful apply metadata for this {env ? `environment (${env})` : 'project'}
+              </div>
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={loadSnapshots}
+              disabled={loadingSnapshots}
+            >
+              <History className="h-3.5 w-3.5" />
+              {loadingSnapshots ? 'Loading...' : 'Load'}
+            </Button>
+          </div>
+          {snapshotError && (
+            <div className="mt-3 flex items-start gap-2 rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+              <AlertCircle className="mt-0.5 h-3.5 w-3.5 flex-shrink-0" />
+              <span>{snapshotError}</span>
+            </div>
+          )}
+          {snapshots.length > 0 && (
+            <div className="mt-3 space-y-2">
+              {snapshots.slice(0, 3).map((snapshot) => (
+                <article
+                  key={snapshot.id}
+                  className="rounded border border-border bg-background/70 px-2 py-2"
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="truncate font-mono text-[10px] font-semibold uppercase tracking-widest text-foreground">
+                      {snapshot.tool} {snapshot.command}
+                    </span>
+                    <span className="flex-shrink-0 text-[10px] text-muted-foreground">
+                      {formatSnapshotTime(snapshot.created_at)}
+                    </span>
+                  </div>
+                  <div className="mt-1 truncate font-mono text-[10px] text-muted-foreground">
+                    {snapshot.work_dir || 'project root'} · {snapshot.id}
+                  </div>
+                  {snapshot.state_path && (
+                    <div className="mt-1 truncate font-mono text-[10px] text-muted-foreground">
+                      state {snapshot.state_path} {shortHash(snapshot.state_sha256)}
+                    </div>
+                  )}
+                  {snapshot.plan_path && (
+                    <div className="mt-1 truncate font-mono text-[10px] text-muted-foreground">
+                      plan {snapshot.plan_path} {shortHash(snapshot.plan_sha256)}
+                    </div>
+                  )}
+                  {snapshot.notes && snapshot.notes.length > 0 && (
+                    <div className="mt-2 text-[10px] leading-4 text-muted-foreground">
+                      {snapshot.notes[0]}
+                    </div>
+                  )}
+                </article>
+              ))}
+              {snapshots.length > 3 && (
+                <div className="text-[10px] text-muted-foreground">
+                  +{snapshots.length - 3} more checkpoint{snapshots.length - 3 === 1 ? '' : 's'}
+                </div>
+              )}
+            </div>
+          )}
+          {!loadingSnapshots && snapshots.length === 0 && !snapshotError && (
+            <div className="mt-3 rounded border border-dashed border-border px-2 py-3 text-center text-[10px] text-muted-foreground">
+              {snapshotsLoaded ? 'No checkpoints recorded yet.' : 'No checkpoints loaded yet.'}
+            </div>
+          )}
+        </section>
       )}
 
       {report && (


### PR DESCRIPTION
## Summary
- record recovery checkpoint metadata after successful apply-style runs
- add a project snapshots API with environment filtering
- surface recent checkpoints in the Drift panel and document the workflow

## Tests
- GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/api
- GOCACHE=/private/tmp/iacstudio-go-cache go test ./...
- npm -C web test -- --run
- npm -C web run build
- npm -C web run lint (passes with existing warnings)
- git diff --check

Refs #44