### PR TITLE
[codex] Add local MCP server for AI workflows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ BUILD    := $(shell git rev-parse --short HEAD 2>/dev/null || echo "dev")
 LDFLAGS  := -ldflags "-s -w -X main.AppVersion=$(VERSION)-$(BUILD)"
 GO_PACKAGES := ./cmd/... ./internal/...
 
-.PHONY: all build dev test clean deps docker install release
+.PHONY: all build build-backend build-mcp dev test clean deps docker install release
 
 all: build
 
@@ -23,7 +23,7 @@ dev:
 
 ## ─── Build ───
 
-build: build-frontend embed-frontend build-backend
+build: build-frontend embed-frontend build-backend build-mcp
 
 build-frontend:
 	cd web && npm run build
@@ -34,6 +34,9 @@ embed-frontend:
 
 build-backend:
 	CGO_ENABLED=0 go build $(LDFLAGS) -o bin/$(APP_NAME) ./cmd/server
+
+build-mcp:
+	CGO_ENABLED=0 go build $(LDFLAGS) -o bin/$(APP_NAME)-mcp ./cmd/mcp
 
 ## ─── Test ───
 
@@ -73,6 +76,11 @@ release: build-frontend embed-frontend
 	GOOS=darwin  GOARCH=amd64 CGO_ENABLED=0 go build $(LDFLAGS) -o dist/$(APP_NAME)-darwin-amd64  ./cmd/server
 	GOOS=darwin  GOARCH=arm64 CGO_ENABLED=0 go build $(LDFLAGS) -o dist/$(APP_NAME)-darwin-arm64  ./cmd/server
 	GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build $(LDFLAGS) -o dist/$(APP_NAME)-windows-amd64.exe ./cmd/server
+	GOOS=linux   GOARCH=amd64 CGO_ENABLED=0 go build $(LDFLAGS) -o dist/$(APP_NAME)-mcp-linux-amd64   ./cmd/mcp
+	GOOS=linux   GOARCH=arm64 CGO_ENABLED=0 go build $(LDFLAGS) -o dist/$(APP_NAME)-mcp-linux-arm64   ./cmd/mcp
+	GOOS=darwin  GOARCH=amd64 CGO_ENABLED=0 go build $(LDFLAGS) -o dist/$(APP_NAME)-mcp-darwin-amd64  ./cmd/mcp
+	GOOS=darwin  GOARCH=arm64 CGO_ENABLED=0 go build $(LDFLAGS) -o dist/$(APP_NAME)-mcp-darwin-arm64  ./cmd/mcp
+	GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build $(LDFLAGS) -o dist/$(APP_NAME)-mcp-windows-amd64.exe ./cmd/mcp
 	@echo "Binaries in dist/"
 
 ## ─── Clean ───

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Most IaC tools are CLI-only. Visual tools are either cloud-hosted SaaS or locked
 - **Cloud connection targets** — test and select AWS, Azure, or GCP auth context before deployment
 - **Topology-aware** — visual connection lines that generate real Terraform references
 - **AI-powered** — local LLM or external API converts natural language to infrastructure
+- **MCP server** — connect AI clients to IaC Studio tools without handing them raw cloud credentials
 - **Security scanning** — graph-based checks with CIS, SOC2, HIPAA compliance mapping
 - **Open source** — Apache 2.0, no telemetry, no accounts, no cloud dependency
 - **Single binary** — download one file, run it, done
@@ -70,6 +71,7 @@ start the local server for you.
 | **Smart Suggestions** | AI predicts your next resource based on IaC best practices |
 | **Import Projects** | Browse filesystem, scan existing .tf/.yml files, auto-detect topology |
 | **Cloud Connections** | Save, test, and select named AWS, Azure, or GCP targets before plan/apply |
+| **MCP Server** | Local stdio server for AI clients to inspect projects, classify plans, run policy/drift checks, and draft remediation workflows |
 | **Semantic Plan Gate** | Classifies Terraform/OpenTofu changes as safe, risky, destructive, or unknown before apply |
 | **Live Code Preview** | Every canvas change updates the code in real time |
 | **Project Persistence** | Auto-save canvas state, restore on reopen |
@@ -122,6 +124,60 @@ IaC Studio works with **any AI provider**:
 
 Click **gear icon** in the app header to switch providers at any time.
 
+## MCP Server for AI Clients
+
+IaC Studio includes a local MCP stdio server for connecting Claude, Cursor,
+Codex, and other MCP-compatible clients to your infrastructure workspace without
+giving the model direct cloud credentials.
+
+Build it from source:
+
+```bash
+make build-mcp
+```
+
+Or run it directly during development:
+
+```bash
+go run ./cmd/mcp --projects-dir "$HOME/iac-projects"
+```
+
+Example MCP client config:
+
+```json
+{
+  "mcpServers": {
+    "iac-studio": {
+      "command": "/path/to/IaCStudio/bin/iac-studio-mcp",
+      "args": ["--projects-dir", "/Users/you/iac-projects"],
+      "env": {
+        "IAC_STUDIO_MCP_APPROVAL_TOKEN": "local-approval-token"
+      }
+    }
+  }
+}
+```
+
+Read-only tools include `list_projects`, `inspect_project`,
+`list_cloud_connections`, `inspect_connection_scope`, `generate_plan`,
+`classify_plan`, `run_policy_check`, `scan_drift`, `explain_resource`, and
+`summarize_recent_changes`.
+
+Proposal tools include `propose_iac_change`, `propose_drift_remediation`,
+`open_remediation_pr`, and `generate_runbook`. Tools that can create local
+review artifacts or branches require the configured approval token.
+
+High-risk tools such as `apply`, `destroy`, `assume_role`,
+`modify_connection`, and `open_public_network_access` are deliberately gated.
+The MCP server records approval attempts but does not become a secret-entry or
+autonomous production-change path.
+
+MCP audit events are written to:
+
+```text
+~/iac-projects/.iac-studio/mcp-audit.jsonl
+```
+
 ### Recommended Local Models
 
 | RAM | Model | Size | Quality |
@@ -145,6 +201,7 @@ IaC Studio runs locally and is designed to be secure by default:
 - **Semantic plan review** — Terraform/OpenTofu plans are classified before apply; risky, destructive, or unknown changes require explicit acknowledgement
 - **Recovery checkpoints** — successful apply-style runs write metadata and state/plan hashes under `.iac-studio/snapshots`; rollback requests generate review artifacts, not automatic undo actions
 - **Review-branch handoff** — drift and rollback PR workflows create local branches that commit only generated `.iac-studio/remediations` or `.iac-studio/rollbacks` artifacts, reject unrelated dirty source files, and return explicit `git push` / `gh pr create` commands instead of collecting GitHub tokens
+- **MCP approval and audit** — AI clients can inspect and propose, while mutating or high-risk MCP tools require explicit approval and are logged to `.iac-studio/mcp-audit.jsonl`
 - **Cloud target checks** — selected Cloud Connections are tested before command execution
 - **Secret redaction** — static credentials are not echoed in API responses, terminal messages, or generated IaC
 - **No telemetry** — zero data collection, no phone-home
@@ -168,6 +225,7 @@ make deps             # Install Go + Node dependencies
 make dev              # Hot reload (frontend :5173, backend :3001)
 make test             # Run all tests
 make build            # Production binary -> bin/iac-studio
