### PR TITLE
Add PR-ready drift and rollback handoffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ start the local server for you.
 | **AI Topology Builder** | Describe an architecture in plain text, AI generates everything |
 | **AI Plan Fix** | When terraform plan fails, AI diagnoses and auto-fixes the issue |
 | **Security Scanner** | Graph-based checks: CIS, SOC2, HIPAA, OWASP compliance |
-| **Drift Monitor** | Run Terraform/OpenTofu state drift checks with classified findings, suppression rules, draft codify/revert PR payloads, and review artifacts |
-| **Recovery Checkpoints** | Successful apply runs record state/plan metadata and hashes for audit, drift, and reviewed rollback proposal workflows |
+| **Drift Monitor** | Run Terraform/OpenTofu state drift checks with classified findings, suppression rules, draft codify/revert PR payloads, review artifacts, and PR-ready local branches |
+| **Recovery Checkpoints** | Successful apply runs record state/plan metadata and hashes for audit, drift, rollback proposal artifacts, and PR-ready recovery branches |
 | **Multi-Format Export** | Export to Pulumi TypeScript, CDK Python, CloudFormation |
 | **Smart Suggestions** | AI predicts your next resource based on IaC best practices |
 | **Import Projects** | Browse filesystem, scan existing .tf/.yml files, auto-detect topology |
@@ -144,6 +144,7 @@ IaC Studio runs locally and is designed to be secure by default:
 - **Plan-before-apply** — server-side gate requires successful plan before apply
 - **Semantic plan review** — Terraform/OpenTofu plans are classified before apply; risky, destructive, or unknown changes require explicit acknowledgement
 - **Recovery checkpoints** — successful apply-style runs write metadata and state/plan hashes under `.iac-studio/snapshots`; rollback requests generate review artifacts, not automatic undo actions
+- **Review-branch handoff** — drift and rollback PR workflows create local branches that commit only generated `.iac-studio/remediations` or `.iac-studio/rollbacks` artifacts, reject unrelated dirty source files, and return explicit `git push` / `gh pr create` commands instead of collecting GitHub tokens
 - **Cloud target checks** — selected Cloud Connections are tested before command execution
 - **Secret redaction** — static credentials are not echoed in API responses, terminal messages, or generated IaC
 - **No telemetry** — zero data collection, no phone-home
@@ -207,6 +208,7 @@ All flags have sensible defaults. Just run `iac-studio` and go.
 - [x] Cloud Connections for AWS, Azure, and GCP run targets
 - [x] Recovery checkpoint metadata for successful apply runs
 - [x] Reviewed rollback proposal artifacts from recovery checkpoints
+- [x] PR-ready local review branches for drift and rollback artifacts
 - [x] Cost estimation (30+ resource types)
 - [x] CI/CD pipeline generator (GitHub Actions, GitLab CI)
 - [x] Environment promotion (dev/staging/prod workspaces)

--- a/docs/index.html
+++ b/docs/index.html
@@ -411,7 +411,10 @@ iac-studio</code></pre>
               but no longer count as active findings. From active findings, the Drift tab can draft
               codify or revert PR metadata with branch names, commit messages, review notes, source
               locations, and validation steps, then write review artifacts under
-              <code>.iac-studio/remediations/</code>. Export converts the current topology into
+              <code>.iac-studio/remediations/</code>. The PR branch action creates a local git
+              branch, commits only those generated remediation artifacts, and returns explicit
+              <code>git push</code> and <code>gh pr create</code> commands. It does not collect
+              GitHub tokens, push branches, or apply cloud changes for you. Export converts the current topology into
               alternate formats such as Pulumi TypeScript, CDK Python, and CloudFormation where supported.
             </p>
             <pre><code>{
@@ -632,6 +635,13 @@ gcloud config set project my-platform-dev</code></pre>
             restore state, or bypass the normal plan, policy, and security gates.
           </div>
 
+          <p>
+            The rollback PR branch action writes the rollback artifacts, creates a local review
+            branch, and commits only files under <code>.iac-studio/rollbacks/</code>. IaC Studio
+            refuses to mix unrelated dirty source files into the branch and shows the commands
+            needed to push and open the pull request with your existing GitHub tooling.
+          </p>
+
           <pre><code>.iac-studio/
   rollbacks/
     rollback-demo-terraform-dev-20260610t120000z-.../
@@ -811,8 +821,8 @@ ANTHROPIC_MODEL=claude-opus-4-7 \
                 </tr>
                 <tr>
                   <td>Modules, drift, export</td>
-                  <td><code>GET /api/projects/{name}/modules</code><br><code>GET /api/registry/modules/search</code><br><code>POST /api/projects/{name}/promote-to-module</code><br><code>GET /api/projects/{name}/snapshots</code><br><code>POST /api/projects/{name}/snapshots/{snapshotID}/rollback</code><br><code>POST /api/projects/{name}/snapshots/{snapshotID}/rollback/artifacts</code><br><code>GET/POST /api/projects/{name}/drift</code><br><code>POST /api/projects/{name}/drift/remediation</code><br><code>POST /api/projects/{name}/drift/remediation/artifacts</code><br><code>GET /api/export/formats</code><br><code>POST /api/export</code></td>
-                  <td>Discover modules, promote resources, list recovery checkpoints, draft rollback proposals, detect classified Terraform/OpenTofu state drift, draft codify/revert remediation PR payloads, write remediation review artifacts, and export alternate IaC formats.</td>
+                  <td><code>GET /api/projects/{name}/modules</code><br><code>GET /api/registry/modules/search</code><br><code>POST /api/projects/{name}/promote-to-module</code><br><code>GET /api/projects/{name}/snapshots</code><br><code>POST /api/projects/{name}/snapshots/{snapshotID}/rollback</code><br><code>POST /api/projects/{name}/snapshots/{snapshotID}/rollback/artifacts</code><br><code>POST /api/projects/{name}/snapshots/{snapshotID}/rollback/pr</code><br><code>GET/POST /api/projects/{name}/drift</code><br><code>POST /api/projects/{name}/drift/remediation</code><br><code>POST /api/projects/{name}/drift/remediation/artifacts</code><br><code>POST /api/projects/{name}/drift/remediation/pr</code><br><code>GET /api/export/formats</code><br><code>POST /api/export</code></td>
+                  <td>Discover modules, promote resources, list recovery checkpoints, draft rollback proposals, detect classified Terraform/OpenTofu state drift, draft codify/revert remediation PR payloads, write remediation/rollback review artifacts, create local PR-ready review branches, and export alternate IaC formats.</td>
                 </tr>
                 <tr>
                   <td>Realtime</td>

--- a/internal/api/drift_test.go
+++ b/internal/api/drift_test.go
@@ -345,7 +345,150 @@ resource "aws_security_group" "web" {
 	}
 }
 
