### PR TITLE
Isolate Cloud Connection command environments

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1480,8 +1480,10 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 		}
 
 		var commandEnv map[string]string
+		scopedConnection := false
 		var connectionSummary cloudconnections.PublicConnection
 		if req.ConnectionID != "" {
+			scopedConnection = true
 			connection, connErr := cloudConnections.Get(req.ConnectionID)
 			if connErr != nil {
 				if errors.Is(connErr, os.ErrNotExist) {
@@ -1586,7 +1588,13 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 		// a request-scoped context and kill the command. SafeRunner applies its
 		// own per-command timeout (init=5m, plan=10m, apply=30m).
 		go func() {
-			result, err := run.ExecuteWithEnv(context.Background(), runPath, effectiveTool, req.Command, req.Env, commandEnv)
+			var result *runner.ExecutionResult
+			var err error
+			if scopedConnection {
+				result, err = run.ExecuteWithScopedEnv(context.Background(), runPath, effectiveTool, req.Command, req.Env, commandEnv)
+			} else {
+				result, err = run.ExecuteWithEnv(context.Background(), runPath, effectiveTool, req.Command, req.Env, commandEnv)
+			}
 			var classification *iacplan.ClassificationResult
 			var snapshot *recovery.StateSnapshot
 			var snapshotErr error
@@ -1598,7 +1606,13 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 			// independently.
 			if err == nil && commandProducesPlan(req.Command) {
 				if planSupportsSemanticClassification(effectiveTool) {
-					exported, exportErr := run.ExportSavedPlanJSON(context.Background(), runPath, effectiveTool, commandEnv)
+					var exported *runner.ExecutionResult
+					var exportErr error
+					if scopedConnection {
+						exported, exportErr = run.ExportSavedPlanJSONWithScopedEnv(context.Background(), runPath, effectiveTool, commandEnv)
+					} else {
+						exported, exportErr = run.ExportSavedPlanJSON(context.Background(), runPath, effectiveTool, commandEnv)
+					}
 					if exportErr != nil {
 						classification = iacplan.UnknownClassification("saved plan JSON export failed; rerun plan before applying")
 						_ = os.Remove(filepath.Join(runPath, savedPlanJSONFile))

--- a/internal/mcp/service.go
+++ b/internal/mcp/service.go
@@ -206,7 +206,13 @@ func (s *Server) handleGeneratePlan(ctx context.Context, raw json.RawMessage) to
 	if err != nil {
 		return errResponse("generate_plan", err, projectAudit("generate_plan", args))
 	}
-	result, runErr := s.run.ExecuteWithEnv(ctx, projectCtx.WorkDir, projectCtx.Tool, "plan", projectCtx.Env, env)
+	var result *runner.ExecutionResult
+	var runErr error
+	if strings.TrimSpace(args.ConnectionID) != "" {
+		result, runErr = s.run.ExecuteWithScopedEnv(ctx, projectCtx.WorkDir, projectCtx.Tool, "plan", projectCtx.Env, env)
+	} else {
+		result, runErr = s.run.ExecuteWithEnv(ctx, projectCtx.WorkDir, projectCtx.Tool, "plan", projectCtx.Env, env)
+	}
 	sanitized := sanitizeExecutionResult(result, env)
 	payload := map[string]any{
 		"project":    projectCtx.Name,

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -342,6 +342,49 @@ func TestScopedCommandEnvBlocksAWSSharedFileFallbackWithoutCompleteAWSCredential
 	}
 }
 
+func TestScopedCommandEnvIgnoresEmptyAWSCredentialSources(t *testing.T) {
+	got := envValues(scopedCommandEnv(
+		[]string{
+			"PATH=/usr/bin",
+			"HOME=/home/alice",
+		},
+		map[string]string{
+			"AWS_PROFILE":                            "",
+			"AWS_ACCESS_KEY_ID":                      "",
+			"AWS_SECRET_ACCESS_KEY":                  "",
+			"AWS_ROLE_ARN":                           "",
+			"AWS_WEB_IDENTITY_TOKEN_FILE":            "",
+			"AWS_SHARED_CREDENTIALS_FILE":            "",
+			"AWS_CONFIG_FILE":                        "",
+			"AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": "",
+			"AWS_CONTAINER_CREDENTIALS_FULL_URI":     "",
+		},
+	))
+
+	if got["AWS_SHARED_CREDENTIALS_FILE"] != os.DevNull || got["AWS_CONFIG_FILE"] != os.DevNull {
+		t.Fatalf("empty AWS credential sources should not reopen shared file fallback: %#v", got)
+	}
+}
+
+func TestScopedCommandEnvForcesMetadataDisabledWhenEmpty(t *testing.T) {
+	env := scopedCommandEnv(
+		[]string{
+			"PATH=/usr/bin",
+		},
+		map[string]string{
+			"AWS_EC2_METADATA_DISABLED": "",
+		},
+	)
+	got := envValues(env)
+
+	if got["AWS_EC2_METADATA_DISABLED"] != "true" {
+		t.Fatalf("empty AWS_EC2_METADATA_DISABLED should be forced to true: %#v", got)
+	}
+	if countEnvKey(env, "AWS_EC2_METADATA_DISABLED") != 1 {
+		t.Fatalf("AWS_EC2_METADATA_DISABLED should be updated in place, got env: %#v", env)
+	}
+}
+
 func TestScopedCommandEnvPreservesWindowsExecutableLookup(t *testing.T) {
 	got := envValues(scopedCommandEnv(
 		[]string{
@@ -474,4 +517,15 @@ func envValues(entries []string) map[string]string {
 		}
 	}
 	return values
+}
+
+func countEnvKey(entries []string, want string) int {
+	count := 0
+	for _, entry := range entries {
+		key, _, ok := strings.Cut(entry, "=")
+		if ok && key == want {
+			count++
+		}
+	}
+	return count
 }

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"os"
 	"strings"
 	"testing"
 )
@@ -284,6 +285,60 @@ func TestScopedCommandEnvDropsAmbientCloudCredentials(t *testing.T) {
 		if _, ok := got[key]; ok {
 			t.Fatalf("scoped env leaked ambient %s: %#v", key, got)
 		}
+	}
+}
+
+func TestScopedCommandEnvBlocksAWSSharedFileFallbackForNonAWSConnection(t *testing.T) {
+	got := envValues(scopedCommandEnv(
+		[]string{
+			"PATH=/usr/bin",
+			"HOME=/home/alice",
+			"USERPROFILE=C:\\Users\\Alice",
+			"AWS_PROFILE=ambient-admin",
+			"AWS_SHARED_CREDENTIALS_FILE=/home/alice/.aws/credentials",
+			"AWS_CONFIG_FILE=/home/alice/.aws/config",
+		},
+		map[string]string{
+			"ARM_CLIENT_ID":       "selected-client",
+			"ARM_CLIENT_SECRET":   "selected-secret",
+			"ARM_TENANT_ID":       "selected-tenant",
+			"ARM_SUBSCRIPTION_ID": "selected-subscription",
+		},
+	))
+
+	if got["HOME"] != "/home/alice" || got["USERPROFILE"] != "C:\\Users\\Alice" {
+		t.Fatalf("home env should remain available for tool runtime context: %#v", got)
+	}
+	if got["ARM_CLIENT_SECRET"] != "selected-secret" || got["ARM_CLIENT_ID"] != "selected-client" {
+		t.Fatalf("selected Azure credentials should be present: %#v", got)
+	}
+	if got["AWS_SHARED_CREDENTIALS_FILE"] != os.DevNull || got["AWS_CONFIG_FILE"] != os.DevNull {
+		t.Fatalf("non-AWS scoped runs should block AWS shared file fallback: %#v", got)
+	}
+	if got["AWS_PROFILE"] == "ambient-admin" {
+		t.Fatalf("non-AWS scoped run leaked ambient AWS_PROFILE: %#v", got)
+	}
+}
+
+func TestScopedCommandEnvBlocksAWSSharedFileFallbackWithoutCompleteAWSCredentials(t *testing.T) {
+	got := envValues(scopedCommandEnv(
+		[]string{
+			"PATH=/usr/bin",
+			"HOME=/home/alice",
+			"AWS_SHARED_CREDENTIALS_FILE=/home/alice/.aws/credentials",
+			"AWS_CONFIG_FILE=/home/alice/.aws/config",
+		},
+		map[string]string{
+			"AWS_ACCESS_KEY_ID": "selected-key",
+			"AWS_REGION":        "us-east-1",
+		},
+	))
+
+	if got["AWS_ACCESS_KEY_ID"] != "selected-key" || got["AWS_REGION"] != "us-east-1" {
+		t.Fatalf("selected AWS values should be present: %#v", got)
+	}
+	if got["AWS_SHARED_CREDENTIALS_FILE"] != os.DevNull || got["AWS_CONFIG_FILE"] != os.DevNull {
+		t.Fatalf("incomplete AWS scoped runs should block shared file fallback: %#v", got)
 	}
 }
 

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -287,6 +287,34 @@ func TestScopedCommandEnvDropsAmbientCloudCredentials(t *testing.T) {
 	}
 }
 
+func TestScopedCommandEnvPreservesWindowsExecutableLookup(t *testing.T) {
+	got := envValues(scopedCommandEnv(
+		[]string{
+			`Path=C:\Windows\System32;C:\tools`,
+			"PATHEXT=.COM;.EXE;.BAT;.CMD",
+			"SystemRoot=C:\\Windows",
+			"WINDIR=C:\\Windows",
+			"AWS_PROFILE=ambient-admin",
+		},
+		map[string]string{
+			"AWS_PROFILE": "selected-profile",
+		},
+	))
+
+	if got["Path"] != `C:\Windows\System32;C:\tools` {
+		t.Fatalf("Windows Path should be preserved for executable lookup: %#v", got)
+	}
+	if got["PATHEXT"] != ".COM;.EXE;.BAT;.CMD" {
+		t.Fatalf("Windows PATHEXT should be preserved for executable lookup: %#v", got)
+	}
+	if got["SystemRoot"] != "C:\\Windows" || got["WINDIR"] != "C:\\Windows" {
+		t.Fatalf("Windows system roots should be preserved: %#v", got)
+	}
+	if got["AWS_PROFILE"] != "selected-profile" {
+		t.Fatalf("selected connection should override ambient AWS_PROFILE: %#v", got)
+	}
+}
+
 func TestScopedCommandEnvAllowsSelectedProfileWithoutAmbientStaticKeys(t *testing.T) {
 	got := envValues(scopedCommandEnv(
 		[]string{

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -236,3 +236,159 @@ func TestMergeEnvOverridesBase(t *testing.T) {
 		t.Fatalf("empty override value should be preserved: %#v", values)
 	}
 }
+
+func TestScopedCommandEnvDropsAmbientCloudCredentials(t *testing.T) {
+	got := envValues(scopedCommandEnv(
+		[]string{
+			"PATH=/usr/bin",
+			"HOME=/home/alice",
+			"AWS_PROFILE=ambient-admin",
+			"AWS_ACCESS_KEY_ID=ambient-key",
+			"AWS_SECRET_ACCESS_KEY=ambient-secret",
+			"AWS_SESSION_TOKEN=ambient-session",
+			"AWS_EC2_METADATA_DISABLED=false",
+			"ARM_CLIENT_SECRET=ambient-azure-secret",
+			"GOOGLE_APPLICATION_CREDENTIALS=/tmp/ambient-gcp.json",
+			"TFE_TOKEN=ambient-tfe-token",
+			"TF_TOKEN_app_terraform_io=ambient-tf-token",
+			"UNRELATED_SECRET=ambient",
+		},
+		map[string]string{
+			"AWS_ACCESS_KEY_ID":     "selected-key",
+			"AWS_SECRET_ACCESS_KEY": "selected-secret",
+			"AWS_REGION":            "us-east-1",
+		},
+	))
+
+	if got["PATH"] != "/usr/bin" || got["HOME"] != "/home/alice" {
+		t.Fatalf("minimal OS env should be preserved: %#v", got)
+	}
+	if got["AWS_ACCESS_KEY_ID"] != "selected-key" || got["AWS_SECRET_ACCESS_KEY"] != "selected-secret" {
+		t.Fatalf("selected connection credentials should be present: %#v", got)
+	}
+	if got["AWS_REGION"] != "us-east-1" {
+		t.Fatalf("selected connection region should be present: %#v", got)
+	}
+	if got["AWS_EC2_METADATA_DISABLED"] != "true" {
+		t.Fatalf("scoped env should disable AWS metadata fallback: %#v", got)
+	}
+	for _, key := range []string{
+		"AWS_PROFILE",
+		"AWS_SESSION_TOKEN",
+		"ARM_CLIENT_SECRET",
+		"GOOGLE_APPLICATION_CREDENTIALS",
+		"TFE_TOKEN",
+		"TF_TOKEN_app_terraform_io",
+		"UNRELATED_SECRET",
+	} {
+		if _, ok := got[key]; ok {
+			t.Fatalf("scoped env leaked ambient %s: %#v", key, got)
+		}
+	}
+}
+
+func TestScopedCommandEnvAllowsSelectedProfileWithoutAmbientStaticKeys(t *testing.T) {
+	got := envValues(scopedCommandEnv(
+		[]string{
+			"PATH=/usr/bin",
+			"HOME=/home/alice",
+			"AWS_ACCESS_KEY_ID=ambient-key",
+			"AWS_SECRET_ACCESS_KEY=ambient-secret",
+			"AWS_SESSION_TOKEN=ambient-session",
+			"AWS_SHARED_CREDENTIALS_FILE=/tmp/wrong-credentials",
+			"AWS_CONFIG_FILE=/tmp/wrong-config",
+		},
+		map[string]string{
+			"AWS_PROFILE":         "prod-sso",
+			"AWS_SDK_LOAD_CONFIG": "1",
+			"AWS_DEFAULT_REGION":  "eu-west-1",
+		},
+	))
+
+	if got["AWS_PROFILE"] != "prod-sso" || got["AWS_SDK_LOAD_CONFIG"] != "1" {
+		t.Fatalf("selected profile connection should be present: %#v", got)
+	}
+	if got["AWS_DEFAULT_REGION"] != "eu-west-1" {
+		t.Fatalf("selected profile region should be present: %#v", got)
+	}
+	for _, key := range []string{
+		"AWS_ACCESS_KEY_ID",
+		"AWS_SECRET_ACCESS_KEY",
+		"AWS_SESSION_TOKEN",
+		"AWS_SHARED_CREDENTIALS_FILE",
+		"AWS_CONFIG_FILE",
+	} {
+		if _, ok := got[key]; ok {
+			t.Fatalf("selected profile run leaked ambient %s: %#v", key, got)
+		}
+	}
+}
+
+func TestScopedCommandEnvKeepsSelectedProviderOnly(t *testing.T) {
+	got := envValues(scopedCommandEnv(
+		[]string{
+			"PATH=/usr/bin",
+			"AWS_ACCESS_KEY_ID=ambient-key",
+			"ARM_CLIENT_SECRET=ambient-azure-secret",
+			"GOOGLE_CREDENTIALS=ambient-gcp-json",
+			"CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=/tmp/ambient-gcp.json",
+		},
+		map[string]string{
+			"ARM_CLIENT_ID":       "selected-client",
+			"ARM_CLIENT_SECRET":   "selected-secret",
+			"ARM_TENANT_ID":       "selected-tenant",
+			"ARM_SUBSCRIPTION_ID": "selected-subscription",
+		},
+	))
+
+	if got["ARM_CLIENT_SECRET"] != "selected-secret" || got["ARM_CLIENT_ID"] != "selected-client" {
+		t.Fatalf("selected Azure credentials should be present: %#v", got)
+	}
+	for _, key := range []string{
+		"AWS_ACCESS_KEY_ID",
+		"GOOGLE_CREDENTIALS",
+		"CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
+	} {
+		if _, ok := got[key]; ok {
+			t.Fatalf("selected Azure run leaked ambient %s: %#v", key, got)
+		}
+	}
+
+	got = envValues(scopedCommandEnv(
+		[]string{
+			"PATH=/usr/bin",
+			"AWS_ACCESS_KEY_ID=ambient-key",
+			"ARM_CLIENT_SECRET=ambient-azure-secret",
+			"GOOGLE_APPLICATION_CREDENTIALS=/tmp/ambient-gcp.json",
+		},
+		map[string]string{
+			"GOOGLE_CREDENTIALS":    `{"type":"service_account"}`,
+			"GOOGLE_CLOUD_PROJECT":  "selected-project",
+			"CLOUDSDK_CORE_PROJECT": "selected-project",
+		},
+	))
+
+	if got["GOOGLE_CREDENTIALS"] != `{"type":"service_account"}` || got["GOOGLE_CLOUD_PROJECT"] != "selected-project" {
+		t.Fatalf("selected GCP credentials should be present: %#v", got)
+	}
+	for _, key := range []string{
+		"AWS_ACCESS_KEY_ID",
+		"ARM_CLIENT_SECRET",
+		"GOOGLE_APPLICATION_CREDENTIALS",
+	} {
+		if _, ok := got[key]; ok {
+			t.Fatalf("selected GCP run leaked ambient %s: %#v", key, got)
+		}
+	}
+}
+
+func envValues(entries []string) map[string]string {
+	values := map[string]string{}
+	for _, entry := range entries {
+		key, value, ok := strings.Cut(entry, "=")
+		if ok {
+			values[key] = value
+		}
+	}
+	return values
+}

--- a/internal/runner/safe_runner.go
+++ b/internal/runner/safe_runner.go
@@ -91,6 +91,17 @@ func (sr *SafeRunner) Execute(ctx context.Context, projectDir, tool, command, en
 // ExecuteWithEnv runs a command with additional environment variables. Values
 // in extraEnv override the inherited process environment for this command only.
 func (sr *SafeRunner) ExecuteWithEnv(ctx context.Context, projectDir, tool, command, env string, extraEnv map[string]string) (*ExecutionResult, error) {
+	return sr.executeWithEnv(ctx, projectDir, tool, command, env, extraEnv, false)
+}
+
+// ExecuteWithScopedEnv runs a command with a minimal command environment plus
+// the selected connection variables. It is intended for Cloud Connection scoped
+// runs where ambient host cloud credentials must not leak into the subprocess.
+func (sr *SafeRunner) ExecuteWithScopedEnv(ctx context.Context, projectDir, tool, command, env string, extraEnv map[string]string) (*ExecutionResult, error) {
+	return sr.executeWithEnv(ctx, projectDir, tool, command, env, extraEnv, true)
+}
+
+func (sr *SafeRunner) executeWithEnv(ctx context.Context, projectDir, tool, command, env string, extraEnv map[string]string, scoped bool) (*ExecutionResult, error) {
 	// Project-level lock — prevent concurrent executions on the same project
 	// which would cause terraform state lock contention and corruption.
 	sr.mu.Lock()
@@ -134,7 +145,10 @@ func (sr *SafeRunner) ExecuteWithEnv(ctx context.Context, projectDir, tool, comm
 
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
 	cmd.Dir = projectDir
-	if len(extraEnv) > 0 {
+	switch {
+	case scoped:
+		cmd.Env = scopedCommandEnv(os.Environ(), extraEnv)
+	case len(extraEnv) > 0:
 		cmd.Env = mergeEnv(os.Environ(), extraEnv)
 	}
 
@@ -189,6 +203,119 @@ func (sr *SafeRunner) ExecuteWithEnv(ctx context.Context, projectDir, tool, comm
 		execution.Status = "completed"
 		result.ExitCode = 0
 		return result, nil
+	}
+}
+
+func scopedCommandEnv(base []string, overrides map[string]string) []string {
+	env := mergeEnv(minimalCommandEnv(base), overrides)
+	if !envHasKey(env, "AWS_EC2_METADATA_DISABLED") {
+		env = append(env, "AWS_EC2_METADATA_DISABLED=true")
+	}
+	return env
+}
+
+func minimalCommandEnv(base []string) []string {
+	allow := map[string]bool{
+		"PATH":               true,
+		"HOME":               true,
+		"USERPROFILE":        true,
+		"HOMEDRIVE":          true,
+		"HOMEPATH":           true,
+		"APPDATA":            true,
+		"LOCALAPPDATA":       true,
+		"SystemRoot":         true,
+		"WINDIR":             true,
+		"TMPDIR":             true,
+		"TMP":                true,
+		"TEMP":               true,
+		"LANG":               true,
+		"LC_ALL":             true,
+		"SSL_CERT_FILE":      true,
+		"SSL_CERT_DIR":       true,
+		"REQUESTS_CA_BUNDLE": true,
+		"CURL_CA_BUNDLE":     true,
+		"HTTP_PROXY":         true,
+		"HTTPS_PROXY":        true,
+		"NO_PROXY":           true,
+		"http_proxy":         true,
+		"https_proxy":        true,
+		"no_proxy":           true,
+	}
+	out := make([]string, 0, len(allow))
+	seen := map[string]bool{}
+	for _, entry := range base {
+		key, value, ok := strings.Cut(entry, "=")
+		if !ok || key == "" || seen[key] || !allow[key] || isCloudCredentialEnvKey(key) {
+			continue
+		}
+		out = append(out, key+"="+value)
+		seen[key] = true
+	}
+	return out
+}
+
+func envHasKey(env []string, want string) bool {
+	for _, entry := range env {
+		key, _, ok := strings.Cut(entry, "=")
+		if ok && key == want {
+			return true
+		}
+	}
+	return false
+}
+
+func isCloudCredentialEnvKey(key string) bool {
+	if strings.HasPrefix(key, "TF_TOKEN_") {
+		return true
+	}
+	switch key {
+	case
+		"AWS_ACCESS_KEY_ID",
+		"AWS_SECRET_ACCESS_KEY",
+		"AWS_SESSION_TOKEN",
+		"AWS_PROFILE",
+		"AWS_DEFAULT_PROFILE",
+		"AWS_SHARED_CREDENTIALS_FILE",
+		"AWS_CONFIG_FILE",
+		"AWS_SDK_LOAD_CONFIG",
+		"AWS_ROLE_ARN",
+		"AWS_WEB_IDENTITY_TOKEN_FILE",
+		"AWS_CONTAINER_CREDENTIALS_FULL_URI",
+		"AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+		"AWS_CONTAINER_AUTHORIZATION_TOKEN",
+		"AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE",
+		"AWS_EC2_METADATA_DISABLED",
+		"AWS_REGION",
+		"AWS_DEFAULT_REGION",
+		"ARM_CLIENT_ID",
+		"ARM_CLIENT_SECRET",
+		"ARM_CLIENT_CERTIFICATE_PATH",
+		"ARM_CLIENT_CERTIFICATE_PASSWORD",
+		"ARM_TENANT_ID",
+		"ARM_SUBSCRIPTION_ID",
+		"ARM_USE_MSI",
+		"ARM_MSI_ENDPOINT",
+		"ARM_OIDC_TOKEN",
+		"ARM_USE_OIDC",
+		"AZURE_CLIENT_ID",
+		"AZURE_CLIENT_SECRET",
+		"AZURE_TENANT_ID",
+		"AZURE_SUBSCRIPTION_ID",
+		"GOOGLE_APPLICATION_CREDENTIALS",
+		"GOOGLE_CREDENTIALS",
+		"GOOGLE_CLOUD_KEYFILE_JSON",
+		"GOOGLE_OAUTH_ACCESS_TOKEN",
+		"GOOGLE_PROJECT",
+		"GOOGLE_CLOUD_PROJECT",
+		"GOOGLE_REGION",
+		"CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
+		"CLOUDSDK_CORE_PROJECT",
+		"CLOUDSDK_COMPUTE_REGION",
+		"TF_CLOUD_TOKEN",
+		"TFE_TOKEN":
+		return true
+	default:
+		return false
 	}
 }
 
@@ -297,6 +424,17 @@ func (sr *SafeRunner) ExecutePlanJSON(ctx context.Context, projectDir, tool stri
 // by `plan -out=tfplan` into full JSON (`show -json tfplan`). The result is
 // used by policy engines and the semantic apply gate.
 func (sr *SafeRunner) ExportSavedPlanJSON(ctx context.Context, projectDir, tool string, extraEnv map[string]string) (*ExecutionResult, error) {
+	return sr.exportSavedPlanJSON(ctx, projectDir, tool, extraEnv, false)
+}
+
+// ExportSavedPlanJSONWithScopedEnv is the Cloud Connection scoped variant of
+// ExportSavedPlanJSON. It avoids leaking ambient host cloud credentials while
+// rendering the saved plan.
+func (sr *SafeRunner) ExportSavedPlanJSONWithScopedEnv(ctx context.Context, projectDir, tool string, extraEnv map[string]string) (*ExecutionResult, error) {
+	return sr.exportSavedPlanJSON(ctx, projectDir, tool, extraEnv, true)
+}
+
+func (sr *SafeRunner) exportSavedPlanJSON(ctx context.Context, projectDir, tool string, extraEnv map[string]string, scoped bool) (*ExecutionResult, error) {
 	timeout := sr.defaults.PlanTimeout
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -313,7 +451,10 @@ func (sr *SafeRunner) ExportSavedPlanJSON(ctx context.Context, projectDir, tool 
 
 	cmd := exec.CommandContext(ctx, binary, "show", "-json", "tfplan")
 	cmd.Dir = projectDir
-	if len(extraEnv) > 0 {
+	switch {
+	case scoped:
+		cmd.Env = scopedCommandEnv(os.Environ(), extraEnv)
+	case len(extraEnv) > 0:
 		cmd.Env = mergeEnv(os.Environ(), extraEnv)
 	}
 	configureCommandCancel(cmd)

--- a/internal/runner/safe_runner.go
+++ b/internal/runner/safe_runner.go
@@ -217,6 +217,8 @@ func scopedCommandEnv(base []string, overrides map[string]string) []string {
 func minimalCommandEnv(base []string) []string {
 	allow := map[string]bool{
 		"PATH":               true,
+		"Path":               true,
+		"PATHEXT":            true,
 		"HOME":               true,
 		"USERPROFILE":        true,
 		"HOMEDRIVE":          true,

--- a/internal/runner/safe_runner.go
+++ b/internal/runner/safe_runner.go
@@ -260,11 +260,6 @@ func minimalCommandEnv(base []string) []string {
 	return out
 }
 
-func envHasKey(env []string, want string) bool {
-	_, ok := envValue(env, want)
-	return ok
-}
-
 func envHasNonEmptyValue(env []string, want string) bool {
 	value, ok := envValue(env, want)
 	return ok && strings.TrimSpace(value) != ""

--- a/internal/runner/safe_runner.go
+++ b/internal/runner/safe_runner.go
@@ -208,6 +208,10 @@ func (sr *SafeRunner) executeWithEnv(ctx context.Context, projectDir, tool, comm
 
 func scopedCommandEnv(base []string, overrides map[string]string) []string {
 	env := mergeEnv(minimalCommandEnv(base), overrides)
+	if !hasAWSCredentialSource(env) {
+		env = setEnvValue(env, "AWS_SHARED_CREDENTIALS_FILE", os.DevNull)
+		env = setEnvValue(env, "AWS_CONFIG_FILE", os.DevNull)
+	}
 	if !envHasKey(env, "AWS_EC2_METADATA_DISABLED") {
 		env = append(env, "AWS_EC2_METADATA_DISABLED=true")
 	}
@@ -264,6 +268,29 @@ func envHasKey(env []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func hasAWSCredentialSource(env []string) bool {
+	hasStaticKey := envHasKey(env, "AWS_ACCESS_KEY_ID") && envHasKey(env, "AWS_SECRET_ACCESS_KEY")
+	hasWebIdentity := envHasKey(env, "AWS_ROLE_ARN") && envHasKey(env, "AWS_WEB_IDENTITY_TOKEN_FILE")
+	return hasStaticKey ||
+		hasWebIdentity ||
+		envHasKey(env, "AWS_PROFILE") ||
+		envHasKey(env, "AWS_DEFAULT_PROFILE") ||
+		envHasKey(env, "AWS_SHARED_CREDENTIALS_FILE") ||
+		envHasKey(env, "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI") ||
+		envHasKey(env, "AWS_CONTAINER_CREDENTIALS_FULL_URI")
+}
+
+func setEnvValue(env []string, key, value string) []string {
+	for i, entry := range env {
+		entryKey, _, ok := strings.Cut(entry, "=")
+		if ok && entryKey == key {
+			env[i] = key + "=" + value
+			return env
+		}
+	}
+	return append(env, key+"="+value)
 }
 
 func isCloudCredentialEnvKey(key string) bool {

--- a/internal/runner/safe_runner.go
+++ b/internal/runner/safe_runner.go
@@ -212,8 +212,8 @@ func scopedCommandEnv(base []string, overrides map[string]string) []string {
 		env = setEnvValue(env, "AWS_SHARED_CREDENTIALS_FILE", os.DevNull)
 		env = setEnvValue(env, "AWS_CONFIG_FILE", os.DevNull)
 	}
-	if !envHasKey(env, "AWS_EC2_METADATA_DISABLED") {
-		env = append(env, "AWS_EC2_METADATA_DISABLED=true")
+	if !envHasNonEmptyValue(env, "AWS_EC2_METADATA_DISABLED") {
+		env = setEnvValue(env, "AWS_EC2_METADATA_DISABLED", "true")
 	}
 	return env
 }
@@ -261,25 +261,36 @@ func minimalCommandEnv(base []string) []string {
 }
 
 func envHasKey(env []string, want string) bool {
+	_, ok := envValue(env, want)
+	return ok
+}
+
+func envHasNonEmptyValue(env []string, want string) bool {
+	value, ok := envValue(env, want)
+	return ok && strings.TrimSpace(value) != ""
+}
+
+func envValue(env []string, want string) (string, bool) {
 	for _, entry := range env {
-		key, _, ok := strings.Cut(entry, "=")
+		key, value, ok := strings.Cut(entry, "=")
 		if ok && key == want {
-			return true
+			return value, true
 		}
 	}
-	return false
+	return "", false
 }
 
 func hasAWSCredentialSource(env []string) bool {
-	hasStaticKey := envHasKey(env, "AWS_ACCESS_KEY_ID") && envHasKey(env, "AWS_SECRET_ACCESS_KEY")
-	hasWebIdentity := envHasKey(env, "AWS_ROLE_ARN") && envHasKey(env, "AWS_WEB_IDENTITY_TOKEN_FILE")
+	hasStaticKey := envHasNonEmptyValue(env, "AWS_ACCESS_KEY_ID") && envHasNonEmptyValue(env, "AWS_SECRET_ACCESS_KEY")
+	hasWebIdentity := envHasNonEmptyValue(env, "AWS_ROLE_ARN") && envHasNonEmptyValue(env, "AWS_WEB_IDENTITY_TOKEN_FILE")
 	return hasStaticKey ||
 		hasWebIdentity ||
-		envHasKey(env, "AWS_PROFILE") ||
-		envHasKey(env, "AWS_DEFAULT_PROFILE") ||
-		envHasKey(env, "AWS_SHARED_CREDENTIALS_FILE") ||
-		envHasKey(env, "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI") ||
-		envHasKey(env, "AWS_CONTAINER_CREDENTIALS_FULL_URI")
+		envHasNonEmptyValue(env, "AWS_PROFILE") ||
+		envHasNonEmptyValue(env, "AWS_DEFAULT_PROFILE") ||
+		envHasNonEmptyValue(env, "AWS_SHARED_CREDENTIALS_FILE") ||
+		envHasNonEmptyValue(env, "AWS_CONFIG_FILE") ||
+		envHasNonEmptyValue(env, "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI") ||
+		envHasNonEmptyValue(env, "AWS_CONTAINER_CREDENTIALS_FULL_URI")
 }
 
 func setEnvValue(env []string, key, value string) []string {


### PR DESCRIPTION
## Summary
- add explicit scoped runner execution paths for Cloud Connection-backed runs
- build scoped subprocess environments from a minimal OS/runtime allowlist plus selected connection variables only
- scrub ambient AWS, Azure, GCP, and Terraform Cloud credential variables from scoped command environments
- disable AWS EC2 metadata fallback in scoped runs unless explicitly provided by the selected env
- block AWS shared credential/config file fallback (`~/.aws/credentials`, `~/.aws/config`) in scoped runs unless the selected connection provides an explicit AWS credential source (static key pair, profile, web identity, shared credentials file, or container credential endpoint)
- preserve Windows executable lookup variables (`Path`, `PATHEXT`) in the scoped env allowlist alongside `PATH`
- route HTTP run/export and MCP generate_plan through scoped execution when connection_id is present
- add runner tests for stale ambient AWS static/profile, Azure, GCP, Terraform Cloud, and unrelated secret env leakage

## Security notes
- Unscoped runs preserve the previous inherited environment behavior.
- Scoped runs keep neutral process necessities like PATH, HOME, temp/cert/proxy vars, and Windows system roots, then layer only the selected connection env.
- `AWS_EC2_METADATA_DISABLED=true` prevents a failed/missing selected AWS credential from silently falling back to an instance role.
- `AWS_SHARED_CREDENTIALS_FILE` and `AWS_CONFIG_FILE` are forced to `os.DevNull` for scoped runs where the selected connection does not provide an explicit AWS credential source, preventing the AWS SDK from silently reading `~/.aws/*` when a non-AWS (Azure/GCP) or incomplete AWS connection is selected.

## Tests
- GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/runner
- GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/api
- GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/mcp
- GOCACHE=/private/tmp/iacstudio-go-cache go test ./...
- git diff --check