### PR TITLE
Add rollback proposal artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ start the local server for you.
 | **AI Plan Fix** | When terraform plan fails, AI diagnoses and auto-fixes the issue |
 | **Security Scanner** | Graph-based checks: CIS, SOC2, HIPAA, OWASP compliance |
 | **Drift Monitor** | Run Terraform/OpenTofu state drift checks with classified findings, suppression rules, draft codify/revert PR payloads, and review artifacts |
-| **Recovery Checkpoints** | Successful apply runs record state/plan metadata and hashes for audit, drift, and future rollback workflows |
+| **Recovery Checkpoints** | Successful apply runs record state/plan metadata and hashes for audit, drift, and reviewed rollback proposal workflows |
 | **Multi-Format Export** | Export to Pulumi TypeScript, CDK Python, CloudFormation |
 | **Smart Suggestions** | AI predicts your next resource based on IaC best practices |
 | **Import Projects** | Browse filesystem, scan existing .tf/.yml files, auto-detect topology |
@@ -143,7 +143,7 @@ IaC Studio runs locally and is designed to be secure by default:
 - **Execution safety** — command timeouts, process group kill, approval gates
 - **Plan-before-apply** — server-side gate requires successful plan before apply
 - **Semantic plan review** — Terraform/OpenTofu plans are classified before apply; risky, destructive, or unknown changes require explicit acknowledgement
-- **Recovery checkpoints** — successful apply-style runs write metadata and state/plan hashes under `.iac-studio/snapshots`
+- **Recovery checkpoints** — successful apply-style runs write metadata and state/plan hashes under `.iac-studio/snapshots`; rollback requests generate review artifacts, not automatic undo actions
 - **Cloud target checks** — selected Cloud Connections are tested before command execution
 - **Secret redaction** — static credentials are not echoed in API responses, terminal messages, or generated IaC
 - **No telemetry** — zero data collection, no phone-home
@@ -206,6 +206,7 @@ All flags have sensible defaults. Just run `iac-studio` and go.
 - [x] Policy engine (15+ built-in guardrails)
 - [x] Cloud Connections for AWS, Azure, and GCP run targets
 - [x] Recovery checkpoint metadata for successful apply runs
+- [x] Reviewed rollback proposal artifacts from recovery checkpoints
 - [x] Cost estimation (30+ resource types)
 - [x] CI/CD pipeline generator (GitHub Actions, GitLab CI)
 - [x] Environment promotion (dev/staging/prod workspaces)

--- a/docs/index.html
+++ b/docs/index.html
@@ -618,6 +618,26 @@ gcloud config set project my-platform-dev</code></pre>
           <pre><code>.iac-studio/
   snapshots/
     20260610T120000Z-terraform-apply-dev-abc12345.json</code></pre>
+
+          <h3>Rollback proposals</h3>
+          <p>
+            Selecting a checkpoint can draft a rollback proposal. The proposal is intentionally
+            fail-closed: until a fresh rollback plan is generated and reviewed, the semantic plan
+            classifier marks the proposal as unknown and requires acknowledgement before any apply
+            path should proceed.
+          </p>
+
+          <div class="callout">
+            Rollback proposals are review artifacts. They do not mutate cloud infrastructure,
+            restore state, or bypass the normal plan, policy, and security gates.
+          </div>
+
+          <pre><code>.iac-studio/
+  rollbacks/
+    rollback-demo-terraform-dev-20260610t120000z-.../
+      README.md
+      proposal.md
+      proposal.json</code></pre>
         </section>
 
         <section id="ai" class="doc-section" data-title="ai setup ollama openai anthropic models settings environment variables">
@@ -791,8 +811,8 @@ ANTHROPIC_MODEL=claude-opus-4-7 \
                 </tr>
                 <tr>
                   <td>Modules, drift, export</td>
-                  <td><code>GET /api/projects/{name}/modules</code><br><code>GET /api/registry/modules/search</code><br><code>POST /api/projects/{name}/promote-to-module</code><br><code>GET /api/projects/{name}/snapshots</code><br><code>GET/POST /api/projects/{name}/drift</code><br><code>POST /api/projects/{name}/drift/remediation</code><br><code>POST /api/projects/{name}/drift/remediation/artifacts</code><br><code>GET /api/export/formats</code><br><code>POST /api/export</code></td>
-                  <td>Discover modules, promote resources, list recovery checkpoints, detect classified Terraform/OpenTofu state drift, draft codify/revert remediation PR payloads, write remediation review artifacts, and export alternate IaC formats.</td>
+                  <td><code>GET /api/projects/{name}/modules</code><br><code>GET /api/registry/modules/search</code><br><code>POST /api/projects/{name}/promote-to-module</code><br><code>GET /api/projects/{name}/snapshots</code><br><code>POST /api/projects/{name}/snapshots/{snapshotID}/rollback</code><br><code>POST /api/projects/{name}/snapshots/{snapshotID}/rollback/artifacts</code><br><code>GET/POST /api/projects/{name}/drift</code><br><code>POST /api/projects/{name}/drift/remediation</code><br><code>POST /api/projects/{name}/drift/remediation/artifacts</code><br><code>GET /api/export/formats</code><br><code>POST /api/export</code></td>
+                  <td>Discover modules, promote resources, list recovery checkpoints, draft rollback proposals, detect classified Terraform/OpenTofu state drift, draft codify/revert remediation PR payloads, write remediation review artifacts, and export alternate IaC formats.</td>
                 </tr>
                 <tr>
                   <td>Realtime</td>
@@ -824,6 +844,7 @@ Local project directory
   main.tf, index.ts, playbooks, modules
   .iac-studio.json
   .iac-studio/snapshots/*.json
+  .iac-studio/rollbacks/*/
   terraform.tfstate when present</code></pre>
 
           <h3>Repository layout</h3>

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -527,6 +527,69 @@ func writeRenderedRemediationArtifacts(projectPath string, rendered []drift.Rend
 	return nil
 }
 