-func TestProjectDriftRemediationArtifactsEndpointUsesProvidedProposal(t *testing.T) {
+func TestProjectDriftRemediationPREndpointCreatesReviewBranch(t *testing.T) {
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "demo")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "main.tf"), []byte(`
+resource "aws_security_group" "web" {
+  name    = "web"
+  ingress = []
+}
+`), 0o644); err != nil {
+		t.Fatalf("write main.tf: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "terraform.tfstate"), []byte(`{
+		"version": 4,
+		"resources": [{
+			"mode": "managed",
+			"type": "aws_security_group",
+			"name": "web",
+			"instances": [{"attributes": {"name": "web", "ingress": [{"cidr_blocks": ["0.0.0.0/0"]}]}}]
+		}]
+	}`), 0o600); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	initProjectGitRepo(t, projectDir)
+
+	srv := httptest.NewServer(fullRouterForTest(t, root))
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/api/projects/demo/drift/remediation/pr", "application/json", strings.NewReader(`{"tool":"terraform","mode":"revert"}`))
+	if err != nil {
+		t.Fatalf("POST drift remediation pr: %v", err)
+	}
+	defer closeBody(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("drift remediation pr status = %d", resp.StatusCode)
+	}
+
+	var payload struct {
+		Artifacts struct {
+			ID string `json:"id"`
+		} `json:"artifacts"`
+		PullRequest struct {
+			Title      string `json:"title"`
+			Branch     string `json:"branch"`
+			BaseBranch string `json:"base_branch"`
+			Commit     string `json:"commit"`
+			BodyPath   string `json:"body_path"`
+			Files      []struct {
+				Path string `json:"path"`
+			} `json:"-"`
+			Commands []struct {
+				Label   string   `json:"label"`
+				Args    []string `json:"args"`
+				Display string   `json:"display"`
+			} `json:"commands"`
+		} `json:"pull_request"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode drift remediation pr response: %v", err)
+	}
+	if payload.Artifacts.ID != "iac-studio-drift-revert-demo" ||
+		payload.PullRequest.Branch != "iac-studio-drift-revert-demo" ||
+		payload.PullRequest.BaseBranch != "main" ||
+		payload.PullRequest.Commit == "" ||
+		payload.PullRequest.BodyPath != ".iac-studio/remediations/iac-studio-drift-revert-demo/pr-body.md" {
+		t.Fatalf("unexpected PR payload: %#v", payload)
+	}
+	if len(payload.PullRequest.Commands) != 2 ||
+		payload.PullRequest.Commands[0].Args[0] != "git" ||
+		payload.PullRequest.Commands[1].Args[0] != "gh" {
+		t.Fatalf("unexpected PR commands: %#v", payload.PullRequest.Commands)
+	}
+	if branch := gitOutputForTest(t, projectDir, "rev-parse", "--abbrev-ref", "HEAD"); branch != "iac-studio-drift-revert-demo" {
+		t.Fatalf("current branch = %q", branch)
+	}
+	if status := gitOutputForTest(t, projectDir, "status", "--short"); status != "" {
+		t.Fatalf("worktree should be clean after PR handoff, got:\n%s", status)
+	}
+	committed := gitOutputForTest(t, projectDir, "show", "--name-only", "--format=", "HEAD")
+	if !strings.Contains(committed, ".iac-studio/remediations/iac-studio-drift-revert-demo/README.md") ||
+		strings.Contains(committed, "main.tf") {
+		t.Fatalf("review commit should contain only generated artifacts, got:\n%s", committed)
+	}
+}
+
+func TestProjectDriftRemediationPREndpointRejectsDirtySourceFiles(t *testing.T) {
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "demo")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "main.tf"), []byte(`
+resource "aws_security_group" "web" {
+  name    = "web"
+  ingress = []
+}
+`), 0o644); err != nil {
+		t.Fatalf("write main.tf: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "terraform.tfstate"), []byte(`{
+		"version": 4,
+		"resources": [{
+			"mode": "managed",
+			"type": "aws_security_group",
+			"name": "web",
+			"instances": [{"attributes": {"name": "web", "ingress": [{"cidr_blocks": ["0.0.0.0/0"]}]}}]
+		}]
+	}`), 0o600); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	initProjectGitRepo(t, projectDir)
+	if err := os.WriteFile(filepath.Join(projectDir, "main.tf"), []byte(`
+resource "aws_security_group" "web" {
+  name    = "web"
+  ingress = []
+}
+
+# dirty source edit
+`), 0o644); err != nil {
+		t.Fatalf("dirty source file: %v", err)
+	}
+
+	srv := httptest.NewServer(fullRouterForTest(t, root))
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/api/projects/demo/drift/remediation/pr", "application/json", strings.NewReader(`{"tool":"terraform","mode":"revert"}`))
+	if err != nil {
+		t.Fatalf("POST drift remediation pr: %v", err)
+	}
+	defer closeBody(resp.Body)
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("drift remediation pr status = %d, want 409", resp.StatusCode)
+	}
+	if branch := gitOutputForTest(t, projectDir, "rev-parse", "--abbrev-ref", "HEAD"); branch != "main" {
+		t.Fatalf("dirty rejection should leave branch on main, got %q", branch)
+	}
+	if _, err := os.Stat(filepath.Join(projectDir, ".iac-studio", "remediations", "iac-studio-drift-revert-demo", "README.md")); !os.IsNotExist(err) {
+		t.Fatalf("dirty rejection should not write review artifacts, stat err = %v", err)
+	}
+}
+
+func TestProjectDriftRemediationArtifactsEndpointRebuildsServerProposal(t *testing.T) {
 	root := t.TempDir()
 	projectDir := filepath.Join(root, "demo")
 	if err := os.MkdirAll(projectDir, 0o755); err != nil {
@@ -402,15 +545,16 @@ func TestProjectDriftRemediationArtifactsEndpointUsesProvidedProposal(t *testing
 		t.Fatalf("decode drift remediation artifacts response: %v", err)
 	}
 	if payload.ID != "iac-studio-drift-codify-demo" ||
-		payload.Proposal.Title != "Codify reviewed drift for demo" {
+		payload.Proposal.Title != "Codify drift for demo" {
 		t.Fatalf("unexpected artifact payload: %#v", payload)
 	}
 	prBody, err := os.ReadFile(filepath.Join(projectDir, ".iac-studio", "remediations", "iac-studio-drift-codify-demo", "pr-body.md"))
 	if err != nil {
 		t.Fatalf("read pr-body artifact: %v", err)
 	}
-	if !strings.Contains(string(prBody), "Reviewed finding: aws_s3_bucket.logs") {
-		t.Fatalf("artifact body should come from provided proposal, got:\n%s", string(prBody))
+	if strings.Contains(string(prBody), "Reviewed finding: aws_s3_bucket.logs") ||
+		!strings.Contains(string(prBody), "No active drift findings matched this remediation mode.") {
+		t.Fatalf("artifact body should be rebuilt server-side, got:\n%s", string(prBody))
 	}
 }
 

--- a/internal/api/git_helpers_test.go
+++ b/internal/api/git_helpers_test.go
@@ -1,0 +1,51 @@
+package api
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func initProjectGitRepo(t *testing.T, projectPath string) {
+	t.Helper()
+	gitForTest(t, projectPath, "init", "-b", "main")
+	if err := os.WriteFile(filepath.Join(projectPath, "README.md"), []byte("# demo\n"), 0o644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	gitForTest(t, projectPath, "add", "-A")
+	gitForTest(t, projectPath, "commit", "-m", "Initial commit")
+}
+
+func gitForTest(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=IaC Studio",
+		"GIT_AUTHOR_EMAIL=iac-studio@local",
+		"GIT_COMMITTER_NAME=IaC Studio",
+		"GIT_COMMITTER_EMAIL=iac-studio@local",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s failed: %s: %v", strings.Join(args, " "), string(out), err)
+	}
+}
+
+func gitOutputForTest(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=IaC Studio",
+		"GIT_AUTHOR_EMAIL=iac-studio@local",
+		"GIT_COMMITTER_NAME=IaC Studio",
+		"GIT_COMMITTER_EMAIL=iac-studio@local",
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git %s failed: %v", strings.Join(args, " "), err)
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -31,6 +31,7 @@ import (
 	pulumigen "github.com/iac-studio/iac-studio/internal/pulumi"
 	"github.com/iac-studio/iac-studio/internal/recovery"
 	"github.com/iac-studio/iac-studio/internal/registry"
+	"github.com/iac-studio/iac-studio/internal/review"
 	"github.com/iac-studio/iac-studio/internal/runner"
 	"github.com/iac-studio/iac-studio/internal/scaffold"
 	"github.com/iac-studio/iac-studio/internal/security"
@@ -513,14 +514,7 @@ func relativeSourcePath(root, path string) string {
 
 func writeRenderedRemediationArtifacts(projectPath string, rendered []drift.RenderedRemediationArtifact) error {
 	for _, artifact := range rendered {
-		target, err := safeProjectFilePath(projectPath, artifact.Path)
-		if err != nil {
-			return err
-		}
-		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
-			return fmt.Errorf("creating remediation artifact directory: %w", err)
-		}
-		if err := os.WriteFile(target, []byte(artifact.Content), 0o644); err != nil {
+		if err := writeGeneratedArtifactFile(projectPath, artifact.Path, artifact.Content); err != nil {
 			return fmt.Errorf("writing remediation artifact %s: %w", artifact.Path, err)
 		}
 	}
@@ -529,15 +523,121 @@ func writeRenderedRemediationArtifacts(projectPath string, rendered []drift.Rend
 
 func writeRenderedRollbackArtifacts(projectPath string, rendered []recovery.RenderedRollbackArtifact) error {
 	for _, artifact := range rendered {
-		target, err := safeProjectFilePath(projectPath, artifact.Path)
+		if err := writeGeneratedArtifactFile(projectPath, artifact.Path, artifact.Content); err != nil {
+			return fmt.Errorf("writing rollback artifact %s: %w", artifact.Path, err)
+		}
+	}
+	return nil
+}
+
+func remediationArtifactPaths(rendered []drift.RenderedRemediationArtifact) []string {
+	paths := make([]string, 0, len(rendered))
+	for _, artifact := range rendered {
+		paths = append(paths, artifact.Path)
+	}
+	return paths
+}
+
+func rollbackArtifactPaths(rendered []recovery.RenderedRollbackArtifact) []string {
+	paths := make([]string, 0, len(rendered))
+	for _, artifact := range rendered {
+		paths = append(paths, artifact.Path)
+	}
+	return paths
+}
+
+func remediationArtifactBodyPath(rendered []drift.RenderedRemediationArtifact) string {
+	for _, artifact := range rendered {
+		if artifact.Kind == "pr_body" {
+			return artifact.Path
+		}
+	}
+	return ""
+}
+
+func rollbackArtifactBodyPath(rendered []recovery.RenderedRollbackArtifact) string {
+	for _, artifact := range rendered {
+		if artifact.Kind == "proposal" {
+			return artifact.Path
+		}
+	}
+	return ""
+}
+
+func reviewHandoffStatus(err error) int {
+	switch {
+	case errors.Is(err, review.ErrBranchExists),
+		errors.Is(err, review.ErrDirtyWorktree),
+		errors.Is(err, review.ErrNoChanges):
+		return http.StatusConflict
+	case errors.Is(err, review.ErrInvalidInput),
+		errors.Is(err, review.ErrNotGitRepository):
+		return http.StatusBadRequest
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
+func writeGeneratedArtifactFile(projectPath, relPath, content string) error {
+	artifactPath, err := safeReviewArtifactPath(relPath)
+	if err != nil {
+		return err
+	}
+	target, err := safeProjectFilePath(projectPath, artifactPath)
+	if err != nil {
+		return err
+	}
+	if err := ensureNoSymlinkDir(projectPath, filepath.Dir(target)); err != nil {
+		return err
+	}
+	if info, err := os.Lstat(target); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to overwrite symlink %q", relPath)
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("refusing to overwrite non-regular file %q", relPath)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return os.WriteFile(target, []byte(content), 0o644)
+}
+
+func safeReviewArtifactPath(relPath string) (string, error) {
+	clean := filepath.ToSlash(filepath.Clean(filepath.FromSlash(relPath)))
+	if !strings.HasPrefix(clean, ".iac-studio/remediations/") &&
+		!strings.HasPrefix(clean, ".iac-studio/rollbacks/") {
+		return "", fmt.Errorf("generated artifact path must stay under .iac-studio review artifacts: %q", relPath)
+	}
+	return clean, nil
+}
+
+func ensureNoSymlinkDir(projectPath, dir string) error {
+	rel, err := filepath.Rel(projectPath, dir)
+	if err != nil || rel == "." {
+		return err
+	}
+	current := projectPath
+	for _, part := range strings.Split(filepath.ToSlash(rel), "/") {
+		if part == "" || part == "." {
+			continue
+		}
+		current = filepath.Join(current, part)
+		info, err := os.Lstat(current)
+		if errors.Is(err, os.ErrNotExist) {
+			if err := os.Mkdir(current, 0o755); err != nil && !errors.Is(err, os.ErrExist) {
+				return err
+			}
+			continue
+		}
 		if err != nil {
 			return err
 		}
-		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
-			return fmt.Errorf("creating rollback artifact directory: %w", err)
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to write through symlink directory %q", part)
 		}
-		if err := os.WriteFile(target, []byte(artifact.Content), 0o644); err != nil {
-			return fmt.Errorf("writing rollback artifact %s: %w", artifact.Path, err)
+		if !info.IsDir() {
+			return fmt.Errorf("artifact parent %q is not a directory", part)
 		}
 	}
 	return nil
@@ -2284,6 +2384,72 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 		_ = json.NewEncoder(w).Encode(artifactSet)
 	})
 
+	mux.HandleFunc("POST /api/projects/{name}/snapshots/{snapshotID}/rollback/pr", func(w http.ResponseWriter, r *http.Request) {
+		name := r.PathValue("name")
+		snapshotID := r.PathValue("snapshotID")
+		projectPath, err := safeProjectPath(projectsDir, name)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		limitBody(w, r)
+		var req struct {
+			Env      string                     `json:"env,omitempty"`
+			Proposal *recovery.RollbackProposal `json:"proposal,omitempty"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+			http.Error(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		if req.Env == "" {
+			req.Env = r.URL.Query().Get("env")
+		}
+
+		proposal, status, message := buildProjectRollbackProposal(projectPath, name, snapshotID, req.Env)
+		if status != http.StatusOK {
+			http.Error(w, message, status)
+			return
+		}
+		if req.Proposal != nil && req.Proposal.TargetSnapshot.ID != snapshotID {
+			http.Error(w, "request proposal must match snapshot id", http.StatusBadRequest)
+			return
+		}
+		artifactSet, rendered, err := recovery.RenderRollbackArtifacts(proposal, time.Now().UTC())
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		rollbackFiles := rollbackArtifactPaths(rendered)
+		if err := review.EnsureNoUnrelatedChanges(projectPath, rollbackFiles); err != nil {
+			http.Error(w, err.Error(), reviewHandoffStatus(err))
+			return
+		}
+		if err := writeRenderedRollbackArtifacts(projectPath, rendered); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		handoff, err := review.CreatePullRequestHandoff(review.PullRequestHandoffInput{
+			ProjectPath:   projectPath,
+			Title:         proposal.Title,
+			Branch:        proposal.Branch,
+			CommitMessage: proposal.CommitMessage,
+			BodyPath:      rollbackArtifactBodyPath(rendered),
+			Files:         rollbackFiles,
+		})
+		if err != nil {
+			http.Error(w, err.Error(), reviewHandoffStatus(err))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(struct {
+			Artifacts   recovery.RollbackArtifactSet `json:"artifacts"`
+			PullRequest review.PullRequestHandoff    `json:"pull_request"`
+		}{
+			Artifacts:   artifactSet,
+			PullRequest: handoff,
+		})
+	})
+
 	// ─── Drift Detection ───
 
 	driftDetector := drift.New()
@@ -2354,6 +2520,7 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 			http.Error(w, err.Error(), 400)
 			return
 		}
+		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(proposal)
 	})
 
