### PR TITLE
Add MCP Airlock registry foundation

### DIFF
--- a/internal/api/mcp_airlock_test.go
+++ b/internal/api/mcp_airlock_test.go
@@ -1,0 +1,57 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestMCPAirlockRoutesExposeTrustedReadOnlyServers(t *testing.T) {
+	srv := httptest.NewServer(fullRouterForTest(t, t.TempDir()))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/mcp-airlock/servers")
+	if err != nil {
+		t.Fatalf("GET servers: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var statuses []struct {
+		Server struct {
+			ID              string `json:"id"`
+			Trusted         bool   `json:"trusted"`
+			ReadOnlyDefault bool   `json:"read_only_default"`
+			CredentialMode  string `json:"credential_mode"`
+		} `json:"server"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&statuses); err != nil {
+		t.Fatalf("decode servers: %v", err)
+	}
+	if len(statuses) < 2 {
+		t.Fatalf("expected built-in Airlock servers, got %+v", statuses)
+	}
+	for _, status := range statuses {
+		if !status.Server.Trusted || !status.Server.ReadOnlyDefault || status.Server.CredentialMode != "none" {
+			t.Fatalf("server is not safe by default: %+v", status.Server)
+		}
+	}
+}
+
+func TestMCPAirlockHealthUnknownServerFailsClosed(t *testing.T) {
+	srv := httptest.NewServer(fullRouterForTest(t, t.TempDir()))
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/api/mcp-airlock/servers/unknown/health", "application/json", nil)
+	if err != nil {
+		t.Fatalf("POST health: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", resp.StatusCode)
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -25,6 +25,7 @@ import (
 	"github.com/iac-studio/iac-studio/internal/exporter"
 	"github.com/iac-studio/iac-studio/internal/generator"
 	"github.com/iac-studio/iac-studio/internal/importer"
+	"github.com/iac-studio/iac-studio/internal/mcpairlock"
 	"github.com/iac-studio/iac-studio/internal/parser"
 	iacplan "github.com/iac-studio/iac-studio/internal/plan"
 	"github.com/iac-studio/iac-studio/internal/project"
@@ -1403,6 +1404,7 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 	})
 
 	cloudConnections := cloudconnections.NewManager(projectsDir)
+	mcpAirlock := mcpairlock.NewManager(projectsDir)
 
 	// Run IaC command (init, plan, apply)
 	mux.HandleFunc("POST /api/projects/{name}/run", func(w http.ResponseWriter, r *http.Request) {
@@ -1870,6 +1872,23 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 			"azure": cloudconnections.SupportedAuthMethods(cloudconnections.ProviderAzure),
 			"gcp":   cloudconnections.SupportedAuthMethods(cloudconnections.ProviderGCP),
 		})
+	})
+
+	mux.HandleFunc("GET /api/mcp-airlock/servers", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(mcpAirlock.List(r.Context()))
+	})
+
+	mux.HandleFunc("POST /api/mcp-airlock/servers/{id}/health", func(w http.ResponseWriter, r *http.Request) {
+		status, err := mcpAirlock.Check(r.Context(), r.PathValue("id"))
+		if err != nil {
+			if errors.Is(err, mcpairlock.ErrUnknownServer) {
+				http.Error(w, "mcp airlock server not found", http.StatusNotFound)
+				return
+			}
+			http.Error(w, "mcp airlock health check failed", http.StatusInternalServerError)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(status)
 	})
 
 	mux.HandleFunc("GET /api/cloud/connections", func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/mcp/protocol.go
+++ b/internal/mcp/protocol.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/iac-studio/iac-studio/internal/cloudconnections"
+	"github.com/iac-studio/iac-studio/internal/mcpairlock"
 	"github.com/iac-studio/iac-studio/internal/runner"
 )
 
@@ -32,6 +33,7 @@ type Server struct {
 	now           func() time.Time
 
 	cloudConnections *cloudconnections.Manager
+	mcpAirlock       *mcpairlock.Manager
 	run              *runner.SafeRunner
 	audit            *AuditLogger
 
@@ -106,6 +108,7 @@ func NewServer(cfg Config) *Server {
 		version:          cfg.Version,
 		now:              cfg.Now,
 		cloudConnections: cloudconnections.NewManager(cfg.ProjectsDir),
+		mcpAirlock:       mcpairlock.NewManager(cfg.ProjectsDir),
 		run:              run,
 		audit:            NewAuditLogger(cfg.ProjectsDir, cfg.Now),
 	}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -58,7 +58,7 @@ func TestServerLifecycleAndToolList(t *testing.T) {
 	if err := json.Unmarshal([]byte(lines[1]), &listResp); err != nil {
 		t.Fatalf("decode tools/list response: %v", err)
 	}
-	for _, name := range []string{"list_projects", "inspect_project", "classify_plan", "scan_drift", "open_remediation_pr", "apply"} {
+	for _, name := range []string{"list_projects", "inspect_project", "list_mcp_airlock_servers", "check_mcp_airlock_server", "classify_plan", "scan_drift", "open_remediation_pr", "apply"} {
 		if !containsTool(listResp.Result.Tools, name) {
 			t.Fatalf("tools/list missing %s", name)
 		}
@@ -178,6 +178,49 @@ func TestConnectionScopeRedactsSecrets(t *testing.T) {
 	mustRemarshal(t, result.StructuredContent, &payload)
 	if !contains(payload.CommandEnvKeys, "AWS_SECRET_ACCESS_KEY") || !contains(payload.Connection.SecretFields, "secret_access_key") {
 		t.Fatalf("expected redacted secret field metadata, got %+v", payload)
+	}
+}
+
+func TestMCPAirlockToolsExposeTrustedReadOnlyStatus(t *testing.T) {
+	server := newTestServer(t)
+
+	listResult := callTool(t, server, "list_mcp_airlock_servers", map[string]any{})
+	if listResult.IsError {
+		t.Fatalf("list_mcp_airlock_servers returned error: %s", listResult.Content[0].Text)
+	}
+	var listPayload struct {
+		Servers []struct {
+			Server struct {
+				ID              string `json:"id"`
+				Trusted         bool   `json:"trusted"`
+				ReadOnlyDefault bool   `json:"read_only_default"`
+				CredentialMode  string `json:"credential_mode"`
+			} `json:"server"`
+		} `json:"servers"`
+	}
+	mustRemarshal(t, listResult.StructuredContent, &listPayload)
+	if len(listPayload.Servers) == 0 {
+		t.Fatal("expected Airlock server definitions")
+	}
+	for _, status := range listPayload.Servers {
+		if !status.Server.Trusted || !status.Server.ReadOnlyDefault || status.Server.CredentialMode != "none" {
+			t.Fatalf("Airlock server is not constrained by default: %+v", status.Server)
+		}
+	}
+
+	checkResult := callTool(t, server, "check_mcp_airlock_server", map[string]any{"server_id": "aws-official"})
+	if checkResult.IsError {
+		t.Fatalf("check_mcp_airlock_server returned error: %s", checkResult.Content[0].Text)
+	}
+	var checkPayload struct {
+		Server struct {
+			State      string `json:"state"`
+			Configured bool   `json:"configured"`
+		} `json:"server"`
+	}
+	mustRemarshal(t, checkResult.StructuredContent, &checkPayload)
+	if checkPayload.Server.State != "not_configured" || checkPayload.Server.Configured {
+		t.Fatalf("expected AWS built-in to require explicit local command config, got %+v", checkPayload.Server)
 	}
 }
 

--- a/internal/mcp/service.go
+++ b/internal/mcp/service.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/iac-studio/iac-studio/internal/cloudconnections"
 	"github.com/iac-studio/iac-studio/internal/drift"
+	"github.com/iac-studio/iac-studio/internal/mcpairlock"
 	"github.com/iac-studio/iac-studio/internal/parser"
 	iacplan "github.com/iac-studio/iac-studio/internal/plan"
 	"github.com/iac-studio/iac-studio/internal/policy"
@@ -158,6 +159,37 @@ func (s *Server) handleInspectConnectionScope(_ context.Context, raw json.RawMes
 			"scope":            "Credentials remain inside IaC Studio's cloud connection broker; MCP responses expose names, providers, readiness, and environment variable keys only.",
 		}),
 		Audit: AuditDecision{Tool: "inspect_connection_scope", ConnectionID: args.ConnectionID, Decision: "allowed"},
+	}
+}
+
+func (s *Server) handleListMCPAirlockServers(ctx context.Context, _ json.RawMessage) toolResponse {
+	servers := s.mcpAirlock.List(ctx)
+	return toolResponse{
+		Result: structuredResult(map[string]any{"servers": servers}),
+		Audit:  AuditDecision{Tool: "list_mcp_airlock_servers", Decision: "allowed"},
+	}
+}
+
+func (s *Server) handleCheckMCPAirlockServer(ctx context.Context, raw json.RawMessage) toolResponse {
+	var args struct {
+		ServerID string `json:"server_id"`
+	}
+	if err := decode(raw, &args); err != nil {
+		return errResponse("check_mcp_airlock_server", err, AuditDecision{Tool: "check_mcp_airlock_server"})
+	}
+	if err := requireNonEmpty("server_id", args.ServerID); err != nil {
+		return errResponse("check_mcp_airlock_server", err, AuditDecision{Tool: "check_mcp_airlock_server"})
+	}
+	status, err := s.mcpAirlock.Check(ctx, args.ServerID)
+	if err != nil {
+		if errors.Is(err, mcpairlock.ErrUnknownServer) {
+			return errResponse("check_mcp_airlock_server", err, AuditDecision{Tool: "check_mcp_airlock_server", Decision: "blocked"})
+		}
+		return errResponse("check_mcp_airlock_server", err, AuditDecision{Tool: "check_mcp_airlock_server"})
+	}
+	return toolResponse{
+		Result: structuredResult(map[string]any{"server": status}),
+		Audit:  AuditDecision{Tool: "check_mcp_airlock_server", Decision: "allowed"},
 	}
 }
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -12,6 +12,10 @@ func (s *Server) buildTools() ([]Tool, map[string]toolHandler) {
 		readTool("inspect_connection_scope", "Inspect Connection Scope", "Inspect a saved cloud connection's provider, auth method, readiness, and environment variable keys without returning secret values.", objectSchema(map[string]any{
 			"connection_id": stringProp("Saved cloud connection ID."),
 		}, []string{"connection_id"})),
+		readTool("list_mcp_airlock_servers", "List MCP Airlock Servers", "List trusted external MCP servers that IaC Studio can route through Airlock without exposing credentials.", objectSchema(nil, nil)),
+		readTool("check_mcp_airlock_server", "Check MCP Airlock Server", "Run a bounded local health check for one trusted external MCP server using a sanitized environment.", objectSchema(map[string]any{
+			"server_id": stringProp("Trusted Airlock server ID."),
+		}, []string{"server_id"})),
 		readTool("generate_plan", "Generate Plan", "Run a local plan/preview command through the IaC Studio safe runner. This reads provider state and may write local plan artifacts, but does not apply changes.", objectSchema(projectExecutionProps(), []string{"project"})),
 		readTool("classify_plan", "Classify Plan", "Classify Terraform/OpenTofu plan JSON into safe, risky, destructive, and unknown changes.", objectSchema(map[string]any{
 			"plan_json": stringProp("Raw terraform show -json output. Use this for direct classification."),
@@ -70,6 +74,8 @@ func (s *Server) buildTools() ([]Tool, map[string]toolHandler) {
 		"inspect_project":            s.handleInspectProject,
 		"list_cloud_connections":     s.handleListCloudConnections,
 		"inspect_connection_scope":   s.handleInspectConnectionScope,
+		"list_mcp_airlock_servers":   s.handleListMCPAirlockServers,
+		"check_mcp_airlock_server":   s.handleCheckMCPAirlockServer,
 		"generate_plan":              s.handleGeneratePlan,
 		"classify_plan":              s.handleClassifyPlan,
 		"run_policy_check":           s.handleRunPolicyCheck,

--- a/internal/mcpairlock/registry.go
+++ b/internal/mcpairlock/registry.go
@@ -1,0 +1,390 @@
+package mcpairlock
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+)
+
+const defaultHealthTimeout = 2 * time.Second
+
+var (
+	// ErrUnknownServer is returned when callers request a server outside the
+	// trusted Airlock registry.
+	ErrUnknownServer = errors.New("mcp airlock server not found")
+
+	secretPatterns = []*regexp.Regexp{
+		regexp.MustCompile(`(?i)(aws_secret_access_key|secret_access_key|session_token|client_secret|access_token|refresh_token|private_key|token)\s*[:=]\s*["']?[^"'\s]+`),
+		regexp.MustCompile(`AKIA[0-9A-Z]{12,}`),
+		regexp.MustCompile(`ASIA[0-9A-Z]{12,}`),
+	}
+)
+
+// Check describes one Airlock validation result.
+type Check struct {
+	Name    string `json:"name"`
+	Status  string `json:"status"`
+	Message string `json:"message"`
+}
+
+// ServerDefinition describes a trusted external MCP server without storing
+// credentials or launcher state.
+type ServerDefinition struct {
+	ID              string   `json:"id"`
+	Name            string   `json:"name"`
+	Vendor          string   `json:"vendor"`
+	Description     string   `json:"description"`
+	SourceURL       string   `json:"source_url"`
+	DocsURL         string   `json:"docs_url,omitempty"`
+	InstallHint     string   `json:"install_hint,omitempty"`
+	Transport       string   `json:"transport"`
+	Command         string   `json:"command,omitempty"`
+	Args            []string `json:"args,omitempty"`
+	HealthCheckArgs []string `json:"health_check_args,omitempty"`
+	Trusted         bool     `json:"trusted"`
+	ReadOnlyDefault bool     `json:"read_only_default"`
+	CredentialMode  string   `json:"credential_mode"`
+	Capabilities    []string `json:"capabilities,omitempty"`
+}
+
+// ServerStatus is the public health/status view returned by the API and MCP
+// tools. It deliberately excludes resolved executable paths and environment.
+type ServerStatus struct {
+	Server           ServerDefinition `json:"server"`
+	Ready            bool             `json:"ready"`
+	Configured       bool             `json:"configured"`
+	CommandAvailable bool             `json:"command_available"`
+	State            string           `json:"state"`
+	Summary          string           `json:"summary"`
+	Checks           []Check          `json:"checks"`
+	CheckedAt        string           `json:"checked_at,omitempty"`
+}
+
+// ProbeResult is the sanitized result shape used by health-check probes.
+type ProbeResult struct {
+	Output   string
+	Err      error
+	TimedOut bool
+}
+
+// ProbeFunc lets tests replace process execution. Production uses exec.Command
+// with a constrained environment and timeout.
+type ProbeFunc func(ctx context.Context, command string, args []string, timeout time.Duration) ProbeResult
+
+// Option configures a Manager.
+type Option func(*Manager)
+
+// Manager owns trusted MCP Airlock server definitions and read-only checks.
+type Manager struct {
+	definitions []ServerDefinition
+	timeout     time.Duration
+	probe       ProbeFunc
+}
+
+// NewManager creates an Airlock registry. projectsDir is accepted for future
+// per-project allowlists, but the first slice only serves built-in trusted
+// definitions and optional process environment command overrides.
+func NewManager(projectsDir string, opts ...Option) *Manager {
+	_ = projectsDir
+	m := &Manager{
+		definitions: builtInDefinitions(),
+		timeout:     defaultHealthTimeout,
+		probe:       defaultProbe,
+	}
+	for _, opt := range opts {
+		opt(m)
+	}
+	m.definitions = normalizeDefinitions(m.definitions)
+	return m
+}
+
+// WithDefinitions replaces trusted definitions. It is intended for tests and
+// future controlled registries.
+func WithDefinitions(definitions []ServerDefinition) Option {
+	return func(m *Manager) {
+		m.definitions = copyDefinitions(definitions)
+	}
+}
+
+// WithProbe replaces the health-check executor.
+func WithProbe(probe ProbeFunc) Option {
+	return func(m *Manager) {
+		if probe != nil {
+			m.probe = probe
+		}
+	}
+}
+
+// WithTimeout changes the health-check timeout.
+func WithTimeout(timeout time.Duration) Option {
+	return func(m *Manager) {
+		if timeout > 0 {
+			m.timeout = timeout
+		}
+	}
+}
+
+// List returns trusted server definitions and passive status. It never starts
+// an external MCP process.
+func (m *Manager) List(_ context.Context) []ServerStatus {
+	statuses := make([]ServerStatus, 0, len(m.definitions))
+	for _, definition := range m.definitions {
+		statuses = append(statuses, m.passiveStatus(definition))
+	}
+	sort.SliceStable(statuses, func(i, j int) bool {
+		return statuses[i].Server.Name < statuses[j].Server.Name
+	})
+	return statuses
+}
+
+// Check runs a bounded, read-only health check for one trusted server.
+func (m *Manager) Check(ctx context.Context, id string) (ServerStatus, error) {
+	definition, ok := m.lookup(id)
+	if !ok {
+		return ServerStatus{}, ErrUnknownServer
+	}
+	status := m.passiveStatus(definition)
+	status.CheckedAt = time.Now().UTC().Format(time.RFC3339)
+	if status.State != "available" {
+		return status, nil
+	}
+	args := append([]string{}, definition.Args...)
+	args = append(args, definition.HealthCheckArgs...)
+	if len(args) == 0 {
+		status.Ready = true
+		status.State = "ready"
+		status.Summary = "Command is available. No active health probe is configured for this server."
+		status.Checks = append(status.Checks, Check{Name: "health_probe", Status: "warn", Message: "no version or health command is configured"})
+		return status, nil
+	}
+	result := m.probe(ctx, definition.Command, args, m.timeout)
+	if result.TimedOut {
+		status.Ready = false
+		status.State = "timeout"
+		status.Summary = "Health check timed out before the MCP server responded."
+		status.Checks = append(status.Checks, Check{Name: "health_probe", Status: "error", Message: "probe timed out"})
+		return status, nil
+	}
+	if result.Err != nil {
+		status.Ready = false
+		status.State = "unhealthy"
+		message := result.Err.Error()
+		if output := redactOutput(result.Output); output != "" {
+			message = fmt.Sprintf("%s: %s", message, output)
+		}
+		status.Summary = "Health check failed. Review the local command configuration before enabling this server."
+		status.Checks = append(status.Checks, Check{Name: "health_probe", Status: "error", Message: message})
+		return status, nil
+	}
+	status.Ready = true
+	status.State = "ready"
+	status.Summary = "Health check completed without exposing cloud credentials."
+	message := "probe succeeded"
+	if output := redactOutput(result.Output); output != "" {
+		message = output
+	}
+	status.Checks = append(status.Checks, Check{Name: "health_probe", Status: "pass", Message: message})
+	return status, nil
+}
+
+func (m *Manager) lookup(id string) (ServerDefinition, bool) {
+	id = strings.TrimSpace(id)
+	for _, definition := range m.definitions {
+		if definition.ID == id {
+			return definition, true
+		}
+	}
+	return ServerDefinition{}, false
+}
+
+func (m *Manager) passiveStatus(definition ServerDefinition) ServerStatus {
+	status := ServerStatus{
+		Server:  definition,
+		State:   "available",
+		Summary: "Command is configured and available. Run a health check before routing an agent to it.",
+		Checks: []Check{
+			{Name: "trusted_registry", Status: "pass", Message: "server is in IaC Studio's trusted MCP Airlock registry"},
+			{Name: "credential_scope", Status: "pass", Message: "Airlock health checks do not forward cloud credentials"},
+		},
+	}
+	if !definition.Trusted {
+		status.State = "blocked"
+		status.Summary = "Server is not marked trusted."
+		status.Checks = append(status.Checks, Check{Name: "trusted_registry", Status: "error", Message: "definition is not trusted"})
+		return status
+	}
+	if !definition.ReadOnlyDefault {
+		status.Checks = append(status.Checks, Check{Name: "default_mode", Status: "warn", Message: "server is not read-only by default"})
+	} else {
+		status.Checks = append(status.Checks, Check{Name: "default_mode", Status: "pass", Message: "server starts in read-only review mode"})
+	}
+	command := strings.TrimSpace(definition.Command)
+	if command == "" {
+		status.Configured = false
+		status.State = "not_configured"
+		status.Summary = "No local command is configured for this MCP server."
+		status.Checks = append(status.Checks, Check{Name: "command", Status: "warn", Message: "configure a command before launching this server"})
+		return status
+	}
+	status.Configured = true
+	if err := validateCommand(command); err != nil {
+		status.State = "invalid_config"
+		status.Summary = "Configured command is invalid."
+		status.Checks = append(status.Checks, Check{Name: "command", Status: "error", Message: err.Error()})
+		return status
+	}
+	if _, err := exec.LookPath(command); err != nil {
+		status.State = "command_missing"
+		status.Summary = "Configured command was not found on PATH."
+		status.Checks = append(status.Checks, Check{Name: "command", Status: "error", Message: "command is not installed or not on PATH"})
+		return status
+	}
+	status.CommandAvailable = true
+	status.Checks = append(status.Checks, Check{Name: "command", Status: "pass", Message: "command is available on PATH"})
+	return status
+}
+
+func builtInDefinitions() []ServerDefinition {
+	return []ServerDefinition{
+		{
+			ID:              "aws-official",
+			Name:            "AWS MCP Server",
+			Vendor:          "AWS",
+			Description:     "Official AWS MCP entry point for cloud inventory and operational context.",
+			SourceURL:       "https://github.com/awslabs/mcp",
+			DocsURL:         "https://github.com/awslabs/mcp",
+			InstallHint:     "Set IAC_STUDIO_MCP_AWS_OFFICIAL_COMMAND after installing the AWS MCP server locally.",
+			Transport:       "stdio",
+			Trusted:         true,
+			ReadOnlyDefault: true,
+			CredentialMode:  "none",
+			Capabilities:    []string{"aws inventory context", "documentation lookup", "read-only operational review"},
+		},
+		{
+			ID:              "terraform-official",
+			Name:            "Terraform MCP Server",
+			Vendor:          "HashiCorp",
+			Description:     "Official Terraform MCP server for registry, module, provider, and Terraform workflow context.",
+			SourceURL:       "https://github.com/hashicorp/terraform-mcp-server",
+			DocsURL:         "https://developer.hashicorp.com/terraform/mcp-server",
+			InstallHint:     "Install terraform-mcp-server on PATH or set IAC_STUDIO_MCP_TERRAFORM_OFFICIAL_COMMAND.",
+			Transport:       "stdio",
+			Command:         "terraform-mcp-server",
+			HealthCheckArgs: []string{"--version"},
+			Trusted:         true,
+			ReadOnlyDefault: true,
+			CredentialMode:  "none",
+			Capabilities:    []string{"terraform registry", "module discovery", "provider documentation", "read-only plan review"},
+		},
+	}
+}
+
+func normalizeDefinitions(definitions []ServerDefinition) []ServerDefinition {
+	out := copyDefinitions(definitions)
+	for i := range out {
+		out[i].ID = strings.TrimSpace(out[i].ID)
+		out[i].Command = strings.TrimSpace(out[i].Command)
+		out[i] = applyEnvOverrides(out[i])
+		if out[i].Transport == "" {
+			out[i].Transport = "stdio"
+		}
+		if out[i].CredentialMode == "" {
+			out[i].CredentialMode = "none"
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}
+
+func copyDefinitions(definitions []ServerDefinition) []ServerDefinition {
+	out := make([]ServerDefinition, len(definitions))
+	for i, definition := range definitions {
+		out[i] = definition
+		out[i].Args = append([]string{}, definition.Args...)
+		out[i].HealthCheckArgs = append([]string{}, definition.HealthCheckArgs...)
+		out[i].Capabilities = append([]string{}, definition.Capabilities...)
+	}
+	return out
+}
+
+func applyEnvOverrides(definition ServerDefinition) ServerDefinition {
+	prefix := "IAC_STUDIO_MCP_" + strings.ToUpper(strings.ReplaceAll(definition.ID, "-", "_"))
+	if command := strings.TrimSpace(os.Getenv(prefix + "_COMMAND")); command != "" {
+		definition.Command = command
+	}
+	if args := splitEnvArgs(os.Getenv(prefix + "_ARGS")); len(args) > 0 {
+		definition.Args = args
+	}
+	if args := splitEnvArgs(os.Getenv(prefix + "_HEALTH_ARGS")); len(args) > 0 {
+		definition.HealthCheckArgs = args
+	}
+	return definition
+}
+
+func splitEnvArgs(value string) []string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	return strings.Fields(value)
+}
+
+func validateCommand(command string) error {
+	if command == "" {
+		return errors.New("command is required")
+	}
+	if strings.ContainsAny(command, "\x00\r\n\t|&;<>`$") || strings.Contains(command, " ") {
+		return fmt.Errorf("command %q must be a single executable name or absolute path without shell metacharacters", command)
+	}
+	return nil
+}
+
+func defaultProbe(ctx context.Context, command string, args []string, timeout time.Duration) ProbeResult {
+	probeCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	cmd := exec.CommandContext(probeCtx, command, args...)
+	cmd.Dir = os.TempDir()
+	cmd.Env = minimalEnv()
+	output, err := cmd.CombinedOutput()
+	return ProbeResult{
+		Output:   string(output),
+		Err:      err,
+		TimedOut: errors.Is(probeCtx.Err(), context.DeadlineExceeded),
+	}
+}
+
+func minimalEnv() []string {
+	env := []string{}
+	if path := os.Getenv("PATH"); path != "" {
+		env = append(env, "PATH="+path)
+	}
+	if runtime.GOOS == "windows" {
+		for _, key := range []string{"SystemRoot", "WINDIR"} {
+			if value := os.Getenv(key); value != "" {
+				env = append(env, key+"="+value)
+			}
+		}
+	}
+	return env
+}
+
+func redactOutput(output string) string {
+	output = strings.TrimSpace(output)
+	if output == "" {
+		return ""
+	}
+	if len(output) > 600 {
+		output = output[:600] + "..."
+	}
+	for _, pattern := range secretPatterns {
+		output = pattern.ReplaceAllString(output, "[REDACTED]")
+	}
+	return output
+}

--- a/internal/mcpairlock/registry_test.go
+++ b/internal/mcpairlock/registry_test.go
@@ -1,0 +1,135 @@
+package mcpairlock
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestListIncludesTrustedBuiltinsWithoutHealthProbe(t *testing.T) {
+	calls := 0
+	manager := NewManager(t.TempDir(), WithProbe(func(context.Context, string, []string, time.Duration) ProbeResult {
+		calls++
+		return ProbeResult{}
+	}))
+
+	statuses := manager.List(context.Background())
+
+	if calls != 0 {
+		t.Fatalf("List must not execute health probes, got %d calls", calls)
+	}
+	if len(statuses) != 2 {
+		t.Fatalf("expected built-in AWS and Terraform servers, got %d", len(statuses))
+	}
+	if !containsStatus(statuses, "aws-official") || !containsStatus(statuses, "terraform-official") {
+		t.Fatalf("missing built-in server statuses: %+v", statuses)
+	}
+	for _, status := range statuses {
+		if !status.Server.Trusted || !status.Server.ReadOnlyDefault || status.Server.CredentialMode != "none" {
+			t.Fatalf("built-in server is not locked down by default: %+v", status.Server)
+		}
+	}
+}
+
+func TestCheckNotConfiguredDoesNotExecuteProbe(t *testing.T) {
+	calls := 0
+	manager := NewManager(t.TempDir(),
+		WithDefinitions([]ServerDefinition{{
+			ID:              "aws",
+			Name:            "AWS",
+			Trusted:         true,
+			ReadOnlyDefault: true,
+			CredentialMode:  "none",
+		}}),
+		WithProbe(func(context.Context, string, []string, time.Duration) ProbeResult {
+			calls++
+			return ProbeResult{}
+		}),
+	)
+
+	status, err := manager.Check(context.Background(), "aws")
+
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("not configured servers must not execute probes, got %d calls", calls)
+	}
+	if status.State != "not_configured" || status.Ready {
+		t.Fatalf("unexpected status: %+v", status)
+	}
+}
+
+func TestCheckRejectsShellCommandConfiguration(t *testing.T) {
+	manager := NewManager(t.TempDir(), WithDefinitions([]ServerDefinition{{
+		ID:              "unsafe",
+		Name:            "Unsafe",
+		Command:         "terraform-mcp-server; aws sts get-caller-identity",
+		Trusted:         true,
+		ReadOnlyDefault: true,
+		CredentialMode:  "none",
+	}}))
+
+	status, err := manager.Check(context.Background(), "unsafe")
+
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if status.State != "invalid_config" || status.CommandAvailable {
+		t.Fatalf("expected invalid command config, got %+v", status)
+	}
+}
+
+func TestCheckRedactsProbeOutput(t *testing.T) {
+	manager := NewManager(t.TempDir(),
+		WithDefinitions([]ServerDefinition{{
+			ID:              "terraform",
+			Name:            "Terraform",
+			Command:         "go",
+			HealthCheckArgs: []string{"version"},
+			Trusted:         true,
+			ReadOnlyDefault: true,
+			CredentialMode:  "none",
+		}}),
+		WithProbe(func(_ context.Context, command string, args []string, _ time.Duration) ProbeResult {
+			if command != "go" || strings.Join(args, " ") != "version" {
+				t.Fatalf("unexpected probe command: %s %v", command, args)
+			}
+			return ProbeResult{Output: "ok aws_secret_access_key=super-secret AKIA1234567890ABCDE"}
+		}),
+	)
+
+	status, err := manager.Check(context.Background(), "terraform")
+
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if !status.Ready || status.State != "ready" {
+		t.Fatalf("expected ready status, got %+v", status)
+	}
+	message := status.Checks[len(status.Checks)-1].Message
+	if strings.Contains(message, "super-secret") || strings.Contains(message, "AKIA") {
+		t.Fatalf("probe output leaked sensitive material: %q", message)
+	}
+}
+
+func TestCheckUnknownServerFailsClosed(t *testing.T) {
+	manager := NewManager(t.TempDir())
+
+	_, err := manager.Check(context.Background(), "unknown")
+
+	if !errors.Is(err, ErrUnknownServer) {
+		t.Fatalf("expected ErrUnknownServer, got %v", err)
+	}
+}
+
+func containsStatus(statuses []ServerStatus, id string) bool {
+	for _, status := range statuses {
+		if status.Server.ID == id {
+			return true
+		}
+	}
+	return false
+}

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -139,6 +139,41 @@ export interface CloudConnectionTestResult {
   checks: { name: string; status: 'pass' | 'warn' | 'error'; message: string }[];
 }
 
+export interface MCPAirlockCheck {
+  name: string;
+  status: 'pass' | 'warn' | 'error';
+  message: string;
+}
+
+export interface MCPAirlockServerDefinition {
+  id: string;
+  name: string;
+  vendor: string;
+  description: string;
+  source_url: string;
+  docs_url?: string;
+  install_hint?: string;
+  transport: string;
+  command?: string;
+  args?: string[];
+  health_check_args?: string[];
+  trusted: boolean;
+  read_only_default: boolean;
+  credential_mode: string;
+  capabilities?: string[];
+}
+
+export interface MCPAirlockServerStatus {
+  server: MCPAirlockServerDefinition;
+  ready: boolean;
+  configured: boolean;
+  command_available: boolean;
+  state: string;
+  summary: string;
+  checks: MCPAirlockCheck[];
+  checked_at?: string;
+}
+
 export type PlanRiskLevel = 'safe' | 'risky' | 'destructive' | 'unknown';
 
 export interface PlanFieldChange {
@@ -368,6 +403,16 @@ async function check(res: Response): Promise<Response> {
 }
 
 export const api = {
+  async listMCPAirlockServers(): Promise<MCPAirlockServerStatus[]> {
+    const res = await fetch(`${BASE}/api/mcp-airlock/servers`);
+    return (await check(res)).json();
+  },
+
+  async checkMCPAirlockServer(id: string): Promise<MCPAirlockServerStatus> {
+    const res = await fetch(`${BASE}/api/mcp-airlock/servers/${encodeURIComponent(id)}/health`, { method: 'POST' });
+    return (await check(res)).json();
+  },
+
   async listCloudConnections(): Promise<CloudConnection[]> {
     const res = await fetch(`${BASE}/api/cloud/connections`);
     return (await check(res)).json();

--- a/web/src/components/Inspector/InspectorPanel.test.tsx
+++ b/web/src/components/Inspector/InspectorPanel.test.tsx
@@ -48,6 +48,12 @@ vi.mock('../ModuleRegistry', () => ({
   ),
 }));
 
+vi.mock('../MCPAirlock', () => ({
+  MCPAirlockPanel: () => (
+    <div>MCP Airlock panel</div>
+  ),
+}));
+
 const nodes: InspectorResource[] = [
   {
     id: 'vpc',
@@ -206,6 +212,7 @@ describe('InspectorPanel', () => {
     renderInspector({ activeTab: 'modules' });
 
     expect(screen.getByRole('button', { name: 'Cloud' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'MCP' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Drift' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Modules' })).toBeInTheDocument();
     expect(screen.getByText('Module registry vpc')).toBeInTheDocument();
@@ -230,6 +237,12 @@ describe('InspectorPanel', () => {
     renderInspector({ activeTab: 'cloud' });
 
     expect(screen.getByText('Cloud connections panel')).toBeInTheDocument();
+  });
+
+  it('renders the MCP Airlock tab', () => {
+    renderInspector({ activeTab: 'mcp' });
+
+    expect(screen.getByText('MCP Airlock panel')).toBeInTheDocument();
   });
 
   it('guards unresolved hybrid environments', () => {

--- a/web/src/components/Inspector/index.tsx
+++ b/web/src/components/Inspector/index.tsx
@@ -4,11 +4,12 @@ import { S } from '../../styles';
 import { CloudConnectionsPanel } from '../CloudConnections';
 import { CodeEditor } from '../CodeEditor';
 import { DriftPanel } from '../DriftPanel';
+import { MCPAirlockPanel } from '../MCPAirlock';
 import { ModuleRegistryPanel } from '../ModuleRegistry';
 import { PolicyStudioPanel } from '../PolicyStudio';
 import { ScanPanel } from '../ScanPanel';
 
-export type RightPanelTab = 'inspect' | 'cloud' | 'drift' | 'policy' | 'scan' | 'modules';
+export type RightPanelTab = 'inspect' | 'cloud' | 'mcp' | 'drift' | 'policy' | 'scan' | 'modules';
 
 export interface InspectorResource extends Resource {
   icon: string;
@@ -100,6 +101,7 @@ export function InspectorPanel({
   const tabs: { key: RightPanelTab; label: string }[] = [
     { key: 'inspect', label: selected || selectedEdge ? 'Inspect' : 'Code' },
     { key: 'cloud', label: 'Cloud' },
+    { key: 'mcp', label: 'MCP' },
     { key: 'drift', label: 'Drift' },
     { key: 'policy', label: 'Policy' },
     { key: 'scan', label: 'Scan' },
@@ -263,6 +265,12 @@ export function InspectorPanel({
             selectedConnectionId={selectedCloudConnection?.id}
             onConnectionSelected={onCloudConnectionSelect}
           />
+        </div>
+      )}
+
+      {activeTab === 'mcp' && (
+        <div style={{ flex: 1, minHeight: 0 }}>
+          <MCPAirlockPanel />
         </div>
       )}
 

--- a/web/src/components/MCPAirlock/MCPAirlockPanel.test.tsx
+++ b/web/src/components/MCPAirlock/MCPAirlockPanel.test.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { MCPAirlockServerStatus } from '../../api';
+import { MCPAirlockPanel } from './MCPAirlockPanel';
+
+function server(overrides: Partial<MCPAirlockServerStatus> = {}): MCPAirlockServerStatus {
+  return {
+    server: {
+      id: 'terraform-official',
+      name: 'Terraform MCP Server',
+      vendor: 'HashiCorp',
+      description: 'Official Terraform MCP server.',
+      source_url: 'https://github.com/hashicorp/terraform-mcp-server',
+      docs_url: 'https://developer.hashicorp.com/terraform/mcp-server',
+      install_hint: 'Install terraform-mcp-server on PATH.',
+      transport: 'stdio',
+      command: 'terraform-mcp-server',
+      trusted: true,
+      read_only_default: true,
+      credential_mode: 'none',
+      capabilities: ['terraform registry'],
+    },
+    ready: false,
+    configured: true,
+    command_available: false,
+    state: 'command_missing',
+    summary: 'Configured command was not found on PATH.',
+    checks: [
+      { name: 'trusted_registry', status: 'pass', message: 'trusted' },
+      { name: 'command', status: 'error', message: 'command is not installed' },
+    ],
+    ...overrides,
+  };
+}
+
+describe('MCPAirlockPanel', () => {
+  it('lists trusted servers and runs health checks', async () => {
+    const initial = server();
+    const checked = server({
+      ready: true,
+      command_available: true,
+      state: 'ready',
+      summary: 'Health check completed without exposing cloud credentials.',
+      checked_at: '2026-06-13T10:00:00Z',
+      checks: [{ name: 'health_probe', status: 'pass', message: 'probe succeeded' }],
+    });
+    const client = {
+      listMCPAirlockServers: vi.fn(async () => [initial]),
+      checkMCPAirlockServer: vi.fn(async () => checked),
+    };
+
+    render(<MCPAirlockPanel client={client} />);
+
+    expect(await screen.findByText('Terraform MCP Server')).toBeInTheDocument();
+    expect(screen.getByText('credentials: none')).toBeInTheDocument();
+    expect(screen.getByText('Install terraform-mcp-server on PATH.')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Check' }));
+
+    await waitFor(() => {
+      expect(client.checkMCPAirlockServer).toHaveBeenCalledWith('terraform-official');
+    });
+    expect(await screen.findByText('Ready')).toBeInTheDocument();
+    expect(screen.getByText('Health check completed without exposing cloud credentials.')).toBeInTheDocument();
+  });
+});

--- a/web/src/components/MCPAirlock/MCPAirlockPanel.tsx
+++ b/web/src/components/MCPAirlock/MCPAirlockPanel.tsx
@@ -1,0 +1,198 @@
+import { useEffect, useState } from 'react';
+import { CheckCircle2, ExternalLink, RefreshCw, ServerCog, ShieldCheck, XCircle } from 'lucide-react';
+
+import { api, type MCPAirlockServerStatus } from '../../api';
+import { Button } from '../ui/button';
+
+type MCPAirlockClient = Pick<typeof api, 'listMCPAirlockServers' | 'checkMCPAirlockServer'>;
+
+export interface MCPAirlockPanelProps {
+  client?: MCPAirlockClient;
+}
+
+const stateLabels: Record<string, string> = {
+  ready: 'Ready',
+  available: 'Available',
+  not_configured: 'Not configured',
+  command_missing: 'Missing',
+  invalid_config: 'Invalid',
+  unhealthy: 'Unhealthy',
+  timeout: 'Timeout',
+  blocked: 'Blocked',
+};
+
+function stateClass(state: string) {
+  if (state === 'ready') return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300';
+  if (state === 'available') return 'border-primary/30 bg-primary/10 text-primary';
+  if (state === 'not_configured' || state === 'command_missing') return 'border-yellow-500/30 bg-yellow-500/10 text-yellow-200';
+  return 'border-destructive/40 bg-destructive/10 text-destructive';
+}
+
+function checkIcon(status: string) {
+  if (status === 'pass') return <CheckCircle2 className="h-3.5 w-3.5 text-emerald-300" />;
+  if (status === 'warn') return <ShieldCheck className="h-3.5 w-3.5 text-yellow-200" />;
+  return <XCircle className="h-3.5 w-3.5 text-destructive" />;
+}
+
+export function MCPAirlockPanel({ client = api }: MCPAirlockPanelProps) {
+  const [servers, setServers] = useState<MCPAirlockServerStatus[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [checkingId, setCheckingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      setServers(await client.listMCPAirlockServers());
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const check = async (id: string) => {
+    setCheckingId(id);
+    setError(null);
+    try {
+      const next = await client.checkMCPAirlockServer(id);
+      setServers(current => current.map(status => status.server.id === id ? next : status));
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setCheckingId(null);
+    }
+  };
+
+  return (
+    <div className="flex h-full flex-col gap-3 bg-background p-4">
+      <header className="flex items-center gap-3">
+        <ServerCog className="h-4 w-4 text-primary" />
+        <h2 className="text-sm font-semibold uppercase tracking-widest text-foreground">
+          MCP Airlock
+        </h2>
+        <Button
+          size="sm"
+          variant="outline"
+          className="ml-auto h-8 w-8 p-0"
+          onClick={load}
+          disabled={loading}
+          title="Refresh MCP Airlock servers"
+          aria-label="Refresh MCP Airlock servers"
+        >
+          <RefreshCw className={`h-3.5 w-3.5 ${loading ? 'animate-spin' : ''}`} />
+        </Button>
+      </header>
+
+      <div className="rounded-md border border-primary/30 bg-primary/10 px-3 py-2 text-xs leading-relaxed text-foreground">
+        Trusted MCP servers run through read-only checks with cloud credentials withheld.
+      </div>
+
+      {error && (
+        <div className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+          {error}
+        </div>
+      )}
+
+      <div className="flex-1 overflow-y-auto">
+        {loading && servers.length === 0 && (
+          <div className="p-6 text-center text-xs text-muted-foreground">Loading servers...</div>
+        )}
+
+        <ul className="flex flex-col gap-3">
+          {servers.map(status => (
+            <li
+              key={status.server.id}
+              className="rounded-md border border-border bg-card p-3"
+            >
+              <div className="flex items-start gap-2">
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <h3 className="truncate text-sm font-semibold text-foreground">
+                      {status.server.name}
+                    </h3>
+                    <span className={`rounded border px-1.5 py-0.5 text-[10px] font-semibold ${stateClass(status.state)}`}>
+                      {stateLabels[status.state] || status.state}
+                    </span>
+                  </div>
+                  <div className="mt-0.5 text-[10px] uppercase tracking-widest text-muted-foreground">
+                    {status.server.vendor} - {status.server.transport}
+                  </div>
+                </div>
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  className="h-7 px-2 text-[10px]"
+                  onClick={() => check(status.server.id)}
+                  disabled={checkingId === status.server.id}
+                >
+                  {checkingId === status.server.id ? 'Checking' : 'Check'}
+                </Button>
+              </div>
+
+              <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+                {status.summary}
+              </p>
+
+              <div className="mt-2 flex flex-wrap gap-1.5">
+                {status.server.trusted && (
+                  <span className="rounded bg-emerald-500/10 px-1.5 py-0.5 text-[10px] text-emerald-300">trusted</span>
+                )}
+                {status.server.read_only_default && (
+                  <span className="rounded bg-primary/10 px-1.5 py-0.5 text-[10px] text-primary">read-only</span>
+                )}
+                <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+                  credentials: {status.server.credential_mode}
+                </span>
+              </div>
+
+              {status.server.install_hint && !status.command_available && (
+                <div className="mt-2 rounded-md border border-border bg-background px-2 py-1.5 text-[11px] leading-relaxed text-muted-foreground">
+                  {status.server.install_hint}
+                </div>
+              )}
+
+              {status.server.capabilities && status.server.capabilities.length > 0 && (
+                <div className="mt-2 flex flex-wrap gap-1">
+                  {status.server.capabilities.slice(0, 4).map(capability => (
+                    <span key={capability} className="rounded border border-border px-1.5 py-0.5 text-[10px] text-muted-foreground">
+                      {capability}
+                    </span>
+                  ))}
+                </div>
+              )}
+
+              <div className="mt-3 grid gap-1.5">
+                {status.checks.map(check => (
+                  <div key={`${status.server.id}-${check.name}`} className="flex items-start gap-2 text-[11px] leading-relaxed text-muted-foreground">
+                    {checkIcon(check.status)}
+                    <span className="min-w-0">
+                      <span className="font-medium text-foreground">{check.name}</span>: {check.message}
+                    </span>
+                  </div>
+                ))}
+              </div>
+
+              <div className="mt-3 flex items-center gap-3 text-[10px] text-muted-foreground">
+                {status.checked_at && <span>checked {new Date(status.checked_at).toLocaleTimeString()}</span>}
+                <a
+                  className="ml-auto inline-flex items-center gap-1 hover:text-foreground"
+                  href={status.server.docs_url || status.server.source_url}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  docs <ExternalLink className="h-3 w-3" />
+                </a>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/MCPAirlock/index.tsx
+++ b/web/src/components/MCPAirlock/index.tsx
@@ -1,0 +1,2 @@
+export { MCPAirlockPanel } from './MCPAirlockPanel';
+export type { MCPAirlockPanelProps } from './MCPAirlockPanel';


### PR DESCRIPTION
## Summary
- add a trusted MCP Airlock registry for official AWS and Terraform MCP servers
- expose read-only Airlock list/health tools through IaC Studio MCP
- add browser API routes and an MCP tab in the Inspector panel
- keep health checks credential-free with bounded execution and redacted output

## Security posture
- no cloud credentials are stored, returned, or forwarded to MCP health checks
- unknown server IDs fail closed
- command configs reject shell metacharacters and are executed without a shell
- probe environment is reduced to PATH plus minimal Windows system vars

## Tests
- `GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/mcpairlock ./internal/mcp`
- `GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/api`
- `npm --prefix web test -- --run MCPAirlock InspectorPanel api.test.ts`
- `npm --prefix web run build`
- `npm --prefix web run lint` (passes with existing warnings)

Refs #60
Refs #62