### PR TITLE
Fix MCP Airlock lifecycle race reviews

### DIFF
--- a/internal/mcpairlock/lifecycle.go
+++ b/internal/mcpairlock/lifecycle.go
@@ -23,9 +23,11 @@ type ProcessHandle interface {
 type LauncherFunc func(ctx context.Context, definition ServerDefinition, timeout time.Duration) (ProcessHandle, error)
 
 type lifecycleStore struct {
-	mu      sync.Mutex
-	running map[string]*processRecord
-	exits   map[string]exitRecord
+	mu       sync.Mutex
+	starting map[string]time.Time
+	running  map[string]*processRecord
+	stopping map[string]*processRecord
+	exits    map[string]exitRecord
 }
 
 type processRecord struct {
@@ -40,8 +42,10 @@ type exitRecord struct {
 
 func newLifecycleStore() *lifecycleStore {
 	return &lifecycleStore{
-		running: make(map[string]*processRecord),
-		exits:   make(map[string]exitRecord),
+		starting: make(map[string]time.Time),
+		running:  make(map[string]*processRecord),
+		stopping: make(map[string]*processRecord),
+		exits:    make(map[string]exitRecord),
 	}
 }
 
@@ -68,15 +72,32 @@ func (m *Manager) Start(ctx context.Context, id string) (ServerStatus, error) {
 
 	now := time.Now().UTC()
 	m.lifecycle.mu.Lock()
-	defer m.lifecycle.mu.Unlock()
 	m.reapLocked(id, now)
+	if startedAt, ok := m.lifecycle.starting[id]; ok {
+		status = m.withStartingStatusLocked(status, startedAt)
+		status.Checks = append(status.Checks, Check{Name: "lifecycle", Status: "warn", Message: "server launch is already in progress"})
+		m.lifecycle.mu.Unlock()
+		return status, nil
+	}
 	if record, ok := m.lifecycle.running[id]; ok {
 		status = m.withLifecycleStatusLocked(status, record)
 		status.Checks = append(status.Checks, Check{Name: "lifecycle", Status: "pass", Message: "server is already running"})
+		m.lifecycle.mu.Unlock()
 		return status, nil
 	}
+	if record, ok := m.lifecycle.stopping[id]; ok {
+		status = m.withStoppingStatusLocked(status, record)
+		status.Checks = append(status.Checks, Check{Name: "lifecycle", Status: "warn", Message: "server stop is in progress"})
+		m.lifecycle.mu.Unlock()
+		return status, nil
+	}
+	m.lifecycle.starting[id] = now
+	m.lifecycle.mu.Unlock()
 
 	handle, err := m.launcher(ctx, definition, m.timeout)
+	m.lifecycle.mu.Lock()
+	defer m.lifecycle.mu.Unlock()
+	delete(m.lifecycle.starting, id)
 	if err != nil {
 		status.State = "launch_failed"
 		status.Summary = "Airlock could not start the MCP server process."
@@ -103,6 +124,18 @@ func (m *Manager) Stop(ctx context.Context, id string) (ServerStatus, error) {
 
 	m.lifecycle.mu.Lock()
 	m.reapLocked(id, now)
+	if record, ok := m.lifecycle.stopping[id]; ok {
+		status = m.withStoppingStatusLocked(status, record)
+		status.Checks = append(status.Checks, Check{Name: "lifecycle", Status: "warn", Message: "server stop is already in progress"})
+		m.lifecycle.mu.Unlock()
+		return status, nil
+	}
+	if startedAt, ok := m.lifecycle.starting[id]; ok {
+		status = m.withStartingStatusLocked(status, startedAt)
+		status.Checks = append(status.Checks, Check{Name: "lifecycle", Status: "warn", Message: "server is still starting"})
+		m.lifecycle.mu.Unlock()
+		return status, nil
+	}
 	record, ok := m.lifecycle.running[id]
 	if !ok {
 		status = m.withLifecycleStatusLocked(status, nil)
@@ -110,13 +143,16 @@ func (m *Manager) Stop(ctx context.Context, id string) (ServerStatus, error) {
 		m.lifecycle.mu.Unlock()
 		return status, nil
 	}
+	delete(m.lifecycle.running, id)
+	m.lifecycle.stopping[id] = record
 	m.lifecycle.mu.Unlock()
 
 	stopCtx, cancel := context.WithTimeout(ctx, m.timeout)
 	defer cancel()
 	if err := record.handle.Stop(stopCtx); err != nil {
 		m.lifecycle.mu.Lock()
-		status = m.withLifecycleStatusLocked(status, record)
+		delete(m.lifecycle.stopping, id)
+		status = m.restoreAfterStopFailureLocked(status, id, record)
 		status.State = "stop_failed"
 		status.Summary = "Airlock could not stop the MCP server process before the timeout."
 		status.Checks = append(status.Checks, Check{Name: "lifecycle", Status: "error", Message: redactOutput(err.Error())})
@@ -125,11 +161,13 @@ func (m *Manager) Stop(ctx context.Context, id string) (ServerStatus, error) {
 	}
 
 	m.lifecycle.mu.Lock()
-	delete(m.lifecycle.running, id)
-	m.lifecycle.exits[id] = exitRecord{at: time.Now().UTC(), reason: "stopped by user"}
-	status = m.withLifecycleStatusLocked(status, nil)
+	delete(m.lifecycle.stopping, id)
+	exit := exitRecord{at: time.Now().UTC(), reason: "stopped by user"}
+	m.lifecycle.exits[id] = exit
 	status.State = "stopped"
 	status.Summary = "MCP server process stopped."
+	status.LastExitAt = exit.at.Format(time.RFC3339)
+	status.LastExitReason = exit.reason
 	status.Checks = append(status.Checks, Check{Name: "lifecycle", Status: "pass", Message: "server process stopped"})
 	m.lifecycle.mu.Unlock()
 	return status, nil
@@ -181,6 +219,12 @@ func (m *Manager) withLifecycleStatusLocked(status ServerStatus, record *process
 		status.Checks = append(status.Checks, Check{Name: "lifecycle", Status: "pass", Message: "server process is running"})
 		return status
 	}
+	if startedAt, ok := m.lifecycle.starting[status.Server.ID]; ok {
+		return m.withStartingStatusLocked(status, startedAt)
+	}
+	if record, ok := m.lifecycle.stopping[status.Server.ID]; ok {
+		return m.withStoppingStatusLocked(status, record)
+	}
 	if exit, ok := m.lifecycle.exits[status.Server.ID]; ok {
 		status.LastExitAt = exit.at.Format(time.RFC3339)
 		status.LastExitReason = exit.reason
@@ -191,6 +235,36 @@ func (m *Manager) withLifecycleStatusLocked(status ServerStatus, record *process
 		}
 	}
 	return status
+}
+
+func (m *Manager) withStartingStatusLocked(status ServerStatus, startedAt time.Time) ServerStatus {
+	status.State = "starting"
+	status.StartedAt = startedAt.Format(time.RFC3339)
+	status.Summary = "MCP server process is starting with cloud credentials withheld."
+	status.Checks = append(status.Checks, Check{Name: "lifecycle", Status: "warn", Message: "server process is starting"})
+	return status
+}
+
+func (m *Manager) withStoppingStatusLocked(status ServerStatus, record *processRecord) ServerStatus {
+	status.State = "stopping"
+	status.StartedAt = record.startedAt.Format(time.RFC3339)
+	status.Summary = "MCP server process is stopping."
+	status.Checks = append(status.Checks, Check{Name: "lifecycle", Status: "warn", Message: "server stop is in progress"})
+	return status
+}
+
+func (m *Manager) restoreAfterStopFailureLocked(status ServerStatus, id string, record *processRecord) ServerStatus {
+	select {
+	case err := <-record.handle.Done():
+		exit := exitRecord{at: time.Now().UTC(), reason: exitReason(err)}
+		m.lifecycle.exits[id] = exit
+		status.LastExitAt = exit.at.Format(time.RFC3339)
+		status.LastExitReason = exit.reason
+		return status
+	default:
+		m.lifecycle.running[id] = record
+		return m.withLifecycleStatusLocked(status, record)
+	}
 }
 
 func (m *Manager) reapLocked(id string, now time.Time) {

--- a/internal/mcpairlock/registry_test.go
+++ b/internal/mcpairlock/registry_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"os"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -223,6 +225,111 @@ func TestStartStopLifecycleUsesLauncherAndReportsRunning(t *testing.T) {
 	if status.Running || status.State != "stopped" || !handle.stopped {
 		t.Fatalf("expected stopped status, got status=%+v stopped=%v", status, handle.stopped)
 	}
+	if status.LastExitReason != "stopped by user" {
+		t.Fatalf("expected user stop exit reason, got %+v", status)
+	}
+	for _, check := range status.Checks {
+		if check.Name == "lifecycle" && check.Status == "warn" {
+			t.Fatalf("successful stop returned lifecycle warning: %+v", status.Checks)
+		}
+	}
+}
+
+func TestStartDoesNotBlockLifecycleStatusDuringLaunch(t *testing.T) {
+	launcherEntered := make(chan struct{})
+	releaseLauncher := make(chan struct{})
+	manager := NewManager(t.TempDir(),
+		WithDefinitions([]ServerDefinition{{
+			ID:              "terraform",
+			Name:            "Terraform",
+			Command:         testExecutable(t),
+			Transport:       "stdio",
+			Trusted:         true,
+			ReadOnlyDefault: true,
+			CredentialMode:  "none",
+		}}),
+		WithLauncher(func(context.Context, ServerDefinition, time.Duration) (ProcessHandle, error) {
+			close(launcherEntered)
+			<-releaseLauncher
+			return newFakeProcess(), nil
+		}),
+	)
+
+	startDone := make(chan error, 1)
+	go func() {
+		_, err := manager.Start(context.Background(), "terraform")
+		startDone <- err
+	}()
+	<-launcherEntered
+
+	statusesDone := make(chan []ServerStatus, 1)
+	go func() {
+		statusesDone <- manager.List(context.Background())
+	}()
+
+	select {
+	case statuses := <-statusesDone:
+		if len(statuses) != 1 || statuses[0].State != "starting" {
+			t.Fatalf("expected starting status during launch, got %+v", statuses)
+		}
+	case <-time.After(250 * time.Millisecond):
+		close(releaseLauncher)
+		t.Fatalf("List blocked behind Start launcher")
+	}
+
+	close(releaseLauncher)
+	if err := <-startDone; err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+}
+
+func TestConcurrentStopClaimsProcessOnce(t *testing.T) {
+	handle := newBlockingStopProcess()
+	manager := NewManager(t.TempDir(),
+		WithDefinitions([]ServerDefinition{{
+			ID:              "terraform",
+			Name:            "Terraform",
+			Command:         testExecutable(t),
+			Transport:       "stdio",
+			Trusted:         true,
+			ReadOnlyDefault: true,
+			CredentialMode:  "none",
+		}}),
+		WithLauncher(func(context.Context, ServerDefinition, time.Duration) (ProcessHandle, error) {
+			return handle, nil
+		}),
+	)
+
+	if _, err := manager.Start(context.Background(), "terraform"); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	firstStopDone := make(chan ServerStatus, 1)
+	go func() {
+		status, err := manager.Stop(context.Background(), "terraform")
+		if err != nil {
+			t.Errorf("Stop: %v", err)
+		}
+		firstStopDone <- status
+	}()
+	<-handle.stopEntered
+
+	secondStatus, err := manager.Stop(context.Background(), "terraform")
+	if err != nil {
+		t.Fatalf("second Stop: %v", err)
+	}
+	if secondStatus.State != "stopping" {
+		t.Fatalf("expected concurrent stop to report stopping, got %+v", secondStatus)
+	}
+	if calls := handle.stopCalls.Load(); calls != 1 {
+		t.Fatalf("expected one ProcessHandle.Stop call, got %d", calls)
+	}
+
+	close(handle.releaseStop)
+	firstStatus := <-firstStopDone
+	if firstStatus.State != "stopped" || firstStatus.Running {
+		t.Fatalf("expected first stop to complete, got %+v", firstStatus)
+	}
 }
 
 func TestStartRejectsUnsupportedTransportWithoutLaunching(t *testing.T) {
@@ -329,6 +436,45 @@ func (p *fakeProcess) Stop(context.Context) error {
 }
 
 func (p *fakeProcess) exit(err error) {
+	select {
+	case p.done <- err:
+	default:
+	}
+}
+
+type blockingStopProcess struct {
+	done        chan error
+	stopEntered chan struct{}
+	releaseStop chan struct{}
+	stopCalls   atomic.Int32
+	once        sync.Once
+}
+
+func newBlockingStopProcess() *blockingStopProcess {
+	return &blockingStopProcess{
+		done:        make(chan error, 1),
+		stopEntered: make(chan struct{}),
+		releaseStop: make(chan struct{}),
+	}
+}
+
+func (p *blockingStopProcess) Done() <-chan error {
+	return p.done
+}
+
+func (p *blockingStopProcess) Stop(ctx context.Context) error {
+	p.stopCalls.Add(1)
+	p.once.Do(func() { close(p.stopEntered) })
+	select {
+	case <-p.releaseStop:
+		p.exit(nil)
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (p *blockingStopProcess) exit(err error) {
 	select {
 	case p.done <- err:
 	default:


### PR DESCRIPTION
## Summary
- avoid holding the Airlock lifecycle mutex while an MCP server launcher performs external process work
- claim stop operations before calling ProcessHandle.Stop so concurrent stops cannot target the same handle twice
- return clean successful stop status without a misleading lifecycle warning
- add regression tests for launch status responsiveness, concurrent stop claiming, and clean stop responses

## Tests
- `GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/mcpairlock`
- `GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/mcp ./cmd/server`
- `GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/api`

Refs #60
Refs #70

@copilot please review this follow-up for the PR #70 Airlock lifecycle findings.