+func writeRenderedRollbackArtifacts(projectPath string, rendered []recovery.RenderedRollbackArtifact) error {
+	for _, artifact := range rendered {
+		target, err := safeProjectFilePath(projectPath, artifact.Path)
+		if err != nil {
+			return err
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return fmt.Errorf("creating rollback artifact directory: %w", err)
+		}
+		if err := os.WriteFile(target, []byte(artifact.Content), 0o644); err != nil {
+			return fmt.Errorf("writing rollback artifact %s: %w", artifact.Path, err)
+		}
+	}
+	return nil
+}
+
+func buildProjectRollbackProposal(projectPath, projectName, snapshotID, env string) (recovery.RollbackProposal, int, string) {
+	if err := safePathSegment(snapshotID); err != nil {
+		return recovery.RollbackProposal{}, http.StatusBadRequest, "invalid snapshot id: " + err.Error()
+	}
+	if env != "" {
+		if err := safePathSegment(env); err != nil {
+			return recovery.RollbackProposal{}, http.StatusBadRequest, "invalid env: " + err.Error()
+		}
+	}
+	snapshots, err := recovery.ListSnapshots(projectPath)
+	if err != nil {
+		return recovery.RollbackProposal{}, http.StatusInternalServerError, err.Error()
+	}
+	var target *recovery.StateSnapshot
+	for i := range snapshots {
+		if snapshots[i].ID == snapshotID {
+			target = &snapshots[i]
+			break
+		}
+	}
+	if target == nil {
+		return recovery.RollbackProposal{}, http.StatusNotFound, "snapshot not found"
+	}
+	if env != "" && target.Env != env {
+		return recovery.RollbackProposal{}, http.StatusBadRequest, "snapshot does not belong to requested env"
+	}
+	var current *recovery.StateSnapshot
+	for i := range snapshots {
+		if snapshots[i].ID == target.ID {
+			continue
+		}
+		if snapshots[i].Tool == target.Tool && snapshots[i].Env == target.Env {
+			current = &snapshots[i]
+			break
+		}
+	}
+	proposal, err := recovery.BuildRollbackProposal(recovery.RollbackInput{
+		ProjectName:     projectName,
+		TargetSnapshot:  *target,
+		CurrentSnapshot: current,
+	})
+	if err != nil {
+		return recovery.RollbackProposal{}, http.StatusBadRequest, err.Error()
+	}
+	return proposal, http.StatusOK, ""
+}
+
 func safeProjectFilePath(projectPath, relPath string) (string, error) {
 	if strings.TrimSpace(relPath) == "" {
 		return "", errors.New("artifact path is required")
@@ -2143,6 +2206,78 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 			snapshots = filtered
 		}
 		_ = json.NewEncoder(w).Encode(snapshots)
+	})
+
+	mux.HandleFunc("POST /api/projects/{name}/snapshots/{snapshotID}/rollback", func(w http.ResponseWriter, r *http.Request) {
+		name := r.PathValue("name")
+		snapshotID := r.PathValue("snapshotID")
+		projectPath, err := safeProjectPath(projectsDir, name)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		limitBody(w, r)
+		var req struct {
+			Env string `json:"env,omitempty"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+			http.Error(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		if req.Env == "" {
+			req.Env = r.URL.Query().Get("env")
+		}
+		proposal, status, message := buildProjectRollbackProposal(projectPath, name, snapshotID, req.Env)
+		if status != http.StatusOK {
+			http.Error(w, message, status)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(proposal)
+	})
+
+	mux.HandleFunc("POST /api/projects/{name}/snapshots/{snapshotID}/rollback/artifacts", func(w http.ResponseWriter, r *http.Request) {
+		name := r.PathValue("name")
+		snapshotID := r.PathValue("snapshotID")
+		projectPath, err := safeProjectPath(projectsDir, name)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		limitBody(w, r)
+		var req struct {
+			Env      string                     `json:"env,omitempty"`
+			Proposal *recovery.RollbackProposal `json:"proposal,omitempty"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+			http.Error(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		if req.Env == "" {
+			req.Env = r.URL.Query().Get("env")
+		}
+
+		proposal, status, message := buildProjectRollbackProposal(projectPath, name, snapshotID, req.Env)
+		if status != http.StatusOK {
+			http.Error(w, message, status)
+			return
+		}
+		if req.Proposal != nil {
+			if req.Proposal.TargetSnapshot.ID != snapshotID {
+				http.Error(w, "request proposal must match snapshot id", http.StatusBadRequest)
+				return
+			}
+			proposal = *req.Proposal
+		}
+		artifactSet, rendered, err := recovery.RenderRollbackArtifacts(proposal, time.Now().UTC())
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if err := writeRenderedRollbackArtifacts(projectPath, rendered); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(artifactSet)
 	})
 
 	// ─── Drift Detection ───

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2232,6 +2232,7 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 			http.Error(w, message, status)
 			return
 		}
+		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(proposal)
 	})
 
@@ -2266,7 +2267,9 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 				http.Error(w, "request proposal must match snapshot id", http.StatusBadRequest)
 				return
 			}
-			proposal = *req.Proposal
+			// The submitted proposal is only a stale-request guard. Artifacts
+			// are always rendered from a fresh server-built proposal so clients
+			// cannot weaken fail-closed classification or scrub warnings.
 		}
 		artifactSet, rendered, err := recovery.RenderRollbackArtifacts(proposal, time.Now().UTC())
 		if err != nil {
@@ -2277,6 +2280,7 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(artifactSet)
 	})
 

--- a/internal/api/snapshots_test.go
+++ b/internal/api/snapshots_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	iacplan "github.com/iac-studio/iac-studio/internal/plan"
 	"github.com/iac-studio/iac-studio/internal/recovery"
 )
 
@@ -127,6 +128,9 @@ func TestCreateRollbackProposalForSnapshot(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("rollback status = %d", resp.StatusCode)
 	}