+make build-mcp        # MCP stdio server -> bin/iac-studio-mcp
 make release          # Cross-compile all platforms -> dist/
 make docker           # Docker image
 ```
@@ -209,6 +267,7 @@ All flags have sensible defaults. Just run `iac-studio` and go.
 - [x] Recovery checkpoint metadata for successful apply runs
 - [x] Reviewed rollback proposal artifacts from recovery checkpoints
 - [x] PR-ready local review branches for drift and rollback artifacts
+- [x] MCP server for AI-native project inspection, plan classification, drift/policy checks, runbooks, and approval-gated workflows
 - [x] Cost estimation (30+ resource types)
 - [x] CI/CD pipeline generator (GitHub Actions, GitLab CI)
 - [x] Environment promotion (dev/staging/prod workspaces)

--- a/cmd/mcp/main.go
+++ b/cmd/mcp/main.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+
+	"github.com/iac-studio/iac-studio/internal/mcp"
+)
+
+const AppVersion = "0.1.0"
+
+func main() {
+	projectsDir := flag.String("projects-dir", defaultProjectsDir(), "Directory for IaC Studio projects")
+	approvalToken := flag.String("approval-token", os.Getenv("IAC_STUDIO_MCP_APPROVAL_TOKEN"), "Approval token for MCP actions that create local review artifacts or request high-risk workflows")
+	version := flag.Bool("version", false, "Print version and exit")
+	flag.Parse()
+
+	if *version {
+		fmt.Printf("%s v%s\n", mcp.ServerName, AppVersion)
+		return
+	}
+	if err := os.MkdirAll(*projectsDir, 0o755); err != nil {
+		log.Fatalf("create projects dir: %v", err)
+	}
+
+	log.SetOutput(os.Stderr)
+	log.Printf("%s starting with projects dir %s", mcp.ServerName, *projectsDir)
+	if *approvalToken == "" {
+		log.Printf("approval token is not configured; mutating MCP tools will return approval_required")
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	server := mcp.NewServer(mcp.Config{
+		ProjectsDir:   *projectsDir,
+		ApprovalToken: *approvalToken,
+		Version:       AppVersion,
+	})
+	if err := server.Serve(ctx, os.Stdin, os.Stdout); err != nil && ctx.Err() == nil {
+		log.Fatalf("mcp server error: %v", err)
+	}
+}
+
+func defaultProjectsDir() string {
+	home, _ := os.UserHomeDir()
+	if home == "" {
+		return "iac-projects"
+	}
+	return filepath.Join(home, "iac-projects")
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -41,6 +41,7 @@
           <a href="#cloud-connections">Cloud Connections</a>
           <a href="#semantic-plan-gate">Semantic Plan Gate</a>
           <a href="#ai">AI Setup</a>
+          <a href="#mcp-server">MCP Server</a>
           <a href="#policy-security">Policy and Security</a>
           <a href="#api-reference">API Reference</a>
           <a href="#architecture">Architecture</a>
@@ -726,6 +727,86 @@ ANTHROPIC_MODEL=claude-opus-4-7 \
             local Ollama requests stay on your machine. API providers receive the prompt content needed
             for the requested action. IaC Studio does not add telemetry or account tracking.
           </div>
+        </section>
+
+        <section id="mcp-server" class="doc-section" data-title="mcp server ai clients claude cursor codex tools approval audit">
+          <h2>MCP Server</h2>
+          <p>
+            IaC Studio includes a local MCP stdio server for AI clients that need
+            structured access to infrastructure projects. The goal is not autonomous
+            production changes. The goal is a safe broker: inspect projects, classify
+            plans, run checks, explain drift, draft remediation, and keep dangerous
+            actions behind explicit approval.
+          </p>
+
+          <h3>Build or run it</h3>
+          <pre><code>make build-mcp
+./bin/iac-studio-mcp --projects-dir "$HOME/iac-projects"</code></pre>
+
+          <p>During development you can run the server without building first.</p>
+          <pre><code>go run ./cmd/mcp --projects-dir "$HOME/iac-projects"</code></pre>
+
+          <h3>Client configuration</h3>
+          <p>
+            MCP clients usually launch stdio servers as subprocesses. Point the client
+            at <code>iac-studio-mcp</code> and pass the same projects directory used by
+            the web app.
+          </p>
+          <pre><code>{
+  "mcpServers": {
+    "iac-studio": {
+      "command": "/path/to/IaCStudio/bin/iac-studio-mcp",
+      "args": ["--projects-dir", "/Users/you/iac-projects"],
+      "env": {
+        "IAC_STUDIO_MCP_APPROVAL_TOKEN": "local-approval-token"
+      }
+    }
+  }
+}</code></pre>
+
+          <div class="callout">
+            <strong>Credential model:</strong>
+            MCP tools reuse IaC Studio Cloud Connections. They can list and inspect
+            redacted connection scope, but they do not return secret values or accept
+            raw credentials as a shortcut.
+          </div>
+
+          <h3>Tool groups</h3>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Group</th>
+                  <th>Tools</th>
+                  <th>Behavior</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Read-only</td>
+                  <td><code>list_projects</code>, <code>inspect_project</code>, <code>list_cloud_connections</code>, <code>inspect_connection_scope</code>, <code>generate_plan</code>, <code>classify_plan</code>, <code>run_policy_check</code>, <code>scan_drift</code>, <code>explain_resource</code>, <code>summarize_recent_changes</code></td>
+                  <td>Return structured context for LLMs without applying infrastructure changes.</td>
+                </tr>
+                <tr>
+                  <td>Proposal</td>
+                  <td><code>propose_iac_change</code>, <code>propose_drift_remediation</code>, <code>open_remediation_pr</code>, <code>generate_runbook</code></td>
+                  <td>Draft review material. Tools that write local artifacts or branches require the approval token.</td>
+                </tr>
+                <tr>
+                  <td>High risk</td>
+                  <td><code>apply</code>, <code>destroy</code>, <code>assume_role</code>, <code>modify_connection</code>, <code>open_public_network_access</code></td>
+                  <td>Return approval gates and audit records. The MCP foundation does not become a direct secret-entry or autonomous apply path.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <h3>Audit log</h3>
+          <p>
+            Every MCP tool call records the tool name, target project, connection scope,
+            approval requirement, approval decision, mutation flag, and errors when present.
+          </p>
+          <pre><code>~/iac-projects/.iac-studio/mcp-audit.jsonl</code></pre>
         </section>
 
         <section id="policy-security" class="doc-section" data-title="policy security scan guardrails local safety apply gate">

--- a/internal/mcp/audit.go
+++ b/internal/mcp/audit.go
@@ -1,0 +1,92 @@
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type AuditDecision struct {
+	ID               string    `json:"id"`
+	Time             time.Time `json:"time"`
+	Tool             string    `json:"tool"`
+	Project          string    `json:"project,omitempty"`
+	ConnectionID     string    `json:"connection_id,omitempty"`
+	ApprovalRequired bool      `json:"approval_required,omitempty"`
+	Approved         bool      `json:"approved,omitempty"`
+	Mutated          bool      `json:"mutated,omitempty"`
+	Decision         string    `json:"decision"`
+	Error            string    `json:"error,omitempty"`
+}
+
+type AuditLogger struct {
+	path string
+	now  func() time.Time
+}
+
+func NewAuditLogger(projectsDir string, now func() time.Time) *AuditLogger {
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	return &AuditLogger{
+		path: filepath.Join(projectsDir, ".iac-studio", "mcp-audit.jsonl"),
+		now:  now,
+	}
+}
+
+func (l *AuditLogger) Append(decision AuditDecision) error {
+	if strings.TrimSpace(l.path) == "" {
+		return fmt.Errorf("audit log path is empty")
+	}
+	if decision.Time.IsZero() {
+		decision.Time = l.now().UTC()
+	}
+	decision.ID = auditID(decision)
+	data, err := json.Marshal(decision)
+	if err != nil {
+		return fmt.Errorf("marshal audit event: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(l.path), 0o755); err != nil {
+		return fmt.Errorf("create audit directory: %w", err)
+	}
+	file, err := os.OpenFile(l.path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("open audit log: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+	if _, err := file.Write(append(data, '\n')); err != nil {
+		return fmt.Errorf("write audit log: %w", err)
+	}
+	return nil
+}
+
+func auditID(decision AuditDecision) string {
+	base := strings.Join([]string{
+		decision.Time.Format("20060102T150405.000000000Z"),
+		cleanIDSegment(decision.Tool),
+		cleanIDSegment(decision.Project),
+		cleanIDSegment(decision.Decision),
+	}, "-")
+	return strings.Trim(base, "-")
+}
+
+func cleanIDSegment(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	var b strings.Builder
+	lastDash := false
+	for _, r := range value {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if !lastDash {
+			b.WriteByte('-')
+			lastDash = true
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}

--- a/internal/mcp/protocol.go
+++ b/internal/mcp/protocol.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"sync"
@@ -320,5 +319,3 @@ func firstErr(errs ...error) error {
 	}
 	return nil
 }
-
-var errApprovalRequired = errors.New("approval required")

--- a/internal/mcp/protocol.go
+++ b/internal/mcp/protocol.go
@@ -1,0 +1,324 @@
+package mcp
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/iac-studio/iac-studio/internal/cloudconnections"
+	"github.com/iac-studio/iac-studio/internal/runner"
+)
+
+const (
+	ProtocolVersion = "2025-06-18"
+	ServerName      = "iac-studio-mcp"
+)
+
+type Config struct {
+	ProjectsDir   string
+	ApprovalToken string
+	Version       string
+	Now           func() time.Time
+}
+
+type Server struct {
+	projectsDir   string
+	approvalToken string
+	version       string
+	now           func() time.Time
+
+	cloudConnections *cloudconnections.Manager
+	run              *runner.SafeRunner
+	audit            *AuditLogger
+
+	tools    []Tool
+	handlers map[string]toolHandler
+	writeMu  sync.Mutex
+}
+
+type Tool struct {
+	Name         string         `json:"name"`
+	Title        string         `json:"title,omitempty"`
+	Description  string         `json:"description"`
+	InputSchema  map[string]any `json:"inputSchema"`
+	OutputSchema map[string]any `json:"outputSchema,omitempty"`
+	Annotations  map[string]any `json:"annotations,omitempty"`
+}
+
+type ToolCallResult struct {
+	Content           []ToolContent `json:"content"`
+	StructuredContent any           `json:"structuredContent,omitempty"`
+	IsError           bool          `json:"isError,omitempty"`
+}
+
+type ToolContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type toolResponse struct {
+	Result ToolCallResult
+	Audit  AuditDecision
+}
+
+type toolHandler func(context.Context, json.RawMessage) toolResponse
+
+type rpcRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type rpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Result  any             `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    any    `json:"data,omitempty"`
+}
+
+type toolCallParams struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments,omitempty"`
+}
+
+func NewServer(cfg Config) *Server {
+	if cfg.Version == "" {
+		cfg.Version = "0.1.0"
+	}
+	if cfg.Now == nil {
+		cfg.Now = func() time.Time { return time.Now().UTC() }
+	}
+	run := runner.NewSafeRunner(runner.DefaultSafetyConfig())
+	s := &Server{
+		projectsDir:      cfg.ProjectsDir,
+		approvalToken:    cfg.ApprovalToken,
+		version:          cfg.Version,
+		now:              cfg.Now,
+		cloudConnections: cloudconnections.NewManager(cfg.ProjectsDir),
+		run:              run,
+		audit:            NewAuditLogger(cfg.ProjectsDir, cfg.Now),
+	}
+	s.tools, s.handlers = s.buildTools()
+	return s
+}
+
+func (s *Server) Serve(ctx context.Context, in io.Reader, out io.Writer) error {
+	scanner := bufio.NewScanner(in)
+	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+	encoder := json.NewEncoder(out)
+	encoder.SetEscapeHTML(false)
+
+	for scanner.Scan() {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		response, respond := s.handleLine(ctx, line)
+		if !respond {
+			continue
+		}
+		s.writeMu.Lock()
+		err := encoder.Encode(response)
+		s.writeMu.Unlock()
+		if err != nil {
+			return err
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *Server) handleLine(ctx context.Context, line []byte) (rpcResponse, bool) {
+	var req rpcRequest
+	if err := json.Unmarshal(line, &req); err != nil {
+		return rpcResponse{
+			JSONRPC: "2.0",
+			Error:   &rpcError{Code: -32700, Message: "parse error", Data: err.Error()},
+		}, true
+	}
+	if len(req.ID) == 0 {
+		s.handleNotification(req)
+		return rpcResponse{}, false
+	}
+	result, rpcErr := s.handleRequest(ctx, req)
+	response := rpcResponse{JSONRPC: "2.0", ID: req.ID}
+	if rpcErr != nil {
+		response.Error = rpcErr
+	} else {
+		response.Result = result
+	}
+	return response, true
+}
+
+func (s *Server) handleNotification(req rpcRequest) {
+	// notifications/initialized is the normal MCP lifecycle notification.
+	// Other notifications are ignored so older or richer clients can still
+	// connect without this local server needing every optional capability.
+	_ = req
+}
+
+func (s *Server) handleRequest(ctx context.Context, req rpcRequest) (any, *rpcError) {
+	switch req.Method {
+	case "initialize":
+		return map[string]any{
+			"protocolVersion": ProtocolVersion,
+			"capabilities": map[string]any{
+				"tools": map[string]any{"listChanged": false},
+			},
+			"serverInfo": map[string]any{
+				"name":    ServerName,
+				"title":   "IaC Studio MCP",
+				"version": s.version,
+			},
+			"instructions": "Use read-only tools for inspection. Mutating or high-risk infrastructure actions require explicit IaC Studio approval and are audited.",
+		}, nil
+	case "ping":
+		return map[string]any{}, nil
+	case "tools/list":
+		return map[string]any{"tools": s.tools}, nil
+	case "tools/call":
+		return s.callTool(ctx, req.Params)
+	default:
+		return nil, &rpcError{Code: -32601, Message: "method not found", Data: req.Method}
+	}
+}
+
+func (s *Server) callTool(ctx context.Context, params json.RawMessage) (ToolCallResult, *rpcError) {
+	var call toolCallParams
+	if err := decode(params, &call); err != nil {
+		return ToolCallResult{}, &rpcError{Code: -32602, Message: "invalid tool call params", Data: err.Error()}
+	}
+	handler := s.handlers[call.Name]
+	if handler == nil {
+		return ToolCallResult{}, &rpcError{Code: -32602, Message: "unknown tool", Data: call.Name}
+	}
+	args := call.Arguments
+	if len(args) == 0 || string(args) == "null" {
+		args = []byte("{}")
+	}
+	response := handler(ctx, args)
+	if response.Audit.Tool == "" {
+		response.Audit.Tool = call.Name
+	}
+	if response.Audit.Decision == "" {
+		response.Audit.Decision = "allowed"
+	}
+	if err := s.audit.Append(response.Audit); err != nil {
+		return errorResult("audit log write failed", map[string]any{"error": err.Error()}), nil
+	}
+	return response.Result, nil
+}
+
+func decode(raw json.RawMessage, target any) error {
+	if len(raw) == 0 {
+		raw = []byte("{}")
+	}
+	if string(raw) == "null" {
+		raw = []byte("{}")
+	}
+	if err := json.Unmarshal(raw, target); err != nil {
+		return err
+	}
+	return nil
+}
+
+func structuredResult(payload any) ToolCallResult {
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		data = []byte(fmt.Sprintf("%v", payload))
+	}
+	return ToolCallResult{
+		Content: []ToolContent{{
+			Type: "text",
+			Text: string(data),
+		}},
+		StructuredContent: payload,
+	}
+}
+
+func errorResult(message string, payload any) ToolCallResult {
+	if payload == nil {
+		payload = map[string]any{"error": message}
+	}
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		data = []byte(message)
+	}
+	return ToolCallResult{
+		Content: []ToolContent{{
+			Type: "text",
+			Text: string(data),
+		}},
+		StructuredContent: payload,
+		IsError:           true,
+	}
+}
+
+func approvalRequiredResult(tool, reason string) ToolCallResult {
+	return structuredResult(map[string]any{
+		"status":            "approval_required",
+		"tool":              tool,
+		"reason":            reason,
+		"approval_required": true,
+		"next_step":         "Approve the action through IaC Studio or retry with the configured local approval token.",
+	})
+}
+
+func (s *Server) approved(token string) bool {
+	if s.approvalToken == "" {
+		return false
+	}
+	return token == s.approvalToken
+}
+
+func errResponse(tool string, err error, audit AuditDecision) toolResponse {
+	if audit.Tool == "" {
+		audit.Tool = tool
+	}
+	audit.Decision = "error"
+	audit.Error = err.Error()
+	return toolResponse{
+		Result: errorResult(err.Error(), map[string]any{
+			"error": err.Error(),
+			"tool":  tool,
+		}),
+		Audit: audit,
+	}
+}
+
+func requireNonEmpty(name, value string) error {
+	if value == "" {
+		return fmt.Errorf("%s is required", name)
+	}
+	return nil
+}
+
+func firstErr(errs ...error) error {
+	for _, err := range errs {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+var errApprovalRequired = errors.New("approval required")

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1,0 +1,323 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/iac-studio/iac-studio/internal/cloudconnections"
+)
+
+func TestServerLifecycleAndToolList(t *testing.T) {
+	server := newTestServer(t)
+	input := strings.NewReader(strings.Join([]string{
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1"}}}`,
+		`{"jsonrpc":"2.0","method":"notifications/initialized"}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}`,
+		"",
+	}, "\n"))
+	var output bytes.Buffer
+
+	if err := server.Serve(context.Background(), input, &output); err != nil {
+		t.Fatalf("Serve: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(output.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected initialize and tools/list responses, got %d: %s", len(lines), output.String())
+	}
+	var initResp struct {
+		Result struct {
+			ProtocolVersion string `json:"protocolVersion"`
+			Capabilities    struct {
+				Tools map[string]any `json:"tools"`
+			} `json:"capabilities"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal([]byte(lines[0]), &initResp); err != nil {
+		t.Fatalf("decode initialize response: %v", err)
+	}
+	if initResp.Result.ProtocolVersion != ProtocolVersion {
+		t.Fatalf("protocol version = %q", initResp.Result.ProtocolVersion)
+	}
+	if initResp.Result.Capabilities.Tools == nil {
+		t.Fatalf("initialize response did not advertise tools capability")
+	}
+
+	var listResp struct {
+		Result struct {
+			Tools []Tool `json:"tools"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal([]byte(lines[1]), &listResp); err != nil {
+		t.Fatalf("decode tools/list response: %v", err)
+	}
+	for _, name := range []string{"list_projects", "inspect_project", "classify_plan", "scan_drift", "open_remediation_pr", "apply"} {
+		if !containsTool(listResp.Result.Tools, name) {
+			t.Fatalf("tools/list missing %s", name)
+		}
+	}
+}
+
+func TestInspectProjectReusesParserAndSnapshots(t *testing.T) {
+	server := newTestServer(t)
+	projectDir := writeTerraformProject(t, server.projectsDir, "demo")
+	if err := os.MkdirAll(filepath.Join(projectDir, ".iac-studio", "snapshots"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, ".iac-studio", "snapshots", "checkpoint.json"), []byte(`{
+  "id": "checkpoint",
+  "project": "demo",
+  "tool": "terraform",
+  "command": "apply",
+  "work_dir": "",
+  "created_at": "2026-06-12T10:00:00Z",
+  "status": "recorded"
+}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result := callTool(t, server, "inspect_project", map[string]any{"project": "demo"})
+	if result.IsError {
+		t.Fatalf("inspect_project returned error: %s", result.Content[0].Text)
+	}
+	var payload struct {
+		Tool          string `json:"tool"`
+		ResourceCount int    `json:"resource_count"`
+		Resources     []struct {
+			ID   string `json:"id"`
+			File string `json:"file"`
+		} `json:"resources"`
+		Snapshots []struct {
+			ID string `json:"id"`
+		} `json:"snapshots"`
+	}
+	mustRemarshal(t, result.StructuredContent, &payload)
+	if payload.Tool != "terraform" || payload.ResourceCount != 1 {
+		t.Fatalf("unexpected project inspection: %+v", payload)
+	}
+	if payload.Resources[0].ID != "aws_s3_bucket.logs" || payload.Resources[0].File != "main.tf" {
+		t.Fatalf("unexpected resource metadata: %+v", payload.Resources[0])
+	}
+	if len(payload.Snapshots) != 1 || payload.Snapshots[0].ID != "checkpoint" {
+		t.Fatalf("expected snapshot metadata, got %+v", payload.Snapshots)
+	}
+}
+
+func TestClassifyPlanReturnsStructuredRisk(t *testing.T) {
+	server := newTestServer(t)
+	planJSON := `{
+  "resource_changes": [
+    {
+      "address": "aws_security_group.web",
+      "type": "aws_security_group",
+      "name": "web",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": ["create"],
+        "before": null,
+        "after": {
+          "ingress": [{"cidr_blocks": ["0.0.0.0/0"], "from_port": 22, "to_port": 22}]
+        }
+      }
+    }
+  ]
+}`
+	result := callTool(t, server, "classify_plan", map[string]any{"plan_json": planJSON})
+	if result.IsError {
+		t.Fatalf("classify_plan returned error: %s", result.Content[0].Text)
+	}
+	var payload struct {
+		Summary struct {
+			Risky                  int  `json:"risky"`
+			RequiresAcknowledgment bool `json:"requires_acknowledgment"`
+		} `json:"summary"`
+		Changes []struct {
+			Risk string `json:"risk"`
+		} `json:"changes"`
+	}
+	mustRemarshal(t, result.StructuredContent, &payload)
+	if payload.Summary.Risky != 1 || !payload.Summary.RequiresAcknowledgment || payload.Changes[0].Risk != "risky" {
+		t.Fatalf("unexpected classification: %+v", payload)
+	}
+}
+
+func TestConnectionScopeRedactsSecrets(t *testing.T) {
+	server := newTestServer(t)
+	connection, err := server.cloudConnections.Save(cloudconnections.Connection{
+		Name:       "prod",
+		Provider:   cloudconnections.ProviderAWS,
+		AuthMethod: "aws_static",
+		Region:     "us-east-1",
+		Metadata:   map[string]string{"access_key_id": "AKIATEST"},
+		Secrets:    map[string]string{"secret_access_key": "super-secret", "session_token": "session-secret"},
+	})
+	if err != nil {
+		t.Fatalf("save connection: %v", err)
+	}
+
+	result := callTool(t, server, "inspect_connection_scope", map[string]any{"connection_id": connection.ID})
+	if result.IsError {
+		t.Fatalf("inspect_connection_scope returned error: %s", result.Content[0].Text)
+	}
+	if strings.Contains(result.Content[0].Text, "super-secret") || strings.Contains(result.Content[0].Text, "session-secret") {
+		t.Fatalf("connection scope leaked secret values: %s", result.Content[0].Text)
+	}
+	var payload struct {
+		CommandEnvKeys []string `json:"command_env_keys"`
+		Connection     struct {
+			SecretFields []string `json:"secret_fields"`
+		} `json:"connection"`
+	}
+	mustRemarshal(t, result.StructuredContent, &payload)
+	if !contains(payload.CommandEnvKeys, "AWS_SECRET_ACCESS_KEY") || !contains(payload.Connection.SecretFields, "secret_access_key") {
+		t.Fatalf("expected redacted secret field metadata, got %+v", payload)
+	}
+}
+
+func TestHighRiskToolRequiresApprovalAndAudits(t *testing.T) {
+	server := newTestServer(t)
+	result := callTool(t, server, "apply", map[string]any{"project": "demo", "reason": "test"})
+	if result.IsError {
+		t.Fatalf("approval_required is a structured gate, not an MCP error: %s", result.Content[0].Text)
+	}
+	var payload struct {
+		Status           string `json:"status"`
+		ApprovalRequired bool   `json:"approval_required"`
+	}
+	mustRemarshal(t, result.StructuredContent, &payload)
+	if payload.Status != "approval_required" || !payload.ApprovalRequired {
+		t.Fatalf("unexpected approval gate payload: %+v", payload)
+	}
+
+	events := readAuditEvents(t, server.projectsDir)
+	if len(events) != 1 {
+		t.Fatalf("expected one audit event, got %d", len(events))
+	}
+	if events[0].Tool != "apply" || events[0].Project != "demo" || !events[0].ApprovalRequired || events[0].Decision != "approval_required" {
+		t.Fatalf("unexpected audit event: %+v", events[0])
+	}
+}
+
+func TestOpenRemediationPRRequiresApprovalBeforeMutation(t *testing.T) {
+	server := newTestServer(t)
+	writeTerraformProject(t, server.projectsDir, "demo")
+
+	result := callTool(t, server, "open_remediation_pr", map[string]any{"project": "demo", "mode": "revert"})
+	if result.IsError {
+		t.Fatalf("approval gate should be a structured response: %s", result.Content[0].Text)
+	}
+	var payload struct {
+		Status string `json:"status"`
+	}
+	mustRemarshal(t, result.StructuredContent, &payload)
+	if payload.Status != "approval_required" {
+		t.Fatalf("expected approval_required, got %+v", payload)
+	}
+	if _, err := os.Stat(filepath.Join(server.projectsDir, "demo", ".iac-studio", "remediations")); !os.IsNotExist(err) {
+		t.Fatalf("remediation artifacts should not be written before approval")
+	}
+}
+
+func newTestServer(t *testing.T) *Server {
+	t.Helper()
+	return NewServer(Config{
+		ProjectsDir:   t.TempDir(),
+		ApprovalToken: "approve-me",
+		Version:       "test",
+		Now: func() time.Time {
+			return time.Date(2026, 6, 12, 10, 0, 0, 0, time.UTC)
+		},
+	})
+}
+
+func callTool(t *testing.T, server *Server, name string, args map[string]any) ToolCallResult {
+	t.Helper()
+	rawArgs, err := json.Marshal(args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	params, err := json.Marshal(toolCallParams{Name: name, Arguments: rawArgs})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, rpcErr := server.callTool(context.Background(), params)
+	if rpcErr != nil {
+		t.Fatalf("tool RPC error: %+v", rpcErr)
+	}
+	return result
+}
+
+func writeTerraformProject(t *testing.T, projectsDir, name string) string {
+	t.Helper()
+	projectDir := filepath.Join(projectsDir, name)
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, ".iac-studio.json"), []byte(`{
+  "name": "demo",
+  "tool": "terraform",
+  "layout": "flat"
+}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "main.tf"), []byte(`resource "aws_s3_bucket" "logs" {
+  bucket = "demo-logs"
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return projectDir
+}
+
+func readAuditEvents(t *testing.T, projectsDir string) []AuditDecision {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(projectsDir, ".iac-studio", "mcp-audit.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	events := make([]AuditDecision, 0, len(lines))
+	for _, line := range lines {
+		var event AuditDecision
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			t.Fatal(err)
+		}
+		events = append(events, event)
+	}
+	return events
+}
+
+func mustRemarshal(t *testing.T, in any, out any) {
+	t.Helper()
+	data, err := json.Marshal(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(data, out); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func containsTool(tools []Tool, name string) bool {
+	for _, tool := range tools {
+		if tool.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func contains(values []string, needle string) bool {
+	for _, value := range values {
+		if value == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/iac-studio/iac-studio/internal/cloudconnections"
+	"github.com/iac-studio/iac-studio/internal/runner"
 )
 
 func TestServerLifecycleAndToolList(t *testing.T) {
@@ -177,6 +178,35 @@ func TestConnectionScopeRedactsSecrets(t *testing.T) {
 	mustRemarshal(t, result.StructuredContent, &payload)
 	if !contains(payload.CommandEnvKeys, "AWS_SECRET_ACCESS_KEY") || !contains(payload.Connection.SecretFields, "secret_access_key") {
 		t.Fatalf("expected redacted secret field metadata, got %+v", payload)
+	}
+}
+
+func TestSanitizeExecutionResultRedactsCredentialValues(t *testing.T) {
+	result := sanitizeExecutionResult(&runner.ExecutionResult{
+		ID:       "plan-1",
+		Output:   "aws=AKIATEST secret=super-secret token=session-secret client=tenant-client-secret creds={\"private_key\":\"abc\"} region=us-east-1",
+		ExitCode: 1,
+		Status:   "failed",
+	}, map[string]string{
+		"AWS_ACCESS_KEY_ID":     "AKIATEST",
+		"AWS_SECRET_ACCESS_KEY": "super-secret",
+		"AWS_SESSION_TOKEN":     "session-secret",
+		"ARM_CLIENT_SECRET":     "tenant-client-secret",
+		"GOOGLE_CREDENTIALS":    "{\"private_key\":\"abc\"}",
+		"AWS_REGION":            "us-east-1",
+	})
+	if result == nil {
+		t.Fatal("expected sanitized result")
+	}
+	if strings.Contains(result.Output, "AKIATEST") ||
+		strings.Contains(result.Output, "super-secret") ||
+		strings.Contains(result.Output, "session-secret") ||
+		strings.Contains(result.Output, "tenant-client-secret") ||
+		strings.Contains(result.Output, "{\"private_key\":\"abc\"}") {
+		t.Fatalf("expected secrets to be redacted, got %q", result.Output)
+	}
+	if !strings.Contains(result.Output, "region=us-east-1") {
+		t.Fatalf("expected non-secret env values to remain visible, got %q", result.Output)
 	}
 }
 

--- a/internal/mcp/service.go
+++ b/internal/mcp/service.go
@@ -21,6 +21,7 @@ import (
 	pulumiparser "github.com/iac-studio/iac-studio/internal/pulumi"
 	"github.com/iac-studio/iac-studio/internal/recovery"
 	"github.com/iac-studio/iac-studio/internal/review"
+	"github.com/iac-studio/iac-studio/internal/runner"
 )
 
 type projectArgs struct {
@@ -175,13 +176,14 @@ func (s *Server) handleGeneratePlan(ctx context.Context, raw json.RawMessage) to
 		return errResponse("generate_plan", err, projectAudit("generate_plan", args))
 	}
 	result, runErr := s.run.ExecuteWithEnv(ctx, projectCtx.WorkDir, projectCtx.Tool, "plan", projectCtx.Env, env)
+	sanitized := sanitizeExecutionResult(result, env)
 	payload := map[string]any{
 		"project":    projectCtx.Name,
 		"tool":       projectCtx.Tool,
 		"env":        projectCtx.Env,
 		"work_dir":   projectCtx.WorkDir,
 		"connection": connSummary,
-		"result":     result,
+		"result":     sanitized,
 	}
 	if runErr != nil {
 		payload["error"] = runErr.Error()
@@ -677,6 +679,41 @@ func (s *Server) commandEnvironment(connectionID string) (map[string]string, any
 		"command_env_keys": keys,
 	}
 	return env, public, nil
+}
+
+func sanitizeExecutionResult(result *runner.ExecutionResult, env map[string]string) *runner.ExecutionResult {
+	if result == nil {
+		return nil
+	}
+	sanitized := *result
+	sanitized.Output = redactExecutionOutput(sanitized.Output, env)
+	return &sanitized
+}
+
+func redactExecutionOutput(output string, env map[string]string) string {
+	if output == "" || len(env) == 0 {
+		return output
+	}
+	redacted := output
+	for key, value := range env {
+		if !sensitiveEnvKey(key) {
+			continue
+		}
+		if strings.TrimSpace(value) == "" {
+			continue
+		}
+		redacted = strings.ReplaceAll(redacted, value, "[REDACTED]")
+	}
+	return redacted
+}
+
+func sensitiveEnvKey(key string) bool {
+	switch key {
+	case "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN", "ARM_CLIENT_SECRET", "GOOGLE_CREDENTIALS":
+		return true
+	default:
+		return false
+	}
 }
 
 func parseResources(dir, tool string) ([]parser.Resource, error) {

--- a/internal/mcp/service.go
+++ b/internal/mcp/service.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/iac-studio/iac-studio/internal/cloudconnections"
 	"github.com/iac-studio/iac-studio/internal/drift"
@@ -907,21 +906,20 @@ func resourceReviewGuidance(res parser.Resource, report *policy.PolicyReport) []
 func classifyChangeRequest(request string) (string, []string) {
 	lower := strings.ToLower(request)
 	cues := []string{}
-	risk := "unknown"
 	for _, cue := range []string{"delete", "destroy", "replace", "public", "0.0.0.0/0", "::/0", "iam", "role", "policy", "security group", "firewall", "database", "rds", "bucket"} {
 		if strings.Contains(lower, cue) {
 			cues = append(cues, cue)
 		}
 	}
+	risk := "review_required"
 	if len(cues) == 0 {
-		risk = "review_required"
-	} else {
-		risk = "risky"
-		for _, cue := range cues {
-			if cue == "delete" || cue == "destroy" || cue == "replace" {
-				risk = "destructive"
-				break
-			}
+		return risk, cues
+	}
+	risk = "risky"
+	for _, cue := range cues {
+		if cue == "delete" || cue == "destroy" || cue == "replace" {
+			risk = "destructive"
+			break
 		}
 	}
 	return risk, cues
@@ -1058,8 +1056,4 @@ func highRiskReason(tool string) string {
 	default:
 		return "high-risk infrastructure action"
 	}
-}
-
-func utcNow() time.Time {
-	return time.Now().UTC()
 }

--- a/internal/mcp/service.go
+++ b/internal/mcp/service.go
@@ -1,0 +1,1028 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/iac-studio/iac-studio/internal/cloudconnections"
+	"github.com/iac-studio/iac-studio/internal/drift"
+	"github.com/iac-studio/iac-studio/internal/parser"
+	iacplan "github.com/iac-studio/iac-studio/internal/plan"
+	"github.com/iac-studio/iac-studio/internal/policy"
+	"github.com/iac-studio/iac-studio/internal/project"
+	pulumiparser "github.com/iac-studio/iac-studio/internal/pulumi"
+	"github.com/iac-studio/iac-studio/internal/recovery"
+	"github.com/iac-studio/iac-studio/internal/review"
+)
+
+type projectArgs struct {
+	Project      string `json:"project"`
+	Tool         string `json:"tool,omitempty"`
+	Env          string `json:"env,omitempty"`
+	ConnectionID string `json:"connection_id,omitempty"`
+}
+
+type projectContext struct {
+	Name        string
+	ProjectPath string
+	WorkDir     string
+	Tool        string
+	Env         string
+	Descriptor  *projectDescriptor
+	Resources   []parser.Resource
+}
+
+type projectDescriptor struct {
+	Name             string            `json:"name,omitempty"`
+	Tool             string            `json:"tool,omitempty"`
+	Layout           string            `json:"layout,omitempty"`
+	Blueprint        string            `json:"blueprint,omitempty"`
+	ProjectName      string            `json:"project_name,omitempty"`
+	Cloud            string            `json:"cloud,omitempty"`
+	Environments     []string          `json:"environments,omitempty"`
+	EnvironmentTools map[string]string `json:"environment_tools,omitempty"`
+	Tags             map[string]string `json:"tags,omitempty"`
+	Drift            struct {
+		Suppressions []drift.SuppressionRule `json:"suppressions,omitempty"`
+	} `json:"drift,omitempty"`
+}
+
+func (s *Server) handleListProjects(_ context.Context, _ json.RawMessage) toolResponse {
+	manager := project.NewManager(s.projectsDir)
+	states, err := manager.ListAll()
+	if err != nil {
+		if os.IsNotExist(err) {
+			states = []*project.State{}
+		} else {
+			return errResponse("list_projects", err, AuditDecision{Tool: "list_projects"})
+		}
+	}
+	sort.SliceStable(states, func(i, j int) bool { return states[i].Name < states[j].Name })
+	projects := make([]map[string]any, 0, len(states))
+	for _, state := range states {
+		projects = append(projects, map[string]any{
+			"name":         state.Name,
+			"path":         state.Path,
+			"tool":         state.Tool,
+			"layout":       state.Layout,
+			"cloud":        state.Cloud,
+			"environments": state.Environments,
+			"updated_at":   state.UpdatedAt,
+		})
+	}
+	return toolResponse{
+		Result: structuredResult(map[string]any{"projects": projects}),
+		Audit:  AuditDecision{Tool: "list_projects", Decision: "allowed"},
+	}
+}
+
+func (s *Server) handleInspectProject(_ context.Context, raw json.RawMessage) toolResponse {
+	var args projectArgs
+	if err := decode(raw, &args); err != nil {
+		return errResponse("inspect_project", err, AuditDecision{Tool: "inspect_project"})
+	}
+	ctx, err := s.loadProject(args)
+	if err != nil {
+		return errResponse("inspect_project", err, projectAudit("inspect_project", args))
+	}
+	snapshots, err := recovery.ListSnapshots(ctx.ProjectPath)
+	if err != nil {
+		return errResponse("inspect_project", err, projectAudit("inspect_project", args))
+	}
+	return toolResponse{
+		Result: structuredResult(map[string]any{
+			"name":           ctx.Name,
+			"path":           ctx.ProjectPath,
+			"work_dir":       ctx.WorkDir,
+			"tool":           ctx.Tool,
+			"env":            ctx.Env,
+			"descriptor":     ctx.Descriptor,
+			"resource_count": len(ctx.Resources),
+			"resources":      relativeResources(ctx.ProjectPath, ctx.Resources),
+			"snapshots":      snapshots,
+		}),
+		Audit: projectAudit("inspect_project", args),
+	}
+}
+
+func (s *Server) handleListCloudConnections(_ context.Context, _ json.RawMessage) toolResponse {
+	connections, err := s.cloudConnections.List()
+	if err != nil {
+		return errResponse("list_cloud_connections", err, AuditDecision{Tool: "list_cloud_connections"})
+	}
+	return toolResponse{
+		Result: structuredResult(map[string]any{"connections": connections}),
+		Audit:  AuditDecision{Tool: "list_cloud_connections", Decision: "allowed"},
+	}
+}
+
+func (s *Server) handleInspectConnectionScope(_ context.Context, raw json.RawMessage) toolResponse {
+	var args struct {
+		ConnectionID string `json:"connection_id"`
+	}
+	if err := decode(raw, &args); err != nil {
+		return errResponse("inspect_connection_scope", err, AuditDecision{Tool: "inspect_connection_scope"})
+	}
+	if err := requireNonEmpty("connection_id", args.ConnectionID); err != nil {
+		return errResponse("inspect_connection_scope", err, AuditDecision{Tool: "inspect_connection_scope", ConnectionID: args.ConnectionID})
+	}
+	connection, err := s.cloudConnections.Get(args.ConnectionID)
+	if err != nil {
+		return errResponse("inspect_connection_scope", err, AuditDecision{Tool: "inspect_connection_scope", ConnectionID: args.ConnectionID})
+	}
+	result, err := s.cloudConnections.Test(args.ConnectionID)
+	if err != nil {
+		return errResponse("inspect_connection_scope", err, AuditDecision{Tool: "inspect_connection_scope", ConnectionID: args.ConnectionID})
+	}
+	env := cloudconnections.CommandEnvironment(*connection)
+	keys := make([]string, 0, len(env))
+	for key := range env {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return toolResponse{
+		Result: structuredResult(map[string]any{
+			"connection":       result.Connection,
+			"ready":            result.OK,
+			"checks":           result.Checks,
+			"summary":          result.Summary,
+			"command_env_keys": keys,
+			"scope":            "Credentials remain inside IaC Studio's cloud connection broker; MCP responses expose names, providers, readiness, and environment variable keys only.",
+		}),
+		Audit: AuditDecision{Tool: "inspect_connection_scope", ConnectionID: args.ConnectionID, Decision: "allowed"},
+	}
+}
+
+func (s *Server) handleGeneratePlan(ctx context.Context, raw json.RawMessage) toolResponse {
+	var args projectArgs
+	if err := decode(raw, &args); err != nil {
+		return errResponse("generate_plan", err, AuditDecision{Tool: "generate_plan"})
+	}
+	projectCtx, err := s.loadProject(args)
+	if err != nil {
+		return errResponse("generate_plan", err, projectAudit("generate_plan", args))
+	}
+	env, connSummary, err := s.commandEnvironment(args.ConnectionID)
+	if err != nil {
+		return errResponse("generate_plan", err, projectAudit("generate_plan", args))
+	}
+	result, runErr := s.run.ExecuteWithEnv(ctx, projectCtx.WorkDir, projectCtx.Tool, "plan", projectCtx.Env, env)
+	payload := map[string]any{
+		"project":    projectCtx.Name,
+		"tool":       projectCtx.Tool,
+		"env":        projectCtx.Env,
+		"work_dir":   projectCtx.WorkDir,
+		"connection": connSummary,
+		"result":     result,
+	}
+	if runErr != nil {
+		payload["error"] = runErr.Error()
+		return toolResponse{
+			Result: errorResult(runErr.Error(), payload),
+			Audit:  projectAudit("generate_plan", args).withError(runErr),
+		}
+	}
+	return toolResponse{
+		Result: structuredResult(payload),
+		Audit:  projectAudit("generate_plan", args),
+	}
+}
+
+func (s *Server) handleClassifyPlan(_ context.Context, raw json.RawMessage) toolResponse {
+	var args struct {
+		PlanJSON string `json:"plan_json,omitempty"`
+		Project  string `json:"project,omitempty"`
+		PlanPath string `json:"plan_path,omitempty"`
+	}
+	if err := decode(raw, &args); err != nil {
+		return errResponse("classify_plan", err, AuditDecision{Tool: "classify_plan"})
+	}
+	planJSON := strings.TrimSpace(args.PlanJSON)
+	if planJSON == "" && args.Project != "" {
+		projectPath, err := safeProjectPath(s.projectsDir, args.Project)
+		if err != nil {
+			return errResponse("classify_plan", err, AuditDecision{Tool: "classify_plan", Project: args.Project})
+		}
+		planPath := args.PlanPath
+		if strings.TrimSpace(planPath) == "" {
+			planPath = "tfplan.json"
+		}
+		path, err := safeProjectFile(projectPath, planPath)
+		if err != nil {
+			return errResponse("classify_plan", err, AuditDecision{Tool: "classify_plan", Project: args.Project})
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return errResponse("classify_plan", err, AuditDecision{Tool: "classify_plan", Project: args.Project})
+		}
+		planJSON = string(data)
+	}
+	if strings.TrimSpace(planJSON) == "" {
+		err := errors.New("plan_json or project plan_path is required")
+		return errResponse("classify_plan", err, AuditDecision{Tool: "classify_plan", Project: args.Project})
+	}
+	classification, err := iacplan.New().ClassifyFullPlan(planJSON)
+	if err != nil {
+		return errResponse("classify_plan", err, AuditDecision{Tool: "classify_plan", Project: args.Project})
+	}
+	return toolResponse{
+		Result: structuredResult(classification),
+		Audit:  AuditDecision{Tool: "classify_plan", Project: args.Project, Decision: "allowed"},
+	}
+}
+
+func (s *Server) handleRunPolicyCheck(_ context.Context, raw json.RawMessage) toolResponse {
+	var args projectArgs
+	if err := decode(raw, &args); err != nil {
+		return errResponse("run_policy_check", err, AuditDecision{Tool: "run_policy_check"})
+	}
+	ctx, err := s.loadProject(args)
+	if err != nil {
+		return errResponse("run_policy_check", err, projectAudit("run_policy_check", args))
+	}
+	report := policy.New().Evaluate(ctx.Resources)
+	return toolResponse{
+		Result: structuredResult(map[string]any{
+			"project": ctx.Name,
+			"tool":    ctx.Tool,
+			"env":     ctx.Env,
+			"report":  report,
+		}),
+		Audit: projectAudit("run_policy_check", args),
+	}
+}
+
+func (s *Server) handleScanDrift(_ context.Context, raw json.RawMessage) toolResponse {
+	var args projectArgs
+	if err := decode(raw, &args); err != nil {
+		return errResponse("scan_drift", err, AuditDecision{Tool: "scan_drift"})
+	}
+	run, err := s.runDrift(args)
+	if err != nil {
+		return errResponse("scan_drift", err, projectAudit("scan_drift", args))
+	}
+	return toolResponse{
+		Result: structuredResult(run.Report),
+		Audit:  projectAudit("scan_drift", args),
+	}
+}
+
+func (s *Server) handleExplainResource(_ context.Context, raw json.RawMessage) toolResponse {
+	var args struct {
+		Project string `json:"project"`
+		Address string `json:"address"`
+		Tool    string `json:"tool,omitempty"`
+		Env     string `json:"env,omitempty"`
+	}
+	if err := decode(raw, &args); err != nil {
+		return errResponse("explain_resource", err, AuditDecision{Tool: "explain_resource"})
+	}
+	if err := firstErr(requireNonEmpty("project", args.Project), requireNonEmpty("address", args.Address)); err != nil {
+		return errResponse("explain_resource", err, AuditDecision{Tool: "explain_resource", Project: args.Project})
+	}
+	projectCtx, err := s.loadProject(projectArgs{Project: args.Project, Tool: args.Tool, Env: args.Env})
+	if err != nil {
+		return errResponse("explain_resource", err, AuditDecision{Tool: "explain_resource", Project: args.Project})
+	}
+	var found *parser.Resource
+	for i := range projectCtx.Resources {
+		if resourceAddress(projectCtx.Resources[i]) == args.Address || projectCtx.Resources[i].ID == args.Address {
+			found = &projectCtx.Resources[i]
+			break
+		}
+	}
+	if found == nil {
+		return errResponse("explain_resource", fmt.Errorf("resource not found: %s", args.Address), AuditDecision{Tool: "explain_resource", Project: args.Project})
+	}
+	report := policy.New().Evaluate([]parser.Resource{*found})
+	relative := relativeResources(projectCtx.ProjectPath, []parser.Resource{*found})
+	return toolResponse{
+		Result: structuredResult(map[string]any{
+			"project":          projectCtx.Name,
+			"tool":             projectCtx.Tool,
+			"env":              projectCtx.Env,
+			"resource":         relative[0],
+			"policy_findings":  report.Violations,
+			"review_guidance":  resourceReviewGuidance(*found, report),
+			"source_reference": fmt.Sprintf("%s:%d", relative[0].File, relative[0].Line),
+		}),
+		Audit: AuditDecision{Tool: "explain_resource", Project: args.Project, Decision: "allowed"},
+	}
+}
+
+func (s *Server) handleSummarizeRecentChanges(_ context.Context, raw json.RawMessage) toolResponse {
+	var args struct {
+		Project string `json:"project"`
+		Limit   int    `json:"limit,omitempty"`
+	}
+	if err := decode(raw, &args); err != nil {
+		return errResponse("summarize_recent_changes", err, AuditDecision{Tool: "summarize_recent_changes"})
+	}
+	if err := requireNonEmpty("project", args.Project); err != nil {
+		return errResponse("summarize_recent_changes", err, AuditDecision{Tool: "summarize_recent_changes", Project: args.Project})
+	}
+	if args.Limit <= 0 || args.Limit > 25 {
+		args.Limit = 5
+	}
+	projectPath, err := safeProjectPath(s.projectsDir, args.Project)
+	if err != nil {
+		return errResponse("summarize_recent_changes", err, AuditDecision{Tool: "summarize_recent_changes", Project: args.Project})
+	}
+	summary := s.projectHistory(projectPath, args.Limit)
+	return toolResponse{
+		Result: structuredResult(summary),
+		Audit:  AuditDecision{Tool: "summarize_recent_changes", Project: args.Project, Decision: "allowed"},
+	}
+}
+
+func (s *Server) handleProposeIaCChange(_ context.Context, raw json.RawMessage) toolResponse {
+	var args struct {
+		Project       string `json:"project"`
+		ChangeRequest string `json:"change_request"`
+		Tool          string `json:"tool,omitempty"`
+		Env           string `json:"env,omitempty"`
+	}
+	if err := decode(raw, &args); err != nil {
+		return errResponse("propose_iac_change", err, AuditDecision{Tool: "propose_iac_change"})
+	}
+	if err := firstErr(requireNonEmpty("project", args.Project), requireNonEmpty("change_request", args.ChangeRequest)); err != nil {
+		return errResponse("propose_iac_change", err, AuditDecision{Tool: "propose_iac_change", Project: args.Project})
+	}
+	projectCtx, err := s.loadProject(projectArgs{Project: args.Project, Tool: args.Tool, Env: args.Env})
+	if err != nil {
+		return errResponse("propose_iac_change", err, AuditDecision{Tool: "propose_iac_change", Project: args.Project})
+	}
+	risk, cues := classifyChangeRequest(args.ChangeRequest)
+	proposal := map[string]any{
+		"project":        projectCtx.Name,
+		"tool":           projectCtx.Tool,
+		"env":            projectCtx.Env,
+		"title":          fmt.Sprintf("Propose IaC change for %s", projectCtx.Name),
+		"change_request": args.ChangeRequest,
+		"risk":           risk,
+		"risk_cues":      cues,
+		"resource_count": len(projectCtx.Resources),
+		"mutates_files":  false,
+		"recommended_flow": []string{
+			"Generate or edit IaC in a branch.",
+			"Run plan and semantic classification.",
+			"Run policy and security checks.",
+			"Open a PR with the plan summary and risk classification.",
+		},
+	}
+	return toolResponse{
+		Result: structuredResult(proposal),
+		Audit:  AuditDecision{Tool: "propose_iac_change", Project: args.Project, Decision: "proposal_generated"},
+	}
+}
+
+func (s *Server) handleProposeDriftRemediation(_ context.Context, raw json.RawMessage) toolResponse {
+	var args struct {
+		Project      string `json:"project"`
+		Mode         string `json:"mode"`
+		Tool         string `json:"tool,omitempty"`
+		Env          string `json:"env,omitempty"`
+		ConnectionID string `json:"connection_id,omitempty"`
+	}
+	if err := decode(raw, &args); err != nil {
+		return errResponse("propose_drift_remediation", err, AuditDecision{Tool: "propose_drift_remediation"})
+	}
+	run, proposal, err := s.driftProposal(projectArgs{Project: args.Project, Tool: args.Tool, Env: args.Env, ConnectionID: args.ConnectionID}, args.Mode)
+	if err != nil {
+		return errResponse("propose_drift_remediation", err, AuditDecision{Tool: "propose_drift_remediation", Project: args.Project, ConnectionID: args.ConnectionID})
+	}
+	return toolResponse{
+		Result: structuredResult(map[string]any{
+			"drift":    run.Report,
+			"proposal": proposal,
+		}),
+		Audit: AuditDecision{Tool: "propose_drift_remediation", Project: args.Project, ConnectionID: args.ConnectionID, Decision: "proposal_generated"},
+	}
+}
+
+func (s *Server) handleOpenRemediationPR(_ context.Context, raw json.RawMessage) toolResponse {
+	var args struct {
+		Project       string `json:"project"`
+		Mode          string `json:"mode"`
+		Tool          string `json:"tool,omitempty"`
+		Env           string `json:"env,omitempty"`
+		ConnectionID  string `json:"connection_id,omitempty"`
+		ApprovalToken string `json:"approval_token,omitempty"`
+	}
+	if err := decode(raw, &args); err != nil {
+		return errResponse("open_remediation_pr", err, AuditDecision{Tool: "open_remediation_pr"})
+	}
+	audit := AuditDecision{
+		Tool:             "open_remediation_pr",
+		Project:          args.Project,
+		ConnectionID:     args.ConnectionID,
+		ApprovalRequired: true,
+	}
+	if !s.approved(args.ApprovalToken) {
+		audit.Decision = "approval_required"
+		return toolResponse{Result: approvalRequiredResult("open_remediation_pr", "writing review artifacts and creating a local PR branch mutates the project repository"), Audit: audit}
+	}
+	audit.Approved = true
+	run, proposal, err := s.driftProposal(projectArgs{Project: args.Project, Tool: args.Tool, Env: args.Env, ConnectionID: args.ConnectionID}, args.Mode)
+	if err != nil {
+		return errResponse("open_remediation_pr", err, audit)
+	}
+	artifactSet, rendered, err := drift.RenderRemediationArtifacts(proposal, s.now())
+	if err != nil {
+		return errResponse("open_remediation_pr", err, audit)
+	}
+	for _, artifact := range rendered {
+		if err := writeArtifactFile(run.ProjectPath, artifact.Path, artifact.Content); err != nil {
+			return errResponse("open_remediation_pr", err, audit)
+		}
+	}
+	files := make([]string, 0, len(rendered))
+	for _, artifact := range rendered {
+		files = append(files, artifact.Path)
+	}
+	handoff, err := review.CreatePullRequestHandoff(review.PullRequestHandoffInput{
+		ProjectPath:   run.ProjectPath,
+		Title:         proposal.Title,
+		Branch:        proposal.Branch,
+		CommitMessage: proposal.CommitMessage,
+		BodyPath:      remediationBodyPath(rendered),
+		Files:         files,
+	})
+	if err != nil {
+		return errResponse("open_remediation_pr", err, audit)
+	}
+	audit.Decision = "approved_handoff_created"
+	audit.Mutated = true
+	return toolResponse{
+		Result: structuredResult(map[string]any{
+			"artifacts":    artifactSet,
+			"pull_request": handoff,
+		}),
+		Audit: audit,
+	}
+}
+
+func (s *Server) handleGenerateRunbook(_ context.Context, raw json.RawMessage) toolResponse {
+	var args struct {
+		Project      string `json:"project"`
+		Incident     string `json:"incident,omitempty"`
+		Tool         string `json:"tool,omitempty"`
+		Env          string `json:"env,omitempty"`
+		ConnectionID string `json:"connection_id,omitempty"`
+	}
+	if err := decode(raw, &args); err != nil {
+		return errResponse("generate_runbook", err, AuditDecision{Tool: "generate_runbook"})
+	}
+	projectCtx, err := s.loadProject(projectArgs{Project: args.Project, Tool: args.Tool, Env: args.Env, ConnectionID: args.ConnectionID})
+	if err != nil {
+		return errResponse("generate_runbook", err, AuditDecision{Tool: "generate_runbook", Project: args.Project, ConnectionID: args.ConnectionID})
+	}
+	history := s.projectHistory(projectCtx.ProjectPath, 5)
+	var driftReport any
+	if run, driftErr := s.runDrift(projectArgs{Project: args.Project, Tool: args.Tool, Env: args.Env, ConnectionID: args.ConnectionID}); driftErr == nil {
+		driftReport = run.Report
+	} else {
+		driftReport = map[string]any{"error": driftErr.Error()}
+	}
+	runbook := renderRunbook(projectCtx, args.Incident, history, driftReport)
+	return toolResponse{
+		Result: structuredResult(map[string]any{
+			"project": projectCtx.Name,
+			"tool":    projectCtx.Tool,
+			"env":     projectCtx.Env,
+			"runbook": runbook,
+			"history": history,
+			"drift":   driftReport,
+		}),
+		Audit: AuditDecision{Tool: "generate_runbook", Project: args.Project, ConnectionID: args.ConnectionID, Decision: "runbook_generated"},
+	}
+}
+
+func (s *Server) handleHighRisk(tool string) toolHandler {
+	return func(_ context.Context, raw json.RawMessage) toolResponse {
+		var args struct {
+			Project       string `json:"project,omitempty"`
+			ConnectionID  string `json:"connection_id,omitempty"`
+			ApprovalToken string `json:"approval_token,omitempty"`
+			Reason        string `json:"reason,omitempty"`
+		}
+		if err := decode(raw, &args); err != nil {
+			return errResponse(tool, err, AuditDecision{Tool: tool})
+		}
+		audit := AuditDecision{
+			Tool:             tool,
+			Project:          args.Project,
+			ConnectionID:     args.ConnectionID,
+			ApprovalRequired: true,
+		}
+		if !s.approved(args.ApprovalToken) {
+			audit.Decision = "approval_required"
+			return toolResponse{Result: approvalRequiredResult(tool, highRiskReason(tool)), Audit: audit}
+		}
+		audit.Approved = true
+		audit.Decision = "approved_handoff_required"
+		return toolResponse{
+			Result: structuredResult(map[string]any{
+				"status":   "approved_handoff_required",
+				"tool":     tool,
+				"executed": false,
+				"reason":   "The local MCP foundation records approval but does not directly execute high-risk infrastructure mutations. Generate a plan, classify it, run policy checks, and complete the action through the IaC Studio UI/API approval flow.",
+			}),
+			Audit: audit,
+		}
+	}
+}
+
+func (s *Server) loadProject(args projectArgs) (*projectContext, error) {
+	if err := requireNonEmpty("project", args.Project); err != nil {
+		return nil, err
+	}
+	projectPath, err := safeProjectPath(s.projectsDir, args.Project)
+	if err != nil {
+		return nil, err
+	}
+	descriptor, _ := readProjectDescriptor(projectPath)
+	tool := effectiveTool(descriptor, args.Tool, args.Env)
+	if tool == "multi" {
+		return nil, fmt.Errorf("env is required to resolve a concrete tool for hybrid projects")
+	}
+	if tool == "" {
+		tool = "terraform"
+	}
+	workDir := projectPath
+	if args.Env != "" {
+		if err := safePathSegment(args.Env); err != nil {
+			return nil, err
+		}
+		workDir = filepath.Join(projectPath, "environments", args.Env)
+		info, err := os.Stat(workDir)
+		if err != nil {
+			return nil, fmt.Errorf("environment %q is not accessible: %w", args.Env, err)
+		}
+		if !info.IsDir() {
+			return nil, fmt.Errorf("environment %q is not a directory", args.Env)
+		}
+	}
+	resources, err := parseResources(workDir, tool)
+	if err != nil {
+		return nil, err
+	}
+	return &projectContext{
+		Name:        args.Project,
+		ProjectPath: projectPath,
+		WorkDir:     workDir,
+		Tool:        tool,
+		Env:         args.Env,
+		Descriptor:  descriptor,
+		Resources:   resources,
+	}, nil
+}
+
+func (s *Server) runDrift(args projectArgs) (*driftRun, error) {
+	projectCtx, err := s.loadProject(args)
+	if err != nil {
+		return nil, err
+	}
+	if projectCtx.Tool != "terraform" && projectCtx.Tool != "opentofu" {
+		return nil, fmt.Errorf("drift detection currently supports Terraform and OpenTofu state")
+	}
+	var conn *cloudconnections.Connection
+	if strings.TrimSpace(args.ConnectionID) != "" {
+		conn, err = s.cloudConnections.Get(args.ConnectionID)
+		if err != nil {
+			return nil, fmt.Errorf("load cloud connection: %w", err)
+		}
+	}
+	codeResources := make(map[string]map[string]interface{}, len(projectCtx.Resources))
+	for _, res := range projectCtx.Resources {
+		codeResources[resourceAddress(res)] = res.Properties
+	}
+	var suppressions []drift.SuppressionRule
+	if projectCtx.Descriptor != nil {
+		suppressions = projectCtx.Descriptor.Drift.Suppressions
+	}
+	report, err := drift.New().DetectWithOptions(projectCtx.WorkDir, codeResources, drift.DetectOptions{
+		Env:          args.Env,
+		Suppressions: suppressions,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if conn != nil {
+		report.ConnectionID = conn.ID
+		report.ConnectionName = conn.Name
+		report.ConnectionProvider = conn.Provider
+	}
+	return &driftRun{
+		projectContext: *projectCtx,
+		Report:         report,
+	}, nil
+}
+
+type driftRun struct {
+	projectContext
+	Report *drift.DriftReport
+}
+
+func (s *Server) driftProposal(args projectArgs, mode string) (*driftRun, drift.RemediationProposal, error) {
+	if err := firstErr(requireNonEmpty("project", args.Project), requireNonEmpty("mode", mode)); err != nil {
+		return nil, drift.RemediationProposal{}, err
+	}
+	run, err := s.runDrift(args)
+	if err != nil {
+		return nil, drift.RemediationProposal{}, err
+	}
+	proposal, err := drift.BuildRemediationProposal(drift.RemediationInput{
+		ProjectName: args.Project,
+		Tool:        run.Tool,
+		Env:         run.Env,
+		Mode:        mode,
+		Findings:    run.Report.Findings,
+		Locations:   driftLocations(run.WorkDir, run.Resources),
+	})
+	if err != nil {
+		return nil, drift.RemediationProposal{}, err
+	}
+	return run, proposal, nil
+}
+
+func (s *Server) commandEnvironment(connectionID string) (map[string]string, any, error) {
+	if strings.TrimSpace(connectionID) == "" {
+		return nil, nil, nil
+	}
+	connection, err := s.cloudConnections.Get(connectionID)
+	if err != nil {
+		return nil, nil, err
+	}
+	env := cloudconnections.CommandEnvironment(*connection)
+	keys := make([]string, 0, len(env))
+	for key := range env {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	public := map[string]any{
+		"id":               connection.ID,
+		"name":             connection.Name,
+		"provider":         connection.Provider,
+		"auth_method":      connection.AuthMethod,
+		"region":           connection.Region,
+		"command_env_keys": keys,
+	}
+	return env, public, nil
+}
+
+func parseResources(dir, tool string) ([]parser.Resource, error) {
+	switch tool {
+	case "pulumi":
+		return (&pulumiparser.TSParser{}).ParseDir(dir)
+	default:
+		return parser.ForTool(tool).ParseDir(dir)
+	}
+}
+
+func readProjectDescriptor(projectPath string) (*projectDescriptor, error) {
+	data, err := os.ReadFile(filepath.Join(projectPath, ".iac-studio.json"))
+	if err != nil {
+		return nil, err
+	}
+	var descriptor projectDescriptor
+	if err := json.Unmarshal(data, &descriptor); err != nil {
+		return nil, err
+	}
+	return &descriptor, nil
+}
+
+func effectiveTool(descriptor *projectDescriptor, requestedTool, env string) string {
+	requestedTool = strings.TrimSpace(requestedTool)
+	if requestedTool == "" {
+		requestedTool = "terraform"
+	}
+	if descriptor == nil {
+		return requestedTool
+	}
+	if env != "" {
+		if tool := descriptor.EnvironmentTools[env]; concreteTool(tool) {
+			return tool
+		}
+	}
+	if requestedTool == "terraform" && descriptorTool(descriptor.Tool) {
+		return descriptor.Tool
+	}
+	if requestedTool == "multi" && concreteTool(descriptor.Tool) {
+		return descriptor.Tool
+	}
+	return requestedTool
+}
+
+func concreteTool(tool string) bool {
+	switch tool {
+	case "terraform", "opentofu", "pulumi", "ansible":
+		return true
+	default:
+		return false
+	}
+}
+
+func descriptorTool(tool string) bool {
+	return tool == "multi" || concreteTool(tool)
+}
+
+func safeProjectPath(projectsDir, name string) (string, error) {
+	if err := safePathSegment(name); err != nil {
+		return "", fmt.Errorf("invalid project name: %w", err)
+	}
+	resolved := filepath.Join(projectsDir, name)
+	absProjects, err := filepath.Abs(projectsDir)
+	if err != nil {
+		return "", fmt.Errorf("resolve projects dir: %w", err)
+	}
+	if eval, err := filepath.EvalSymlinks(absProjects); err == nil {
+		absProjects = eval
+	}
+	absResolved, err := filepath.Abs(resolved)
+	if err != nil {
+		return "", fmt.Errorf("resolve project path: %w", err)
+	}
+	if eval, err := filepath.EvalSymlinks(resolved); err == nil {
+		if abs, absErr := filepath.Abs(eval); absErr == nil {
+			absResolved = abs
+		}
+	}
+	rel, err := filepath.Rel(absProjects, absResolved)
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("project path escapes root")
+	}
+	return resolved, nil
+}
+
+func safePathSegment(value string) error {
+	if value == "" || value == "." || value == ".." || strings.Contains(value, "..") || strings.ContainsAny(value, `/\`) {
+		return fmt.Errorf("unsafe path segment %q", value)
+	}
+	for _, r := range value {
+		if !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_') {
+			return fmt.Errorf("unsafe path segment %q", value)
+		}
+	}
+	return nil
+}
+
+func safeProjectFile(projectPath, requested string) (string, error) {
+	if strings.TrimSpace(requested) == "" {
+		return "", fmt.Errorf("file path is required")
+	}
+	clean := filepath.Clean(filepath.FromSlash(requested))
+	if filepath.IsAbs(clean) || clean == "." || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("unsafe project file path")
+	}
+	target := filepath.Join(projectPath, clean)
+	absProject, err := filepath.Abs(projectPath)
+	if err != nil {
+		return "", err
+	}
+	absTarget, err := filepath.Abs(target)
+	if err != nil {
+		return "", err
+	}
+	rel, err := filepath.Rel(absProject, absTarget)
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("file path escapes project root")
+	}
+	return absTarget, nil
+}
+
+func relativeResources(projectPath string, resources []parser.Resource) []parser.Resource {
+	out := make([]parser.Resource, len(resources))
+	for i, res := range resources {
+		out[i] = res
+		if res.File != "" {
+			if rel, err := filepath.Rel(projectPath, res.File); err == nil && rel != "." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+				out[i].File = filepath.ToSlash(rel)
+			} else {
+				out[i].File = filepath.ToSlash(filepath.Base(res.File))
+			}
+		}
+	}
+	return out
+}
+
+func resourceAddress(res parser.Resource) string {
+	if strings.TrimSpace(res.ID) != "" {
+		return res.ID
+	}
+	if strings.TrimSpace(res.Type) == "" {
+		return res.Name
+	}
+	if strings.TrimSpace(res.Name) == "" {
+		return res.Type
+	}
+	return res.Type + "." + res.Name
+}
+
+func driftLocations(workDir string, resources []parser.Resource) map[string]drift.ResourceLocation {
+	locations := make(map[string]drift.ResourceLocation, len(resources))
+	for _, res := range resources {
+		file := filepath.ToSlash(filepath.Base(res.File))
+		if rel, err := filepath.Rel(workDir, res.File); err == nil && rel != "." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			file = filepath.ToSlash(rel)
+		}
+		locations[resourceAddress(res)] = drift.ResourceLocation{File: file, Line: res.Line}
+	}
+	return locations
+}
+
+func projectAudit(tool string, args projectArgs) AuditDecision {
+	return AuditDecision{Tool: tool, Project: args.Project, ConnectionID: args.ConnectionID, Decision: "allowed"}
+}
+
+func (a AuditDecision) withError(err error) AuditDecision {
+	a.Decision = "error"
+	a.Error = err.Error()
+	return a
+}
+
+func resourceReviewGuidance(res parser.Resource, report *policy.PolicyReport) []string {
+	guidance := []string{
+		"Review provider defaults and dependencies before applying changes.",
+	}
+	switch {
+	case strings.Contains(res.Type, "iam"):
+		guidance = append(guidance, "Check principals, actions, resources, conditions, and trust relationships.")
+	case strings.Contains(res.Type, "security_group"), strings.Contains(res.Type, "firewall"), strings.Contains(res.Type, "route"):
+		guidance = append(guidance, "Check public CIDRs, ports, protocols, routes, and exposure boundaries.")
+	case strings.Contains(res.Type, "db"), strings.Contains(res.Type, "bucket"), strings.Contains(res.Type, "volume"):
+		guidance = append(guidance, "Check encryption, retention, deletion protection, backups, and cost impact.")
+	}
+	if report != nil && len(report.Violations) > 0 {
+		guidance = append(guidance, "Resolve policy findings or document an explicit exception before approval.")
+	}
+	return guidance
+}
+
+func classifyChangeRequest(request string) (string, []string) {
+	lower := strings.ToLower(request)
+	cues := []string{}
+	risk := "unknown"
+	for _, cue := range []string{"delete", "destroy", "replace", "public", "0.0.0.0/0", "::/0", "iam", "role", "policy", "security group", "firewall", "database", "rds", "bucket"} {
+		if strings.Contains(lower, cue) {
+			cues = append(cues, cue)
+		}
+	}
+	if len(cues) == 0 {
+		risk = "review_required"
+	} else {
+		risk = "risky"
+		for _, cue := range cues {
+			if cue == "delete" || cue == "destroy" || cue == "replace" {
+				risk = "destructive"
+				break
+			}
+		}
+	}
+	return risk, cues
+}
+
+func (s *Server) projectHistory(projectPath string, limit int) map[string]any {
+	out := map[string]any{}
+	if limit <= 0 {
+		limit = 5
+	}
+	if commits, err := gitLines(projectPath, "log", "--oneline", fmt.Sprintf("-%d", limit)); err == nil {
+		out["git_commits"] = commits
+	} else {
+		out["git_error"] = err.Error()
+	}
+	if changed, err := gitLines(projectPath, "status", "--short"); err == nil {
+		out["git_status"] = changed
+	}
+	if snapshots, err := recovery.ListSnapshots(projectPath); err == nil {
+		if len(snapshots) > limit {
+			snapshots = snapshots[:limit]
+		}
+		out["snapshots"] = snapshots
+	}
+	out["review_artifacts"] = listReviewArtifacts(projectPath)
+	return out
+}
+
+func gitLines(projectPath string, args ...string) ([]string, error) {
+	cmd := exec.Command("git", append([]string{"-C", projectPath}, args...)...)
+	data, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	out := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if strings.TrimSpace(line) != "" {
+			out = append(out, line)
+		}
+	}
+	return out, nil
+}
+
+func listReviewArtifacts(projectPath string) []string {
+	roots := []string{
+		filepath.Join(projectPath, ".iac-studio", "remediations"),
+		filepath.Join(projectPath, ".iac-studio", "rollbacks"),
+	}
+	var artifacts []string
+	for _, root := range roots {
+		_ = filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+			if err != nil || entry.IsDir() {
+				return nil
+			}
+			if rel, relErr := filepath.Rel(projectPath, path); relErr == nil {
+				artifacts = append(artifacts, filepath.ToSlash(rel))
+			}
+			return nil
+		})
+	}
+	sort.Strings(artifacts)
+	return artifacts
+}
+
+func writeArtifactFile(projectPath, relPath, content string) error {
+	if !strings.HasPrefix(relPath, ".iac-studio/remediations/") {
+		return fmt.Errorf("unsupported artifact path: %s", relPath)
+	}
+	target, err := safeProjectFile(projectPath, relPath)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(target, []byte(content), 0o644)
+}
+
+func remediationBodyPath(rendered []drift.RenderedRemediationArtifact) string {
+	for _, artifact := range rendered {
+		if artifact.Kind == "pr_body" {
+			return artifact.Path
+		}
+	}
+	if len(rendered) == 0 {
+		return ""
+	}
+	return rendered[0].Path
+}
+
+func renderRunbook(ctx *projectContext, incident string, history map[string]any, driftReport any) string {
+	var b strings.Builder
+	b.WriteString("# IaC Studio Runbook: ")
+	b.WriteString(ctx.Name)
+	b.WriteString("\n\n")
+	if strings.TrimSpace(incident) != "" {
+		b.WriteString("## Incident context\n")
+		b.WriteString(strings.TrimSpace(incident))
+		b.WriteString("\n\n")
+	}
+	b.WriteString("## Scope\n")
+	b.WriteString(fmt.Sprintf("- Project: `%s`\n", ctx.Name))
+	b.WriteString(fmt.Sprintf("- Tool: `%s`\n", ctx.Tool))
+	if ctx.Env != "" {
+		b.WriteString(fmt.Sprintf("- Environment: `%s`\n", ctx.Env))
+	}
+	b.WriteString(fmt.Sprintf("- Resources parsed: `%d`\n\n", len(ctx.Resources)))
+	b.WriteString("## Triage sequence\n")
+	b.WriteString("1. Inspect recent commits, generated remediation artifacts, and snapshots.\n")
+	b.WriteString("2. Run a fresh plan and semantic classification.\n")
+	b.WriteString("3. Run policy and security checks before approval.\n")
+	b.WriteString("4. Run drift scan again after remediation to confirm closure.\n")
+	b.WriteString("5. Apply only through the IaC Studio approval flow when risk is acknowledged.\n\n")
+	b.WriteString("## Captured context\n")
+	data, _ := json.MarshalIndent(map[string]any{"history": history, "drift": driftReport}, "", "  ")
+	b.Write(data)
+	b.WriteByte('\n')
+	return b.String()
+}
+
+func highRiskReason(tool string) string {
+	switch tool {
+	case "apply":
+		return "apply can create, update, replace, or delete cloud resources"
+	case "destroy":
+		return "destroy can remove cloud resources and data"
+	case "assume_role":
+		return "role assumption changes cloud identity and access scope"
+	case "modify_connection":
+		return "cloud connection changes can add or replace credentials"
+	case "open_public_network_access":
+		return "public network exposure can expand reachability to the internet"
+	default:
+		return "high-risk infrastructure action"
+	}
+}
+
+func utcNow() time.Time {
+	return time.Now().UTC()
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1,0 +1,174 @@
+package mcp
+
+func (s *Server) buildTools() ([]Tool, map[string]toolHandler) {
+	tools := []Tool{
+		readTool("list_projects", "List Projects", "List IaC Studio projects available under the configured projects directory.", objectSchema(nil, nil)),
+		readTool("inspect_project", "Inspect Project", "Parse project metadata, resources, snapshots, and environment scope for an IaC Studio project.", objectSchema(map[string]any{
+			"project": stringProp("Project name under the IaC Studio projects directory."),
+			"tool":    stringProp("Optional IaC tool override: terraform, opentofu, pulumi, or ansible."),
+			"env":     stringProp("Optional layered environment name."),
+		}, []string{"project"})),
+		readTool("list_cloud_connections", "List Cloud Connections", "List saved cloud connections using redacted public metadata only.", objectSchema(nil, nil)),
+		readTool("inspect_connection_scope", "Inspect Connection Scope", "Inspect a saved cloud connection's provider, auth method, readiness, and environment variable keys without returning secret values.", objectSchema(map[string]any{
+			"connection_id": stringProp("Saved cloud connection ID."),
+		}, []string{"connection_id"})),
+		readTool("generate_plan", "Generate Plan", "Run a local plan/preview command through the IaC Studio safe runner. This reads provider state and may write local plan artifacts, but does not apply changes.", objectSchema(projectExecutionProps(), []string{"project"})),
+		readTool("classify_plan", "Classify Plan", "Classify Terraform/OpenTofu plan JSON into safe, risky, destructive, and unknown changes.", objectSchema(map[string]any{
+			"plan_json": stringProp("Raw terraform show -json output. Use this for direct classification."),
+			"project":   stringProp("Optional project name when reading a plan JSON file from disk."),
+			"plan_path": stringProp("Optional project-relative plan JSON path. Defaults to tfplan.json when project is provided."),
+		}, nil)),
+		readTool("run_policy_check", "Run Policy Check", "Run IaC Studio's built-in policy engine against parsed project resources.", objectSchema(projectExecutionProps(), []string{"project"})),
+		readTool("scan_drift", "Scan Drift", "Compare code against local Terraform/OpenTofu state and classify drift findings.", objectSchema(projectExecutionProps(), []string{"project"})),
+		readTool("explain_resource", "Explain Resource", "Explain one parsed resource, including source location, properties, and policy findings.", objectSchema(map[string]any{
+			"project": stringProp("Project name under the IaC Studio projects directory."),
+			"address": stringProp("Resource address, for example aws_vpc.main."),
+			"tool":    stringProp("Optional IaC tool override."),
+			"env":     stringProp("Optional layered environment name."),
+		}, []string{"project", "address"})),
+		readTool("summarize_recent_changes", "Summarize Recent Changes", "Summarize recent local git changes, snapshots, and generated IaC Studio review artifacts for a project.", objectSchema(map[string]any{
+			"project": stringProp("Project name under the IaC Studio projects directory."),
+			"limit":   map[string]any{"type": "integer", "description": "Maximum git commits to include.", "minimum": 1, "maximum": 25},
+		}, []string{"project"})),
+		proposalTool("propose_iac_change", "Propose IaC Change", "Turn a natural-language infrastructure change request into a deterministic review proposal without editing files.", objectSchema(map[string]any{
+			"project":        stringProp("Project name under the IaC Studio projects directory."),
+			"change_request": stringProp("Human request describing the infrastructure change."),
+			"tool":           stringProp("Optional IaC tool override."),
+			"env":            stringProp("Optional layered environment name."),
+		}, []string{"project", "change_request"})),
+		proposalTool("propose_drift_remediation", "Propose Drift Remediation", "Build a PR-ready codify/revert remediation proposal from current drift findings without writing files.", objectSchema(map[string]any{
+			"project":       stringProp("Project name under the IaC Studio projects directory."),
+			"mode":          enumProp("Remediation mode.", []string{"codify", "revert"}),
+			"tool":          stringProp("Optional IaC tool override."),
+			"env":           stringProp("Optional layered environment name."),
+			"connection_id": stringProp("Optional cloud connection ID for scope labeling."),
+		}, []string{"project", "mode"})),
+		proposalTool("open_remediation_pr", "Open Remediation PR Handoff", "Generate drift remediation artifacts and a local review branch handoff after explicit approval. It never applies cloud changes.", objectSchema(map[string]any{
+			"project":        stringProp("Project name under the IaC Studio projects directory."),
+			"mode":           enumProp("Remediation mode.", []string{"codify", "revert"}),
+			"tool":           stringProp("Optional IaC tool override."),
+			"env":            stringProp("Optional layered environment name."),
+			"connection_id":  stringProp("Optional cloud connection ID for scope labeling."),
+			"approval_token": stringProp("Configured local approval token required before writing artifacts and creating a review branch."),
+		}, []string{"project", "mode"})),
+		proposalTool("generate_runbook", "Generate Runbook", "Generate a deterministic remediation runbook from project history, drift, snapshots, and optional incident context.", objectSchema(map[string]any{
+			"project":       stringProp("Project name under the IaC Studio projects directory."),
+			"incident":      stringProp("Optional incident or operational context."),
+			"tool":          stringProp("Optional IaC tool override."),
+			"env":           stringProp("Optional layered environment name."),
+			"connection_id": stringProp("Optional cloud connection ID for scope labeling."),
+		}, []string{"project"})),
+		riskyTool("apply", "Apply", "High-risk apply action. The local MCP foundation does not execute applies directly without explicit IaC Studio approval.", objectSchema(highRiskProps(), []string{"project"})),
+		riskyTool("destroy", "Destroy", "High-risk destroy action. The local MCP foundation does not execute destroys directly without explicit IaC Studio approval.", objectSchema(highRiskProps(), []string{"project"})),
+		riskyTool("assume_role", "Assume Role", "High-risk role assumption request. IaC Studio MCP does not accept raw role escalation through the agent path.", objectSchema(highRiskProps(), nil)),
+		riskyTool("modify_connection", "Modify Connection", "High-risk cloud connection mutation. Direct secret entry through MCP is blocked by policy.", objectSchema(highRiskProps(), nil)),
+		riskyTool("open_public_network_access", "Open Public Network Access", "High-risk public network exposure request. MCP returns a proposal gate instead of changing infrastructure.", objectSchema(highRiskProps(), []string{"project"})),
+	}
+
+	handlers := map[string]toolHandler{
+		"list_projects":              s.handleListProjects,
+		"inspect_project":            s.handleInspectProject,
+		"list_cloud_connections":     s.handleListCloudConnections,
+		"inspect_connection_scope":   s.handleInspectConnectionScope,
+		"generate_plan":              s.handleGeneratePlan,
+		"classify_plan":              s.handleClassifyPlan,
+		"run_policy_check":           s.handleRunPolicyCheck,
+		"scan_drift":                 s.handleScanDrift,
+		"explain_resource":           s.handleExplainResource,
+		"summarize_recent_changes":   s.handleSummarizeRecentChanges,
+		"propose_iac_change":         s.handleProposeIaCChange,
+		"propose_drift_remediation":  s.handleProposeDriftRemediation,
+		"open_remediation_pr":        s.handleOpenRemediationPR,
+		"generate_runbook":           s.handleGenerateRunbook,
+		"apply":                      s.handleHighRisk("apply"),
+		"destroy":                    s.handleHighRisk("destroy"),
+		"assume_role":                s.handleHighRisk("assume_role"),
+		"modify_connection":          s.handleHighRisk("modify_connection"),
+		"open_public_network_access": s.handleHighRisk("open_public_network_access"),
+	}
+	return tools, handlers
+}
+
+func readTool(name, title, description string, input map[string]any) Tool {
+	return Tool{
+		Name:        name,
+		Title:       title,
+		Description: description,
+		InputSchema: input,
+		Annotations: map[string]any{
+			"readOnlyHint":    true,
+			"destructiveHint": false,
+			"idempotentHint":  true,
+			"openWorldHint":   false,
+		},
+	}
+}
+
+func proposalTool(name, title, description string, input map[string]any) Tool {
+	return Tool{
+		Name:        name,
+		Title:       title,
+		Description: description,
+		InputSchema: input,
+		Annotations: map[string]any{
+			"readOnlyHint":    false,
+			"destructiveHint": false,
+			"idempotentHint":  false,
+			"openWorldHint":   false,
+		},
+	}
+}
+
+func riskyTool(name, title, description string, input map[string]any) Tool {
+	return Tool{
+		Name:        name,
+		Title:       title,
+		Description: description,
+		InputSchema: input,
+		Annotations: map[string]any{
+			"readOnlyHint":    false,
+			"destructiveHint": true,
+			"idempotentHint":  false,
+			"openWorldHint":   true,
+		},
+	}
+}
+
+func objectSchema(properties map[string]any, required []string) map[string]any {
+	if properties == nil {
+		properties = map[string]any{}
+	}
+	schema := map[string]any{
+		"type":                 "object",
+		"properties":           properties,
+		"additionalProperties": false,
+	}
+	if len(required) > 0 {
+		schema["required"] = required
+	}
+	return schema
+}
+
+func projectExecutionProps() map[string]any {
+	return map[string]any{
+		"project":       stringProp("Project name under the IaC Studio projects directory."),
+		"tool":          stringProp("Optional IaC tool override."),
+		"env":           stringProp("Optional layered environment name."),
+		"connection_id": stringProp("Optional saved cloud connection ID."),
+	}
+}
+
+func highRiskProps() map[string]any {
+	props := projectExecutionProps()
+	props["approval_token"] = stringProp("Configured local approval token required for high-risk operations.")
+	props["reason"] = stringProp("Human-readable reason for requesting this high-risk action.")
+	return props
+}
+
+func stringProp(description string) map[string]any {
+	return map[string]any{"type": "string", "description": description}
+}
+
+func enumProp(description string, values []string) map[string]any {
+	return map[string]any{"type": "string", "description": description, "enum": values}
+}


### PR DESCRIPTION
## Summary
- add a local stdio MCP server at `cmd/mcp` using the 2025-06-18 MCP JSON-RPC tool flow
- expose safe read-only and proposal tools for projects, cloud connections, plan classification, policy checks, drift, remediation proposals, and runbooks
- gate high-risk tools and local remediation PR handoffs behind an approval token and audit every MCP call to `.iac-studio/mcp-audit.jsonl`
- document MCP client setup in README and GitHub Pages docs, and add build/release targets for `iac-studio-mcp`

## Validation
- `GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/mcp ./cmd/mcp`
- `GOCACHE=/private/tmp/iacstudio-go-cache go test ./cmd/... ./internal/...`
- `npm -C web test -- --run`
- `npm -C web run build`
- `GOCACHE=/private/tmp/iacstudio-go-cache make build-mcp`

Closes #45