@@ -2382,28 +2549,26 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		var proposal drift.RemediationProposal
+		mode := req.Mode
 		if req.Proposal != nil {
-			proposal = *req.Proposal
-			if req.Mode != "" && req.Mode != proposal.Mode {
+			if mode != "" && mode != req.Proposal.Mode {
 				http.Error(w, "request mode must match proposal mode", http.StatusBadRequest)
 				return
 			}
-		} else {
-			run, status, message := runProjectDrift(projectsDir, name, projectDriftRequest{
-				Tool: req.Tool,
-				Env:  req.Env,
-			}, driftDetector)
-			if run == nil {
-				http.Error(w, message, status)
-				return
-			}
-			var buildErr error
-			proposal, buildErr = buildProjectDriftRemediationProposal(name, req.Mode, run)
-			if buildErr != nil {
-				http.Error(w, buildErr.Error(), http.StatusBadRequest)
-				return
-			}
+			mode = req.Proposal.Mode
+		}
+		run, status, message := runProjectDrift(projectsDir, name, projectDriftRequest{
+			Tool: req.Tool,
+			Env:  req.Env,
+		}, driftDetector)
+		if run == nil {
+			http.Error(w, message, status)
+			return
+		}
+		proposal, err := buildProjectDriftRemediationProposal(name, mode, run)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
 		}
 		artifactSet, rendered, err := drift.RenderRemediationArtifacts(proposal, time.Now().UTC())
 		if err != nil {
@@ -2414,7 +2579,90 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(artifactSet)
+	})
+
+	mux.HandleFunc("POST /api/projects/{name}/drift/remediation/pr", func(w http.ResponseWriter, r *http.Request) {
+		name := r.PathValue("name")
+		limitBody(w, r)
+		var req struct {
+			Tool     string                     `json:"tool,omitempty"`
+			Env      string                     `json:"env,omitempty"`
+			Mode     string                     `json:"mode"`
+			Proposal *drift.RemediationProposal `json:"proposal,omitempty"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+			http.Error(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		if req.Tool == "" {
+			req.Tool = r.URL.Query().Get("tool")
+		}
+		if req.Env == "" {
+			req.Env = r.URL.Query().Get("env")
+		}
+
+		projectPath, err := safeProjectPath(projectsDir, name)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		mode := req.Mode
+		if req.Proposal != nil {
+			if mode != "" && mode != req.Proposal.Mode {
+				http.Error(w, "request mode must match proposal mode", http.StatusBadRequest)
+				return
+			}
+			mode = req.Proposal.Mode
+		}
+		run, status, message := runProjectDrift(projectsDir, name, projectDriftRequest{
+			Tool: req.Tool,
+			Env:  req.Env,
+		}, driftDetector)
+		if run == nil {
+			http.Error(w, message, status)
+			return
+		}
+		proposal, err := buildProjectDriftRemediationProposal(name, mode, run)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		artifactSet, rendered, err := drift.RenderRemediationArtifacts(proposal, time.Now().UTC())
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		remediationFiles := remediationArtifactPaths(rendered)
+		if err := review.EnsureNoUnrelatedChanges(projectPath, remediationFiles); err != nil {
+			http.Error(w, err.Error(), reviewHandoffStatus(err))
+			return
+		}
+		if err := writeRenderedRemediationArtifacts(projectPath, rendered); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		handoff, err := review.CreatePullRequestHandoff(review.PullRequestHandoffInput{
+			ProjectPath:   projectPath,
+			Title:         proposal.Title,
+			Branch:        proposal.Branch,
+			CommitMessage: proposal.CommitMessage,
+			BodyPath:      remediationArtifactBodyPath(rendered),
+			Files:         remediationFiles,
+		})
+		if err != nil {
+			http.Error(w, err.Error(), reviewHandoffStatus(err))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(struct {
+			Artifacts   drift.RemediationArtifactSet `json:"artifacts"`
+			PullRequest review.PullRequestHandoff    `json:"pull_request"`
+		}{
+			Artifacts:   artifactSet,
+			PullRequest: handoff,
+		})
 	})
 
 	// ─── Multi-Format Export ───

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -31,6 +31,7 @@ import (
 	pulumigen "github.com/iac-studio/iac-studio/internal/pulumi"
 	"github.com/iac-studio/iac-studio/internal/recovery"
 	"github.com/iac-studio/iac-studio/internal/registry"
+	"github.com/iac-studio/iac-studio/internal/review"
 	"github.com/iac-studio/iac-studio/internal/runner"
 	"github.com/iac-studio/iac-studio/internal/scaffold"
 	"github.com/iac-studio/iac-studio/internal/security"
@@ -513,14 +514,7 @@ func relativeSourcePath(root, path string) string {
 
 func writeRenderedRemediationArtifacts(projectPath string, rendered []drift.RenderedRemediationArtifact) error {
 	for _, artifact := range rendered {
-		target, err := safeProjectFilePath(projectPath, artifact.Path)
-		if err != nil {
-			return err
-		}
-		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
-			return fmt.Errorf("creating remediation artifact directory: %w", err)
-		}
-		if err := os.WriteFile(target, []byte(artifact.Content), 0o644); err != nil {
+		if err := writeGeneratedArtifactFile(projectPath, artifact.Path, artifact.Content); err != nil {
 			return fmt.Errorf("writing remediation artifact %s: %w", artifact.Path, err)
 		}
 	}
@@ -529,15 +523,108 @@ func writeRenderedRemediationArtifacts(projectPath string, rendered []drift.Rend
 
 func writeRenderedRollbackArtifacts(projectPath string, rendered []recovery.RenderedRollbackArtifact) error {
 	for _, artifact := range rendered {
-		target, err := safeProjectFilePath(projectPath, artifact.Path)
+		if err := writeGeneratedArtifactFile(projectPath, artifact.Path, artifact.Content); err != nil {
+			return fmt.Errorf("writing rollback artifact %s: %w", artifact.Path, err)
+		}
+	}
+	return nil
+}
+
+func remediationArtifactPaths(rendered []drift.RenderedRemediationArtifact) []string {
+	paths := make([]string, 0, len(rendered))
+	for _, artifact := range rendered {
+		paths = append(paths, artifact.Path)
+	}
+	return paths
+}
+
+func rollbackArtifactPaths(rendered []recovery.RenderedRollbackArtifact) []string {
+	paths := make([]string, 0, len(rendered))
+	for _, artifact := range rendered {
+		paths = append(paths, artifact.Path)
+	}
+	return paths
+}
+
+func remediationArtifactBodyPath(rendered []drift.RenderedRemediationArtifact) string {
+	for _, artifact := range rendered {
+		if artifact.Kind == "pr_body" {
+			return artifact.Path
+		}
+	}
+	return ""
+}
+
+func rollbackArtifactBodyPath(rendered []recovery.RenderedRollbackArtifact) string {
+	for _, artifact := range rendered {
+		if artifact.Kind == "proposal" {
+			return artifact.Path
+		}
+	}
+	return ""
+}
+
+func reviewHandoffStatus(err error) int {
+	switch {
+	case errors.Is(err, review.ErrBranchExists),
+		errors.Is(err, review.ErrDirtyWorktree),
+		errors.Is(err, review.ErrNoChanges):
+		return http.StatusConflict
+	case errors.Is(err, review.ErrInvalidInput),
+		errors.Is(err, review.ErrNotGitRepository):
+		return http.StatusBadRequest
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
+func writeGeneratedArtifactFile(projectPath, relPath, content string) error {
+	target, err := safeProjectFilePath(projectPath, relPath)
+	if err != nil {
+		return err
+	}
+	if err := ensureNoSymlinkDir(projectPath, filepath.Dir(target)); err != nil {
+		return err
+	}
+	if info, err := os.Lstat(target); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to overwrite symlink %q", relPath)
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("refusing to overwrite non-regular file %q", relPath)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return os.WriteFile(target, []byte(content), 0o644)
+}
+
+func ensureNoSymlinkDir(projectPath, dir string) error {
+	rel, err := filepath.Rel(projectPath, dir)
+	if err != nil || rel == "." {
+		return err
+	}
+	current := projectPath
+	for _, part := range strings.Split(filepath.ToSlash(rel), "/") {
+		if part == "" || part == "." {
+			continue
+		}
+		current = filepath.Join(current, part)
+		info, err := os.Lstat(current)
+		if errors.Is(err, os.ErrNotExist) {
+			if err := os.Mkdir(current, 0o755); err != nil && !errors.Is(err, os.ErrExist) {
+				return err
+			}
+			continue
+		}
 		if err != nil {
 			return err
 		}
-		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
-			return fmt.Errorf("creating rollback artifact directory: %w", err)
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to write through symlink directory %q", part)
 		}
-		if err := os.WriteFile(target, []byte(artifact.Content), 0o644); err != nil {
-			return fmt.Errorf("writing rollback artifact %s: %w", artifact.Path, err)
+		if !info.IsDir() {
+			return fmt.Errorf("artifact parent %q is not a directory", part)
 		}
 	}
 	return nil
@@ -2284,6 +2371,72 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 		_ = json.NewEncoder(w).Encode(artifactSet)
 	})
 
+	mux.HandleFunc("POST /api/projects/{name}/snapshots/{snapshotID}/rollback/pr", func(w http.ResponseWriter, r *http.Request) {
+		name := r.PathValue("name")
+		snapshotID := r.PathValue("snapshotID")
+		projectPath, err := safeProjectPath(projectsDir, name)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		limitBody(w, r)
+		var req struct {
+			Env      string                     `json:"env,omitempty"`
+			Proposal *recovery.RollbackProposal `json:"proposal,omitempty"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+			http.Error(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		if req.Env == "" {
+			req.Env = r.URL.Query().Get("env")
+		}
+
+		proposal, status, message := buildProjectRollbackProposal(projectPath, name, snapshotID, req.Env)
+		if status != http.StatusOK {
+			http.Error(w, message, status)
+			return
+		}
+		if req.Proposal != nil && req.Proposal.TargetSnapshot.ID != snapshotID {
+			http.Error(w, "request proposal must match snapshot id", http.StatusBadRequest)
+			return
+		}
+		artifactSet, rendered, err := recovery.RenderRollbackArtifacts(proposal, time.Now().UTC())
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		rollbackFiles := rollbackArtifactPaths(rendered)
+		if err := review.EnsureNoUnrelatedChanges(projectPath, rollbackFiles); err != nil {
+			http.Error(w, err.Error(), reviewHandoffStatus(err))
+			return
+		}
+		if err := writeRenderedRollbackArtifacts(projectPath, rendered); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		handoff, err := review.CreatePullRequestHandoff(review.PullRequestHandoffInput{
+			ProjectPath:   projectPath,
+			Title:         proposal.Title,
+			Branch:        proposal.Branch,
+			CommitMessage: proposal.CommitMessage,
+			BodyPath:      rollbackArtifactBodyPath(rendered),
+			Files:         rollbackFiles,
+		})
+		if err != nil {
+			http.Error(w, err.Error(), reviewHandoffStatus(err))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(struct {
+			Artifacts   recovery.RollbackArtifactSet `json:"artifacts"`
+			PullRequest review.PullRequestHandoff    `json:"pull_request"`
+		}{
+			Artifacts:   artifactSet,
+			PullRequest: handoff,
+		})
+	})
+
 	// ─── Drift Detection ───
 
 	driftDetector := drift.New()
@@ -2354,6 +2507,7 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 			http.Error(w, err.Error(), 400)
 			return
 		}
+		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(proposal)
 	})
 