+	if got := resp.Header.Get("Content-Type"); !strings.Contains(got, "application/json") {
+		t.Fatalf("rollback content-type = %q, want application/json", got)
+	}
 
 	var proposal recovery.RollbackProposal
 	if err := json.NewDecoder(resp.Body).Decode(&proposal); err != nil {
@@ -184,6 +188,9 @@ func TestCreateRollbackArtifactsWritesReviewFiles(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("rollback artifacts status = %d", resp.StatusCode)
 	}
+	if got := resp.Header.Get("Content-Type"); !strings.Contains(got, "application/json") {
+		t.Fatalf("rollback artifacts content-type = %q, want application/json", got)
+	}
 
 	var set recovery.RollbackArtifactSet
 	if err := json.NewDecoder(resp.Body).Decode(&set); err != nil {
@@ -199,6 +206,91 @@ func TestCreateRollbackArtifactsWritesReviewFiles(t *testing.T) {
 	}
 	if !strings.Contains(string(data), "does not apply infrastructure changes automatically") {
 		t.Fatalf("runbook missing safety warning:\n%s", string(data))
+	}
+}
+
+func TestCreateRollbackArtifactsRebuildsServerProposal(t *testing.T) {
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "demo")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	target, err := recovery.RecordSnapshot(projectDir, projectDir, recovery.SnapshotInput{
+		Project: "demo",
+		Tool:    "terraform",
+		Command: "apply",
+	}, time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("record target snapshot: %v", err)
+	}
+	proposal, err := recovery.BuildRollbackProposal(recovery.RollbackInput{
+		ProjectName:    "demo",
+		TargetSnapshot: target,
+	})
+	if err != nil {
+		t.Fatalf("build proposal: %v", err)
+	}
+	proposal.Branch = "client-controlled-branch"
+	proposal.Body = "safe to apply"
+	proposal.Warnings = nil
+	proposal.Classification = &iacplan.ClassificationResult{
+		Summary: iacplan.ClassificationSummary{
+			Safe:                   1,
+			Total:                  1,
+			RequiresAcknowledgment: false,
+			Text:                   "Semantic plan: 1 safe change",
+		},
+	}
+	body, err := json.Marshal(map[string]any{"proposal": proposal})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	srv := httptest.NewServer(fullRouterForTest(t, root))
+	defer srv.Close()
+
+	resp, err := http.Post(
+		srv.URL+"/api/projects/demo/snapshots/"+target.ID+"/rollback/artifacts",
+		"application/json",
+		bytes.NewReader(body),
+	)
+	if err != nil {
+		t.Fatalf("POST rollback artifacts: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("rollback artifacts status = %d", resp.StatusCode)
+	}
+
+	var set recovery.RollbackArtifactSet
+	if err := json.NewDecoder(resp.Body).Decode(&set); err != nil {
+		t.Fatalf("decode rollback artifacts: %v", err)
+	}
+	if set.Proposal.Branch == "client-controlled-branch" || set.Proposal.Body == "safe to apply" {
+		t.Fatalf("artifact set should use server-built proposal, got %#v", set.Proposal)
+	}
+	if set.Proposal.Classification == nil ||
+		!set.Proposal.Classification.Summary.RequiresAcknowledgment ||
+		set.Proposal.Classification.Summary.Unknown != 1 {
+		t.Fatalf("artifact set should preserve fail-closed classification: %#v", set.Proposal.Classification)
+	}
+	if !strings.Contains(strings.Join(set.Proposal.Warnings, "\n"), "Generate and review a fresh plan") {
+		t.Fatalf("artifact set should preserve server warnings: %#v", set.Proposal.Warnings)
+	}
+
+	metadataPath := filepath.Join(projectDir, ".iac-studio", "rollbacks", set.ID, "proposal.json")
+	metadataData, err := os.ReadFile(metadataPath)
+	if err != nil {
+		t.Fatalf("read rollback metadata: %v", err)
+	}
+	var metadata recovery.RollbackArtifactSet
+	if err := json.Unmarshal(metadataData, &metadata); err != nil {
+		t.Fatalf("decode rollback metadata: %v", err)
+	}
+	if metadata.Proposal.Classification == nil ||
+		!metadata.Proposal.Classification.Summary.RequiresAcknowledgment ||
+		metadata.Proposal.Classification.Summary.Unknown != 1 {
+		t.Fatalf("metadata should preserve fail-closed classification: %#v", metadata.Proposal.Classification)
 	}
 }
 

--- a/internal/api/snapshots_test.go
+++ b/internal/api/snapshots_test.go
@@ -1,11 +1,13 @@
 package api
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -81,5 +83,165 @@ func TestListSnapshotsRejectsUnsafeEnvironmentFilter(t *testing.T) {
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("unsafe env status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestCreateRollbackProposalForSnapshot(t *testing.T) {
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "demo")
+	devDir := filepath.Join(projectDir, "environments", "dev")
+	if err := os.MkdirAll(devDir, 0o755); err != nil {
+		t.Fatalf("mkdir dev env: %v", err)
+	}
+	target, err := recovery.RecordSnapshot(projectDir, devDir, recovery.SnapshotInput{
+		Project: "demo",
+		Tool:    "terraform",
+		Env:     "dev",
+		Command: "apply",
+	}, time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("record target snapshot: %v", err)
+	}
+	current, err := recovery.RecordSnapshot(projectDir, devDir, recovery.SnapshotInput{
+		Project: "demo",
+		Tool:    "terraform",
+		Env:     "dev",
+		Command: "apply",
+	}, time.Date(2026, 6, 10, 13, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("record current snapshot: %v", err)
+	}
+
+	srv := httptest.NewServer(fullRouterForTest(t, root))
+	defer srv.Close()
+
+	resp, err := http.Post(
+		srv.URL+"/api/projects/demo/snapshots/"+target.ID+"/rollback",
+		"application/json",
+		strings.NewReader(`{"env":"dev"}`),
+	)
+	if err != nil {
+		t.Fatalf("POST rollback: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("rollback status = %d", resp.StatusCode)
+	}
+
+	var proposal recovery.RollbackProposal
+	if err := json.NewDecoder(resp.Body).Decode(&proposal); err != nil {
+		t.Fatalf("decode rollback proposal: %v", err)
+	}
+	if proposal.TargetSnapshot.ID != target.ID || proposal.CurrentSnapshot == nil || proposal.CurrentSnapshot.ID != current.ID {
+		t.Fatalf("unexpected snapshot linkage: %#v", proposal)
+	}
+	if proposal.Classification == nil || !proposal.Classification.Summary.RequiresAcknowledgment {
+		t.Fatalf("rollback proposal should include fail-closed classification: %#v", proposal.Classification)
+	}
+	if !strings.Contains(proposal.Body, "not an unconditional undo button") {
+		t.Fatalf("rollback body should explain review semantics:\n%s", proposal.Body)
+	}
+}
+
+func TestCreateRollbackArtifactsWritesReviewFiles(t *testing.T) {
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "demo")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	target, err := recovery.RecordSnapshot(projectDir, projectDir, recovery.SnapshotInput{
+		Project: "demo",
+		Tool:    "terraform",
+		Command: "apply",
+	}, time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("record target snapshot: %v", err)
+	}
+	proposal, err := recovery.BuildRollbackProposal(recovery.RollbackInput{
+		ProjectName:    "demo",
+		TargetSnapshot: target,
+	})
+	if err != nil {
+		t.Fatalf("build proposal: %v", err)
+	}
+
+	body, err := json.Marshal(map[string]any{"proposal": proposal})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	srv := httptest.NewServer(fullRouterForTest(t, root))
+	defer srv.Close()
+
+	resp, err := http.Post(
+		srv.URL+"/api/projects/demo/snapshots/"+target.ID+"/rollback/artifacts",
+		"application/json",
+		bytes.NewReader(body),
+	)
+	if err != nil {
+		t.Fatalf("POST rollback artifacts: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("rollback artifacts status = %d", resp.StatusCode)
+	}
+
+	var set recovery.RollbackArtifactSet
+	if err := json.NewDecoder(resp.Body).Decode(&set); err != nil {
+		t.Fatalf("decode rollback artifacts: %v", err)
+	}
+	if set.Proposal.TargetSnapshot.ID != target.ID || set.Root == "" {
+		t.Fatalf("unexpected artifact set: %#v", set)
+	}
+	runbook := filepath.Join(projectDir, ".iac-studio", "rollbacks", set.ID, "README.md")
+	data, err := os.ReadFile(runbook)
+	if err != nil {
+		t.Fatalf("read rollback runbook: %v", err)
+	}
+	if !strings.Contains(string(data), "does not apply infrastructure changes automatically") {
+		t.Fatalf("runbook missing safety warning:\n%s", string(data))
+	}
+}
+
+func TestCreateRollbackArtifactsRejectsMismatchedProposal(t *testing.T) {
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "demo")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	target, err := recovery.RecordSnapshot(projectDir, projectDir, recovery.SnapshotInput{
+		Project: "demo",
+		Tool:    "terraform",
+		Command: "apply",
+	}, time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("record target snapshot: %v", err)
+	}
+	proposal, err := recovery.BuildRollbackProposal(recovery.RollbackInput{
+		ProjectName:    "demo",
+		TargetSnapshot: target,
+	})
+	if err != nil {
+		t.Fatalf("build proposal: %v", err)
+	}
+	proposal.TargetSnapshot.ID = "other-snapshot"
+	body, err := json.Marshal(map[string]any{"proposal": proposal})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	srv := httptest.NewServer(fullRouterForTest(t, root))
+	defer srv.Close()
+
+	resp, err := http.Post(
+		srv.URL+"/api/projects/demo/snapshots/"+target.ID+"/rollback/artifacts",
+		"application/json",
+		bytes.NewReader(body),
+	)
+	if err != nil {
+		t.Fatalf("POST rollback artifacts mismatch: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("rollback artifacts mismatch status = %d, want 400", resp.StatusCode)
 	}
 }

--- a/internal/recovery/rollback.go
+++ b/internal/recovery/rollback.go
@@ -1,0 +1,302 @@
+package recovery
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	iacplan "github.com/iac-studio/iac-studio/internal/plan"
+)
+
+const rollbackArtifactRoot = ".iac-studio/rollbacks"
+
+// RollbackProposal is a review artifact, not an executable undo operation. It
+// identifies the target checkpoint and carries a fail-closed semantic
+// classification until a generated rollback plan is reviewed.
+type RollbackProposal struct {
+	ID              string                        `json:"id"`
+	Title           string                        `json:"title"`
+	Branch          string                        `json:"branch"`
+	CommitMessage   string                        `json:"commit_message"`
+	Body            string                        `json:"body"`
+	Tool            string                        `json:"tool"`
+	Env             string                        `json:"env,omitempty"`
+	WorkDir         string                        `json:"work_dir"`
+	TargetSnapshot  StateSnapshot                 `json:"target_snapshot"`
+	CurrentSnapshot *StateSnapshot                `json:"current_snapshot,omitempty"`
+	Classification  *iacplan.ClassificationResult `json:"classification"`
+	Warnings        []string                      `json:"warnings,omitempty"`
+}
+
+type RollbackInput struct {
+	ProjectName     string
+	TargetSnapshot  StateSnapshot
+	CurrentSnapshot *StateSnapshot
+}
+
+type RollbackArtifactSet struct {
+	ID        string                 `json:"id"`
+	Root      string                 `json:"root"`
+	CreatedAt time.Time              `json:"created_at"`
+	Proposal  RollbackProposal       `json:"proposal"`
+	Files     []RollbackArtifactFile `json:"files"`
+}
+
+type RollbackArtifactFile struct {
+	Path    string `json:"path"`
+	Kind    string `json:"kind"`
+	Summary string `json:"summary"`
+	Size    int    `json:"size"`
+}
+
+type RenderedRollbackArtifact struct {
+	RollbackArtifactFile
+	Content string `json:"-"`
+}
+
+func BuildRollbackProposal(input RollbackInput) (RollbackProposal, error) {
+	projectName := strings.TrimSpace(input.ProjectName)
+	if projectName == "" {
+		projectName = input.TargetSnapshot.Project
+	}
+	if strings.TrimSpace(projectName) == "" {
+		return RollbackProposal{}, errors.New("project name is required")
+	}
+	if strings.TrimSpace(input.TargetSnapshot.ID) == "" {
+		return RollbackProposal{}, errors.New("target snapshot is required")
+	}
+
+	id := rollbackID(projectName, input.TargetSnapshot)
+	proposal := RollbackProposal{
+		ID:              id,
+		Title:           fmt.Sprintf("Rollback %s to checkpoint %s", projectName, input.TargetSnapshot.ID),
+		Branch:          "iac-studio-rollback-" + slug(projectName) + "-" + slug(input.TargetSnapshot.ID),
+		CommitMessage:   fmt.Sprintf("Document rollback proposal for %s", projectName),
+		Tool:            input.TargetSnapshot.Tool,
+		Env:             input.TargetSnapshot.Env,
+		WorkDir:         input.TargetSnapshot.WorkDir,
+		TargetSnapshot:  input.TargetSnapshot,
+		CurrentSnapshot: input.CurrentSnapshot,
+		Classification: iacplan.UnknownClassification(
+			"rollback reverse plan has not been generated yet; create and review a fresh plan before applying",
+		),
+		Warnings: rollbackWarnings(input.TargetSnapshot),
+	}
+	proposal.Body = renderRollbackBody(proposal)
+	return proposal, nil
+}
+
+func RenderRollbackArtifacts(proposal RollbackProposal, createdAt time.Time) (RollbackArtifactSet, []RenderedRollbackArtifact, error) {
+	if strings.TrimSpace(proposal.ID) == "" {
+		return RollbackArtifactSet{}, nil, errors.New("rollback proposal id is required")
+	}
+	if strings.TrimSpace(proposal.Title) == "" {
+		return RollbackArtifactSet{}, nil, errors.New("rollback proposal title is required")
+	}
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC()
+	} else {
+		createdAt = createdAt.UTC()
+	}
+
+	root := rollbackArtifactRoot + "/" + cleanArtifactSegment(proposal.ID)
+	rendered := []RenderedRollbackArtifact{
+		{
+			RollbackArtifactFile: RollbackArtifactFile{
+				Path:    root + "/README.md",
+				Kind:    "runbook",
+				Summary: "Human-readable rollback review runbook.",
+			},
+			Content: renderRollbackRunbook(proposal, createdAt),
+		},
+		{
+			RollbackArtifactFile: RollbackArtifactFile{
+				Path:    root + "/proposal.md",
+				Kind:    "proposal",
+				Summary: "Markdown rollback proposal for code review.",
+			},
+			Content: proposal.Body,
+		},
+	}
+
+	metadataContent, err := renderRollbackMetadata(root, createdAt, proposal, rendered)
+	if err != nil {
+		return RollbackArtifactSet{}, nil, err
+	}
+	rendered = append(rendered, RenderedRollbackArtifact{
+		RollbackArtifactFile: RollbackArtifactFile{
+			Path:    root + "/proposal.json",
+			Kind:    "metadata",
+			Summary: "Machine-readable rollback proposal metadata.",
+		},
+		Content: metadataContent,
+	})
+
+	set := RollbackArtifactSet{
+		ID:        cleanArtifactSegment(proposal.ID),
+		Root:      root,
+		CreatedAt: createdAt,
+		Proposal:  proposal,
+		Files:     make([]RollbackArtifactFile, 0, len(rendered)),
+	}
+	for i := range rendered {
+		rendered[i].Size = len(rendered[i].Content)
+		set.Files = append(set.Files, rendered[i].RollbackArtifactFile)
+	}
+	return set, rendered, nil
+}
+
+func rollbackWarnings(target StateSnapshot) []string {
+	warnings := []string{
+		"This proposal does not apply infrastructure changes automatically.",
+		"Generate and review a fresh plan before applying any rollback.",
+	}
+	if target.StatePath == "" {
+		warnings = append(warnings, "The target checkpoint has no local state file metadata.")
+	}
+	if target.PlanPath == "" {
+		warnings = append(warnings, "The target checkpoint has no saved plan metadata.")
+	}
+	switch target.Tool {
+	case "terraform", "opentofu":
+	default:
+		warnings = append(warnings, "Semantic rollback plan classification is currently fail-closed for this tool.")
+	}
+	return warnings
+}
+
+func rollbackID(projectName string, target StateSnapshot) string {
+	parts := []string{"rollback", slug(projectName), slug(target.Tool)}
+	if target.Env != "" {
+		parts = append(parts, slug(target.Env))
+	}
+	parts = append(parts, slug(target.ID))
+	return strings.Join(parts, "-")
+}
+
+func renderRollbackBody(proposal RollbackProposal) string {
+	var b strings.Builder
+	b.WriteString("## Summary\n")
+	b.WriteString("IaC Studio generated this rollback proposal for review. It is not an unconditional undo button and does not apply changes automatically.\n\n")
+	b.WriteString("## Target checkpoint\n")
+	writeSnapshotBullets(&b, proposal.TargetSnapshot)
+	if proposal.CurrentSnapshot != nil {
+		b.WriteString("\n## Current checkpoint\n")
+		writeSnapshotBullets(&b, *proposal.CurrentSnapshot)
+	}
+	b.WriteString("\n## Classification\n")
+	if proposal.Classification != nil {
+		b.WriteString("- Semantic result: `")
+		b.WriteString(proposal.Classification.Summary.Text)
+		b.WriteString("`\n")
+		b.WriteString("- Requires acknowledgement: `")
+		b.WriteString(fmt.Sprintf("%t", proposal.Classification.Summary.RequiresAcknowledgment))
+		b.WriteString("`\n")
+	}
+	b.WriteString("\n## Required review steps\n")
+	b.WriteString("- Restore or generate the rollback candidate from the target checkpoint and current cloud state.\n")
+	b.WriteString("- Run init and plan in the recorded work directory.\n")
+	b.WriteString("- Confirm the generated plan matches the intended rollback, then run semantic plan classification.\n")
+	b.WriteString("- Run policy and security checks before any apply.\n")
+	b.WriteString("- Apply only after reviewers acknowledge risky, destructive, or unknown changes.\n")
+	if len(proposal.Warnings) > 0 {
+		b.WriteString("\n## Warnings\n")
+		for _, warning := range proposal.Warnings {
+			b.WriteString("- ")
+			b.WriteString(warning)
+			b.WriteByte('\n')
+		}
+	}
+	return b.String()
+}
+
+func writeSnapshotBullets(b *strings.Builder, snapshot StateSnapshot) {
+	b.WriteString(fmt.Sprintf("- ID: `%s`\n", snapshot.ID))
+	b.WriteString(fmt.Sprintf("- Tool: `%s`\n", snapshot.Tool))
+	if snapshot.Env != "" {
+		b.WriteString(fmt.Sprintf("- Environment: `%s`\n", snapshot.Env))
+	}
+	if snapshot.WorkDir != "" {
+		b.WriteString(fmt.Sprintf("- Work directory: `%s`\n", snapshot.WorkDir))
+	}
+	b.WriteString(fmt.Sprintf("- Command: `%s`\n", snapshot.Command))
+	b.WriteString(fmt.Sprintf("- Created: `%s`\n", snapshot.CreatedAt.Format(time.RFC3339)))
+	if snapshot.StatePath != "" {
+		b.WriteString(fmt.Sprintf("- State: `%s` (`%s`)\n", snapshot.StatePath, shortHash(snapshot.StateSHA)))
+	}
+	if snapshot.PlanPath != "" {
+		b.WriteString(fmt.Sprintf("- Saved plan: `%s` (`%s`)\n", snapshot.PlanPath, shortHash(snapshot.PlanSHA)))
+	}
+}
+
+func renderRollbackRunbook(proposal RollbackProposal, createdAt time.Time) string {
+	var b strings.Builder
+	b.WriteString("# ")
+	b.WriteString(proposal.Title)
+	b.WriteString("\n\n")
+	b.WriteString("Generated by IaC Studio for human review. This artifact does not apply infrastructure changes automatically.\n\n")
+	b.WriteString("## PR metadata\n")
+	b.WriteString(fmt.Sprintf("- Branch: `%s`\n", proposal.Branch))
+	b.WriteString(fmt.Sprintf("- Commit message: `%s`\n", proposal.CommitMessage))
+	b.WriteString(fmt.Sprintf("- Generated: `%s`\n", createdAt.Format(time.RFC3339)))
+	b.WriteString(fmt.Sprintf("- Tool: `%s`\n", proposal.Tool))
+	if proposal.Env != "" {
+		b.WriteString(fmt.Sprintf("- Environment: `%s`\n", proposal.Env))
+	}
+	b.WriteString("\n")
+	b.WriteString(proposal.Body)
+	b.WriteString("\n\n## Operator checklist\n")
+	b.WriteString("- Do not apply this proposal directly.\n")
+	b.WriteString("- Generate a fresh rollback plan from the target checkpoint.\n")
+	b.WriteString("- Run semantic plan classification and policy gates before apply.\n")
+	b.WriteString("- Preserve this artifact with the incident or change record.\n")
+	return b.String()
+}
+
+func renderRollbackMetadata(root string, createdAt time.Time, proposal RollbackProposal, rendered []RenderedRollbackArtifact) (string, error) {
+	files := make([]RollbackArtifactFile, 0, len(rendered)+1)
+	for _, file := range rendered {
+		files = append(files, RollbackArtifactFile{
+			Path:    file.Path,
+			Kind:    file.Kind,
+			Summary: file.Summary,
+			Size:    len(file.Content),
+		})
+	}
+	files = append(files, RollbackArtifactFile{
+		Path:    root + "/proposal.json",
+		Kind:    "metadata",
+		Summary: "Machine-readable rollback proposal metadata.",
+	})
+	payload := struct {
+		ID        string                 `json:"id"`
+		Root      string                 `json:"root"`
+		CreatedAt time.Time              `json:"created_at"`
+		Proposal  RollbackProposal       `json:"proposal"`
+		Files     []RollbackArtifactFile `json:"files"`
+	}{
+		ID:        cleanArtifactSegment(proposal.ID),
+		Root:      root,
+		CreatedAt: createdAt,
+		Proposal:  proposal,
+		Files:     files,
+	}
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("rendering rollback metadata: %w", err)
+	}
+	return string(data) + "\n", nil
+}
+
+func cleanArtifactSegment(value string) string {
+	return slug(value)
+}
+
+func shortHash(value string) string {
+	if len(value) <= 12 {
+		return value
+	}
+	return value[:12]
+}

