### PR TITLE
Harden MCP approval token validation

### DIFF
--- a/internal/cloudconnections/connections.go
+++ b/internal/cloudconnections/connections.go
@@ -181,10 +181,10 @@ func (m *Manager) Get(id string) (*Connection, error) {
 	}
 	for _, connection := range connections {
 		if connection.ID == id {
-			copy := connection
-			copy.Metadata = cloneMap(connection.Metadata)
-			copy.Secrets = cloneMap(connection.Secrets)
-			return &copy, nil
+			connectionCopy := connection
+			connectionCopy.Metadata = cloneMap(connection.Metadata)
+			connectionCopy.Secrets = cloneMap(connection.Secrets)
+			return &connectionCopy, nil
 		}
 	}
 	return nil, os.ErrNotExist

--- a/internal/mcp/protocol.go
+++ b/internal/mcp/protocol.go
@@ -291,6 +291,9 @@ func (s *Server) approved(token string) bool {
 	if s.approvalToken == "" || token == "" {
 		return false
 	}
+	if len(token) != len(s.approvalToken) {
+		return false
+	}
 	expected := sha256.Sum256([]byte(s.approvalToken))
 	provided := sha256.Sum256([]byte(token))
 	return subtle.ConstantTimeCompare(provided[:], expected[:]) == 1

--- a/internal/mcp/protocol.go
+++ b/internal/mcp/protocol.go
@@ -3,6 +3,8 @@ package mcp
 import (
 	"bufio"
 	"context"
+	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -286,10 +288,12 @@ func approvalRequiredResult(tool, reason string) ToolCallResult {
 }
 
 func (s *Server) approved(token string) bool {
-	if s.approvalToken == "" {
+	if s.approvalToken == "" || token == "" {
 		return false
 	}
-	return token == s.approvalToken
+	expected := sha256.Sum256([]byte(s.approvalToken))
+	provided := sha256.Sum256([]byte(token))
+	return subtle.ConstantTimeCompare(provided[:], expected[:]) == 1
 }
 
 func errResponse(tool string, err error, audit AuditDecision) toolResponse {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -302,7 +302,7 @@ func TestApprovalTokenValidation(t *testing.T) {
 	if !server.approved("approve-me") {
 		t.Fatalf("expected configured approval token to validate")
 	}
-	for _, token := range []string{"", "approve-m", "approve-me "} {
+	for _, token := range []string{"", "approve-m", "approve-me ", strings.Repeat("x", 1024)} {
 		if server.approved(token) {
 			t.Fatalf("expected token %q to be rejected", token)
 		}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -297,6 +297,23 @@ func TestOpenRemediationPRRequiresApprovalBeforeMutation(t *testing.T) {
 	}
 }
 
+func TestApprovalTokenValidation(t *testing.T) {
+	server := newTestServer(t)
+	if !server.approved("approve-me") {
+		t.Fatalf("expected configured approval token to validate")
+	}
+	for _, token := range []string{"", "approve-m", "approve-me "} {
+		if server.approved(token) {
+			t.Fatalf("expected token %q to be rejected", token)
+		}
+	}
+
+	withoutToken := NewServer(Config{ProjectsDir: t.TempDir()})
+	if withoutToken.approved("approve-me") {
+		t.Fatalf("expected approval to be disabled without a configured token")
+	}
+}
+
 func newTestServer(t *testing.T) *Server {
 	t.Helper()
 	return NewServer(Config{


### PR DESCRIPTION
## Summary
- Compare MCP approval tokens using hashed constant-time comparison instead of direct string equality.
- Add coverage for valid, missing, and malformed approval tokens.
- Rename a local cloud connection copy variable to avoid shadowing the built-in copy identifier.

## Validation
- GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/mcp ./internal/cloudconnections
- GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/...