### PR TITLE
Harden local web trust boundary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,4 +54,4 @@ ENV IAC_STUDIO_PROJECTS_DIR=/projects
 EXPOSE 3000
 
 ENTRYPOINT ["/app/iac-studio"]
-CMD ["--host", "0.0.0.0", "--port", "3000", "--projects-dir", "/projects"]
+CMD ["--host", "127.0.0.1", "--port", "3000", "--projects-dir", "/projects"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     environment:
       - IAC_STUDIO_AI_ENDPOINT=http://ollama:11434
       - IAC_STUDIO_AI_MODEL=deepseek-coder:6.7b
+    command: ["--host", "0.0.0.0", "--port", "3000", "--projects-dir", "/projects"]
     depends_on:
       - ollama
     restart: unless-stopped

--- a/docs/index.html
+++ b/docs/index.html
@@ -223,9 +223,10 @@ iac-studio</code></pre>
           <h3>Run with Docker</h3>
           <p>The container includes the server, built web UI, Terraform, and OpenTofu.</p>
           <pre><code>docker run --rm -it \
-  -p 3000:3000 \
+  -p 127.0.0.1:3000:3000 \
   -v "$HOME/iac-projects:/projects" \
-  ghcr.io/olandodeflexy/iacstudio:latest</code></pre>
+  ghcr.io/olandodeflexy/iacstudio:latest \
+  --host 0.0.0.0 --port 3000 --projects-dir /projects</code></pre>
 
           <div class="callout">
             <strong>Default server behavior:</strong>
@@ -814,11 +815,11 @@ ANTHROPIC_MODEL=claude-opus-4-7 \
           <div class="feature-grid compact">
             <article>
               <h3>Local binding</h3>
-              <p>The default server binds to <code>127.0.0.1</code>. Docker uses <code>0.0.0.0</code> inside the container so the host port can map correctly.</p>
+              <p>The default server binds to <code>127.0.0.1</code>. Docker examples explicitly use <code>0.0.0.0</code> inside the container only with a host port pinned to <code>127.0.0.1</code>.</p>
             </article>
             <article>
               <h3>Origin checks</h3>
-              <p>CORS and WebSocket origin validation are intended to accept localhost development and app origins only.</p>
+              <p>CORS and WebSocket origin validation accept localhost development and app origins only; disallowed browser origins are rejected before API handlers run.</p>
             </article>
             <article>
               <h3>Path sandboxing</h3>

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2827,32 +2827,41 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 }
 
 // allowedOrigins is populated at startup from the server's actual bind address.
-var allowedOrigins = map[string]bool{}
+var allowedOrigins = struct {
+	mu   sync.RWMutex
+	list map[string]bool
+}{list: map[string]bool{}}
 
 // InitAllowedOrigins builds the origin allowlist from the server's host and port.
 // Called once at startup so the list matches the actual deployment.
 func InitAllowedOrigins(host string, port int) {
 	serverPort := fmt.Sprintf("%d", port)
 	isWildcardBind := host == "0.0.0.0" || host == "::" || host == ""
-	allowedOrigins = map[string]bool{}
+	origins := map[string]bool{}
 
 	// Always allow localhost variants
 	for _, h := range []string{"localhost", "127.0.0.1"} {
-		allowedOrigins["http://"+h+":"+serverPort] = true
+		origins["http://"+h+":"+serverPort] = true
 	}
 	// If binding a specific host, allow that too
 	if !isWildcardBind {
-		allowedOrigins["http://"+host+":"+serverPort] = true
+		origins["http://"+host+":"+serverPort] = true
 	}
 	// Also allow the Vite dev server (port 5173) for development
 	for _, h := range []string{"localhost", "127.0.0.1"} {
-		allowedOrigins["http://"+h+":5173"] = true
+		origins["http://"+h+":5173"] = true
 	}
+
+	allowedOrigins.mu.Lock()
+	allowedOrigins.list = origins
+	allowedOrigins.mu.Unlock()
 }
 
 // IsAllowedOrigin checks whether an origin is in the allowlist.
 func IsAllowedOrigin(origin string) bool {
-	return allowedOrigins[origin]
+	allowedOrigins.mu.RLock()
+	defer allowedOrigins.mu.RUnlock()
+	return allowedOrigins.list[origin]
 }
 
 // CORS restricts cross-origin requests to the localhost allowlist.

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2829,17 +2829,12 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 // allowedOrigins is populated at startup from the server's actual bind address.
 var allowedOrigins = map[string]bool{}
 