--- a/internal/recovery/rollback.go
+++ b/internal/recovery/rollback.go
@@ -265,11 +265,26 @@ func renderRollbackMetadata(root string, createdAt time.Time, proposal RollbackP
 			Size:    len(file.Content),
 		})
 	}
-	files = append(files, RollbackArtifactFile{
+	metadataFile := RollbackArtifactFile{
 		Path:    root + "/proposal.json",
 		Kind:    "metadata",
 		Summary: "Machine-readable rollback proposal metadata.",
-	})
+	}
+	for range 8 {
+		content, err := marshalRollbackMetadata(cleanArtifactSegment(proposal.ID), root, createdAt, proposal, append(files, metadataFile))
+		if err != nil {
+			return "", err
+		}
+		size := len(content)
+		if metadataFile.Size == size {
+			return content, nil
+		}
+		metadataFile.Size = size
+	}
+	return marshalRollbackMetadata(cleanArtifactSegment(proposal.ID), root, createdAt, proposal, append(files, metadataFile))
+}
+
+func marshalRollbackMetadata(id, root string, createdAt time.Time, proposal RollbackProposal, files []RollbackArtifactFile) (string, error) {
 	payload := struct {
 		ID        string                 `json:"id"`
 		Root      string                 `json:"root"`
@@ -277,7 +292,7 @@ func renderRollbackMetadata(root string, createdAt time.Time, proposal RollbackP
 		Proposal  RollbackProposal       `json:"proposal"`
 		Files     []RollbackArtifactFile `json:"files"`
 	}{
-		ID:        cleanArtifactSegment(proposal.ID),
+		ID:        id,
 		Root:      root,
 		CreatedAt: createdAt,
 		Proposal:  proposal,

--- a/internal/recovery/rollback_test.go
+++ b/internal/recovery/rollback_test.go
@@ -130,4 +130,8 @@ func TestRenderRollbackArtifactsIncludesRunbookAndMetadata(t *testing.T) {
 	if metadata.Proposal.ID != proposal.ID || metadata.Files[0].Size == 0 {
 		t.Fatalf("unexpected metadata: %#v", metadata)
 	}
+	metadataFile := metadata.Files[len(metadata.Files)-1]
+	if metadataFile.Path != set.Root+"/proposal.json" || metadataFile.Size != len(contents[set.Root+"/proposal.json"]) {
+		t.Fatalf("metadata self-size = %#v, content length = %d", metadataFile, len(contents[set.Root+"/proposal.json"]))
+	}
 }

--- a/internal/recovery/rollback_test.go
+++ b/internal/recovery/rollback_test.go
@@ -1,0 +1,133 @@
+package recovery
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBuildRollbackProposalIsFailClosedAndExplicit(t *testing.T) {
+	target := StateSnapshot{
+		ID:        "20260610T120000Z-terraform-apply-dev-abc12345",
+		Project:   "demo",
+		Tool:      "terraform",
+		Env:       "dev",
+		Command:   "apply",
+		WorkDir:   "environments/dev",
+		StatePath: "environments/dev/terraform.tfstate",
+		StateSHA:  "abc1234567890abcdef",
+		PlanPath:  "environments/dev/tfplan.json",
+		PlanSHA:   "def4567890abcdef",
+		CreatedAt: time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC),
+	}
+	current := target
+	current.ID = "20260610T130000Z-terraform-apply-dev-current"
+	current.CreatedAt = target.CreatedAt.Add(time.Hour)
+
+	proposal, err := BuildRollbackProposal(RollbackInput{
+		ProjectName:     "demo",
+		TargetSnapshot:  target,
+		CurrentSnapshot: &current,
+	})
+	if err != nil {
+		t.Fatalf("build rollback proposal: %v", err)
+	}
+
+	if proposal.ID == "" || proposal.Branch == "" || proposal.CommitMessage == "" {
+		t.Fatalf("expected PR metadata to be populated: %#v", proposal)
+	}
+	if proposal.TargetSnapshot.ID != target.ID || proposal.CurrentSnapshot == nil || proposal.CurrentSnapshot.ID != current.ID {
+		t.Fatalf("unexpected snapshot linkage: %#v", proposal)
+	}
+	if proposal.Classification == nil ||
+		!proposal.Classification.Summary.RequiresAcknowledgment ||
+		proposal.Classification.Summary.Unknown != 1 {
+		t.Fatalf("rollback proposal should fail closed with unknown classification: %#v", proposal.Classification)
+	}
+	for _, want := range []string{
+		"not an unconditional undo button",
+		"run semantic plan classification",
+		target.ID,
+		current.ID,
+	} {
+		if !strings.Contains(proposal.Body, want) {
+			t.Fatalf("proposal body missing %q:\n%s", want, proposal.Body)
+		}
+	}
+}
+
+func TestBuildRollbackProposalWarnsWhenCheckpointLacksArtifacts(t *testing.T) {
+	proposal, err := BuildRollbackProposal(RollbackInput{
+		ProjectName: "demo",
+		TargetSnapshot: StateSnapshot{
+			ID:        "ansible-checkpoint",
+			Project:   "demo",
+			Tool:      "ansible",
+			Command:   "playbook",
+			CreatedAt: time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC),
+		},
+	})
+	if err != nil {
+		t.Fatalf("build rollback proposal: %v", err)
+	}
+
+	warnings := strings.Join(proposal.Warnings, "\n")
+	for _, want := range []string{
+		"no local state file metadata",
+		"no saved plan metadata",
+		"fail-closed for this tool",
+	} {
+		if !strings.Contains(warnings, want) {
+			t.Fatalf("warnings missing %q: %#v", want, proposal.Warnings)
+		}
+	}
+}
+
+func TestRenderRollbackArtifactsIncludesRunbookAndMetadata(t *testing.T) {
+	proposal, err := BuildRollbackProposal(RollbackInput{
+		ProjectName: "demo",
+		TargetSnapshot: StateSnapshot{
+			ID:        "checkpoint-1",
+			Project:   "demo",
+			Tool:      "terraform",
+			Command:   "apply",
+			CreatedAt: time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC),
+		},
+	})
+	if err != nil {
+		t.Fatalf("build rollback proposal: %v", err)
+	}
+
+	set, rendered, err := RenderRollbackArtifacts(proposal, time.Date(2026, 6, 10, 14, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("render rollback artifacts: %v", err)
+	}
+
+	if set.ID != "rollback-demo-terraform-checkpoint-1" {
+		t.Fatalf("artifact set id = %q", set.ID)
+	}
+	if set.Root != ".iac-studio/rollbacks/rollback-demo-terraform-checkpoint-1" {
+		t.Fatalf("artifact root = %q", set.Root)
+	}
+	if len(rendered) != 3 || len(set.Files) != 3 {
+		t.Fatalf("rendered %d artifacts, set has %d files", len(rendered), len(set.Files))
+	}
+	contents := map[string]string{}
+	for _, artifact := range rendered {
+		contents[artifact.Path] = artifact.Content
+	}
+	if !strings.Contains(contents[set.Root+"/README.md"], "does not apply infrastructure changes automatically") {
+		t.Fatalf("runbook missing safety warning:\n%s", contents[set.Root+"/README.md"])
+	}
+	if contents[set.Root+"/proposal.md"] != proposal.Body {
+		t.Fatal("proposal markdown should match proposal body")
+	}
+	var metadata RollbackArtifactSet
+	if err := json.Unmarshal([]byte(contents[set.Root+"/proposal.json"]), &metadata); err != nil {
+		t.Fatalf("metadata json: %v", err)
+	}
+	if metadata.Proposal.ID != proposal.ID || metadata.Files[0].Size == 0 {
+		t.Fatalf("unexpected metadata: %#v", metadata)
+	}
+}

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -366,6 +366,126 @@ describe('api.listStateSnapshots', () => {
   });
 });
 
