### PR TITLE
Pass cloud connection context into drift workflows

### DIFF
--- a/internal/api/drift_test.go
+++ b/internal/api/drift_test.go
@@ -2,17 +2,21 @@ package api
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/iac-studio/iac-studio/internal/cloudconnections"
 )
 
-func TestProjectDriftEndpointReturnsClassifiedFindings(t *testing.T) {
-	root := t.TempDir()
-	projectDir := filepath.Join(root, "demo")
+func writeTerraformDriftFixture(t *testing.T, root, name string) {
+	t.Helper()
+
+	projectDir := filepath.Join(root, name)
 	if err := os.MkdirAll(projectDir, 0o755); err != nil {
 		t.Fatalf("mkdir project: %v", err)
 	}
@@ -35,6 +39,11 @@ resource "aws_security_group" "web" {
 	}`), 0o600); err != nil {
 		t.Fatalf("write state: %v", err)
 	}
+}
+
+func TestProjectDriftEndpointReturnsClassifiedFindings(t *testing.T) {
+	root := t.TempDir()
+	writeTerraformDriftFixture(t, root, "demo")
 
 	srv := httptest.NewServer(fullRouterForTest(t, root))
 	defer srv.Close()
@@ -47,7 +56,6 @@ resource "aws_security_group" "web" {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("drift status = %d", resp.StatusCode)
 	}
-
 	var payload struct {
 		Findings []struct {
 			Address           string `json:"address"`
@@ -73,6 +81,80 @@ resource "aws_security_group" "web" {
 	if payload.Classifications["unauthorized_change"] != 1 {
 		t.Fatalf("unexpected classification counts: %#v", payload.Classifications)
 	}
+}
+
+func TestProjectDriftEndpointIncludesRedactedConnectionContext(t *testing.T) {
+	root := t.TempDir()
+	writeTerraformDriftFixture(t, root, "demo")
+
+	manager := cloudconnections.NewManager(root)
+	connection, err := manager.Save(cloudconnections.Connection{
+		Name:       "prod-aws",
+		Provider:   cloudconnections.ProviderAWS,
+		AuthMethod: "aws_static",
+		Region:     "us-east-1",
+		Metadata: map[string]string{
+			"access_key_id": "AKIAIOSFODNN7EXAMPLE",
+		},
+		Secrets: map[string]string{
+			"secret_access_key": "SECRET_SHOULD_NOT_LEAK",
+		},
+	})
+	if err != nil {
+		t.Fatalf("save cloud connection: %v", err)
+	}
+
+	srv := httptest.NewServer(fullRouterForTest(t, root))
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/api/projects/demo/drift", "application/json", strings.NewReader(`{"tool":"terraform","connection_id":"`+connection.ID+`"}`))
+	if err != nil {
+		t.Fatalf("POST drift: %v", err)
+	}
+	defer closeBody(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("drift status = %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read drift response: %v", err)
+	}
+	if strings.Contains(string(body), "SECRET_SHOULD_NOT_LEAK") ||
+		strings.Contains(string(body), "AKIAIOSFODNN7EXAMPLE") {
+		t.Fatalf("drift response leaked connection credential material: %s", string(body))
+	}
+
+	var payload struct {
+		ConnectionID       string `json:"connection_id"`
+		ConnectionName     string `json:"connection_name"`
+		ConnectionProvider string `json:"connection_provider"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("decode drift response: %v", err)
+	}
+	if payload.ConnectionID != connection.ID ||
+		payload.ConnectionName != "prod-aws" ||
+		payload.ConnectionProvider != cloudconnections.ProviderAWS {
+		t.Fatalf("unexpected connection context: %#v", payload)
+	}
+}
+
+func TestProjectDriftEndpointRejectsUnknownConnection(t *testing.T) {
+	root := t.TempDir()
+	writeTerraformDriftFixture(t, root, "demo")
+
+	srv := httptest.NewServer(fullRouterForTest(t, root))
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/api/projects/demo/drift", "application/json", strings.NewReader(`{"tool":"terraform","connection_id":"missing"}`))
+	if err != nil {
+		t.Fatalf("POST drift: %v", err)
+	}
+	defer closeBody(resp.Body)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("drift status = %d, want 404", resp.StatusCode)
+	}
+	assertResponseBodyContains(t, resp, "cloud connection not found")
 }
 
 func TestProjectDriftEndpointAppliesConfiguredSuppressions(t *testing.T) {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -411,8 +411,9 @@ func hybridToolResolutionMessage(missingEnvMessage, env string) string {
 }
 
 type projectDriftRequest struct {
-	Tool string
-	Env  string
+	Tool         string
+	Env          string
+	ConnectionID string
 }
 
 type projectDriftRun struct {
@@ -424,10 +425,25 @@ type projectDriftRun struct {
 	Env         string
 }
 
-func runProjectDrift(projectsDir, name string, req projectDriftRequest, detector *drift.Detector) (*projectDriftRun, int, string) {
+func runProjectDrift(projectsDir, name string, req projectDriftRequest, detector *drift.Detector, cloudConnections *cloudconnections.Manager) (*projectDriftRun, int, string) {
 	projectPath, err := safeProjectPath(projectsDir, name)
 	if err != nil {
 		return nil, http.StatusBadRequest, err.Error()
+	}
+
+	connectionID := strings.TrimSpace(req.ConnectionID)
+	var connection *cloudconnections.Connection
+	if connectionID != "" {
+		if cloudConnections == nil {
+			return nil, http.StatusInternalServerError, "cloud connections are not available"
+		}
+		connection, err = cloudConnections.Get(connectionID)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return nil, http.StatusNotFound, "cloud connection not found"
+			}
+			return nil, http.StatusInternalServerError, "load cloud connection: " + err.Error()
+		}
 	}
 
 	tool := effectiveProjectTool(projectPath, req.Tool, req.Env)
@@ -467,6 +483,11 @@ func runProjectDrift(projectsDir, name string, req projectDriftRequest, detector
 	})
 	if err != nil {
 		return nil, http.StatusInternalServerError, err.Error()
+	}
+	if connection != nil {
+		report.ConnectionID = connection.ID
+		report.ConnectionName = connection.Name
+		report.ConnectionProvider = connection.Provider
 	}
 	return &projectDriftRun{
 		Report:      report,
@@ -2459,8 +2480,9 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 
 		limitBody(w, r)
 		var req struct {
-			Tool string `json:"tool,omitempty"`
-			Env  string `json:"env,omitempty"`
+			Tool         string `json:"tool,omitempty"`
+			Env          string `json:"env,omitempty"`
+			ConnectionID string `json:"connection_id,omitempty"`
 		}
 		if r.Method == http.MethodPost {
 			if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
@@ -2474,11 +2496,15 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 		if req.Env == "" {
 			req.Env = r.URL.Query().Get("env")
 		}
+		if req.ConnectionID == "" {
+			req.ConnectionID = r.URL.Query().Get("connection_id")
+		}
 
 		run, status, message := runProjectDrift(projectsDir, name, projectDriftRequest{
-			Tool: req.Tool,
-			Env:  req.Env,
-		}, driftDetector)
+			Tool:         req.Tool,
+			Env:          req.Env,
+			ConnectionID: req.ConnectionID,
+		}, driftDetector, cloudConnections)
 		if run == nil {
 			http.Error(w, message, status)
 			return
@@ -2492,9 +2518,10 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 		name := r.PathValue("name")
 		limitBody(w, r)
 		var req struct {
-			Tool string `json:"tool,omitempty"`
-			Env  string `json:"env,omitempty"`
-			Mode string `json:"mode"`
+			Tool         string `json:"tool,omitempty"`
+			Env          string `json:"env,omitempty"`
+			ConnectionID string `json:"connection_id,omitempty"`
+			Mode         string `json:"mode"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
 			http.Error(w, "invalid request body: "+err.Error(), 400)
@@ -2506,11 +2533,15 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 		if req.Env == "" {
 			req.Env = r.URL.Query().Get("env")
 		}
+		if req.ConnectionID == "" {
+			req.ConnectionID = r.URL.Query().Get("connection_id")
+		}
 
 		run, status, message := runProjectDrift(projectsDir, name, projectDriftRequest{
-			Tool: req.Tool,
-			Env:  req.Env,
-		}, driftDetector)
+			Tool:         req.Tool,
+			Env:          req.Env,
+			ConnectionID: req.ConnectionID,
+		}, driftDetector, cloudConnections)
 		if run == nil {
 			http.Error(w, message, status)
 			return
@@ -2528,10 +2559,11 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 		name := r.PathValue("name")
 		limitBody(w, r)
 		var req struct {
-			Tool     string                     `json:"tool,omitempty"`
-			Env      string                     `json:"env,omitempty"`
-			Mode     string                     `json:"mode"`
-			Proposal *drift.RemediationProposal `json:"proposal,omitempty"`
+			Tool         string                     `json:"tool,omitempty"`
+			Env          string                     `json:"env,omitempty"`
+			ConnectionID string                     `json:"connection_id,omitempty"`
+			Mode         string                     `json:"mode"`
+			Proposal     *drift.RemediationProposal `json:"proposal,omitempty"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
 			http.Error(w, "invalid request body: "+err.Error(), 400)
@@ -2542,6 +2574,9 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 		}
 		if req.Env == "" {
 			req.Env = r.URL.Query().Get("env")
+		}
+		if req.ConnectionID == "" {
+			req.ConnectionID = r.URL.Query().Get("connection_id")
 		}
 
 		projectPath, err := safeProjectPath(projectsDir, name)
@@ -2558,9 +2593,10 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 			mode = req.Proposal.Mode
 		}
 		run, status, message := runProjectDrift(projectsDir, name, projectDriftRequest{
-			Tool: req.Tool,
-			Env:  req.Env,
-		}, driftDetector)
+			Tool:         req.Tool,
+			Env:          req.Env,
+			ConnectionID: req.ConnectionID,
+		}, driftDetector, cloudConnections)
 		if run == nil {
 			http.Error(w, message, status)
 			return
@@ -2587,10 +2623,11 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 		name := r.PathValue("name")
 		limitBody(w, r)
 		var req struct {
-			Tool     string                     `json:"tool,omitempty"`
-			Env      string                     `json:"env,omitempty"`
-			Mode     string                     `json:"mode"`
-			Proposal *drift.RemediationProposal `json:"proposal,omitempty"`
+			Tool         string                     `json:"tool,omitempty"`
+			Env          string                     `json:"env,omitempty"`
+			ConnectionID string                     `json:"connection_id,omitempty"`
+			Mode         string                     `json:"mode"`
+			Proposal     *drift.RemediationProposal `json:"proposal,omitempty"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
 			http.Error(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
@@ -2601,6 +2638,9 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 		}
 		if req.Env == "" {
 			req.Env = r.URL.Query().Get("env")
+		}
+		if req.ConnectionID == "" {
+			req.ConnectionID = r.URL.Query().Get("connection_id")
 		}
 
 		projectPath, err := safeProjectPath(projectsDir, name)
@@ -2617,9 +2657,10 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 			mode = req.Proposal.Mode
 		}
 		run, status, message := runProjectDrift(projectsDir, name, projectDriftRequest{
-			Tool: req.Tool,
-			Env:  req.Env,
-		}, driftDetector)
+			Tool:         req.Tool,
+			Env:          req.Env,
+			ConnectionID: req.ConnectionID,
+		}, driftDetector, cloudConnections)
 		if run == nil {
 			http.Error(w, message, status)
 			return

--- a/internal/drift/drift.go
+++ b/internal/drift/drift.go
@@ -32,6 +32,9 @@ const (
 type DriftReport struct {
 	HasState           bool              `json:"has_state"`
 	StatePath          string            `json:"state_path"`
+	ConnectionID       string            `json:"connection_id,omitempty"`
+	ConnectionName     string            `json:"connection_name,omitempty"`
+	ConnectionProvider string            `json:"connection_provider,omitempty"`
 	Drifted            []DriftedResource `json:"drifted"`
 	Findings           []DriftFinding    `json:"findings"`
 	SuppressedFindings []DriftFinding    `json:"suppressed_findings"`

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -227,7 +227,7 @@ describe('api.runDrift', () => {
     vi.unstubAllGlobals();
   });
 
-  it('posts tool and environment to the drift endpoint', async () => {
+  it('posts tool, environment, and connection context to the drift endpoint', async () => {
     const response = {
       has_state: true,
       state_path: '/tmp/demo/terraform.tfstate',
@@ -250,12 +250,12 @@ describe('api.runDrift', () => {
     );
     vi.stubGlobal('fetch', fetchMock);
 
-    await expect(api.runDrift('demo', { tool: 'terraform', env: 'dev' })).resolves.toEqual(response);
+    await expect(api.runDrift('demo', { tool: 'terraform', env: 'dev', connectionId: 'conn_1' })).resolves.toEqual(response);
 
     expect(fetchMock).toHaveBeenCalledWith('/api/projects/demo/drift', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ tool: 'terraform', env: 'dev' }),
+      body: JSON.stringify({ tool: 'terraform', env: 'dev', connection_id: 'conn_1' }),
     });
   });
 });
@@ -265,7 +265,7 @@ describe('api.createDriftRemediation', () => {
     vi.unstubAllGlobals();
   });
 
-  it('posts remediation mode with tool and environment', async () => {
+  it('posts remediation mode with tool, environment, and connection context', async () => {
     const response = {
       mode: 'revert',
       title: 'Revert unauthorized drift for demo',
@@ -283,12 +283,12 @@ describe('api.createDriftRemediation', () => {
     );
     vi.stubGlobal('fetch', fetchMock);
 
-    await expect(api.createDriftRemediation('demo', { tool: 'terraform', env: 'dev', mode: 'revert' })).resolves.toEqual(response);
+    await expect(api.createDriftRemediation('demo', { tool: 'terraform', env: 'dev', connectionId: 'conn_1', mode: 'revert' })).resolves.toEqual(response);
 
     expect(fetchMock).toHaveBeenCalledWith('/api/projects/demo/drift/remediation', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ tool: 'terraform', env: 'dev', mode: 'revert' }),
+      body: JSON.stringify({ tool: 'terraform', env: 'dev', connection_id: 'conn_1', mode: 'revert' }),
     });
   });
 });
@@ -323,12 +323,12 @@ describe('api.createDriftRemediationArtifacts', () => {
     vi.stubGlobal('fetch', fetchMock);
 
     const proposal = response.proposal;
-    await expect(api.createDriftRemediationArtifacts('demo', { tool: 'terraform', env: 'dev', mode: 'revert', proposal })).resolves.toEqual(response);
+    await expect(api.createDriftRemediationArtifacts('demo', { tool: 'terraform', env: 'dev', connectionId: 'conn_1', mode: 'revert', proposal })).resolves.toEqual(response);
 
     expect(fetchMock).toHaveBeenCalledWith('/api/projects/demo/drift/remediation/artifacts', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ tool: 'terraform', env: 'dev', mode: 'revert', proposal }),
+      body: JSON.stringify({ tool: 'terraform', env: 'dev', connection_id: 'conn_1', mode: 'revert', proposal }),
     });
   });
 });
@@ -375,12 +375,12 @@ describe('api.createDriftRemediationPullRequest', () => {
     );
     vi.stubGlobal('fetch', fetchMock);
 
-    await expect(api.createDriftRemediationPullRequest('demo', { tool: 'terraform', env: 'dev', mode: 'revert', proposal })).resolves.toEqual(response);
+    await expect(api.createDriftRemediationPullRequest('demo', { tool: 'terraform', env: 'dev', connectionId: 'conn_1', mode: 'revert', proposal })).resolves.toEqual(response);
 
     expect(fetchMock).toHaveBeenCalledWith('/api/projects/demo/drift/remediation/pr', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ tool: 'terraform', env: 'dev', mode: 'revert', proposal }),
+      body: JSON.stringify({ tool: 'terraform', env: 'dev', connection_id: 'conn_1', mode: 'revert', proposal }),
     });
   });
 });

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -213,6 +213,9 @@ export interface DriftFinding {
 export interface DriftReport {
   has_state: boolean;
   state_path: string;
+  connection_id?: string;
+  connection_name?: string;
+  connection_provider?: string;
   drifted: DriftResource[];
   findings: DriftFinding[];
   suppressed_findings?: DriftFinding[];
@@ -226,6 +229,12 @@ export interface DriftReport {
 }
 
 export type DriftRemediationMode = 'codify' | 'revert';
+
+export interface DriftRequestScope {
+  tool?: string;
+  env?: string;
+  connectionId?: string | null;
+}
 
 export interface DriftRemediationFileChange {
   path?: string;
@@ -595,38 +604,59 @@ export const api = {
     return (await check(res)).json();
   },
 
-  async runDrift(projectName: string, req: { tool?: string; env?: string } = {}): Promise<DriftReport> {
+  async runDrift(projectName: string, req: DriftRequestScope = {}): Promise<DriftReport> {
     const res = await fetch(`${BASE}/api/projects/${projectName}/drift`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(req),
+      body: JSON.stringify({
+        tool: req.tool,
+        env: req.env,
+        connection_id: req.connectionId || undefined,
+      }),
     });
     return (await check(res)).json();
   },
 
-  async createDriftRemediation(projectName: string, req: { tool?: string; env?: string; mode: DriftRemediationMode }): Promise<DriftRemediationProposal> {
+  async createDriftRemediation(projectName: string, req: DriftRequestScope & { mode: DriftRemediationMode }): Promise<DriftRemediationProposal> {
     const res = await fetch(`${BASE}/api/projects/${projectName}/drift/remediation`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(req),
+      body: JSON.stringify({
+        tool: req.tool,
+        env: req.env,
+        connection_id: req.connectionId || undefined,
+        mode: req.mode,
+      }),
     });
     return (await check(res)).json();
   },
 
-  async createDriftRemediationArtifacts(projectName: string, req: { tool?: string; env?: string; mode: DriftRemediationMode; proposal?: DriftRemediationProposal }): Promise<DriftRemediationArtifactSet> {
+  async createDriftRemediationArtifacts(projectName: string, req: DriftRequestScope & { mode: DriftRemediationMode; proposal?: DriftRemediationProposal }): Promise<DriftRemediationArtifactSet> {
     const res = await fetch(`${BASE}/api/projects/${projectName}/drift/remediation/artifacts`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(req),
+      body: JSON.stringify({
+        tool: req.tool,
+        env: req.env,
+        connection_id: req.connectionId || undefined,
+        mode: req.mode,
+        proposal: req.proposal,
+      }),
     });
     return (await check(res)).json();
   },
 
-  async createDriftRemediationPullRequest(projectName: string, req: { tool?: string; env?: string; mode: DriftRemediationMode; proposal?: DriftRemediationProposal }): Promise<DriftRemediationPullRequestResponse> {
+  async createDriftRemediationPullRequest(projectName: string, req: DriftRequestScope & { mode: DriftRemediationMode; proposal?: DriftRemediationProposal }): Promise<DriftRemediationPullRequestResponse> {
     const res = await fetch(`${BASE}/api/projects/${projectName}/drift/remediation/pr`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(req),
+      body: JSON.stringify({
+        tool: req.tool,
+        env: req.env,
+        connection_id: req.connectionId || undefined,
+        mode: req.mode,
+        proposal: req.proposal,
+      }),
     });
     return (await check(res)).json();
   },

--- a/web/src/components/DriftPanel/DriftPanel.test.tsx
+++ b/web/src/components/DriftPanel/DriftPanel.test.tsx
@@ -9,6 +9,9 @@ describe('DriftPanel', () => {
       runDrift: vi.fn().mockResolvedValue({
         has_state: true,
         state_path: '/tmp/demo/environments/dev/terraform.tfstate',
+        connection_id: 'conn_1',
+        connection_name: 'prod-aws',
+        connection_provider: 'aws',
         drifted: [],
         findings: [
           {
@@ -33,14 +36,15 @@ describe('DriftPanel', () => {
       }),
     };
 
-    render(<DriftPanel projectName="demo" tool="terraform" env="dev" client={client} />);
+    render(<DriftPanel projectName="demo" tool="terraform" env="dev" connectionId="conn_1" client={client} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Run drift' }));
 
     await waitFor(() => {
-      expect(client.runDrift).toHaveBeenCalledWith('demo', { tool: 'terraform', env: 'dev' });
+      expect(client.runDrift).toHaveBeenCalledWith('demo', { tool: 'terraform', env: 'dev', connectionId: 'conn_1' });
     });
 
+    expect(screen.getByText('cloud prod-aws (aws)')).toBeInTheDocument();
     expect(screen.getByText('aws_security_group.web')).toBeInTheDocument();
     expect(screen.getByText('unauthorized change')).toBeInTheDocument();
     expect(screen.getByText('revert or codify after review')).toBeInTheDocument();
@@ -252,7 +256,7 @@ describe('DriftPanel', () => {
       }),
     };
 
-    render(<DriftPanel projectName="demo" tool="terraform" env="dev" client={client} />);
+    render(<DriftPanel projectName="demo" tool="terraform" env="dev" connectionId="conn_1" client={client} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Run drift' }));
     expect(await screen.findByText('aws_security_group.web')).toBeInTheDocument();
@@ -260,7 +264,7 @@ describe('DriftPanel', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Draft revert PR' }));
 
     await waitFor(() => {
-      expect(client.createDriftRemediation).toHaveBeenCalledWith('demo', { tool: 'terraform', env: 'dev', mode: 'revert' });
+      expect(client.createDriftRemediation).toHaveBeenCalledWith('demo', { tool: 'terraform', env: 'dev', connectionId: 'conn_1', mode: 'revert' });
     });
     expect(await screen.findByText('Revert unauthorized drift for demo')).toBeInTheDocument();
     expect(screen.getByText('branch iac-studio-drift-revert-demo-dev')).toBeInTheDocument();
@@ -374,7 +378,7 @@ describe('DriftPanel', () => {
       }),
     };
 
-    render(<DriftPanel projectName="demo" tool="terraform" env="dev" client={client} />);
+    render(<DriftPanel projectName="demo" tool="terraform" env="dev" connectionId="conn_1" client={client} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Run drift' }));
     expect(await screen.findByText('aws_security_group.web')).toBeInTheDocument();
@@ -384,7 +388,7 @@ describe('DriftPanel', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Write artifacts' }));
 
     await waitFor(() => {
-      expect(client.createDriftRemediationArtifacts).toHaveBeenCalledWith('demo', { tool: 'terraform', env: 'dev', mode: 'revert', proposal });
+      expect(client.createDriftRemediationArtifacts).toHaveBeenCalledWith('demo', { tool: 'terraform', env: 'dev', connectionId: 'conn_1', mode: 'revert', proposal });
     });
     expect(await screen.findByText('Review artifacts written')).toBeInTheDocument();
     expect(screen.getByText('.iac-studio/remediations/iac-studio-drift-revert-demo-dev')).toBeInTheDocument();
@@ -393,7 +397,7 @@ describe('DriftPanel', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Create PR branch' }));
 
     await waitFor(() => {
-      expect(client.createDriftRemediationPullRequest).toHaveBeenCalledWith('demo', { tool: 'terraform', env: 'dev', mode: 'revert', proposal });
+      expect(client.createDriftRemediationPullRequest).toHaveBeenCalledWith('demo', { tool: 'terraform', env: 'dev', connectionId: 'conn_1', mode: 'revert', proposal });
     });
     expect(await screen.findByText('Remediation PR branch ready')).toBeInTheDocument();
     expect(screen.getByText(/iac-studio-drift-revert-demo-dev from main · def4567/)).toBeInTheDocument();

--- a/web/src/components/DriftPanel/DriftPanel.tsx
+++ b/web/src/components/DriftPanel/DriftPanel.tsx
@@ -8,6 +8,7 @@ import {
   type DriftRemediationMode,
   type DriftRemediationPullRequestResponse,
   type DriftRemediationProposal,
+  type DriftRequestScope,
   type DriftReport,
   type PullRequestHandoff,
   type RollbackArtifactSet,
@@ -21,6 +22,7 @@ export interface DriftPanelProps {
   projectName: string;
   tool?: string;
   env?: string;
+  connectionId?: string | null;
   client?: Pick<typeof api, 'runDrift'> & Partial<Pick<typeof api,
     'createDriftRemediation' |
     'createDriftRemediationArtifacts' |
@@ -154,6 +156,7 @@ export function DriftPanel({
   projectName,
   tool = 'terraform',
   env,
+  connectionId,
   client = api,
 }: DriftPanelProps) {
   const [running, setRunning] = useState(false);
@@ -189,6 +192,13 @@ export function DriftPanel({
   const canListSnapshots = Boolean(client.listStateSnapshots);
   const canDraftRollback = Boolean(client.createRollbackProposal);
 
+  const driftScope = (): DriftRequestScope & { tool: string } => {
+    const scope: DriftRequestScope & { tool: string } = { tool };
+    if (env) scope.env = env;
+    if (connectionId) scope.connectionId = connectionId;
+    return scope;
+  };
+
   const run = async () => {
     if (!supported) return;
     setRunning(true);
@@ -201,9 +211,7 @@ export function DriftPanel({
     setArtifacts(null);
     setPullRequest(null);
     try {
-      const req: { tool: string; env?: string } = { tool };
-      if (env) req.env = env;
-      const response = await client.runDrift(projectName, req);
+      const response = await client.runDrift(projectName, driftScope());
       setReport(response);
     } catch (err) {
       setError(String(err));
@@ -222,8 +230,7 @@ export function DriftPanel({
     setArtifacts(null);
     setPullRequest(null);
     try {
-      const req: { tool: string; env?: string; mode: DriftRemediationMode } = { tool, mode };
-      if (env) req.env = env;
+      const req: DriftRequestScope & { tool: string; mode: DriftRemediationMode } = { ...driftScope(), mode };
       const response = await client.createDriftRemediation(projectName, req);
       setProposal(response);
     } catch (err) {
@@ -239,8 +246,7 @@ export function DriftPanel({
     setArtifactError(null);
     setArtifacts(null);
     try {
-      const req: { tool: string; env?: string; mode: DriftRemediationMode; proposal: DriftRemediationProposal } = { tool, mode: proposal.mode, proposal };
-      if (env) req.env = env;
+      const req: DriftRequestScope & { tool: string; mode: DriftRemediationMode; proposal: DriftRemediationProposal } = { ...driftScope(), mode: proposal.mode, proposal };
       const response = await client.createDriftRemediationArtifacts(projectName, req);
       setArtifacts(response);
     } catch (err) {
@@ -256,8 +262,7 @@ export function DriftPanel({
     setPullRequestError(null);
     setPullRequest(null);
     try {
-      const req: { tool: string; env?: string; mode: DriftRemediationMode; proposal: DriftRemediationProposal } = { tool, mode: proposal.mode, proposal };
-      if (env) req.env = env;
+      const req: DriftRequestScope & { tool: string; mode: DriftRemediationMode; proposal: DriftRemediationProposal } = { ...driftScope(), mode: proposal.mode, proposal };
       const response: DriftRemediationPullRequestResponse = await client.createDriftRemediationPullRequest(projectName, req);
       setArtifacts(response.artifacts);
       setPullRequest(response.pull_request);
@@ -568,6 +573,12 @@ export function DriftPanel({
               {report.state_path && (
                 <div className="mt-1 truncate text-[10px] font-mono text-muted-foreground">
                   state {report.state_path}
+                </div>
+              )}
+              {report.connection_id && (
+                <div className="mt-1 truncate text-[10px] font-mono text-muted-foreground">
+                  cloud {report.connection_name || report.connection_id}
+                  {report.connection_provider ? ` (${report.connection_provider})` : ''}
                 </div>
               )}
             </div>

--- a/web/src/components/Inspector/InspectorPanel.test.tsx
+++ b/web/src/components/Inspector/InspectorPanel.test.tsx
@@ -37,8 +37,8 @@ vi.mock('../ScanPanel', () => ({
 }));
 
 vi.mock('../DriftPanel', () => ({
-  DriftPanel: ({ projectName, tool, env }: any) => (
-    <div>Drift panel {projectName} {tool} {env}</div>
+  DriftPanel: ({ projectName, tool, env, connectionId }: any) => (
+    <div>Drift panel {projectName} {tool} {env} {connectionId || 'no-connection'}</div>
   ),
 }));
 
@@ -212,9 +212,18 @@ describe('InspectorPanel', () => {
   });
 
   it('renders the drift tab with tool and environment context', () => {
-    renderInspector({ activeTab: 'drift', activeEnv: 'dev' });
+    renderInspector({
+      activeTab: 'drift',
+      activeEnv: 'dev',
+      selectedCloudConnection: {
+        id: 'conn_1',
+        name: 'prod-aws',
+        provider: 'aws',
+        auth_method: 'aws_profile',
+      },
+    });
 
-    expect(screen.getByText('Drift panel demo terraform dev')).toBeInTheDocument();
+    expect(screen.getByText('Drift panel demo terraform dev conn_1')).toBeInTheDocument();
   });
 
   it('renders the cloud connections tab', () => {

--- a/web/src/components/Inspector/index.tsx
+++ b/web/src/components/Inspector/index.tsx
@@ -285,7 +285,12 @@ export function InspectorPanel({
               Environment "{activeEnv}" has no configured IaC tool in .iac-studio.json.
             </div>
           ) : (
-            <DriftPanel projectName={projectId} tool={tool} env={activeEnv || undefined} />
+            <DriftPanel
+              projectName={projectId}
+              tool={tool}
+              env={activeEnv || undefined}
+              connectionId={selectedCloudConnection?.id}
+            />
           )}
         </div>
       )}


### PR DESCRIPTION
## Summary
- Thread optional `connection_id` through drift scan, remediation proposal, remediation artifact, and remediation PR branch endpoints.
- Validate the selected cloud connection server-side and return only redacted drift report context (`id`, `name`, `provider`).
- Pass the selected cloud connection from the Inspector into the Drift panel and display the redacted cloud context after a run.

## Security notes
- Drift reports do not serialize connection metadata or secret fields.
- Unknown/stale connection IDs fail closed with `404 cloud connection not found`.
- Existing remediation artifact/PR generation still rebuilds server-side from the selected project state.

## Verification
- `GOCACHE=/private/tmp/iacstudio-go-cache go test ./...`
- `npm -C web test -- --run`
- `npm -C web run build`

Refs #44