### PR TITLE
Add MCP Airlock server lifecycle controls

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/iac-studio/iac-studio/internal/ai"
 	"github.com/iac-studio/iac-studio/internal/ai/providers"
 	"github.com/iac-studio/iac-studio/internal/api"
+	"github.com/iac-studio/iac-studio/internal/mcpairlock"
 	"github.com/iac-studio/iac-studio/internal/runner"
 	"github.com/iac-studio/iac-studio/internal/watcher"
 )
@@ -94,8 +95,15 @@ func main() {
 	// Build origin allowlist from actual bind address
 	api.InitAllowedOrigins(*host, *port)
 
+	mcpAirlock := mcpairlock.NewManager(*projectsDir)
+	defer func() {
+		if err := mcpAirlock.Close(); err != nil {
+			log.Printf("mcp airlock cleanup: %v", err)
+		}
+	}()
+
 	// Build router
-	router := api.NewRouter(hub, fw, aiClient, safeRun, *projectsDir)
+	router := api.NewRouterWithOptions(hub, fw, aiClient, safeRun, *projectsDir, api.RouterOptions{MCPAirlock: mcpAirlock})
 
 	// Serve embedded frontend
 	frontendContent, _ := fs.Sub(frontendFS, "frontend/dist")

--- a/internal/api/mcp_airlock_test.go
+++ b/internal/api/mcp_airlock_test.go
@@ -1,10 +1,18 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
+	"time"
+
+	"github.com/iac-studio/iac-studio/internal/ai"
+	"github.com/iac-studio/iac-studio/internal/mcpairlock"
+	"github.com/iac-studio/iac-studio/internal/runner"
+	"github.com/iac-studio/iac-studio/internal/watcher"
 )
 
 func TestMCPAirlockRoutesExposeTrustedReadOnlyServers(t *testing.T) {
@@ -54,4 +62,111 @@ func TestMCPAirlockHealthUnknownServerFailsClosed(t *testing.T) {
 	if resp.StatusCode != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d", resp.StatusCode)
 	}
+}
+
+func TestMCPAirlockStartStopRoutesUseLifecycle(t *testing.T) {
+	root := t.TempDir()
+	handle := newAPIFakeProcess()
+	manager := mcpairlock.NewManager(root,
+		mcpairlock.WithDefinitions([]mcpairlock.ServerDefinition{{
+			ID:              "terraform",
+			Name:            "Terraform",
+			Command:         apiTestExecutable(t),
+			Transport:       "stdio",
+			Trusted:         true,
+			ReadOnlyDefault: true,
+			CredentialMode:  "none",
+		}}),
+		mcpairlock.WithLauncher(func(context.Context, mcpairlock.ServerDefinition, time.Duration) (mcpairlock.ProcessHandle, error) {
+			return handle, nil
+		}),
+	)
+	srv := httptest.NewServer(fullRouterForTestWithAirlock(t, root, manager))
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/api/mcp-airlock/servers/terraform/start", "application/json", nil)
+	if err != nil {
+		t.Fatalf("POST start: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	var started struct {
+		Running bool   `json:"running"`
+		State   string `json:"state"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&started); err != nil {
+		t.Fatalf("decode start: %v", err)
+	}
+	if !started.Running || started.State != "running" {
+		t.Fatalf("expected running response, got %+v", started)
+	}
+
+	resp, err = http.Post(srv.URL+"/api/mcp-airlock/servers/terraform/stop", "application/json", nil)
+	if err != nil {
+		t.Fatalf("POST stop: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	var stopped struct {
+		Running bool   `json:"running"`
+		State   string `json:"state"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&stopped); err != nil {
+		t.Fatalf("decode stop: %v", err)
+	}
+	if stopped.Running || stopped.State != "stopped" || !handle.stopped {
+		t.Fatalf("expected stopped response, got response=%+v stopped=%v", stopped, handle.stopped)
+	}
+}
+
+func fullRouterForTestWithAirlock(t *testing.T, projectsDir string, airlock *mcpairlock.Manager) *http.ServeMux {
+	t.Helper()
+	hub := NewHub()
+	go hub.Run()
+	t.Cleanup(hub.Close)
+	fw := watcher.New(hub)
+	t.Cleanup(fw.Close)
+	return NewRouterWithOptions(
+		hub,
+		fw,
+		ai.NewClient("http://127.0.0.1:1", "ignored"),
+		runner.NewSafeRunner(runner.DefaultSafetyConfig()),
+		projectsDir,
+		RouterOptions{MCPAirlock: airlock},
+	)
+}
+
+func apiTestExecutable(t *testing.T) string {
+	t.Helper()
+	path, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+type apiFakeProcess struct {
+	done    chan error
+	stopped bool
+}
+
+func newAPIFakeProcess() *apiFakeProcess {
+	return &apiFakeProcess{done: make(chan error, 1)}
+}
+
+func (p *apiFakeProcess) Done() <-chan error {
+	return p.done
+}
+
+func (p *apiFakeProcess) Stop(context.Context) error {
+	p.stopped = true
+	select {
+	case p.done <- nil:
+	default:
+	}
+	return nil
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -969,8 +969,19 @@ func limitBody(w http.ResponseWriter, r *http.Request) {
 	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBody)
 }
 
+// RouterOptions allows callers to provide long-lived services that need
+// explicit lifecycle management outside the router.
+type RouterOptions struct {
+	MCPAirlock *mcpairlock.Manager
+}
+
 // NewRouter creates the HTTP router with all endpoints.
 func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runner.SafeRunner, projectsDir string) *http.ServeMux {
+	return NewRouterWithOptions(hub, fw, aiClient, run, projectsDir, RouterOptions{})
+}
+
+// NewRouterWithOptions creates the HTTP router with explicit service options.
+func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runner.SafeRunner, projectsDir string, opts RouterOptions) *http.ServeMux {
 	mux := http.NewServeMux()
 
 	// Health
@@ -1404,7 +1415,10 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 	})
 
 	cloudConnections := cloudconnections.NewManager(projectsDir)