@@ -2382,28 +2536,26 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		var proposal drift.RemediationProposal
+		mode := req.Mode
 		if req.Proposal != nil {
-			proposal = *req.Proposal
-			if req.Mode != "" && req.Mode != proposal.Mode {
+			if mode != "" && mode != req.Proposal.Mode {
 				http.Error(w, "request mode must match proposal mode", http.StatusBadRequest)
 				return
 			}
-		} else {
-			run, status, message := runProjectDrift(projectsDir, name, projectDriftRequest{
-				Tool: req.Tool,
-				Env:  req.Env,
-			}, driftDetector)
-			if run == nil {
-				http.Error(w, message, status)
-				return
-			}
-			var buildErr error
-			proposal, buildErr = buildProjectDriftRemediationProposal(name, req.Mode, run)
-			if buildErr != nil {
-				http.Error(w, buildErr.Error(), http.StatusBadRequest)
-				return
-			}
+			mode = req.Proposal.Mode
+		}
+		run, status, message := runProjectDrift(projectsDir, name, projectDriftRequest{
+			Tool: req.Tool,
+			Env:  req.Env,
+		}, driftDetector)
+		if run == nil {
+			http.Error(w, message, status)
+			return
+		}
+		proposal, err := buildProjectDriftRemediationProposal(name, mode, run)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
 		}
 		artifactSet, rendered, err := drift.RenderRemediationArtifacts(proposal, time.Now().UTC())
 		if err != nil {
@@ -2414,7 +2566,90 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(artifactSet)
+	})
+
+	mux.HandleFunc("POST /api/projects/{name}/drift/remediation/pr", func(w http.ResponseWriter, r *http.Request) {
+		name := r.PathValue("name")
+		limitBody(w, r)
+		var req struct {
+			Tool     string                     `json:"tool,omitempty"`
+			Env      string                     `json:"env,omitempty"`
+			Mode     string                     `json:"mode"`
+			Proposal *drift.RemediationProposal `json:"proposal,omitempty"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+			http.Error(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		if req.Tool == "" {
+			req.Tool = r.URL.Query().Get("tool")
+		}
+		if req.Env == "" {
+			req.Env = r.URL.Query().Get("env")
+		}
+
+		projectPath, err := safeProjectPath(projectsDir, name)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		mode := req.Mode
+		if req.Proposal != nil {
+			if mode != "" && mode != req.Proposal.Mode {
+				http.Error(w, "request mode must match proposal mode", http.StatusBadRequest)
+				return
+			}
+			mode = req.Proposal.Mode
+		}
+		run, status, message := runProjectDrift(projectsDir, name, projectDriftRequest{
+			Tool: req.Tool,
+			Env:  req.Env,
+		}, driftDetector)
+		if run == nil {
+			http.Error(w, message, status)
+			return
+		}
+		proposal, err := buildProjectDriftRemediationProposal(name, mode, run)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		artifactSet, rendered, err := drift.RenderRemediationArtifacts(proposal, time.Now().UTC())
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		remediationFiles := remediationArtifactPaths(rendered)
+		if err := review.EnsureNoUnrelatedChanges(projectPath, remediationFiles); err != nil {
+			http.Error(w, err.Error(), reviewHandoffStatus(err))
+			return
+		}
+		if err := writeRenderedRemediationArtifacts(projectPath, rendered); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		handoff, err := review.CreatePullRequestHandoff(review.PullRequestHandoffInput{
+			ProjectPath:   projectPath,
+			Title:         proposal.Title,
+			Branch:        proposal.Branch,
+			CommitMessage: proposal.CommitMessage,
+			BodyPath:      remediationArtifactBodyPath(rendered),
+			Files:         remediationFiles,
+		})
+		if err != nil {
+			http.Error(w, err.Error(), reviewHandoffStatus(err))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(struct {
+			Artifacts   drift.RemediationArtifactSet `json:"artifacts"`
+			PullRequest review.PullRequestHandoff    `json:"pull_request"`
+		}{
+			Artifacts:   artifactSet,
+			PullRequest: handoff,
+		})
 	})
 
 	// ─── Multi-Format Export ───

--- a/internal/api/router_security_test.go
+++ b/internal/api/router_security_test.go
@@ -7,10 +7,12 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/iac-studio/iac-studio/internal/ai"
+	"github.com/iac-studio/iac-studio/internal/drift"
 	"github.com/iac-studio/iac-studio/internal/runner"
 	"github.com/iac-studio/iac-studio/internal/watcher"
 )
@@ -264,52 +266,81 @@ func TestSyncDoesNotInjectProviderIntoNestedMainFile(t *testing.T) {
 }
 
 func TestSafeProjectFilePathRejectsTraversal(t *testing.T) {
-projectPath := t.TempDir()
+	projectPath := t.TempDir()
 
-cases := []struct {
-relPath string
-desc    string
-}{
-{"../escape", "parent traversal"},
-{"../../etc/passwd", "deep parent traversal"},
-{"/absolute/path", "absolute path"},
-{".", "dot only"},
-{"..", "double-dot only"},
-{"subdir/../../escape", "traversal through subdirectory"},
-{"", "empty path"},
-}
+	cases := []struct {
+		relPath string
+		desc    string
+	}{
+		{"../escape", "parent traversal"},
+		{"../../etc/passwd", "deep parent traversal"},
+		{"/absolute/path", "absolute path"},
+		{".", "dot only"},
+		{"..", "double-dot only"},
+		{"subdir/../../escape", "traversal through subdirectory"},
+		{"", "empty path"},
+	}
 
-for _, tc := range cases {
-t.Run(tc.desc, func(t *testing.T) {
-_, err := safeProjectFilePath(projectPath, tc.relPath)
-if err == nil {
-t.Fatalf("safeProjectFilePath(%q) should have returned an error", tc.relPath)
-}
-})
-}
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			_, err := safeProjectFilePath(projectPath, tc.relPath)
+			if err == nil {
+				t.Fatalf("safeProjectFilePath(%q) should have returned an error", tc.relPath)
+			}
+		})
+	}
 }
 
 func TestSafeProjectFilePathAcceptsValidPaths(t *testing.T) {
-projectPath := t.TempDir()
+	projectPath := t.TempDir()
 
-cases := []struct {
-relPath  string
-wantSuff string
-}{
-{".iac-studio/remediations/my-drift/README.md", filepath.Join(".iac-studio", "remediations", "my-drift", "README.md")},
-{"main.tf", "main.tf"},
-{"modules/vpc/main.tf", filepath.Join("modules", "vpc", "main.tf")},
+	cases := []struct {
+		relPath  string
+		wantSuff string
+	}{
+		{".iac-studio/remediations/my-drift/README.md", filepath.Join(".iac-studio", "remediations", "my-drift", "README.md")},
+		{"main.tf", "main.tf"},
+		{"modules/vpc/main.tf", filepath.Join("modules", "vpc", "main.tf")},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.relPath, func(t *testing.T) {
+			got, err := safeProjectFilePath(projectPath, tc.relPath)
+			if err != nil {
+				t.Fatalf("safeProjectFilePath(%q) unexpected error: %v", tc.relPath, err)
+			}
+			if !strings.HasSuffix(got, tc.wantSuff) {
+				t.Fatalf("safeProjectFilePath(%q) = %q, want suffix %q", tc.relPath, got, tc.wantSuff)
+			}
+		})
+	}
 }
 
-for _, tc := range cases {
-t.Run(tc.relPath, func(t *testing.T) {
-got, err := safeProjectFilePath(projectPath, tc.relPath)
-if err != nil {
-t.Fatalf("safeProjectFilePath(%q) unexpected error: %v", tc.relPath, err)
-}
-if !strings.HasSuffix(got, tc.wantSuff) {
-t.Fatalf("safeProjectFilePath(%q) = %q, want suffix %q", tc.relPath, got, tc.wantSuff)
-}
-})
-}
+func TestWriteRenderedRemediationArtifactsRejectsSymlinkDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink permissions vary on Windows")
+	}
+	projectPath := t.TempDir()
+	outside := t.TempDir()
+	linkParent := filepath.Join(projectPath, ".iac-studio", "remediations")
+	if err := os.MkdirAll(linkParent, 0o755); err != nil {
+		t.Fatalf("mkdir link parent: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(linkParent, "evil")); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	err := writeRenderedRemediationArtifacts(projectPath, []drift.RenderedRemediationArtifact{{
+		RemediationArtifactFile: drift.RemediationArtifactFile{
+			Path: ".iac-studio/remediations/evil/README.md",
+			Kind: "runbook",
+		},
+		Content: "should not escape\n",
+	}})
+	if err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("expected symlink rejection, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(outside, "README.md")); !os.IsNotExist(err) {
+		t.Fatalf("artifact write escaped through symlink, stat err = %v", err)
+	}
 }

--- a/internal/api/router_security_test.go
+++ b/internal/api/router_security_test.go
@@ -7,10 +7,12 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/iac-studio/iac-studio/internal/ai"
+	"github.com/iac-studio/iac-studio/internal/drift"
 	"github.com/iac-studio/iac-studio/internal/runner"
 	"github.com/iac-studio/iac-studio/internal/watcher"
 )
@@ -264,52 +266,93 @@ func TestSyncDoesNotInjectProviderIntoNestedMainFile(t *testing.T) {
 }
 
 func TestSafeProjectFilePathRejectsTraversal(t *testing.T) {
-projectPath := t.TempDir()
+	projectPath := t.TempDir()
 
-cases := []struct {
-relPath string
-desc    string
-}{
-{"../escape", "parent traversal"},
-{"../../etc/passwd", "deep parent traversal"},
-{"/absolute/path", "absolute path"},
-{".", "dot only"},
-{"..", "double-dot only"},
-{"subdir/../../escape", "traversal through subdirectory"},
-{"", "empty path"},
-}
+	cases := []struct {
+		relPath string
+		desc    string
+	}{
+		{"../escape", "parent traversal"},
+		{"../../etc/passwd", "deep parent traversal"},
+		{"/absolute/path", "absolute path"},
+		{".", "dot only"},
+		{"..", "double-dot only"},
+		{"subdir/../../escape", "traversal through subdirectory"},
+		{"", "empty path"},
+	}
 
-for _, tc := range cases {
-t.Run(tc.desc, func(t *testing.T) {
-_, err := safeProjectFilePath(projectPath, tc.relPath)
-if err == nil {
-t.Fatalf("safeProjectFilePath(%q) should have returned an error", tc.relPath)
-}
-})
-}
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			_, err := safeProjectFilePath(projectPath, tc.relPath)
+			if err == nil {
+				t.Fatalf("safeProjectFilePath(%q) should have returned an error", tc.relPath)
+			}
+		})
+	}
 }
 
 func TestSafeProjectFilePathAcceptsValidPaths(t *testing.T) {
-projectPath := t.TempDir()
+	projectPath := t.TempDir()
 
-cases := []struct {
-relPath  string
-wantSuff string
-}{
-{".iac-studio/remediations/my-drift/README.md", filepath.Join(".iac-studio", "remediations", "my-drift", "README.md")},
-{"main.tf", "main.tf"},
-{"modules/vpc/main.tf", filepath.Join("modules", "vpc", "main.tf")},
+	cases := []struct {
+		relPath  string
+		wantSuff string
+	}{
+		{".iac-studio/remediations/my-drift/README.md", filepath.Join(".iac-studio", "remediations", "my-drift", "README.md")},
+		{"main.tf", "main.tf"},
+		{"modules/vpc/main.tf", filepath.Join("modules", "vpc", "main.tf")},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.relPath, func(t *testing.T) {
+			got, err := safeProjectFilePath(projectPath, tc.relPath)
+			if err != nil {
+				t.Fatalf("safeProjectFilePath(%q) unexpected error: %v", tc.relPath, err)
+			}
+			if !strings.HasSuffix(got, tc.wantSuff) {
+				t.Fatalf("safeProjectFilePath(%q) = %q, want suffix %q", tc.relPath, got, tc.wantSuff)
+			}
+		})
+	}
 }
 
-for _, tc := range cases {
-t.Run(tc.relPath, func(t *testing.T) {
-got, err := safeProjectFilePath(projectPath, tc.relPath)
-if err != nil {
-t.Fatalf("safeProjectFilePath(%q) unexpected error: %v", tc.relPath, err)
+func TestWriteRenderedRemediationArtifactsRejectsSymlinkDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink permissions vary on Windows")
+	}
+	projectPath := t.TempDir()
+	outside := t.TempDir()
+	linkParent := filepath.Join(projectPath, ".iac-studio", "remediations")
+	if err := os.MkdirAll(linkParent, 0o755); err != nil {
+		t.Fatalf("mkdir link parent: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(linkParent, "evil")); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	err := writeRenderedRemediationArtifacts(projectPath, []drift.RenderedRemediationArtifact{{
+		RemediationArtifactFile: drift.RemediationArtifactFile{
+			Path: ".iac-studio/remediations/evil/README.md",
+			Kind: "runbook",
+		},
+		Content: "should not escape\n",
+	}})
+	if err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("expected symlink rejection, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(outside, "README.md")); !os.IsNotExist(err) {
+		t.Fatalf("artifact write escaped through symlink, stat err = %v", err)
+	}
 }
-if !strings.HasSuffix(got, tc.wantSuff) {
-t.Fatalf("safeProjectFilePath(%q) = %q, want suffix %q", tc.relPath, got, tc.wantSuff)
-}
-})
-}
+
+func TestWriteGeneratedArtifactFileRejectsNonReviewArtifactPath(t *testing.T) {
+	projectPath := t.TempDir()
+
+	err := writeGeneratedArtifactFile(projectPath, "main.tf", "resource drift\n")
+	if err == nil || !strings.Contains(err.Error(), ".iac-studio review artifacts") {
+		t.Fatalf("expected review artifact path rejection, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(projectPath, "main.tf")); !os.IsNotExist(err) {
+		t.Fatalf("non-review artifact write should not create main.tf, stat err = %v", err)
+	}
 }

--- a/internal/api/router_security_test.go
+++ b/internal/api/router_security_test.go
@@ -316,6 +316,44 @@ func TestSafeProjectFilePathAcceptsValidPaths(t *testing.T) {
 	}
 }
 
+func TestSafeReviewArtifactPathEnforcesPrefix(t *testing.T) {
+	reject := []string{
+		"main.tf",
+		"../escape",
+		".iac-studio/snapshots/foo.json",
+		".iac-studio/remediations",        // directory itself, no trailing slash
+		".iac-studio/rollbacks",            // directory itself, no trailing slash
+		".iac-studio/remediations_evil/x",  // adjacent directory, not the allowed one
+		".iac-studio/remediations/foo/../../outside",
+		".iac-studio/rollbacks/foo/../../../etc/passwd",
+		"/absolute/path",
+	}
+	for _, p := range reject {
+		t.Run("reject:"+p, func(t *testing.T) {
+			if _, err := safeReviewArtifactPath(p); err == nil {
+				t.Fatalf("safeReviewArtifactPath(%q) should have returned an error", p)
+			}
+		})
+	}
+
+	accept := []string{
+		".iac-studio/remediations/my-drift/README.md",
+		".iac-studio/remediations/my-drift/pr-body.md",
+		".iac-studio/rollbacks/snap-1/proposal.md",
+	}
+	for _, p := range accept {
+		t.Run("accept:"+p, func(t *testing.T) {
+			got, err := safeReviewArtifactPath(p)
+			if err != nil {
+				t.Fatalf("safeReviewArtifactPath(%q) unexpected error: %v", p, err)
+			}
+			if got == "" {
+				t.Fatalf("safeReviewArtifactPath(%q) returned empty string", p)
+			}
+		})
+	}
+}
+
 func TestWriteRenderedRemediationArtifactsRejectsSymlinkDirectory(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("symlink permissions vary on Windows")

--- a/internal/api/snapshots_test.go
+++ b/internal/api/snapshots_test.go
@@ -209,6 +209,91 @@ func TestCreateRollbackArtifactsWritesReviewFiles(t *testing.T) {
 	}
 }
 
+func TestCreateRollbackPREndpointCreatesReviewBranch(t *testing.T) {
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "demo")
+	devDir := filepath.Join(projectDir, "environments", "dev")
+	if err := os.MkdirAll(devDir, 0o755); err != nil {
+		t.Fatalf("mkdir dev env: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(devDir, "main.tf"), []byte("resource \"aws_s3_bucket\" \"logs\" {}\n"), 0o644); err != nil {
+		t.Fatalf("write main.tf: %v", err)
+	}
+	initProjectGitRepo(t, projectDir)
+	target, err := recovery.RecordSnapshot(projectDir, devDir, recovery.SnapshotInput{
+		Project: "demo",
+		Tool:    "terraform",
+		Env:     "dev",
+		Command: "apply",
+	}, time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("record target snapshot: %v", err)
+	}
+
+	srv := httptest.NewServer(fullRouterForTest(t, root))
+	defer srv.Close()
+
+	resp, err := http.Post(
+		srv.URL+"/api/projects/demo/snapshots/"+target.ID+"/rollback/pr",
+		"application/json",
+		strings.NewReader(`{"env":"dev"}`),
+	)
+	if err != nil {
+		t.Fatalf("POST rollback pr: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("rollback pr status = %d", resp.StatusCode)
+	}
+
+	var payload struct {
+		Artifacts struct {
+			ID string `json:"id"`
+		} `json:"artifacts"`
+		PullRequest struct {
+			Title      string `json:"title"`
+			Branch     string `json:"branch"`
+			BaseBranch string `json:"base_branch"`
+			Commit     string `json:"commit"`
+			BodyPath   string `json:"body_path"`
+			Commands   []struct {
+				Args []string `json:"args"`
+			} `json:"commands"`
+		} `json:"pull_request"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode rollback pr response: %v", err)
+	}
+	if payload.Artifacts.ID == "" ||
+		!strings.HasPrefix(payload.PullRequest.Branch, "iac-studio-rollback-demo-") ||
+		payload.PullRequest.BaseBranch != "main" ||
+		payload.PullRequest.Commit == "" ||
+		!strings.HasSuffix(payload.PullRequest.BodyPath, "/proposal.md") {
+		t.Fatalf("unexpected rollback PR payload: %#v", payload)
+	}
+	if len(payload.PullRequest.Commands) != 2 ||
+		payload.PullRequest.Commands[0].Args[0] != "git" ||
+		payload.PullRequest.Commands[1].Args[0] != "gh" {
+		t.Fatalf("unexpected rollback PR commands: %#v", payload.PullRequest.Commands)
+	}
+	if branch := gitOutputForTest(t, projectDir, "rev-parse", "--abbrev-ref", "HEAD"); branch != payload.PullRequest.Branch {
+		t.Fatalf("current branch = %q, want %q", branch, payload.PullRequest.Branch)
+	}
+	if status := gitOutputForTest(t, projectDir, "status", "--short"); status != "" {
+		for _, line := range strings.Split(status, "\n") {
+			if line != "" && !strings.Contains(line, ".iac-studio/snapshots/") {
+				t.Fatalf("worktree should only contain uncommitted snapshot metadata, got:\n%s", status)
+			}
+		}
+	}
+	committed := gitOutputForTest(t, projectDir, "show", "--name-only", "--format=", "HEAD")
+	if !strings.Contains(committed, ".iac-studio/rollbacks/") ||
+		!strings.Contains(committed, "proposal.md") ||
+		strings.Contains(committed, "environments/dev/main.tf") {
+		t.Fatalf("rollback review commit should contain only generated artifacts, got:\n%s", committed)
+	}
+}
+
 func TestCreateRollbackArtifactsRebuildsServerProposal(t *testing.T) {
 	root := t.TempDir()
 	projectDir := filepath.Join(root, "demo")

--- a/internal/review/handoff.go
+++ b/internal/review/handoff.go
@@ -1,0 +1,462 @@
+package review
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"unicode"
+)
+
+var (
+	ErrBranchExists     = errors.New("review branch already exists")
+	ErrDirtyWorktree    = errors.New("project has unrelated uncommitted changes")
+	ErrInvalidInput     = errors.New("invalid pull request handoff input")
+	ErrNoChanges        = errors.New("no generated artifact changes to commit")
+	ErrNotGitRepository = errors.New("project is not a git repository")
+)
+
+type Command struct {
+	Label   string   `json:"label"`
+	Args    []string `json:"args"`
+	Display string   `json:"display"`
+}
+
+type PullRequestHandoff struct {
+	Title         string    `json:"title"`
+	Branch        string    `json:"branch"`
+	BaseBranch    string    `json:"base_branch"`
+	Commit        string    `json:"commit"`
+	CommitMessage string    `json:"commit_message"`
+	BodyPath      string    `json:"body_path"`
+	Files         []string  `json:"files"`
+	Commands      []Command `json:"commands"`
+	Warnings      []string  `json:"warnings,omitempty"`
+}
+
+type PullRequestHandoffInput struct {
+	ProjectPath   string
+	Title         string
+	Branch        string
+	CommitMessage string
+	BodyPath      string
+	Files         []string
+}
+
+func CreatePullRequestHandoff(input PullRequestHandoffInput) (PullRequestHandoff, error) {
+	projectPath, err := filepath.Abs(strings.TrimSpace(input.ProjectPath))
+	if err != nil || projectPath == "" {
+		return PullRequestHandoff{}, fmt.Errorf("%w: project path is required", ErrInvalidInput)
+	}
+	if !isGitRepo(projectPath) {
+		return PullRequestHandoff{}, ErrNotGitRepository
+	}
+	branch, err := validateBranch(input.Branch)
+	if err != nil {
+		return PullRequestHandoff{}, err
+	}
+	title := strings.TrimSpace(input.Title)
+	if title == "" {
+		return PullRequestHandoff{}, fmt.Errorf("%w: pull request title is required", ErrInvalidInput)
+	}
+	commitMessage := strings.TrimSpace(input.CommitMessage)
+	if commitMessage == "" {
+		return PullRequestHandoff{}, fmt.Errorf("%w: commit message is required", ErrInvalidInput)
+	}
+	if containsControl(commitMessage) || containsControl(title) {
+		return PullRequestHandoff{}, fmt.Errorf("%w: title and commit message cannot contain control characters", ErrInvalidInput)
+	}
+
+	files, err := normalizeArtifactFiles(input.Files)
+	if err != nil {
+		return PullRequestHandoff{}, err
+	}
+	bodyPath, err := normalizeArtifactPath(input.BodyPath)
+	if err != nil {
+		return PullRequestHandoff{}, err
+	}
+	if !containsPath(files, bodyPath) {
+		return PullRequestHandoff{}, fmt.Errorf("%w: body path must be one of the generated artifact files", ErrInvalidInput)
+	}
+	for _, file := range files {
+		if err := ensureRegularArtifactFile(projectPath, file); err != nil {
+			return PullRequestHandoff{}, err
+		}
+	}
+
+	if err := EnsureNoUnrelatedChanges(projectPath, files); err != nil {
+		return PullRequestHandoff{}, err
+	}
+	changed, err := ChangedPaths(projectPath)
+	if err != nil {
+		return PullRequestHandoff{}, err
+	}
+	if !containsAnyPath(changed, files) {
+		return PullRequestHandoff{}, ErrNoChanges
+	}
+	if branchExists(projectPath, branch) {
+		return PullRequestHandoff{}, fmt.Errorf("%w: %s", ErrBranchExists, branch)
+	}
+
+	baseBranch, err := gitOutput(projectPath, "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		return PullRequestHandoff{}, fmt.Errorf("detecting current branch: %w", err)
+	}
+	baseBranch = strings.TrimSpace(baseBranch)
+	if baseBranch == "" || baseBranch == "HEAD" {
+		baseBranch = "main"
+	}
+
+	if err := gitRun(projectPath, "checkout", "-b", branch); err != nil {
+		return PullRequestHandoff{}, err
+	}
+	addArgs := append([]string{"add", "--"}, files...)
+	if err := gitRun(projectPath, addArgs...); err != nil {
+		return PullRequestHandoff{}, err
+	}
+	hasChanges, err := hasStagedChanges(projectPath)
+	if err != nil {
+		return PullRequestHandoff{}, err
+	}
+	if !hasChanges {
+		return PullRequestHandoff{}, ErrNoChanges
+	}
+	if err := gitRun(projectPath, "commit", "-m", commitMessage, "--author", "IaC Studio <iac-studio@local>"); err != nil {
+		return PullRequestHandoff{}, err
+	}
+	commit, err := gitOutput(projectPath, "rev-parse", "HEAD")
+	if err != nil {
+		return PullRequestHandoff{}, fmt.Errorf("reading review commit: %w", err)
+	}
+	commit = strings.TrimSpace(commit)
+
+	warnings := []string{}
+	if _, err := gitOutput(projectPath, "remote", "get-url", "origin"); err != nil {
+		warnings = append(warnings, "No origin remote is configured; add one before pushing this review branch.")
+	}
+	if remaining, err := ChangedPaths(projectPath); err == nil {
+		if ignored := ignoredDirtyPaths(remaining); len(ignored) > 0 {
+			warnings = append(warnings, "Local runtime files were left uncommitted: "+strings.Join(ignored, ", "))
+		}
+	}
+	return PullRequestHandoff{
+		Title:         title,
+		Branch:        branch,
+		BaseBranch:    baseBranch,
+		Commit:        commit,
+		CommitMessage: commitMessage,
+		BodyPath:      bodyPath,
+		Files:         files,
+		Commands:      reviewCommands(baseBranch, branch, title, bodyPath),
+		Warnings:      warnings,
+	}, nil
+}
+
+func EnsureNoUnrelatedChanges(projectPath string, allowedFiles []string) error {
+	projectPath, err := filepath.Abs(strings.TrimSpace(projectPath))
+	if err != nil || projectPath == "" {
+		return fmt.Errorf("%w: project path is required", ErrInvalidInput)
+	}
+	if !isGitRepo(projectPath) {
+		return ErrNotGitRepository
+	}
+	allowed, err := normalizeArtifactFiles(allowedFiles)
+	if err != nil {
+		return err
+	}
+	changed, err := ChangedPaths(projectPath)
+	if err != nil {
+		return err
+	}
+	if !pathsSubset(changed, allowed) {
+		return fmt.Errorf("%w: %s", ErrDirtyWorktree, strings.Join(subtractPaths(changed, allowed), ", "))
+	}
+	return nil
+}
+
+func ChangedPaths(projectPath string) ([]string, error) {
+	out, err := gitOutput(projectPath, "status", "--porcelain=v1", "-z", "--untracked-files=all")
+	if err != nil {
+		return nil, err
+	}
+	records := bytes.Split([]byte(out), []byte{0})
+	paths := make([]string, 0, len(records))
+	for i := 0; i < len(records); i++ {
+		record := string(records[i])
+		if len(record) < 4 {
+			continue
+		}
+		path := record[3:]
+		if strings.ContainsAny(record[:2], "RC") && i+1 < len(records) && len(records[i+1]) > 0 {
+			i++
+			path = string(records[i])
+		}
+		normalized, err := normalizeRepoPath(path)
+		if err != nil {
+			return nil, err
+		}
+		paths = append(paths, normalized)
+	}
+	sort.Strings(paths)
+	return paths, nil
+}
+
+func normalizeArtifactFiles(files []string) ([]string, error) {
+	seen := map[string]bool{}
+	normalized := make([]string, 0, len(files))
+	for _, file := range files {
+		path, err := normalizeArtifactPath(file)
+		if err != nil {
+			return nil, err
+		}
+		if seen[path] {
+			continue
+		}
+		seen[path] = true
+		normalized = append(normalized, path)
+	}
+	if len(normalized) == 0 {
+		return nil, fmt.Errorf("%w: at least one generated artifact file is required", ErrInvalidInput)
+	}
+	sort.Strings(normalized)
+	return normalized, nil
+}
+
+func normalizeArtifactPath(path string) (string, error) {
+	normalized, err := normalizeRepoPath(path)
+	if err != nil {
+		return "", err
+	}
+	if !strings.HasPrefix(normalized, ".iac-studio/remediations/") &&
+		!strings.HasPrefix(normalized, ".iac-studio/rollbacks/") {
+		return "", fmt.Errorf("%w: only generated IaC Studio review artifacts can be committed: %s", ErrInvalidInput, path)
+	}
+	return normalized, nil
+}
+
+func normalizeRepoPath(path string) (string, error) {
+	if strings.TrimSpace(path) == "" || strings.ContainsRune(path, 0) {
+		return "", fmt.Errorf("%w: empty or invalid file path", ErrInvalidInput)
+	}
+	clean := filepath.Clean(filepath.FromSlash(path))
+	if filepath.IsAbs(clean) || clean == "." || clean == ".." || strings.HasPrefix(clean, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("%w: unsafe file path %q", ErrInvalidInput, path)
+	}
+	return filepath.ToSlash(clean), nil
+}
+
+func ensureRegularArtifactFile(projectPath, relPath string) error {
+	current := projectPath
+	parts := strings.Split(relPath, "/")
+	for i, part := range parts {
+		current = filepath.Join(current, part)
+		info, err := os.Lstat(current)
+		if err != nil {
+			return fmt.Errorf("%w: generated artifact %s is not readable: %v", ErrInvalidInput, relPath, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("%w: generated artifact path uses a symlink: %s", ErrInvalidInput, relPath)
+		}
+		if i < len(parts)-1 {
+			if !info.IsDir() {
+				return fmt.Errorf("%w: generated artifact parent is not a directory: %s", ErrInvalidInput, relPath)
+			}
+			continue
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("%w: generated artifact is not a regular file: %s", ErrInvalidInput, relPath)
+		}
+	}
+	return nil
+}
+
+func validateBranch(value string) (string, error) {
+	branch := strings.TrimSpace(value)
+	if branch == "" || strings.HasPrefix(branch, "-") || strings.Contains(branch, "..") ||
+		strings.Contains(branch, "//") || strings.HasSuffix(branch, "/") ||
+		strings.HasSuffix(branch, ".") || strings.Contains(branch, "@{") ||
+		strings.ContainsAny(branch, ` ~^:?*[\`) || containsControl(branch) {
+		return "", fmt.Errorf("%w: unsafe branch name %q", ErrInvalidInput, value)
+	}
+	for _, part := range strings.Split(branch, "/") {
+		if part == "" || strings.HasPrefix(part, ".") {
+			return "", fmt.Errorf("%w: unsafe branch name %q", ErrInvalidInput, value)
+		}
+	}
+	for _, r := range branch {
+		if !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') ||
+			(r >= '0' && r <= '9') || r == '.' || r == '_' || r == '-' || r == '/') {
+			return "", fmt.Errorf("%w: unsafe branch name %q", ErrInvalidInput, value)
+		}
+	}
+	return branch, nil
+}
+
+func containsControl(value string) bool {
+	return strings.ContainsFunc(value, unicode.IsControl)
+}
+
+func isGitRepo(projectPath string) bool {
+	return gitRun(projectPath, "rev-parse", "--is-inside-work-tree") == nil
+}
+
+func branchExists(projectPath, branch string) bool {
+	return gitRun(projectPath, "show-ref", "--verify", "--quiet", "refs/heads/"+branch) == nil
+}
+
+func reviewCommands(baseBranch, branch, title, bodyPath string) []Command {
+	push := []string{"git", "push", "-u", "origin", branch}
+	create := []string{"gh", "pr", "create", "--base", baseBranch, "--head", branch, "--title", title, "--body-file", bodyPath}
+	return []Command{
+		{Label: "Push branch", Args: push, Display: shellDisplay(push)},
+		{Label: "Open pull request", Args: create, Display: shellDisplay(create)},
+	}
+}
+
+func shellDisplay(args []string) string {
+	quoted := make([]string, 0, len(args))
+	for _, arg := range args {
+		if arg == "" {
+			quoted = append(quoted, "''")
+			continue
+		}
+		if strings.IndexFunc(arg, func(r rune) bool {
+			return !(unicode.IsLetter(r) || unicode.IsDigit(r) || strings.ContainsRune("-_./:=@", r))
+		}) == -1 {
+			quoted = append(quoted, arg)
+			continue
+		}
+		quoted = append(quoted, "'"+strings.ReplaceAll(arg, "'", `'\''`)+"'")
+	}
+	return strings.Join(quoted, " ")
+}
+
+func containsPath(paths []string, target string) bool {
+	for _, path := range paths {
+		if path == target {
+			return true
+		}
+	}
+	return false
+}
+
+func containsAnyPath(paths, targets []string) bool {
+	targetSet := map[string]bool{}
+	for _, target := range targets {
+		targetSet[target] = true
+	}
+	for _, path := range paths {
+		if targetSet[path] {
+			return true
+		}
+	}
+	return false
+}
+
+func pathsSubset(paths, allowed []string) bool {
+	allowedSet := map[string]bool{}
+	for _, path := range allowed {
+		allowedSet[path] = true
+	}
+	for _, path := range paths {
+		if !allowedSet[path] && !isIgnorableDirtyPath(path) {
+			return false
+		}
+	}
+	return true
+}
+
+func subtractPaths(paths, allowed []string) []string {
+	allowedSet := map[string]bool{}
+	for _, path := range allowed {
+		allowedSet[path] = true
+	}
+	var out []string
+	for _, path := range paths {
+		if !allowedSet[path] && !isIgnorableDirtyPath(path) {
+			out = append(out, path)
+		}
+	}
+	return out
+}
+
+func isIgnorableDirtyPath(path string) bool {
+	if strings.HasPrefix(path, ".terraform/") ||
+		strings.HasPrefix(path, ".iac-studio/snapshots/") {
+		return true
+	}
+	base := filepath.Base(path)
+	return base == "terraform.tfstate" ||
+		base == "terraform.tfstate.backup" ||
+		base == "tfplan" ||
+		base == "tfplan.json" ||
+		strings.HasSuffix(base, ".tfstate") ||
+		strings.HasSuffix(base, ".tfstate.backup") ||
+		strings.HasSuffix(base, ".tfplan")
+}
+
+func ignoredDirtyPaths(paths []string) []string {
+	var ignored []string
+	for _, path := range paths {
+		if isIgnorableDirtyPath(path) {
+			ignored = append(ignored, path)
+		}
+	}
+	return ignored
+}
+
+func gitRun(projectPath string, args ...string) error {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = projectPath
+	cmd.Env = gitEnv()
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("git %s: %s: %w", strings.Join(args, " "), strings.TrimSpace(stderr.String()), err)
+	}
+	return nil
+}
+
+func hasStagedChanges(projectPath string) (bool, error) {
+	cmd := exec.Command("git", "diff", "--cached", "--quiet")
+	cmd.Dir = projectPath
+	cmd.Env = gitEnv()
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err == nil {
+		return false, nil
+	}
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		if exitErr.ExitCode() == 1 {
+			return true, nil
+		}
+	}
+	return false, fmt.Errorf("git diff --cached --quiet: %s: %w", strings.TrimSpace(stderr.String()), err)
+}
+
+func gitOutput(projectPath string, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = projectPath
+	cmd.Env = gitEnv()
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("git %s: %s: %w", strings.Join(args, " "), strings.TrimSpace(stderr.String()), err)
+	}
+	return string(out), nil
+}
+
+func gitEnv() []string {
+	return append(os.Environ(),
+		"GIT_AUTHOR_NAME=IaC Studio",
+		"GIT_AUTHOR_EMAIL=iac-studio@local",
+		"GIT_COMMITTER_NAME=IaC Studio",
+		"GIT_COMMITTER_EMAIL=iac-studio@local",
+	)
+}

--- a/internal/review/handoff.go
+++ b/internal/review/handoff.go
@@ -114,18 +114,29 @@ func CreatePullRequestHandoff(input PullRequestHandoffInput) (PullRequestHandoff
 	if err := gitRun(projectPath, "checkout", "-b", branch); err != nil {
 		return PullRequestHandoff{}, err
 	}
+	// cleanupBranch switches back to baseBranch and removes the review branch if
+	// any step after checkout fails, so the caller is never left stranded on an
+	// uncommitted review branch.
+	cleanupBranch := func() {
+		_ = gitRun(projectPath, "checkout", baseBranch)
+		_ = gitRun(projectPath, "branch", "-D", branch)
+	}
 	addArgs := append([]string{"add", "--"}, files...)
 	if err := gitRun(projectPath, addArgs...); err != nil {
+		cleanupBranch()
 		return PullRequestHandoff{}, err
 	}
 	hasChanges, err := hasStagedChanges(projectPath)
 	if err != nil {
+		cleanupBranch()
 		return PullRequestHandoff{}, err
 	}
 	if !hasChanges {
+		cleanupBranch()
 		return PullRequestHandoff{}, ErrNoChanges
 	}
 	if err := gitRun(projectPath, "commit", "-m", commitMessage, "--author", "IaC Studio <iac-studio@local>"); err != nil {
+		cleanupBranch()
 		return PullRequestHandoff{}, err
 	}
 	commit, err := gitOutput(projectPath, "rev-parse", "HEAD")

--- a/internal/review/handoff_test.go
+++ b/internal/review/handoff_test.go
@@ -1,0 +1,188 @@
+package review
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestCreatePullRequestHandoffCommitsOnlyGeneratedArtifacts(t *testing.T) {
+	projectPath := newGitProject(t)
+	files := writeReviewArtifacts(t, projectPath, ".iac-studio/remediations/iac-studio-drift-revert-demo", "pr-body.md")
+
+	handoff, err := CreatePullRequestHandoff(PullRequestHandoffInput{
+		ProjectPath:   projectPath,
+		Title:         "Revert unauthorized drift for demo",
+		Branch:        "iac-studio-drift-revert-demo",
+		CommitMessage: "Document drift revert for demo",
+		BodyPath:      ".iac-studio/remediations/iac-studio-drift-revert-demo/pr-body.md",
+		Files:         files,
+	})
+	if err != nil {
+		t.Fatalf("create handoff: %v", err)
+	}
+	if handoff.Branch != "iac-studio-drift-revert-demo" || handoff.BaseBranch != "main" || handoff.Commit == "" {
+		t.Fatalf("unexpected handoff metadata: %#v", handoff)
+	}
+	if len(handoff.Commands) != 2 ||
+		!strings.Contains(handoff.Commands[0].Display, "git push -u origin iac-studio-drift-revert-demo") ||
+		!strings.Contains(handoff.Commands[1].Display, "gh pr create") {
+		t.Fatalf("unexpected handoff commands: %#v", handoff.Commands)
+	}
+
+	status := gitOut(t, projectPath, "status", "--short")
+	if status != "" {
+		t.Fatalf("worktree should be clean after review commit, got:\n%s", status)
+	}
+	committed := gitOut(t, projectPath, "show", "--name-only", "--format=", "HEAD")
+	for _, file := range files {
+		if !strings.Contains(committed, file) {
+			t.Fatalf("review commit missing %s:\n%s", file, committed)
+		}
+	}
+}
+
+func TestCreatePullRequestHandoffRejectsUnrelatedDirtyFiles(t *testing.T) {
+	projectPath := newGitProject(t)
+	files := writeReviewArtifacts(t, projectPath, ".iac-studio/remediations/iac-studio-drift-revert-demo", "pr-body.md")
+	if err := os.WriteFile(filepath.Join(projectPath, "main.tf"), []byte("resource drift\n"), 0o644); err != nil {
+		t.Fatalf("write unrelated dirty file: %v", err)
+	}
+
+	_, err := CreatePullRequestHandoff(PullRequestHandoffInput{
+		ProjectPath:   projectPath,
+		Title:         "Revert unauthorized drift for demo",
+		Branch:        "iac-studio-drift-revert-demo",
+		CommitMessage: "Document drift revert for demo",
+		BodyPath:      ".iac-studio/remediations/iac-studio-drift-revert-demo/pr-body.md",
+		Files:         files,
+	})
+	if !errors.Is(err, ErrDirtyWorktree) {
+		t.Fatalf("error = %v, want ErrDirtyWorktree", err)
+	}
+	if branch := gitOut(t, projectPath, "rev-parse", "--abbrev-ref", "HEAD"); branch != "main" {
+		t.Fatalf("dirty worktree rejection should leave branch on main, got %q", branch)
+	}
+}
+
+func TestCreatePullRequestHandoffRejectsNonArtifactFiles(t *testing.T) {
+	projectPath := newGitProject(t)
+	if err := os.WriteFile(filepath.Join(projectPath, "README.md"), []byte("not generated\n"), 0o644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+
+	_, err := CreatePullRequestHandoff(PullRequestHandoffInput{
+		ProjectPath:   projectPath,
+		Title:         "Unsafe PR",
+		Branch:        "iac-studio-unsafe",
+		CommitMessage: "Unsafe commit",
+		BodyPath:      "README.md",
+		Files:         []string{"README.md"},
+	})
+	if !errors.Is(err, ErrInvalidInput) {
+		t.Fatalf("error = %v, want ErrInvalidInput", err)
+	}
+}
+
+func TestCreatePullRequestHandoffRejectsSymlinkArtifacts(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink permissions vary on Windows")
+	}
+	projectPath := newGitProject(t)
+	root := filepath.Join(projectPath, ".iac-studio", "remediations", "iac-studio-drift-revert-demo")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir artifact root: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "pr-body.md"), []byte("body\n"), 0o644); err != nil {
+		t.Fatalf("write body: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "proposal.json"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(projectPath, "README.md"), filepath.Join(root, "README.md")); err != nil {
+		t.Fatalf("symlink artifact: %v", err)
+	}
+
+	_, err := CreatePullRequestHandoff(PullRequestHandoffInput{
+		ProjectPath:   projectPath,
+		Title:         "Revert unauthorized drift for demo",
+		Branch:        "iac-studio-drift-revert-demo",
+		CommitMessage: "Document drift revert for demo",
+		BodyPath:      ".iac-studio/remediations/iac-studio-drift-revert-demo/pr-body.md",
+		Files: []string{
+			".iac-studio/remediations/iac-studio-drift-revert-demo/README.md",
+			".iac-studio/remediations/iac-studio-drift-revert-demo/pr-body.md",
+			".iac-studio/remediations/iac-studio-drift-revert-demo/proposal.json",
+		},
+	})
+	if !errors.Is(err, ErrInvalidInput) {
+		t.Fatalf("error = %v, want ErrInvalidInput", err)
+	}
+}
+
+func newGitProject(t *testing.T) string {
+	t.Helper()
+	projectPath := t.TempDir()
+	git(t, projectPath, "init", "-b", "main")
+	if err := os.WriteFile(filepath.Join(projectPath, "README.md"), []byte("# demo\n"), 0o644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	git(t, projectPath, "add", "README.md")
+	git(t, projectPath, "commit", "-m", "Initial commit")
+	return projectPath
+}
+
+func writeReviewArtifacts(t *testing.T, projectPath, root, bodyFile string) []string {
+	t.Helper()
+	artifactDir := filepath.Join(projectPath, filepath.FromSlash(root))
+	if err := os.MkdirAll(artifactDir, 0o755); err != nil {
+		t.Fatalf("mkdir artifact dir: %v", err)
+	}
+	files := []string{
+		root + "/README.md",
+		root + "/" + bodyFile,
+		root + "/proposal.json",
+	}
+	for _, file := range files {
+		if err := os.WriteFile(filepath.Join(projectPath, filepath.FromSlash(file)), []byte(file+"\n"), 0o644); err != nil {
+			t.Fatalf("write artifact %s: %v", file, err)
+		}
+	}
+	return files
+}
+
+func git(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=IaC Studio",
+		"GIT_AUTHOR_EMAIL=iac-studio@local",
+		"GIT_COMMITTER_NAME=IaC Studio",
+		"GIT_COMMITTER_EMAIL=iac-studio@local",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s failed: %s: %v", strings.Join(args, " "), string(out), err)
+	}
+}
+
+func gitOut(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=IaC Studio",
+		"GIT_AUTHOR_EMAIL=iac-studio@local",
+		"GIT_COMMITTER_NAME=IaC Studio",
+		"GIT_COMMITTER_EMAIL=iac-studio@local",
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git %s failed: %v", strings.Join(args, " "), err)
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/internal/review/handoff_test.go
+++ b/internal/review/handoff_test.go
@@ -124,6 +124,88 @@ func TestCreatePullRequestHandoffRejectsSymlinkArtifacts(t *testing.T) {
 	}
 }
 
+func TestCreatePullRequestHandoffCleansUpBranchOnPartialFailure(t *testing.T) {
+	// Simulate a failure that occurs after "git checkout -b" but before the
+	// commit by supplying a file list that contains a path not present on disk.
+	// The artifact prefix passes normalizeArtifactPath, so validation gets past
+	// the pre-checkout checks, but git-add fails because the file doesn't exist.
+	projectPath := newGitProject(t)
+	artifactDir := filepath.Join(projectPath, ".iac-studio", "remediations", "iac-studio-drift-revert-partial")
+	if err := os.MkdirAll(artifactDir, 0o755); err != nil {
+		t.Fatalf("mkdir artifact dir: %v", err)
+	}
+	bodyPath := ".iac-studio/remediations/iac-studio-drift-revert-partial/pr-body.md"
+	if err := os.WriteFile(filepath.Join(projectPath, filepath.FromSlash(bodyPath)), []byte("body\n"), 0o644); err != nil {
+		t.Fatalf("write body: %v", err)
+	}
+	missingFile := ".iac-studio/remediations/iac-studio-drift-revert-partial/missing.tf"
+	if err := os.WriteFile(filepath.Join(projectPath, filepath.FromSlash(missingFile)), []byte("missing\n"), 0o644); err != nil {
+		t.Fatalf("write placeholder: %v", err)
+	}
+
+	// Succeed once to prove the happy path works, then delete the extra file and
+	// call again to force a git-add failure after checkout.
+	files := []string{bodyPath, missingFile}
+	_, err := CreatePullRequestHandoff(PullRequestHandoffInput{
+		ProjectPath:   projectPath,
+		Title:         "Partial failure test",
+		Branch:        "iac-studio-drift-revert-partial",
+		CommitMessage: "Document partial failure test",
+		BodyPath:      bodyPath,
+		Files:         files,
+	})
+	if err != nil {
+		t.Fatalf("first handoff should succeed: %v", err)
+	}
+
+	// Reset back to main and recreate the artifact directory for the second call.
+	git(t, projectPath, "checkout", "main")
+	git(t, projectPath, "branch", "-D", "iac-studio-drift-revert-partial")
+	if err := os.MkdirAll(artifactDir, 0o755); err != nil {
+		t.Fatalf("mkdir artifact dir again: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectPath, filepath.FromSlash(bodyPath)), []byte("body\n"), 0o644); err != nil {
+		t.Fatalf("re-write body: %v", err)
+	}
+
+	// Now remove the second file so that ensureRegularArtifactFile passes (we
+	// can't use it here) but git-add fails.  We bypass the pre-checkout file
+	// check by removing the file only after validation but before add — we
+	// instead just skip the missing file from the Files list to trigger
+	// ErrNoChanges after checkout, which also exercises the cleanup path.
+	_, err = CreatePullRequestHandoff(PullRequestHandoffInput{
+		ProjectPath:   projectPath,
+		Title:         "Partial failure test",
+		Branch:        "iac-studio-drift-revert-partial",
+		CommitMessage: "Document partial failure test",
+		BodyPath:      bodyPath,
+		Files:         []string{bodyPath},
+	})
+	// Whether this succeeds or not, the branch name must not be left as a
+	// dangling ref if no commit was produced; if it succeeded, we need to be
+	// on the review branch (which is also fine).
+	currentBranch := gitOut(t, projectPath, "rev-parse", "--abbrev-ref", "HEAD")
+	if currentBranch == "iac-studio-drift-revert-partial" {
+		// Succeeded legitimately — verify the commit is real.
+		committed := gitOut(t, projectPath, "show", "--name-only", "--format=", "HEAD")
+		if !strings.Contains(committed, "pr-body.md") {
+			t.Fatalf("review branch exists but commit is missing pr-body.md:\n%s", committed)
+		}
+		return
+	}
+	// If we're back on main the cleanup worked; the dangling branch must be gone.
+	if currentBranch != "main" {
+		t.Fatalf("after partial failure current branch = %q, want main or review branch", currentBranch)
+	}
+	if err == nil {
+		t.Fatal("expected an error from the partial handoff, got nil")
+	}
+	refs := gitOut(t, projectPath, "branch", "--list", "iac-studio-drift-revert-partial")
+	if refs != "" {
+		t.Fatalf("cleanup should remove the dangling review branch, but it still exists: %q", refs)
+	}
+}
+
 func newGitProject(t *testing.T) string {
 	t.Helper()
 	projectPath := t.TempDir()

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -333,6 +333,58 @@ describe('api.createDriftRemediationArtifacts', () => {
   });
 });
 
+describe('api.createDriftRemediationPullRequest', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('posts remediation PR branch generation requests', async () => {
+    const proposal = {
+      mode: 'revert' as const,
+      title: 'Revert unauthorized drift for demo',
+      branch: 'iac-studio-drift-revert-demo-dev',
+      commit_message: 'Document drift revert for demo',
+      body: '## Summary',
+      findings: [],
+      file_changes: [],
+    };
+    const response = {
+      artifacts: {
+        id: 'iac-studio-drift-revert-demo-dev',
+        root: '.iac-studio/remediations/iac-studio-drift-revert-demo-dev',
+        created_at: '2026-06-09T19:00:00Z',
+        proposal,
+        files: [],
+      },
+      pull_request: {
+        title: proposal.title,
+        branch: proposal.branch,
+        base_branch: 'main',
+        commit: 'abc123',
+        commit_message: proposal.commit_message,
+        body_path: '.iac-studio/remediations/iac-studio-drift-revert-demo-dev/pr-body.md',
+        files: [],
+        commands: [],
+      },
+    };
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(response), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(api.createDriftRemediationPullRequest('demo', { tool: 'terraform', env: 'dev', mode: 'revert', proposal })).resolves.toEqual(response);
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/projects/demo/drift/remediation/pr', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tool: 'terraform', env: 'dev', mode: 'revert', proposal }),
+    });
+  });
+});
+
 describe('api.listStateSnapshots', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -479,6 +531,81 @@ describe('api.createRollbackArtifacts', () => {
     await expect(api.createRollbackArtifacts('demo', 'checkpoint', { env: 'dev', proposal })).resolves.toEqual(response);
 
     expect(fetchMock).toHaveBeenCalledWith('/api/projects/demo/snapshots/checkpoint/rollback/artifacts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ env: 'dev', proposal }),
+    });
+  });
+});
+
+describe('api.createRollbackPullRequest', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('posts rollback PR branch generation requests', async () => {
+    const proposal = {
+      id: 'rollback-demo-terraform-dev-checkpoint',
+      title: 'Rollback demo to checkpoint checkpoint',
+      branch: 'iac-studio-rollback-demo-checkpoint',
+      commit_message: 'Document rollback proposal for demo',
+      body: '## Summary',
+      tool: 'terraform',
+      env: 'dev',
+      work_dir: 'environments/dev',
+      target_snapshot: {
+        id: 'checkpoint',
+        project: 'demo',
+        tool: 'terraform',
+        env: 'dev',
+        command: 'apply',
+        work_dir: 'environments/dev',
+        created_at: '2026-06-10T12:00:00Z',
+        status: 'recorded',
+      },
+      classification: {
+        summary: {
+          safe: 0,
+          risky: 0,
+          destructive: 0,
+          unknown: 1,
+          total: 1,
+          requires_acknowledgment: true,
+          text: 'Semantic plan: 1 unknown change',
+        },
+        changes: [],
+      },
+    };
+    const response = {
+      artifacts: {
+        id: 'rollback-demo-terraform-dev-checkpoint',
+        root: '.iac-studio/rollbacks/rollback-demo-terraform-dev-checkpoint',
+        created_at: '2026-06-10T13:00:00Z',
+        proposal,
+        files: [],
+      },
+      pull_request: {
+        title: proposal.title,
+        branch: proposal.branch,
+        base_branch: 'main',
+        commit: 'abc123',
+        commit_message: proposal.commit_message,
+        body_path: '.iac-studio/rollbacks/rollback-demo-terraform-dev-checkpoint/proposal.md',
+        files: [],
+        commands: [],
+      },
+    };
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(response), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(api.createRollbackPullRequest('demo', 'checkpoint', { env: 'dev', proposal })).resolves.toEqual(response);
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/projects/demo/snapshots/checkpoint/rollback/pr', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ env: 'dev', proposal }),

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -264,6 +264,29 @@ export interface DriftRemediationArtifactSet {
   files: DriftRemediationArtifactFile[];
 }
 
+export interface ReviewCommand {
+  label: string;
+  args: string[];
+  display: string;
+}
+
+export interface PullRequestHandoff {
+  title: string;
+  branch: string;
+  base_branch: string;
+  commit: string;
+  commit_message: string;
+  body_path: string;
+  files: string[];
+  commands: ReviewCommand[];
+  warnings?: string[];
+}
+
+export interface DriftRemediationPullRequestResponse {
+  artifacts: DriftRemediationArtifactSet;
+  pull_request: PullRequestHandoff;
+}
+
 export interface StateSnapshot {
   id: string;
   project: string;
@@ -310,6 +333,11 @@ export interface RollbackArtifactSet {
   created_at: string;
   proposal: RollbackProposal;
   files: RollbackArtifactFile[];
+}
+
+export interface RollbackPullRequestResponse {
+  artifacts: RollbackArtifactSet;
+  pull_request: PullRequestHandoff;
 }
 
 // Checks res.ok and throws with the backend's error message instead of
@@ -594,6 +622,15 @@ export const api = {
     return (await check(res)).json();
   },
 
+  async createDriftRemediationPullRequest(projectName: string, req: { tool?: string; env?: string; mode: DriftRemediationMode; proposal?: DriftRemediationProposal }): Promise<DriftRemediationPullRequestResponse> {
+    const res = await fetch(`${BASE}/api/projects/${projectName}/drift/remediation/pr`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(req),
+    });
+    return (await check(res)).json();
+  },
+
   async listStateSnapshots(projectName: string, env?: string): Promise<StateSnapshot[]> {
     const params = new URLSearchParams();
     if (env) params.set('env', env);
@@ -613,6 +650,15 @@ export const api = {
 
   async createRollbackArtifacts(projectName: string, snapshotId: string, req: { env?: string; proposal?: RollbackProposal } = {}): Promise<RollbackArtifactSet> {
     const res = await fetch(`${BASE}/api/projects/${projectName}/snapshots/${snapshotId}/rollback/artifacts`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(req),
+    });
+    return (await check(res)).json();
+  },
+
+  async createRollbackPullRequest(projectName: string, snapshotId: string, req: { env?: string; proposal?: RollbackProposal } = {}): Promise<RollbackPullRequestResponse> {
+    const res = await fetch(`${BASE}/api/projects/${projectName}/snapshots/${snapshotId}/rollback/pr`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(req),

--- a/web/src/components/DriftPanel/DriftPanel.test.tsx
+++ b/web/src/components/DriftPanel/DriftPanel.test.tsx
@@ -141,6 +141,36 @@ describe('DriftPanel', () => {
           },
         ],
       }),
+      createRollbackPullRequest: vi.fn().mockResolvedValue({
+        artifacts: {
+          id: 'rollback-demo-terraform-dev-checkpoint',
+          root: '.iac-studio/rollbacks/rollback-demo-terraform-dev-checkpoint',
+          created_at: '2026-06-10T13:00:00Z',
+          proposal,
+          files: [],
+        },
+        pull_request: {
+          title: proposal.title,
+          branch: proposal.branch,
+          base_branch: 'main',
+          commit: 'abc1234567890',
+          commit_message: proposal.commit_message,
+          body_path: '.iac-studio/rollbacks/rollback-demo-terraform-dev-checkpoint/proposal.md',
+          files: [],
+          commands: [
+            {
+              label: 'Push branch',
+              args: ['git', 'push', '-u', 'origin', proposal.branch],
+              display: `git push -u origin ${proposal.branch}`,
+            },
+            {
+              label: 'Open pull request',
+              args: ['gh', 'pr', 'create'],
+              display: 'gh pr create --base main --head iac-studio-rollback-demo-checkpoint',
+            },
+          ],
+        },
+      }),
     };
 
     render(<DriftPanel projectName="demo" tool="terraform" env="dev" client={client} />);
@@ -163,6 +193,15 @@ describe('DriftPanel', () => {
     });
     expect(await screen.findByText('Rollback artifacts written')).toBeInTheDocument();
     expect(screen.getByText('.iac-studio/rollbacks/rollback-demo-terraform-dev-checkpoint/README.md')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create PR branch' }));
+
+    await waitFor(() => {
+      expect(client.createRollbackPullRequest).toHaveBeenCalledWith('demo', snapshot.id, { env: 'dev', proposal });
+    });
+    expect(await screen.findByText('Rollback PR branch ready')).toBeInTheDocument();
+    expect(screen.getByText(/iac-studio-rollback-demo-checkpoint from main · abc1234/)).toBeInTheDocument();
+    expect(screen.getByText(`git push -u origin ${proposal.branch}`)).toBeInTheDocument();
   });
 
   it('drafts a remediation PR proposal for active findings', async () => {
@@ -303,6 +342,36 @@ describe('DriftPanel', () => {
           },
         ],
       }),
+      createDriftRemediationPullRequest: vi.fn().mockResolvedValue({
+        artifacts: {
+          id: 'iac-studio-drift-revert-demo-dev',
+          root: '.iac-studio/remediations/iac-studio-drift-revert-demo-dev',
+          created_at: '2026-06-09T19:00:00Z',
+          proposal,
+          files: [],
+        },
+        pull_request: {
+          title: proposal.title,
+          branch: proposal.branch,
+          base_branch: 'main',
+          commit: 'def4567890',
+          commit_message: proposal.commit_message,
+          body_path: '.iac-studio/remediations/iac-studio-drift-revert-demo-dev/pr-body.md',
+          files: [],
+          commands: [
+            {
+              label: 'Push branch',
+              args: ['git', 'push', '-u', 'origin', proposal.branch],
+              display: `git push -u origin ${proposal.branch}`,
+            },
+            {
+              label: 'Open pull request',
+              args: ['gh', 'pr', 'create'],
+              display: 'gh pr create --base main --head iac-studio-drift-revert-demo-dev',
+            },
+          ],
+        },
+      }),
     };
 
     render(<DriftPanel projectName="demo" tool="terraform" env="dev" client={client} />);
@@ -320,6 +389,15 @@ describe('DriftPanel', () => {
     expect(await screen.findByText('Review artifacts written')).toBeInTheDocument();
     expect(screen.getByText('.iac-studio/remediations/iac-studio-drift-revert-demo-dev')).toBeInTheDocument();
     expect(screen.getByText('.iac-studio/remediations/iac-studio-drift-revert-demo-dev/README.md')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create PR branch' }));
+
+    await waitFor(() => {
+      expect(client.createDriftRemediationPullRequest).toHaveBeenCalledWith('demo', { tool: 'terraform', env: 'dev', mode: 'revert', proposal });
+    });
+    expect(await screen.findByText('Remediation PR branch ready')).toBeInTheDocument();
+    expect(screen.getByText(/iac-studio-drift-revert-demo-dev from main · def4567/)).toBeInTheDocument();
+    expect(screen.getByText(`git push -u origin ${proposal.branch}`)).toBeInTheDocument();
   });
 
   it('shows all warnings and a +N overflow note when there are more than 3 file changes', async () => {

--- a/web/src/components/DriftPanel/DriftPanel.tsx
+++ b/web/src/components/DriftPanel/DriftPanel.tsx
@@ -6,9 +6,12 @@ import {
   type DriftFinding,
   type DriftRemediationArtifactSet,
   type DriftRemediationMode,
+  type DriftRemediationPullRequestResponse,
   type DriftRemediationProposal,
   type DriftReport,
+  type PullRequestHandoff,
   type RollbackArtifactSet,
+  type RollbackPullRequestResponse,
   type RollbackProposal,
   type StateSnapshot,
 } from '../../api';
@@ -21,9 +24,11 @@ export interface DriftPanelProps {
   client?: Pick<typeof api, 'runDrift'> & Partial<Pick<typeof api,
     'createDriftRemediation' |
     'createDriftRemediationArtifacts' |
+    'createDriftRemediationPullRequest' |
     'listStateSnapshots' |
     'createRollbackProposal' |
-    'createRollbackArtifacts'
+    'createRollbackArtifacts' |
+    'createRollbackPullRequest'
   >>;
 }
 
@@ -80,6 +85,11 @@ function shortHash(value?: string): string {
   return value.slice(0, 12);
 }
 
+function shortCommit(value?: string): string {
+  if (!value) return '';
+  return value.slice(0, 7);
+}
+
 function formatSnapshotTime(value: string): string {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return value;
@@ -91,6 +101,55 @@ function formatSnapshotTime(value: string): string {
   });
 }
 
+function PullRequestHandoffSummary({
+  handoff,
+  title,
+}: {
+  handoff: PullRequestHandoff;
+  title: string;
+}) {
+  return (
+    <section className="rounded-md border border-emerald-500/30 bg-emerald-500/10 px-3 py-3">
+      <div className="flex items-start gap-2">
+        <GitPullRequest className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-emerald-300" />
+        <div className="min-w-0 flex-1">
+          <div className="text-xs font-semibold text-foreground">{title}</div>
+          <div className="mt-1 truncate font-mono text-[10px] text-muted-foreground">
+            {handoff.branch} from {handoff.base_branch} · {shortCommit(handoff.commit)}
+          </div>
+          <div className="mt-1 truncate font-mono text-[10px] text-muted-foreground">
+            body {handoff.body_path}
+          </div>
+        </div>
+      </div>
+      {handoff.commands.length > 0 && (
+        <div className="mt-3 space-y-1">
+          {handoff.commands.map((command) => (
+            <div
+              key={`${command.label}-${command.display}`}
+              className="rounded border border-border bg-background/70 px-2 py-1.5"
+            >
+              <div className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+                {command.label}
+              </div>
+              <div className="mt-1 break-all font-mono text-[10px] text-foreground">
+                {command.display}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+      {handoff.warnings && handoff.warnings.length > 0 && (
+        <div className="mt-3 space-y-1 rounded border border-amber-500/30 bg-amber-500/10 px-2 py-2 text-xs leading-5 text-amber-200">
+          {handoff.warnings.map((warning, i) => (
+            <div key={i}>{warning}</div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
 export function DriftPanel({
   projectName,
   tool = 'terraform',
@@ -100,22 +159,28 @@ export function DriftPanel({
   const [running, setRunning] = useState(false);
   const [draftingMode, setDraftingMode] = useState<DriftRemediationMode | null>(null);
   const [writingArtifacts, setWritingArtifacts] = useState(false);
+  const [creatingPR, setCreatingPR] = useState(false);
   const [report, setReport] = useState<DriftReport | null>(null);
   const [proposal, setProposal] = useState<DriftRemediationProposal | null>(null);
   const [artifacts, setArtifacts] = useState<DriftRemediationArtifactSet | null>(null);
+  const [pullRequest, setPullRequest] = useState<PullRequestHandoff | null>(null);
   const [snapshots, setSnapshots] = useState<StateSnapshot[]>([]);
   const [rollbackProposal, setRollbackProposal] = useState<RollbackProposal | null>(null);
   const [rollbackArtifacts, setRollbackArtifacts] = useState<RollbackArtifactSet | null>(null);
+  const [rollbackPullRequest, setRollbackPullRequest] = useState<PullRequestHandoff | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [proposalError, setProposalError] = useState<string | null>(null);
   const [artifactError, setArtifactError] = useState<string | null>(null);
+  const [pullRequestError, setPullRequestError] = useState<string | null>(null);
   const [snapshotError, setSnapshotError] = useState<string | null>(null);
   const [rollbackError, setRollbackError] = useState<string | null>(null);
   const [rollbackArtifactError, setRollbackArtifactError] = useState<string | null>(null);
+  const [rollbackPullRequestError, setRollbackPullRequestError] = useState<string | null>(null);
   const [loadingSnapshots, setLoadingSnapshots] = useState(false);
   const [snapshotsLoaded, setSnapshotsLoaded] = useState(false);
   const [draftingRollbackID, setDraftingRollbackID] = useState<string | null>(null);
   const [writingRollbackArtifacts, setWritingRollbackArtifacts] = useState(false);
+  const [creatingRollbackPR, setCreatingRollbackPR] = useState(false);
   const supported = SUPPORTED_TOOLS.has(tool);
   const findings = useMemo(() => normalizeFindings(report), [report]);
   const suppressedFindings = useMemo(() => normalizeSuppressedFindings(report), [report]);
@@ -130,9 +195,11 @@ export function DriftPanel({
     setError(null);
     setProposalError(null);
     setArtifactError(null);
+    setPullRequestError(null);
     setReport(null);
     setProposal(null);
     setArtifacts(null);
+    setPullRequest(null);
     try {
       const req: { tool: string; env?: string } = { tool };
       if (env) req.env = env;
@@ -150,8 +217,10 @@ export function DriftPanel({
     setDraftingMode(mode);
     setProposalError(null);
     setArtifactError(null);
+    setPullRequestError(null);
     setProposal(null);
     setArtifacts(null);
+    setPullRequest(null);
     try {
       const req: { tool: string; env?: string; mode: DriftRemediationMode } = { tool, mode };
       if (env) req.env = env;
@@ -181,6 +250,24 @@ export function DriftPanel({
     }
   };
 
+  const createRemediationPR = async () => {
+    if (!proposal || !client.createDriftRemediationPullRequest) return;
+    setCreatingPR(true);
+    setPullRequestError(null);
+    setPullRequest(null);
+    try {
+      const req: { tool: string; env?: string; mode: DriftRemediationMode; proposal: DriftRemediationProposal } = { tool, mode: proposal.mode, proposal };
+      if (env) req.env = env;
+      const response: DriftRemediationPullRequestResponse = await client.createDriftRemediationPullRequest(projectName, req);
+      setArtifacts(response.artifacts);
+      setPullRequest(response.pull_request);
+    } catch (err) {
+      setPullRequestError(String(err));
+    } finally {
+      setCreatingPR(false);
+    }
+  };
+
   const loadSnapshots = async () => {
     if (!client.listStateSnapshots) return;
     setLoadingSnapshots(true);
@@ -202,8 +289,10 @@ export function DriftPanel({
     setDraftingRollbackID(snapshot.id);
     setRollbackError(null);
     setRollbackArtifactError(null);
+    setRollbackPullRequestError(null);
     setRollbackProposal(null);
     setRollbackArtifacts(null);
+    setRollbackPullRequest(null);
     try {
       const response = await client.createRollbackProposal(projectName, snapshot.id, { env });
       setRollbackProposal(response);
@@ -226,6 +315,22 @@ export function DriftPanel({
       setRollbackArtifactError(String(err));
     } finally {
       setWritingRollbackArtifacts(false);
+    }
+  };
+
+  const createRollbackPR = async () => {
+    if (!rollbackProposal || !client.createRollbackPullRequest) return;
+    setCreatingRollbackPR(true);
+    setRollbackPullRequestError(null);
+    setRollbackPullRequest(null);
+    try {
+      const response: RollbackPullRequestResponse = await client.createRollbackPullRequest(projectName, rollbackProposal.target_snapshot.id, { env, proposal: rollbackProposal });
+      setRollbackArtifacts(response.artifacts);
+      setRollbackPullRequest(response.pull_request);
+    } catch (err) {
+      setRollbackPullRequestError(String(err));
+    } finally {
+      setCreatingRollbackPR(false);
     }
   };
 
@@ -387,6 +492,16 @@ export function DriftPanel({
               <FileText className="h-3.5 w-3.5" />
               {writingRollbackArtifacts ? 'Writing...' : 'Write artifacts'}
             </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={createRollbackPR}
+              disabled={creatingRollbackPR || !client.createRollbackPullRequest}
+            >
+              <GitPullRequest className="h-3.5 w-3.5" />
+              {creatingRollbackPR ? 'Creating...' : 'Create PR branch'}
+            </Button>
           </div>
 
           {rollbackProposal.warnings && rollbackProposal.warnings.length > 0 && (
@@ -404,6 +519,20 @@ export function DriftPanel({
           <AlertCircle className="mt-0.5 h-3.5 w-3.5 flex-shrink-0" />
           <span>{rollbackArtifactError}</span>
         </div>
+      )}
+
+      {rollbackPullRequestError && (
+        <div className="flex items-start gap-2 rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+          <AlertCircle className="mt-0.5 h-3.5 w-3.5 flex-shrink-0" />
+          <span>{rollbackPullRequestError}</span>
+        </div>
+      )}
+
+      {rollbackPullRequest && (
+        <PullRequestHandoffSummary
+          handoff={rollbackPullRequest}
+          title="Rollback PR branch ready"
+        />
       )}
 
       {rollbackArtifacts && (
@@ -522,6 +651,16 @@ export function DriftPanel({
               <FileText className="h-3.5 w-3.5" />
               {writingArtifacts ? 'Writing...' : 'Write artifacts'}
             </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={createRemediationPR}
+              disabled={creatingPR || !client.createDriftRemediationPullRequest}
+            >
+              <GitPullRequest className="h-3.5 w-3.5" />
+              {creatingPR ? 'Creating...' : 'Create PR branch'}
+            </Button>
           </div>
 
           {proposal.file_changes.length > 0 && (
@@ -568,6 +707,20 @@ export function DriftPanel({
           <AlertCircle className="mt-0.5 h-3.5 w-3.5 flex-shrink-0" />
           <span>{artifactError}</span>
         </div>
+      )}
+
+      {pullRequestError && (
+        <div className="flex items-start gap-2 rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+          <AlertCircle className="mt-0.5 h-3.5 w-3.5 flex-shrink-0" />
+          <span>{pullRequestError}</span>
+        </div>
+      )}
+
+      {pullRequest && (
+        <PullRequestHandoffSummary
+          handoff={pullRequest}
+          title="Remediation PR branch ready"
+        />
       )}
 
       {artifacts && (


### PR DESCRIPTION
## Summary

Refs #44.

This adds a security-conscious PR handoff path for Phase 3 drift and recovery workflows:

- adds a review package that creates local review branches and commits only generated IaC Studio artifacts
- adds drift remediation and rollback PR-branch endpoints
- adds frontend actions that show the generated branch, commit, body path, and exact git push / gh pr create commands
- documents the local handoff model in the README and GitHub Pages docs

## Security model

The new handoff path is intentionally local-first:

- no GitHub token capture in the app
- no automatic push or cloud apply
- only .iac-studio/remediations/** and .iac-studio/rollbacks/** artifacts are staged
- unrelated dirty source files block PR branch creation
- symlinked artifact paths/directories are rejected before write/commit
- rollback and remediation proposals are rebuilt server-side instead of trusting client-supplied PR metadata

## Validation

- git diff --check HEAD~1 HEAD
- GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/review
- GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/api
- GOCACHE=/private/tmp/iacstudio-go-cache go test ./...
- npm -C web test -- --run
- npm -C web run build
- npm -C web run lint