+describe('api.createRollbackProposal', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('posts rollback proposal requests for a selected checkpoint', async () => {
+    const response = {
+      id: 'rollback-demo-terraform-dev-checkpoint',
+      title: 'Rollback demo to checkpoint checkpoint',
+      branch: 'iac-studio-rollback-demo-checkpoint',
+      commit_message: 'Document rollback proposal for demo',
+      body: '## Summary',
+      tool: 'terraform',
+      env: 'dev',
+      work_dir: 'environments/dev',
+      target_snapshot: {
+        id: 'checkpoint',
+        project: 'demo',
+        tool: 'terraform',
+        env: 'dev',
+        command: 'apply',
+        work_dir: 'environments/dev',
+        created_at: '2026-06-10T12:00:00Z',
+        status: 'recorded',
+      },
+      classification: {
+        summary: {
+          safe: 0,
+          risky: 0,
+          destructive: 0,
+          unknown: 1,
+          total: 1,
+          requires_acknowledgment: true,
+          text: 'Semantic plan: 1 unknown change',
+        },
+        changes: [],
+      },
+      warnings: ['Generate and review a fresh plan before applying any rollback.'],
+    };
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(response), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(api.createRollbackProposal('demo', 'checkpoint', { env: 'dev' })).resolves.toEqual(response);
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/projects/demo/snapshots/checkpoint/rollback', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ env: 'dev' }),
+    });
+  });
+});
+
+describe('api.createRollbackArtifacts', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('posts rollback artifact generation requests with the reviewed proposal', async () => {
+    const proposal = {
+      id: 'rollback-demo-terraform-dev-checkpoint',
+      title: 'Rollback demo to checkpoint checkpoint',
+      branch: 'iac-studio-rollback-demo-checkpoint',
+      commit_message: 'Document rollback proposal for demo',
+      body: '## Summary',
+      tool: 'terraform',
+      env: 'dev',
+      work_dir: 'environments/dev',
+      target_snapshot: {
+        id: 'checkpoint',
+        project: 'demo',
+        tool: 'terraform',
+        env: 'dev',
+        command: 'apply',
+        work_dir: 'environments/dev',
+        created_at: '2026-06-10T12:00:00Z',
+        status: 'recorded',
+      },
+      classification: {
+        summary: {
+          safe: 0,
+          risky: 0,
+          destructive: 0,
+          unknown: 1,
+          total: 1,
+          requires_acknowledgment: true,
+          text: 'Semantic plan: 1 unknown change',
+        },
+        changes: [],
+      },
+    };
+    const response = {
+      id: 'rollback-demo-terraform-dev-checkpoint',
+      root: '.iac-studio/rollbacks/rollback-demo-terraform-dev-checkpoint',
+      created_at: '2026-06-10T13:00:00Z',
+      proposal,
+      files: [],
+    };
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(response), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(api.createRollbackArtifacts('demo', 'checkpoint', { env: 'dev', proposal })).resolves.toEqual(response);
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/projects/demo/snapshots/checkpoint/rollback/artifacts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ env: 'dev', proposal }),
+    });
+  });
+});
+
 describe('api.suggest', () => {
   afterEach(() => {
     vi.unstubAllGlobals();

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -282,6 +282,36 @@ export interface StateSnapshot {
   notes?: string[];
 }
 
+export interface RollbackProposal {
+  id: string;
+  title: string;
+  branch: string;
+  commit_message: string;
+  body: string;
+  tool: string;
+  env?: string;
+  work_dir: string;
+  target_snapshot: StateSnapshot;
+  current_snapshot?: StateSnapshot;
+  classification: PlanClassification;
+  warnings?: string[];
+}
+
+export interface RollbackArtifactFile {
+  path: string;
+  kind: string;
+  summary: string;
+  size: number;
+}
+
+export interface RollbackArtifactSet {
+  id: string;
+  root: string;
+  created_at: string;
+  proposal: RollbackProposal;
+  files: RollbackArtifactFile[];
+}
+
 // Checks res.ok and throws with the backend's error message instead of
 // letting callers hit an opaque JSON parse failure on text/plain errors.
 async function check(res: Response): Promise<Response> {
@@ -569,6 +599,24 @@ export const api = {
     if (env) params.set('env', env);
     const query = params.toString();
     const res = await fetch(`${BASE}/api/projects/${projectName}/snapshots${query ? `?${query}` : ''}`);
+    return (await check(res)).json();
+  },
+
+  async createRollbackProposal(projectName: string, snapshotId: string, req: { env?: string } = {}): Promise<RollbackProposal> {
+    const res = await fetch(`${BASE}/api/projects/${projectName}/snapshots/${snapshotId}/rollback`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(req),
+    });
+    return (await check(res)).json();
+  },
+
+  async createRollbackArtifacts(projectName: string, snapshotId: string, req: { env?: string; proposal?: RollbackProposal } = {}): Promise<RollbackArtifactSet> {
+    const res = await fetch(`${BASE}/api/projects/${projectName}/snapshots/${snapshotId}/rollback/artifacts`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(req),
+    });
     return (await check(res)).json();
   },
 

--- a/web/src/components/DriftPanel/DriftPanel.test.tsx
+++ b/web/src/components/DriftPanel/DriftPanel.test.tsx
@@ -85,6 +85,86 @@ describe('DriftPanel', () => {
     expect(screen.getByText(/plan environments\/dev\/tfplan\.json def4567890ab/)).toBeInTheDocument();
   });
 
+  it('drafts rollback proposals and writes review artifacts from checkpoints', async () => {
+    const snapshot = {
+      id: '20260610T120000Z-terraform-apply-dev-abc12345',
+      project: 'demo',
+      tool: 'terraform',
+      env: 'dev',
+      command: 'apply',
+      work_dir: 'environments/dev',
+      state_path: 'environments/dev/terraform.tfstate',
+      state_sha256: 'abc1234567890abcdef',
+      state_size: 42,
+      created_at: '2026-06-10T12:00:00Z',
+      status: 'recorded',
+    };
+    const proposal = {
+      id: 'rollback-demo-terraform-dev-checkpoint',
+      title: 'Rollback demo to checkpoint 20260610T120000Z-terraform-apply-dev-abc12345',
+      branch: 'iac-studio-rollback-demo-checkpoint',
+      commit_message: 'Document rollback proposal for demo',
+      body: '## Summary',
+      tool: 'terraform',
+      env: 'dev',
+      work_dir: 'environments/dev',
+      target_snapshot: snapshot,
+      classification: {
+        summary: {
+          safe: 0,
+          risky: 0,
+          destructive: 0,
+          unknown: 1,
+          total: 1,
+          requires_acknowledgment: true,
+          text: 'Semantic plan: 1 unknown change',
+        },
+        changes: [],
+      },
+      warnings: ['Generate and review a fresh plan before applying any rollback.'],
+    };
+    const client = {
+      runDrift: vi.fn(),
+      listStateSnapshots: vi.fn().mockResolvedValue([snapshot]),
+      createRollbackProposal: vi.fn().mockResolvedValue(proposal),
+      createRollbackArtifacts: vi.fn().mockResolvedValue({
+        id: 'rollback-demo-terraform-dev-checkpoint',
+        root: '.iac-studio/rollbacks/rollback-demo-terraform-dev-checkpoint',
+        created_at: '2026-06-10T13:00:00Z',
+        proposal,
+        files: [
+          {
+            path: '.iac-studio/rollbacks/rollback-demo-terraform-dev-checkpoint/README.md',
+            kind: 'runbook',
+            summary: 'Human-readable rollback review runbook.',
+            size: 100,
+          },
+        ],
+      }),
+    };
+
+    render(<DriftPanel projectName="demo" tool="terraform" env="dev" client={client} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Load' }));
+    expect(await screen.findByText('terraform apply')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Rollback proposal' }));
+
+    await waitFor(() => {
+      expect(client.createRollbackProposal).toHaveBeenCalledWith('demo', snapshot.id, { env: 'dev' });
+    });
+    expect(await screen.findByText(proposal.title)).toBeInTheDocument();
+    expect(screen.getByText(/Not an automatic undo/)).toBeInTheDocument();
+    expect(screen.getByText('Generate and review a fresh plan before applying any rollback.')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Write artifacts' }));
+
+    await waitFor(() => {
+      expect(client.createRollbackArtifacts).toHaveBeenCalledWith('demo', snapshot.id, { env: 'dev', proposal });
+    });
+    expect(await screen.findByText('Rollback artifacts written')).toBeInTheDocument();
+    expect(screen.getByText('.iac-studio/rollbacks/rollback-demo-terraform-dev-checkpoint/README.md')).toBeInTheDocument();
+  });
+
   it('drafts a remediation PR proposal for active findings', async () => {
     const client = {
       runDrift: vi.fn().mockResolvedValue({

--- a/web/src/components/DriftPanel/DriftPanel.tsx
+++ b/web/src/components/DriftPanel/DriftPanel.tsx
@@ -8,6 +8,8 @@ import {
   type DriftRemediationMode,
   type DriftRemediationProposal,
   type DriftReport,
+  type RollbackArtifactSet,
+  type RollbackProposal,
   type StateSnapshot,
 } from '../../api';
 import { Button } from '../ui/button';
@@ -16,7 +18,13 @@ export interface DriftPanelProps {
   projectName: string;
   tool?: string;
   env?: string;
-  client?: Pick<typeof api, 'runDrift'> & Partial<Pick<typeof api, 'createDriftRemediation' | 'createDriftRemediationArtifacts' | 'listStateSnapshots'>>;
+  client?: Pick<typeof api, 'runDrift'> & Partial<Pick<typeof api,
+    'createDriftRemediation' |
+    'createDriftRemediationArtifacts' |
+    'listStateSnapshots' |
+    'createRollbackProposal' |
+    'createRollbackArtifacts'
+  >>;
 }
 
 const SUPPORTED_TOOLS = new Set(['terraform', 'opentofu']);
@@ -96,18 +104,25 @@ export function DriftPanel({
   const [proposal, setProposal] = useState<DriftRemediationProposal | null>(null);
   const [artifacts, setArtifacts] = useState<DriftRemediationArtifactSet | null>(null);
   const [snapshots, setSnapshots] = useState<StateSnapshot[]>([]);
+  const [rollbackProposal, setRollbackProposal] = useState<RollbackProposal | null>(null);
+  const [rollbackArtifacts, setRollbackArtifacts] = useState<RollbackArtifactSet | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [proposalError, setProposalError] = useState<string | null>(null);
   const [artifactError, setArtifactError] = useState<string | null>(null);
   const [snapshotError, setSnapshotError] = useState<string | null>(null);
+  const [rollbackError, setRollbackError] = useState<string | null>(null);
+  const [rollbackArtifactError, setRollbackArtifactError] = useState<string | null>(null);
   const [loadingSnapshots, setLoadingSnapshots] = useState(false);
   const [snapshotsLoaded, setSnapshotsLoaded] = useState(false);
+  const [draftingRollbackID, setDraftingRollbackID] = useState<string | null>(null);
+  const [writingRollbackArtifacts, setWritingRollbackArtifacts] = useState(false);
   const supported = SUPPORTED_TOOLS.has(tool);
   const findings = useMemo(() => normalizeFindings(report), [report]);
   const suppressedFindings = useMemo(() => normalizeSuppressedFindings(report), [report]);
   const classifications = useMemo(() => normalizeClassifications(report), [report]);
   const canDraftRemediation = supported && findings.length > 0 && Boolean(client.createDriftRemediation);
   const canListSnapshots = Boolean(client.listStateSnapshots);
+  const canDraftRollback = Boolean(client.createRollbackProposal);
 
   const run = async () => {
     if (!supported) return;
@@ -174,10 +189,43 @@ export function DriftPanel({
       const response = await client.listStateSnapshots(projectName, env);
       setSnapshots(response);
       setSnapshotsLoaded(true);
+      setRollbackError(null);
     } catch (err) {
       setSnapshotError(String(err));
     } finally {
       setLoadingSnapshots(false);
+    }
+  };
+
+  const draftRollback = async (snapshot: StateSnapshot) => {
+    if (!client.createRollbackProposal) return;
+    setDraftingRollbackID(snapshot.id);
+    setRollbackError(null);
+    setRollbackArtifactError(null);
+    setRollbackProposal(null);
+    setRollbackArtifacts(null);
+    try {
+      const response = await client.createRollbackProposal(projectName, snapshot.id, { env });
+      setRollbackProposal(response);
+    } catch (err) {
+      setRollbackError(String(err));
+    } finally {
+      setDraftingRollbackID(null);
+    }
+  };
+
+  const writeRollbackArtifacts = async () => {
+    if (!rollbackProposal || !client.createRollbackArtifacts) return;
+    setWritingRollbackArtifacts(true);
+    setRollbackArtifactError(null);
+    setRollbackArtifacts(null);
+    try {
+      const response = await client.createRollbackArtifacts(projectName, rollbackProposal.target_snapshot.id, { env, proposal: rollbackProposal });
+      setRollbackArtifacts(response);
+    } catch (err) {
+      setRollbackArtifactError(String(err));
+    } finally {
+      setWritingRollbackArtifacts(false);
     }
   };
 
@@ -253,9 +301,23 @@ export function DriftPanel({
                     <span className="truncate font-mono text-[10px] font-semibold uppercase tracking-widest text-foreground">
                       {snapshot.tool} {snapshot.command}
                     </span>
-                    <span className="flex-shrink-0 text-[10px] text-muted-foreground">
-                      {formatSnapshotTime(snapshot.created_at)}
-                    </span>
+                    <div className="flex flex-shrink-0 items-center gap-2">
+                      <span className="text-[10px] text-muted-foreground">
+                        {formatSnapshotTime(snapshot.created_at)}
+                      </span>
+                      {canDraftRollback && (
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          onClick={() => draftRollback(snapshot)}
+                          disabled={draftingRollbackID !== null}
+                        >
+                          <RotateCcw className="h-3.5 w-3.5" />
+                          {draftingRollbackID === snapshot.id ? 'Drafting...' : 'Rollback proposal'}
+                        </Button>
+                      )}
+                    </div>
                   </div>
                   <div className="mt-1 truncate font-mono text-[10px] text-muted-foreground">
                     {snapshot.work_dir || 'project root'} · {snapshot.id}
@@ -289,6 +351,83 @@ export function DriftPanel({
               {snapshotsLoaded ? 'No checkpoints recorded yet.' : 'No checkpoints loaded yet.'}
             </div>
           )}
+        </section>
+      )}
+
+      {rollbackError && (
+        <div className="flex items-start gap-2 rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+          <AlertCircle className="mt-0.5 h-3.5 w-3.5 flex-shrink-0" />
+          <span>{rollbackError}</span>
+        </div>
+      )}
+
+      {rollbackProposal && (
+        <section className="rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-3">
+          <div className="flex items-start gap-2">
+            <RotateCcw className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-amber-300" />
+            <div className="min-w-0 flex-1">
+              <div className="truncate text-xs font-semibold text-foreground">{rollbackProposal.title}</div>
+              <div className="mt-1 truncate font-mono text-[10px] text-muted-foreground">
+                branch {rollbackProposal.branch}
+              </div>
+              <div className="mt-1 truncate font-mono text-[10px] text-muted-foreground">
+                target {rollbackProposal.target_snapshot.id}
+              </div>
+              <div className="mt-2 rounded border border-amber-500/30 bg-background/70 px-2 py-2 text-xs leading-5 text-amber-100">
+                Not an automatic undo. {rollbackProposal.classification.summary.text}; plan review is required before apply.
+              </div>
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={writeRollbackArtifacts}
+              disabled={writingRollbackArtifacts || !client.createRollbackArtifacts}
+            >
+              <FileText className="h-3.5 w-3.5" />
+              {writingRollbackArtifacts ? 'Writing...' : 'Write artifacts'}
+            </Button>
+          </div>
+
+          {rollbackProposal.warnings && rollbackProposal.warnings.length > 0 && (
+            <div className="mt-3 space-y-1 rounded border border-amber-500/30 bg-background/60 px-2 py-2 text-xs leading-5 text-amber-100">
+              {rollbackProposal.warnings.map((warning, i) => (
+                <div key={i}>{warning}</div>
+              ))}
+            </div>
+          )}
+        </section>
+      )}
+
+      {rollbackArtifactError && (
+        <div className="flex items-start gap-2 rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+          <AlertCircle className="mt-0.5 h-3.5 w-3.5 flex-shrink-0" />
+          <span>{rollbackArtifactError}</span>
+        </div>
+      )}
+
+      {rollbackArtifacts && (
+        <section className="rounded-md border border-border bg-card px-3 py-3">
+          <div className="flex items-start gap-2">
+            <FileText className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-primary" />
+            <div className="min-w-0">
+              <div className="text-xs font-semibold text-foreground">Rollback artifacts written</div>
+              <div className="mt-1 truncate font-mono text-[10px] text-muted-foreground">
+                {rollbackArtifacts.root}
+              </div>
+            </div>
+          </div>
+          <div className="mt-3 space-y-1">
+            {rollbackArtifacts.files.map((file) => (
+              <div
+                key={file.path}
+                className="flex items-center justify-between gap-2 rounded border border-border bg-background/70 px-2 py-1.5"
+              >
+                <span className="truncate font-mono text-[10px] text-foreground">{file.path}</span>
+                <span className="flex-shrink-0 font-mono text-[10px] uppercase tracking-widest text-muted-foreground">{file.kind}</span>
+              </div>
+            ))}
+          </div>
         </section>
       )}
 


### PR DESCRIPTION
## Summary
- add recovery rollback proposal generation from state checkpoints
- add rollback proposal/artifact API endpoints under snapshots
- surface rollback proposal and artifact actions in the Drift panel
- document review-only rollback semantics in README and GitHub Pages docs

## Tests
- GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/recovery ./internal/api
- GOCACHE=/private/tmp/iacstudio-go-cache go test ./...
- npm -C web test -- --run src/api.test.ts src/components/DriftPanel/DriftPanel.test.tsx
- npm -C web test -- --run
- npm -C web run build
- npm -C web run lint (passes with existing warnings)
- git diff --check

Refs #44