-	mcpAirlock := mcpairlock.NewManager(projectsDir)
+	mcpAirlock := opts.MCPAirlock
+	if mcpAirlock == nil {
+		mcpAirlock = mcpairlock.NewManager(projectsDir)
+	}
 
 	// Run IaC command (init, plan, apply)
 	mux.HandleFunc("POST /api/projects/{name}/run", func(w http.ResponseWriter, r *http.Request) {
@@ -1886,6 +1900,32 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 				return
 			}
 			http.Error(w, "mcp airlock health check failed", http.StatusInternalServerError)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(status)
+	})
+
+	mux.HandleFunc("POST /api/mcp-airlock/servers/{id}/start", func(w http.ResponseWriter, r *http.Request) {
+		status, err := mcpAirlock.Start(r.Context(), r.PathValue("id"))
+		if err != nil {
+			if errors.Is(err, mcpairlock.ErrUnknownServer) {
+				http.Error(w, "mcp airlock server not found", http.StatusNotFound)
+				return
+			}
+			http.Error(w, "mcp airlock start failed", http.StatusInternalServerError)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(status)
+	})
+
+	mux.HandleFunc("POST /api/mcp-airlock/servers/{id}/stop", func(w http.ResponseWriter, r *http.Request) {
+		status, err := mcpAirlock.Stop(r.Context(), r.PathValue("id"))
+		if err != nil {
+			if errors.Is(err, mcpairlock.ErrUnknownServer) {
+				http.Error(w, "mcp airlock server not found", http.StatusNotFound)
+				return
+			}
+			http.Error(w, "mcp airlock stop failed", http.StatusInternalServerError)
 			return
 		}
 		_ = json.NewEncoder(w).Encode(status)

--- a/internal/mcpairlock/lifecycle.go
+++ b/internal/mcpairlock/lifecycle.go
@@ -1,0 +1,307 @@
+package mcpairlock
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"sync"
+	"time"
+)
+
+const startupGrace = 250 * time.Millisecond
+
+// ProcessHandle is a running external MCP server process.
+type ProcessHandle interface {
+	Done() <-chan error
+	Stop(context.Context) error
+}
+
+// LauncherFunc starts a configured external MCP server process.
+type LauncherFunc func(ctx context.Context, definition ServerDefinition, timeout time.Duration) (ProcessHandle, error)
+
+type lifecycleStore struct {
+	mu      sync.Mutex
+	running map[string]*processRecord
+	exits   map[string]exitRecord
+}
+
+type processRecord struct {
+	handle    ProcessHandle
+	startedAt time.Time
+}
+
+type exitRecord struct {
+	at     time.Time
+	reason string
+}
+
+func newLifecycleStore() *lifecycleStore {
+	return &lifecycleStore{
+		running: make(map[string]*processRecord),
+		exits:   make(map[string]exitRecord),
+	}
+}
+
+// WithLauncher replaces the process launcher. It is intended for tests and
+// future launcher policies.
+func WithLauncher(launcher LauncherFunc) Option {
+	return func(m *Manager) {
+		if launcher != nil {
+			m.launcher = launcher
+		}
+	}
+}
+
+// Start launches one configured stdio MCP server with a sanitized environment.
+func (m *Manager) Start(ctx context.Context, id string) (ServerStatus, error) {
+	definition, ok := m.lookup(id)
+	if !ok {
+		return ServerStatus{}, ErrUnknownServer
+	}
+	status := m.passiveStatus(definition)
+	if status.State != "available" {
+		return m.withLifecycleStatus(status), nil
+	}
+
+	now := time.Now().UTC()
+	m.lifecycle.mu.Lock()
+	defer m.lifecycle.mu.Unlock()
+	m.reapLocked(id, now)
+	if record, ok := m.lifecycle.running[id]; ok {
+		status = m.withLifecycleStatusLocked(status, record)
+		status.Checks = append(status.Checks, Check{Name: "lifecycle", Status: "pass", Message: "server is already running"})
+		return status, nil
+	}
+
+	handle, err := m.launcher(ctx, definition, m.timeout)
+	if err != nil {
+		status.State = "launch_failed"
+		status.Summary = "Airlock could not start the MCP server process."
+		status.Checks = append(status.Checks, Check{Name: "lifecycle", Status: "error", Message: redactOutput(err.Error())})
+		return status, nil
+	}
+	record := &processRecord{handle: handle, startedAt: now}
+	m.lifecycle.running[id] = record
+	delete(m.lifecycle.exits, id)
+	status = m.withLifecycleStatusLocked(status, record)
+	status.Checks = append(status.Checks, Check{Name: "lifecycle", Status: "pass", Message: "server process started with a sanitized environment"})
+	return status, nil
+}
+
+// Stop terminates one running MCP server process. It is safe to call when the
+// server is already stopped.
+func (m *Manager) Stop(ctx context.Context, id string) (ServerStatus, error) {
+	definition, ok := m.lookup(id)
+	if !ok {
+		return ServerStatus{}, ErrUnknownServer
+	}
+	status := m.passiveStatus(definition)
+	now := time.Now().UTC()
+
+	m.lifecycle.mu.Lock()
+	m.reapLocked(id, now)
+	record, ok := m.lifecycle.running[id]
+	if !ok {
+		status = m.withLifecycleStatusLocked(status, nil)
+		status.Checks = append(status.Checks, Check{Name: "lifecycle", Status: "warn", Message: "server is not running"})
+		m.lifecycle.mu.Unlock()
+		return status, nil
+	}
+	m.lifecycle.mu.Unlock()
+
+	stopCtx, cancel := context.WithTimeout(ctx, m.timeout)
+	defer cancel()
+	if err := record.handle.Stop(stopCtx); err != nil {
+		m.lifecycle.mu.Lock()
+		status = m.withLifecycleStatusLocked(status, record)
+		status.State = "stop_failed"
+		status.Summary = "Airlock could not stop the MCP server process before the timeout."
+		status.Checks = append(status.Checks, Check{Name: "lifecycle", Status: "error", Message: redactOutput(err.Error())})
+		m.lifecycle.mu.Unlock()
+		return status, nil
+	}
+
+	m.lifecycle.mu.Lock()
+	delete(m.lifecycle.running, id)
+	m.lifecycle.exits[id] = exitRecord{at: time.Now().UTC(), reason: "stopped by user"}
+	status = m.withLifecycleStatusLocked(status, nil)
+	status.State = "stopped"
+	status.Summary = "MCP server process stopped."
+	status.Checks = append(status.Checks, Check{Name: "lifecycle", Status: "pass", Message: "server process stopped"})
+	m.lifecycle.mu.Unlock()
+	return status, nil
+}
+
+// Close stops all running MCP server processes. It is best-effort cleanup for
+// application shutdown.
+func (m *Manager) Close() error {
+	ctx, cancel := context.WithTimeout(context.Background(), m.timeout)
+	defer cancel()
+	return m.StopAll(ctx)
+}
+
+// StopAll terminates all running MCP server processes.
+func (m *Manager) StopAll(ctx context.Context) error {
+	m.lifecycle.mu.Lock()
+	ids := make([]string, 0, len(m.lifecycle.running))
+	for id := range m.lifecycle.running {
+		ids = append(ids, id)
+	}
+	m.lifecycle.mu.Unlock()
+
+	var joined error
+	for _, id := range ids {
+		if _, err := m.Stop(ctx, id); err != nil {
+			joined = errors.Join(joined, err)
+		}
+	}
+	return joined
+}
+
+func (m *Manager) withLifecycleStatus(status ServerStatus) ServerStatus {
+	m.lifecycle.mu.Lock()
+	defer m.lifecycle.mu.Unlock()
+	m.reapLocked(status.Server.ID, time.Now().UTC())
+	return m.withLifecycleStatusLocked(status, nil)
+}
+
+func (m *Manager) withLifecycleStatusLocked(status ServerStatus, record *processRecord) ServerStatus {
+	if record == nil {
+		record = m.lifecycle.running[status.Server.ID]
+	}
+	if record != nil {
+		status.Running = true
+		status.Ready = true
+		status.State = "running"
+		status.StartedAt = record.startedAt.Format(time.RFC3339)
+		status.Summary = "MCP server process is running with cloud credentials withheld."
+		status.Checks = append(status.Checks, Check{Name: "lifecycle", Status: "pass", Message: "server process is running"})
+		return status
+	}
+	if exit, ok := m.lifecycle.exits[status.Server.ID]; ok {
+		status.LastExitAt = exit.at.Format(time.RFC3339)
+		status.LastExitReason = exit.reason
+		if status.State == "available" {
+			status.State = "exited"
+			status.Summary = "MCP server process is not running."
+			status.Checks = append(status.Checks, Check{Name: "lifecycle", Status: "warn", Message: exit.reason})
+		}
+	}
+	return status
+}
+
+func (m *Manager) reapLocked(id string, now time.Time) {
+	record := m.lifecycle.running[id]
+	if record == nil {
+		return
+	}
+	select {
+	case err := <-record.handle.Done():
+		delete(m.lifecycle.running, id)
+		m.lifecycle.exits[id] = exitRecord{at: now, reason: exitReason(err)}
+	default:
+	}
+}
+
+func exitReason(err error) string {
+	if err == nil {
+		return "process exited"
+	}
+	return redactOutput(err.Error())
+}
+
+type osProcessHandle struct {
+	cmd    *exec.Cmd
+	cancel context.CancelFunc
+	stdin  io.Closer
+	done   chan error
+}
+
+func (p *osProcessHandle) Done() <-chan error {
+	return p.done
+}
+
+func (p *osProcessHandle) Stop(ctx context.Context) error {
+	if p.stdin != nil {
+		_ = p.stdin.Close()
+	}
+	grace := startupGrace
+	timer := time.NewTimer(grace)
+	defer timer.Stop()
+	select {
+	case <-p.done:
+		p.cancel()
+		return nil
+	case <-timer.C:
+	}
+
+	p.cancel()
+	select {
+	case <-p.done:
+		return nil
+	case <-ctx.Done():
+		if p.cmd.Process != nil {
+			_ = p.cmd.Process.Kill()
+		}
+		select {
+		case <-p.done:
+			return nil
+		case <-time.After(100 * time.Millisecond):
+			return ctx.Err()
+		}
+	}
+}
+
+func defaultLauncher(ctx context.Context, definition ServerDefinition, timeout time.Duration) (ProcessHandle, error) {
+	runCtx, cancel := context.WithCancel(context.Background())
+	cmd := exec.CommandContext(runCtx, definition.Command, definition.Args...)
+	cmd.Dir = os.TempDir()
+	cmd.Env = minimalEnv()
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	if err := cmd.Start(); err != nil {
+		_ = stdin.Close()
+		cancel()
+		return nil, err
+	}
+	handle := &osProcessHandle{
+		cmd:    cmd,
+		cancel: cancel,
+		stdin:  stdin,
+		done:   make(chan error, 1),
+	}
+	go func() {
+		handle.done <- cmd.Wait()
+		close(handle.done)
+	}()
+
+	grace := startupGrace
+	if timeout > 0 && timeout < grace {
+		grace = timeout
+	}
+	timer := time.NewTimer(grace)
+	defer timer.Stop()
+	select {
+	case err := <-handle.done:
+		cancel()
+		if err == nil {
+			return nil, errors.New("process exited during startup")
+		}
+		return nil, fmt.Errorf("process exited during startup: %w", err)
+	case <-ctx.Done():
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), timeout)
+		defer stopCancel()
+		_ = handle.Stop(stopCtx)
+		return nil, ctx.Err()
+	case <-timer.C:
+		return handle, nil
+	}
+}