-// serverPort stores the configured port for same-origin checks.
-var serverPort string
-
-// isWildcardBind is true when the server binds to 0.0.0.0 or [::].
-var isWildcardBind bool
-
 // InitAllowedOrigins builds the origin allowlist from the server's host and port.
 // Called once at startup so the list matches the actual deployment.
 func InitAllowedOrigins(host string, port int) {
-	serverPort = fmt.Sprintf("%d", port)
-	isWildcardBind = host == "0.0.0.0" || host == "::" || host == ""
+	serverPort := fmt.Sprintf("%d", port)
+	isWildcardBind := host == "0.0.0.0" || host == "::" || host == ""
+	allowedOrigins = map[string]bool{}
 
 	// Always allow localhost variants
 	for _, h := range []string{"localhost", "127.0.0.1"} {
@@ -2856,29 +2851,23 @@ func InitAllowedOrigins(host string, port int) {
 }
 
 // IsAllowedOrigin checks whether an origin is in the allowlist.
-// When the server binds to 0.0.0.0, browsers send the LAN IP as the origin
-// (e.g. http://192.168.1.5:3000). We can't predict all LAN IPs at startup,
-// so for wildcard binds we also accept any origin whose port matches the
-// configured server port — the same trust level as listening on all interfaces.
 func IsAllowedOrigin(origin string) bool {
-	if allowedOrigins[origin] {
-		return true
-	}
-	if isWildcardBind && strings.HasPrefix(origin, "http://") && strings.HasSuffix(origin, ":"+serverPort) {
-		return true
-	}
-	return false
+	return allowedOrigins[origin]
 }
 
 // CORS restricts cross-origin requests to the localhost allowlist.
 func CORS(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		origin := r.Header.Get("Origin")
-		if origin != "" && IsAllowedOrigin(origin) {
+		if origin != "" {
+			w.Header().Set("Vary", "Origin")
+			if !IsAllowedOrigin(origin) {
+				http.Error(w, "origin not allowed", http.StatusForbidden)
+				return
+			}
 			w.Header().Set("Access-Control-Allow-Origin", origin)
 			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
 			w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
-			w.Header().Set("Vary", "Origin")
 		}
 		if r.Method == "OPTIONS" {
 			w.WriteHeader(http.StatusOK)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
@@ -2841,20 +2842,25 @@ func InitAllowedOrigins(host string, port int) {
 
 	// Always allow localhost variants
 	for _, h := range []string{"localhost", "127.0.0.1"} {
-		origins["http://"+h+":"+serverPort] = true
+		origins[localHTTPOrigin(h, serverPort)] = true
 	}
 	// If binding a specific host, allow that too
 	if !isWildcardBind {
-		origins["http://"+host+":"+serverPort] = true
+		origins[localHTTPOrigin(host, serverPort)] = true
 	}
 	// Also allow the Vite dev server (port 5173) for development
 	for _, h := range []string{"localhost", "127.0.0.1"} {
-		origins["http://"+h+":5173"] = true
+		origins[localHTTPOrigin(h, "5173")] = true
 	}
 
 	allowedOrigins.mu.Lock()
 	allowedOrigins.list = origins
 	allowedOrigins.mu.Unlock()
+}
+
+func localHTTPOrigin(host, port string) string {
+	host = strings.TrimPrefix(strings.TrimSuffix(host, "]"), "[")
+	return "http://" + net.JoinHostPort(host, port)
 }
 
 // IsAllowedOrigin checks whether an origin is in the allowlist.

--- a/internal/api/router_security_test.go
+++ b/internal/api/router_security_test.go
@@ -47,6 +47,79 @@ func assertResponseBodyContains(t *testing.T, resp *http.Response, want ...strin
 	}
 }
 
+func TestCORSRejectsDisallowedOriginBeforeHandler(t *testing.T) {
+	InitAllowedOrigins("127.0.0.1", 3000)
+	t.Cleanup(func() { InitAllowedOrigins("127.0.0.1", 3000) })
+	called := false
+	handler := CORS(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	req := httptest.NewRequest(http.MethodPost, "/api/projects/demo/sync", strings.NewReader(`{"resources":[]}`))
+	req.Header.Set("Origin", "http://attacker.example")
+	req.Header.Set("Content-Type", "text/plain")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected disallowed origin to be rejected with 403, got %d", rec.Code)
+	}
+	if called {
+		t.Fatal("disallowed origin reached wrapped handler")
+	}
+}
+
+func TestCORSAllowsConfiguredLocalhostOrigin(t *testing.T) {
+	InitAllowedOrigins("127.0.0.1", 3000)
+	t.Cleanup(func() { InitAllowedOrigins("127.0.0.1", 3000) })
+	handler := CORS(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	req := httptest.NewRequest(http.MethodPost, "/api/projects/demo/sync", strings.NewReader(`{"resources":[]}`))
+	req.Header.Set("Origin", "http://localhost:3000")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected allowed origin through handler, got %d", rec.Code)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "http://localhost:3000" {
+		t.Fatalf("expected CORS allow header for localhost, got %q", got)
+	}
+}
+
+func TestCORSRejectsDisallowedPreflight(t *testing.T) {
+	InitAllowedOrigins("127.0.0.1", 3000)
+	t.Cleanup(func() { InitAllowedOrigins("127.0.0.1", 3000) })
+	handler := CORS(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	req := httptest.NewRequest(http.MethodOptions, "/api/projects/demo/run", nil)
+	req.Header.Set("Origin", "http://attacker.example")
+	req.Header.Set("Access-Control-Request-Method", "POST")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected disallowed preflight to be rejected with 403, got %d", rec.Code)
+	}
+}
+
+func TestWildcardBindDoesNotAllowArbitrarySamePortOrigin(t *testing.T) {
+	InitAllowedOrigins("0.0.0.0", 3000)
+	t.Cleanup(func() { InitAllowedOrigins("127.0.0.1", 3000) })
+
+	if IsAllowedOrigin("http://192.168.1.25:3000") {
+		t.Fatal("wildcard bind should not trust arbitrary LAN origins")
+	}
+	if !IsAllowedOrigin("http://localhost:3000") || !IsAllowedOrigin("http://127.0.0.1:3000") {
+		t.Fatal("wildcard bind should still allow localhost browser origins")
+	}
+}
+
 func TestStateRoutesRejectTraversalProjectName(t *testing.T) {
 	root := t.TempDir()
 	srv := httptest.NewServer(fullRouterForTest(t, root))
@@ -322,8 +395,8 @@ func TestSafeReviewArtifactPathEnforcesPrefix(t *testing.T) {
 		"../escape",
 		".iac-studio/snapshots/foo.json",
 		".iac-studio/remediations",        // directory itself, no trailing slash
-		".iac-studio/rollbacks",            // directory itself, no trailing slash
-		".iac-studio/remediations_evil/x",  // adjacent directory, not the allowed one
+		".iac-studio/rollbacks",           // directory itself, no trailing slash
+		".iac-studio/remediations_evil/x", // adjacent directory, not the allowed one
 		".iac-studio/remediations/foo/../../outside",
 		".iac-studio/rollbacks/foo/../../../etc/passwd",
 		"/absolute/path",

--- a/internal/api/router_security_test.go
+++ b/internal/api/router_security_test.go
@@ -120,6 +120,18 @@ func TestWildcardBindDoesNotAllowArbitrarySamePortOrigin(t *testing.T) {
 	}
 }
 
+func TestInitAllowedOriginsFormatsIPv6LoopbackOrigin(t *testing.T) {
+	InitAllowedOrigins("::1", 3000)
+	t.Cleanup(func() { InitAllowedOrigins("127.0.0.1", 3000) })
+
+	if !IsAllowedOrigin("http://[::1]:3000") {
+		t.Fatal("IPv6 loopback bind should allow bracketed browser origin")
+	}
+	if IsAllowedOrigin("http://::1:3000") {
+		t.Fatal("IPv6 origins should not use unbracketed host syntax")
+	}
+}
+
 func TestStateRoutesRejectTraversalProjectName(t *testing.T) {
 	root := t.TempDir()
 	srv := httptest.NewServer(fullRouterForTest(t, root))


### PR DESCRIPTION
## Summary
- reject disallowed browser origins before API handlers run, closing the CORS simple-request bypass
- remove wildcard-bind trust for arbitrary same-port LAN origins
- guard the origin allowlist with a `sync.RWMutex` to prevent data races on concurrent reads during WebSocket upgrades and HTTP requests
- fix IPv6 origin formatting by replacing manual concatenation with `net.JoinHostPort` via a `localHTTPOrigin` helper, so browsers on IPv6 loopback (`http://[::1]:3000`) are correctly allowed
- make the Docker image default local-only and require explicit container-internal wildcard binding in Docker examples
- keep Docker host port publishing pinned to 127.0.0.1 in docs and compose
- add regression tests for blocked origins, preflight rejection, allowed localhost origins, wildcard-bind origin behavior, and IPv6 loopback origin formatting

## Security notes
- Requests without an Origin header still work for same-origin and non-browser local clients.
- Docker users can still run the app through published ports, but the documented command explicitly pairs `--host 0.0.0.0` inside the container with `-p 127.0.0.1:3000:3000` on the host.

## Tests
- `GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/api`
- `GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/runner ./internal/mcp ./cmd/server`
- `GOCACHE=/private/tmp/iacstudio-go-cache go test ./...`

Refs CODE_REVIEW.md findings #1 and #2.