### PR TITLE
Fix MCP Airlock Copilot review findings

### DIFF
--- a/internal/mcpairlock/registry.go
+++ b/internal/mcpairlock/registry.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"sort"
@@ -219,7 +220,6 @@ func (m *Manager) passiveStatus(definition ServerDefinition) ServerStatus {
 		State:   "available",
 		Summary: "Command is configured and available. Run a health check before routing an agent to it.",
 		Checks: []Check{
-			{Name: "trusted_registry", Status: "pass", Message: "server is in IaC Studio's trusted MCP Airlock registry"},
 			{Name: "credential_scope", Status: "pass", Message: "Airlock health checks do not forward cloud credentials"},
 		},
 	}
@@ -229,6 +229,7 @@ func (m *Manager) passiveStatus(definition ServerDefinition) ServerStatus {
 		status.Checks = append(status.Checks, Check{Name: "trusted_registry", Status: "error", Message: "definition is not trusted"})
 		return status
 	}
+	status.Checks = append(status.Checks, Check{Name: "trusted_registry", Status: "pass", Message: "server is in IaC Studio's trusted MCP Airlock registry"})
 	if !definition.ReadOnlyDefault {
 		status.Checks = append(status.Checks, Check{Name: "default_mode", Status: "warn", Message: "server is not read-only by default"})
 	} else {
@@ -355,10 +356,27 @@ func validateCommand(command string) error {
 	if command == "" {
 		return errors.New("command is required")
 	}
-	if strings.ContainsAny(command, "\x00\r\n\t|&;<>`$") || strings.Contains(command, " ") {
-		return fmt.Errorf("command %q must be a single executable name or absolute path without shell metacharacters", command)
+	if strings.ContainsAny(command, "\x00\r\n\t|&;<>`$") {
+		return fmt.Errorf("command %q must not contain control characters or shell metacharacters", command)
+	}
+	if strings.Contains(command, " ") && !isAbsoluteCommandPath(command) {
+		return fmt.Errorf("command %q contains spaces; use an absolute executable path or put arguments in IAC_STUDIO_MCP_*_ARGS", command)
 	}
 	return nil
+}
+
+func isAbsoluteCommandPath(command string) bool {
+	if filepath.IsAbs(command) {
+		return true
+	}
+	if len(command) >= 3 && isASCIIAlpha(command[0]) && command[1] == ':' && (command[2] == '\\' || command[2] == '/') {
+		return true
+	}
+	return strings.HasPrefix(command, `\\`)
+}
+
+func isASCIIAlpha(char byte) bool {
+	return (char >= 'A' && char <= 'Z') || (char >= 'a' && char <= 'z')
 }
 
 func defaultProbe(ctx context.Context, command string, args []string, timeout time.Duration) ProbeResult {

--- a/internal/mcpairlock/registry_test.go
+++ b/internal/mcpairlock/registry_test.go
@@ -83,6 +83,62 @@ func TestCheckRejectsShellCommandConfiguration(t *testing.T) {
 	}
 }
 
+func TestListReportsSingleTrustVerdictForUntrustedDefinitions(t *testing.T) {
+	manager := NewManager(t.TempDir(), WithDefinitions([]ServerDefinition{{
+		ID:              "untrusted",
+		Name:            "Untrusted",
+		Command:         testExecutable(t),
+		Trusted:         false,
+		ReadOnlyDefault: true,
+		CredentialMode:  "none",
+	}}))
+
+	statuses := manager.List(context.Background())
+
+	if len(statuses) != 1 {
+		t.Fatalf("expected one status, got %+v", statuses)
+	}
+	status := statuses[0]
+	if status.State != "blocked" {
+		t.Fatalf("expected blocked status, got %+v", status)
+	}
+	trustChecks := 0
+	for _, check := range status.Checks {
+		if check.Name != "trusted_registry" {
+			continue
+		}
+		trustChecks++
+		if check.Status != "error" {
+			t.Fatalf("expected trusted_registry error check, got %+v", check)
+		}
+	}
+	if trustChecks != 1 {
+		t.Fatalf("expected one trusted_registry check, got %d in %+v", trustChecks, status.Checks)
+	}
+}
+
+func TestValidateCommandAllowsAbsolutePathsWithSpaces(t *testing.T) {
+	commands := []string{
+		"/Applications/Hashi Corp/terraform-mcp-server",
+		`C:\Program Files\Terraform MCP\terraform-mcp-server.exe`,
+		`\\server\Terraform MCP\terraform-mcp-server.exe`,
+	}
+
+	for _, command := range commands {
+		if err := validateCommand(command); err != nil {
+			t.Fatalf("validateCommand(%q): %v", command, err)
+		}
+	}
+}
+
+func TestValidateCommandRejectsRelativeCommandsWithSpaces(t *testing.T) {
+	command := "terraform mcp server"
+
+	if err := validateCommand(command); err == nil {
+		t.Fatalf("expected relative command with spaces to be rejected")
+	}
+}
+
 func TestCheckRedactsProbeOutput(t *testing.T) {
 	manager := NewManager(t.TempDir(),
 		WithDefinitions([]ServerDefinition{{


### PR DESCRIPTION
## Summary
- emit a single trusted_registry verdict for untrusted MCP Airlock definitions
- allow shell-free absolute executable paths with spaces while continuing to block control characters and shell metacharacters
- add regression coverage for both Copilot review findings from PR #69

## Tests
- `GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/mcpairlock`
- `GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/mcp`
- `GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/api`

Refs #60
Refs #69

@copilot please review this follow-up for the PR #69 Airlock findings.