--- a/internal/mcpairlock/registry.go
+++ b/internal/mcpairlock/registry.go
@@ -37,21 +37,22 @@ type Check struct {
 // ServerDefinition describes a trusted external MCP server without storing
 // credentials or launcher state.
 type ServerDefinition struct {
-	ID              string   `json:"id"`
-	Name            string   `json:"name"`
-	Vendor          string   `json:"vendor"`
-	Description     string   `json:"description"`
-	SourceURL       string   `json:"source_url"`
-	DocsURL         string   `json:"docs_url,omitempty"`
-	InstallHint     string   `json:"install_hint,omitempty"`
-	Transport       string   `json:"transport"`
-	Command         string   `json:"command,omitempty"`
-	Args            []string `json:"args,omitempty"`
-	HealthCheckArgs []string `json:"health_check_args,omitempty"`
-	Trusted         bool     `json:"trusted"`
-	ReadOnlyDefault bool     `json:"read_only_default"`
-	CredentialMode  string   `json:"credential_mode"`
-	Capabilities    []string `json:"capabilities,omitempty"`
+	ID                string   `json:"id"`
+	Name              string   `json:"name"`
+	Vendor            string   `json:"vendor"`
+	Description       string   `json:"description"`
+	SourceURL         string   `json:"source_url"`
+	DocsURL           string   `json:"docs_url,omitempty"`
+	InstallHint       string   `json:"install_hint,omitempty"`
+	Transport         string   `json:"transport"`
+	Command           string   `json:"command,omitempty"`
+	Args              []string `json:"args,omitempty"`
+	HealthCheckArgs   []string `json:"health_check_args,omitempty"`
+	VersionConstraint string   `json:"version_constraint,omitempty"`
+	Trusted           bool     `json:"trusted"`
+	ReadOnlyDefault   bool     `json:"read_only_default"`
+	CredentialMode    string   `json:"credential_mode"`
+	Capabilities      []string `json:"capabilities,omitempty"`
 }
 
 // ServerStatus is the public health/status view returned by the API and MCP
@@ -59,12 +60,16 @@ type ServerDefinition struct {
 type ServerStatus struct {
 	Server           ServerDefinition `json:"server"`
 	Ready            bool             `json:"ready"`
+	Running          bool             `json:"running"`
 	Configured       bool             `json:"configured"`
 	CommandAvailable bool             `json:"command_available"`
 	State            string           `json:"state"`
 	Summary          string           `json:"summary"`
 	Checks           []Check          `json:"checks"`
 	CheckedAt        string           `json:"checked_at,omitempty"`
+	StartedAt        string           `json:"started_at,omitempty"`
+	LastExitAt       string           `json:"last_exit_at,omitempty"`
+	LastExitReason   string           `json:"last_exit_reason,omitempty"`
 }
 
 // ProbeResult is the sanitized result shape used by health-check probes.
@@ -86,6 +91,8 @@ type Manager struct {
 	definitions []ServerDefinition
 	timeout     time.Duration
 	probe       ProbeFunc
+	launcher    LauncherFunc
+	lifecycle   *lifecycleStore
 }
 
 // NewManager creates an Airlock registry. projectsDir is accepted for future
@@ -97,6 +104,8 @@ func NewManager(projectsDir string, opts ...Option) *Manager {
 		definitions: builtInDefinitions(),
 		timeout:     defaultHealthTimeout,
 		probe:       defaultProbe,
+		launcher:    defaultLauncher,
+		lifecycle:   newLifecycleStore(),
 	}
 	for _, opt := range opts {
 		opt(m)
@@ -136,7 +145,7 @@ func WithTimeout(timeout time.Duration) Option {
 func (m *Manager) List(_ context.Context) []ServerStatus {
 	statuses := make([]ServerStatus, 0, len(m.definitions))
 	for _, definition := range m.definitions {
-		statuses = append(statuses, m.passiveStatus(definition))
+		statuses = append(statuses, m.withLifecycleStatus(m.passiveStatus(definition)))
 	}
 	sort.SliceStable(statuses, func(i, j int) bool {
 		return statuses[i].Server.Name < statuses[j].Server.Name
@@ -153,7 +162,7 @@ func (m *Manager) Check(ctx context.Context, id string) (ServerStatus, error) {
 	status := m.passiveStatus(definition)
 	status.CheckedAt = time.Now().UTC().Format(time.RFC3339)
 	if status.State != "available" {
-		return status, nil
+		return m.withLifecycleStatus(status), nil
 	}
 	args := append([]string{}, definition.Args...)
 	args = append(args, definition.HealthCheckArgs...)
@@ -162,7 +171,7 @@ func (m *Manager) Check(ctx context.Context, id string) (ServerStatus, error) {
 		status.State = "ready"
 		status.Summary = "Command is available. No active health probe is configured for this server."
 		status.Checks = append(status.Checks, Check{Name: "health_probe", Status: "warn", Message: "no version or health command is configured"})
-		return status, nil
+		return m.withLifecycleStatus(status), nil
 	}
 	result := m.probe(ctx, definition.Command, args, m.timeout)
 	if result.TimedOut {
@@ -170,7 +179,7 @@ func (m *Manager) Check(ctx context.Context, id string) (ServerStatus, error) {
 		status.State = "timeout"
 		status.Summary = "Health check timed out before the MCP server responded."
 		status.Checks = append(status.Checks, Check{Name: "health_probe", Status: "error", Message: "probe timed out"})
-		return status, nil
+		return m.withLifecycleStatus(status), nil
 	}
 	if result.Err != nil {
 		status.Ready = false
@@ -181,7 +190,7 @@ func (m *Manager) Check(ctx context.Context, id string) (ServerStatus, error) {
 		}
 		status.Summary = "Health check failed. Review the local command configuration before enabling this server."
 		status.Checks = append(status.Checks, Check{Name: "health_probe", Status: "error", Message: message})
-		return status, nil
+		return m.withLifecycleStatus(status), nil
 	}
 	status.Ready = true
 	status.State = "ready"
@@ -191,7 +200,7 @@ func (m *Manager) Check(ctx context.Context, id string) (ServerStatus, error) {
 		message = output
 	}
 	status.Checks = append(status.Checks, Check{Name: "health_probe", Status: "pass", Message: message})
-	return status, nil
+	return m.withLifecycleStatus(status), nil
 }
 
 func (m *Manager) lookup(id string) (ServerDefinition, bool) {
@@ -224,6 +233,12 @@ func (m *Manager) passiveStatus(definition ServerDefinition) ServerStatus {
 		status.Checks = append(status.Checks, Check{Name: "default_mode", Status: "warn", Message: "server is not read-only by default"})
 	} else {
 		status.Checks = append(status.Checks, Check{Name: "default_mode", Status: "pass", Message: "server starts in read-only review mode"})
+	}
+	if definition.Transport != "stdio" {
+		status.State = "unsupported_transport"
+		status.Summary = "Only stdio MCP servers are supported by this Airlock launcher."
+		status.Checks = append(status.Checks, Check{Name: "transport", Status: "error", Message: "unsupported transport: " + definition.Transport})
+		return status
 	}
 	command := strings.TrimSpace(definition.Command)
 	if command == "" {

--- a/internal/mcpairlock/registry_test.go
+++ b/internal/mcpairlock/registry_test.go
@@ -3,6 +3,7 @@ package mcpairlock
 import (
 	"context"
 	"errors"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -125,6 +126,115 @@ func TestCheckUnknownServerFailsClosed(t *testing.T) {
 	}
 }
 
+func TestStartStopLifecycleUsesLauncherAndReportsRunning(t *testing.T) {
+	command := testExecutable(t)
+	handle := newFakeProcess()
+	manager := NewManager(t.TempDir(),
+		WithDefinitions([]ServerDefinition{{
+			ID:              "terraform",
+			Name:            "Terraform",
+			Command:         command,
+			Transport:       "stdio",
+			Trusted:         true,
+			ReadOnlyDefault: true,
+			CredentialMode:  "none",
+		}}),
+		WithLauncher(func(_ context.Context, definition ServerDefinition, _ time.Duration) (ProcessHandle, error) {
+			if definition.Command != command {
+				t.Fatalf("unexpected launch command: %q", definition.Command)
+			}
+			return handle, nil
+		}),
+	)
+
+	status, err := manager.Start(context.Background(), "terraform")
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if !status.Running || status.State != "running" || status.StartedAt == "" {
+		t.Fatalf("expected running status, got %+v", status)
+	}
+
+	listed := manager.List(context.Background())
+	if len(listed) != 1 || !listed[0].Running {
+		t.Fatalf("expected running status in list, got %+v", listed)
+	}
+
+	status, err = manager.Stop(context.Background(), "terraform")
+	if err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if status.Running || status.State != "stopped" || !handle.stopped {
+		t.Fatalf("expected stopped status, got status=%+v stopped=%v", status, handle.stopped)
+	}
+}
+
+func TestStartRejectsUnsupportedTransportWithoutLaunching(t *testing.T) {
+	calls := 0
+	manager := NewManager(t.TempDir(),
+		WithDefinitions([]ServerDefinition{{
+			ID:              "http",
+			Name:            "HTTP",
+			Command:         testExecutable(t),
+			Transport:       "sse",
+			Trusted:         true,
+			ReadOnlyDefault: true,
+			CredentialMode:  "none",
+		}}),
+		WithLauncher(func(context.Context, ServerDefinition, time.Duration) (ProcessHandle, error) {
+			calls++
+			return newFakeProcess(), nil
+		}),
+	)
+
+	status, err := manager.Start(context.Background(), "http")
+
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("unsupported transport should not launch, got %d calls", calls)
+	}
+	if status.State != "unsupported_transport" || status.Running {
+		t.Fatalf("expected unsupported transport status, got %+v", status)
+	}
+}
+
+func TestExitedProcessIsReapedIntoStatus(t *testing.T) {
+	handle := newFakeProcess()
+	manager := NewManager(t.TempDir(),
+		WithDefinitions([]ServerDefinition{{
+			ID:              "terraform",
+			Name:            "Terraform",
+			Command:         testExecutable(t),
+			Transport:       "stdio",
+			Trusted:         true,
+			ReadOnlyDefault: true,
+			CredentialMode:  "none",
+		}}),
+		WithLauncher(func(context.Context, ServerDefinition, time.Duration) (ProcessHandle, error) {
+			return handle, nil
+		}),
+	)
+
+	if _, err := manager.Start(context.Background(), "terraform"); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	handle.exit(errors.New("boom secret_access_key=super-secret"))
+
+	statuses := manager.List(context.Background())
+	if len(statuses) != 1 {
+		t.Fatalf("expected one status, got %+v", statuses)
+	}
+	status := statuses[0]
+	if status.Running || status.State != "exited" || status.LastExitAt == "" {
+		t.Fatalf("expected reaped exited status, got %+v", status)
+	}
+	if strings.Contains(status.LastExitReason, "super-secret") {
+		t.Fatalf("exit reason leaked secret value: %q", status.LastExitReason)
+	}
+}
+
 func containsStatus(statuses []ServerStatus, id string) bool {
 	for _, status := range statuses {
 		if status.Server.ID == id {
@@ -132,4 +242,39 @@ func containsStatus(statuses []ServerStatus, id string) bool {
 		}
 	}
 	return false
+}
+
+func testExecutable(t *testing.T) string {
+	t.Helper()
+	path, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+type fakeProcess struct {
+	done    chan error
+	stopped bool
+}
+
+func newFakeProcess() *fakeProcess {
+	return &fakeProcess{done: make(chan error, 1)}
+}
+
+func (p *fakeProcess) Done() <-chan error {
+	return p.done
+}
+
+func (p *fakeProcess) Stop(context.Context) error {
+	p.stopped = true
+	p.exit(nil)
+	return nil
+}
+
+func (p *fakeProcess) exit(err error) {
+	select {
+	case p.done <- err:
+	default:
+	}
 }

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -94,17 +94,59 @@ describe('api.cloudConnections', () => {
       },
       checks: [{ name: 'auth_method', status: 'pass', message: 'configured' }],
     };
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify(response), {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify(response), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
-      }),
-    );
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(response), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }));
     vi.stubGlobal('fetch', fetchMock);
 
     await expect(api.testCloudConnection('conn_1')).resolves.toEqual(response);
 
     expect(fetchMock).toHaveBeenCalledWith('/api/cloud/connections/conn_1/test', {
+      method: 'POST',
+    });
+  });
+});
+
+describe('api.mcpAirlock', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('calls MCP Airlock lifecycle endpoints', async () => {
+    const response = {
+      server: { id: 'terraform-official', name: 'Terraform MCP Server' },
+      ready: true,
+      running: true,
+      configured: true,
+      command_available: true,
+      state: 'running',
+      summary: 'running',
+      checks: [],
+    };
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify(response), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(response), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(api.startMCPAirlockServer('terraform-official')).resolves.toEqual(response);
+    await expect(api.stopMCPAirlockServer('terraform-official')).resolves.toEqual(response);
+
+    expect(fetchMock).toHaveBeenNthCalledWith(1, '/api/mcp-airlock/servers/terraform-official/start', {
+      method: 'POST',
+    });
+    expect(fetchMock).toHaveBeenNthCalledWith(2, '/api/mcp-airlock/servers/terraform-official/stop', {
       method: 'POST',
     });
   });

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -166,12 +166,16 @@ export interface MCPAirlockServerDefinition {
 export interface MCPAirlockServerStatus {
   server: MCPAirlockServerDefinition;
   ready: boolean;
+  running: boolean;
   configured: boolean;
   command_available: boolean;
   state: string;
   summary: string;
   checks: MCPAirlockCheck[];
   checked_at?: string;
+  started_at?: string;
+  last_exit_at?: string;
+  last_exit_reason?: string;
 }
 
 export type PlanRiskLevel = 'safe' | 'risky' | 'destructive' | 'unknown';
@@ -410,6 +414,16 @@ export const api = {
 
   async checkMCPAirlockServer(id: string): Promise<MCPAirlockServerStatus> {
     const res = await fetch(`${BASE}/api/mcp-airlock/servers/${encodeURIComponent(id)}/health`, { method: 'POST' });
+    return (await check(res)).json();
+  },
+
+  async startMCPAirlockServer(id: string): Promise<MCPAirlockServerStatus> {
+    const res = await fetch(`${BASE}/api/mcp-airlock/servers/${encodeURIComponent(id)}/start`, { method: 'POST' });
+    return (await check(res)).json();
+  },
+
+  async stopMCPAirlockServer(id: string): Promise<MCPAirlockServerStatus> {
+    const res = await fetch(`${BASE}/api/mcp-airlock/servers/${encodeURIComponent(id)}/stop`, { method: 'POST' });
     return (await check(res)).json();
   },
 

--- a/web/src/components/MCPAirlock/MCPAirlockPanel.test.tsx
+++ b/web/src/components/MCPAirlock/MCPAirlockPanel.test.tsx
@@ -22,6 +22,7 @@ function server(overrides: Partial<MCPAirlockServerStatus> = {}): MCPAirlockServ
       capabilities: ['terraform registry'],
     },
     ready: false,
+    running: false,
     configured: true,
     command_available: false,
     state: 'command_missing',
@@ -48,6 +49,8 @@ describe('MCPAirlockPanel', () => {
     const client = {
       listMCPAirlockServers: vi.fn(async () => [initial]),
       checkMCPAirlockServer: vi.fn(async () => checked),
+      startMCPAirlockServer: vi.fn(async () => checked),
+      stopMCPAirlockServer: vi.fn(async () => checked),
     };
 
     render(<MCPAirlockPanel client={client} />);
@@ -63,5 +66,50 @@ describe('MCPAirlockPanel', () => {
     });
     expect(await screen.findByText('Ready')).toBeInTheDocument();
     expect(screen.getByText('Health check completed without exposing cloud credentials.')).toBeInTheDocument();
+  });
+
+  it('starts and stops configured servers', async () => {
+    const initial = server({
+      command_available: true,
+      state: 'available',
+      summary: 'Command is available.',
+    });
+    const running = server({
+      ready: true,
+      running: true,
+      command_available: true,
+      state: 'running',
+      summary: 'MCP server process is running with cloud credentials withheld.',
+      started_at: '2026-06-13T10:00:00Z',
+    });
+    const stopped = server({
+      command_available: true,
+      state: 'stopped',
+      summary: 'MCP server process stopped.',
+      last_exit_at: '2026-06-13T10:01:00Z',
+      last_exit_reason: 'stopped by user',
+    });
+    const client = {
+      listMCPAirlockServers: vi.fn(async () => [initial]),
+      checkMCPAirlockServer: vi.fn(async () => initial),
+      startMCPAirlockServer: vi.fn(async () => running),
+      stopMCPAirlockServer: vi.fn(async () => stopped),
+    };
+
+    render(<MCPAirlockPanel client={client} />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Start Terraform MCP Server' }));
+
+    await waitFor(() => {
+      expect(client.startMCPAirlockServer).toHaveBeenCalledWith('terraform-official');
+    });
+    expect(await screen.findByText('Running')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Stop Terraform MCP Server' }));
+
+    await waitFor(() => {
+      expect(client.stopMCPAirlockServer).toHaveBeenCalledWith('terraform-official');
+    });
+    expect(await screen.findByText('MCP server process stopped.')).toBeInTheDocument();
   });
 });

--- a/web/src/components/MCPAirlock/MCPAirlockPanel.tsx
+++ b/web/src/components/MCPAirlock/MCPAirlockPanel.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from 'react';
-import { CheckCircle2, ExternalLink, RefreshCw, ServerCog, ShieldCheck, XCircle } from 'lucide-react';
+import { CheckCircle2, ExternalLink, Play, RefreshCw, ServerCog, ShieldCheck, Square, XCircle } from 'lucide-react';
 
 import { api, type MCPAirlockServerStatus } from '../../api';
 import { Button } from '../ui/button';
 
-type MCPAirlockClient = Pick<typeof api, 'listMCPAirlockServers' | 'checkMCPAirlockServer'>;
+type MCPAirlockClient = Pick<typeof api, 'listMCPAirlockServers' | 'checkMCPAirlockServer' | 'startMCPAirlockServer' | 'stopMCPAirlockServer'>;
 
 export interface MCPAirlockPanelProps {
   client?: MCPAirlockClient;
@@ -12,6 +12,7 @@ export interface MCPAirlockPanelProps {
 
 const stateLabels: Record<string, string> = {
   ready: 'Ready',
+  running: 'Running',
   available: 'Available',
   not_configured: 'Not configured',
   command_missing: 'Missing',
@@ -22,6 +23,7 @@ const stateLabels: Record<string, string> = {
 };
 
 function stateClass(state: string) {
+  if (state === 'running') return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300';
   if (state === 'ready') return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300';
   if (state === 'available') return 'border-primary/30 bg-primary/10 text-primary';
   if (state === 'not_configured' || state === 'command_missing') return 'border-yellow-500/30 bg-yellow-500/10 text-yellow-200';
@@ -37,7 +39,7 @@ function checkIcon(status: string) {
 export function MCPAirlockPanel({ client = api }: MCPAirlockPanelProps) {
   const [servers, setServers] = useState<MCPAirlockServerStatus[]>([]);
   const [loading, setLoading] = useState(false);
-  const [checkingId, setCheckingId] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const load = async () => {
@@ -57,7 +59,7 @@ export function MCPAirlockPanel({ client = api }: MCPAirlockPanelProps) {
   }, []);
 
   const check = async (id: string) => {
-    setCheckingId(id);
+    setBusyId(id);
     setError(null);
     try {
       const next = await client.checkMCPAirlockServer(id);
@@ -65,7 +67,33 @@ export function MCPAirlockPanel({ client = api }: MCPAirlockPanelProps) {
     } catch (err) {
       setError(String(err));
     } finally {
-      setCheckingId(null);
+      setBusyId(null);
+    }
+  };
+
+  const start = async (id: string) => {
+    setBusyId(id);
+    setError(null);
+    try {
+      const next = await client.startMCPAirlockServer(id);
+      setServers(current => current.map(status => status.server.id === id ? next : status));
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const stop = async (id: string) => {
+    setBusyId(id);
+    setError(null);
+    try {
+      const next = await client.stopMCPAirlockServer(id);
+      setServers(current => current.map(status => status.server.id === id ? next : status));
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setBusyId(null);
     }
   };
 
@@ -110,6 +138,11 @@ export function MCPAirlockPanel({ client = api }: MCPAirlockPanelProps) {
               key={status.server.id}
               className="rounded-md border border-border bg-card p-3"
             >
+              {(() => {
+                const busy = busyId === status.server.id;
+                const startDisabled = busy || status.running || !status.command_available;
+                const stopDisabled = busy || !status.running;
+                return (
               <div className="flex items-start gap-2">
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-2">
@@ -124,16 +157,42 @@ export function MCPAirlockPanel({ client = api }: MCPAirlockPanelProps) {
                     {status.server.vendor} - {status.server.transport}
                   </div>
                 </div>
-                <Button
-                  size="sm"
-                  variant="secondary"
-                  className="h-7 px-2 text-[10px]"
-                  onClick={() => check(status.server.id)}
-                  disabled={checkingId === status.server.id}
-                >
-                  {checkingId === status.server.id ? 'Checking' : 'Check'}
-                </Button>
+                <div className="flex shrink-0 gap-1">
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    className="h-7 px-2 text-[10px]"
+                    onClick={() => check(status.server.id)}
+                    disabled={busy}
+                  >
+                    {busy ? '...' : 'Check'}
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="h-7 w-7 p-0"
+                    title="Start MCP server"
+                    aria-label={`Start ${status.server.name}`}
+                    onClick={() => start(status.server.id)}
+                    disabled={startDisabled}
+                  >
+                    <Play className="h-3.5 w-3.5" />
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="h-7 w-7 p-0"
+                    title="Stop MCP server"
+                    aria-label={`Stop ${status.server.name}`}
+                    onClick={() => stop(status.server.id)}
+                    disabled={stopDisabled}
+                  >
+                    <Square className="h-3.5 w-3.5" />
+                  </Button>
+                </div>
               </div>
+                );
+              })()}
 
               <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
                 {status.summary}
@@ -179,6 +238,8 @@ export function MCPAirlockPanel({ client = api }: MCPAirlockPanelProps) {
               </div>
 
               <div className="mt-3 flex items-center gap-3 text-[10px] text-muted-foreground">
+                {status.started_at && <span>started {new Date(status.started_at).toLocaleTimeString()}</span>}
+                {status.last_exit_at && !status.running && <span>last exit {new Date(status.last_exit_at).toLocaleTimeString()}</span>}
                 {status.checked_at && <span>checked {new Date(status.checked_at).toLocaleTimeString()}</span>}
                 <a
                   className="ml-auto inline-flex items-center gap-1 hover:text-foreground"


### PR DESCRIPTION
## Summary
- add bounded start/stop lifecycle management for trusted stdio MCP servers
- expose Airlock start/stop routes and UI controls in the MCP panel
- keep launched MCP processes credential-free and shell-free
- stop running Airlock processes during app shutdown

## Security posture
- only trusted registry entries can be started
- only stdio transport is supported; other transports are reported as unsupported
- command execution still uses exec.Command without a shell and minimal environment
- lifecycle status avoids exposing local process IDs
- stop/cleanup is bounded by timeout and best-effort shutdown cleanup

## Tests
- `GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/mcpairlock ./internal/mcp ./cmd/server`
- `GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/api`
- `npm --prefix web test -- --run MCPAirlock api.test.ts`
- `npm --prefix web run build`
- `npm --prefix web run lint` (passes with existing warnings)

Closes #62
Refs #60