### PR TITLE
Bind apply approval to saved plan hash

### DIFF
--- a/cmd/server/frontend/dist/index.html
+++ b/cmd/server/frontend/dist/index.html
@@ -13,8 +13,8 @@
       ::-webkit-scrollbar-track { background: transparent; }
       ::-webkit-scrollbar-thumb { background: #2a2a3e; border-radius: 3px; }
     </style>
-    <script type="module" crossorigin src="/assets/index-C1Rlc5kD.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-Du1yRNW4.css">
+    <script type="module" crossorigin src="/assets/index-z8RqkAUi.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-Cc11d1M6.css">
   </head>
   <body>
     <div id="root"></div>

--- a/internal/api/plan_classification_test.go
+++ b/internal/api/plan_classification_test.go
@@ -71,7 +71,6 @@ func TestApplyGateBlocksUnacknowledgedPlanRisk(t *testing.T) {
 		t.Fatalf("mkdir project: %v", err)
 	}
 	t.Cleanup(func() { invalidatePlan(projectDir) })
-	recordPlan(projectDir)
 	if err := os.WriteFile(filepath.Join(projectDir, savedPlanJSONFile), []byte(`{
 		"resource_changes": [{
 			"address": "aws_db_instance.primary",
@@ -86,6 +85,7 @@ func TestApplyGateBlocksUnacknowledgedPlanRisk(t *testing.T) {
 	}`), 0o600); err != nil {
 		t.Fatalf("write plan json: %v", err)
 	}
+	planRef := recordCommandPlan(projectDir, "terraform", "", "", "plan", "replace primary database")
 
 	srv := httptest.NewServer(fullRouterForTest(t, root))
 	defer srv.Close()
@@ -93,7 +93,7 @@ func TestApplyGateBlocksUnacknowledgedPlanRisk(t *testing.T) {
 	resp, err := http.Post(
 		srv.URL+"/api/projects/demo/run",
 		"application/json",
-		strings.NewReader(`{"tool":"terraform","command":"apply","approved":true}`),
+		strings.NewReader(`{"tool":"terraform","command":"apply","approved":true,"plan_hash":"`+planRef.Hash+`"}`),
 	)
 	if err != nil {
 		t.Fatalf("POST run apply: %v", err)

--- a/internal/api/plan_gate.go
+++ b/internal/api/plan_gate.go
@@ -1,0 +1,190 @@
+package api
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	planGateTTL            = time.Hour
+	savedTerraformPlanFile = "tfplan"
+)
+
+type planReference struct {
+	Hash         string `json:"hash"`
+	Tool         string `json:"tool"`
+	Env          string `json:"env,omitempty"`
+	ConnectionID string `json:"connection_id,omitempty"`
+	PlanCommand  string `json:"plan_command"`
+	CreatedAt    string `json:"created_at"`
+	ExpiresAt    string `json:"expires_at"`
+}
+
+type planRecord struct {
+	reference planReference
+	createdAt time.Time
+}
+
+type planGateRejection struct {
+	Error  string
+	Detail string
+}
+
+// planGate tracks the exact successful plan/preview/check artifact that must
+// be acknowledged before a mutating command can run.
+var planGate = struct {
+	mu    sync.Mutex
+	plans map[string]planRecord // projectPath -> latest plan record
+}{plans: make(map[string]planRecord)}
+
+func invalidatePlan(projectPaths ...string) {
+	planGate.mu.Lock()
+	defer planGate.mu.Unlock()
+	for _, projectPath := range projectPaths {
+		delete(planGate.plans, projectPath)
+	}
+}
+
+func invalidatePlanForChangedFile(projectsDir, file string) {
+	absProjects, err := filepath.Abs(projectsDir)
+	if err != nil {
+		return
+	}
+	absFile, err := filepath.Abs(file)
+	if err != nil {
+		return
+	}
+	rel, err := filepath.Rel(absProjects, absFile)
+	if err != nil || rel == "." || strings.HasPrefix(rel, "..") {
+		return
+	}
+	parts := strings.Split(filepath.ToSlash(rel), "/")
+	if len(parts) < 2 || parts[0] == "" {
+		return
+	}
+	projectPath := filepath.Join(absProjects, parts[0])
+	invalidatePlan(planInvalidationPaths(projectPath, absFile)...)
+}
+
+func recordPlan(projectPath string) string {
+	return recordCommandPlan(projectPath, "terraform", "", "", "plan", "").Hash
+}
+
+func recordCommandPlan(projectPath, tool, env, connectionID, command, output string) planReference {
+	return recordCommandPlanAt(projectPath, tool, env, connectionID, command, output, time.Now().UTC())
+}
+
+func recordCommandPlanAt(projectPath, tool, env, connectionID, command, output string, now time.Time) planReference {
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	now = now.UTC()
+	ref := planReference{
+		Hash:         planHash(projectPath, tool, env, connectionID, command, output),
+		Tool:         tool,
+		Env:          env,
+		ConnectionID: connectionID,
+		PlanCommand:  command,
+		CreatedAt:    now.Format(time.RFC3339),
+		ExpiresAt:    now.Add(planGateTTL).Format(time.RFC3339),
+	}
+
+	planGate.mu.Lock()
+	planGate.plans[projectPath] = planRecord{reference: ref, createdAt: now}
+	planGate.mu.Unlock()
+	return ref
+}
+
+func hasPlan(projectPath string) bool {
+	planGate.mu.Lock()
+	defer planGate.mu.Unlock()
+	record, ok := planGate.plans[projectPath]
+	return ok && time.Since(record.createdAt) < planGateTTL
+}
+
+func validatePlanForCommand(projectPath, tool, env, connectionID, command, providedHash string) (*planReference, *planGateRejection) {
+	planGate.mu.Lock()
+	record, ok := planGate.plans[projectPath]
+	planGate.mu.Unlock()
+	if !ok || time.Since(record.createdAt) >= planGateTTL {
+		return nil, &planGateRejection{
+			Error:  "plan_required",
+			Detail: "run plan first; no current saved plan exists for this project, environment, and connection",
+		}
+	}
+
+	ref := record.reference
+	if ref.Tool != tool || ref.Env != env || ref.ConnectionID != connectionID || !planCommandAllowsMutation(tool, ref.PlanCommand, command) {
+		return &ref, &planGateRejection{
+			Error:  "plan_hash_mismatch",
+			Detail: "saved plan does not match the requested tool, environment, connection, or command; rerun plan",
+		}
+	}
+
+	if strings.TrimSpace(providedHash) == "" {
+		return &ref, &planGateRejection{
+			Error:  "plan_hash_required",
+			Detail: "saved plan exists, but apply requires the exact plan_hash returned by the latest plan run",
+		}
+	}
+	if strings.TrimSpace(providedHash) != ref.Hash {
+		return &ref, &planGateRejection{
+			Error:  "plan_hash_mismatch",
+			Detail: "submitted plan_hash does not match the latest saved plan; rerun plan",
+		}
+	}
+	return &ref, nil
+}
+
+func planCommandAllowsMutation(tool, planCommand, mutationCommand string) bool {
+	switch tool {
+	case "ansible":
+		return planCommand == "check" && (mutationCommand == "apply" || mutationCommand == "playbook")
+	case "pulumi":
+		return (planCommand == "plan" || planCommand == "preview") &&
+			(mutationCommand == "apply" || mutationCommand == "up" || mutationCommand == "destroy" || mutationCommand == "refresh")
+	case "terraform", "opentofu":
+		return planCommand == "plan" && (mutationCommand == "apply" || mutationCommand == "destroy")
+	default:
+		return commandProducesPlan(planCommand)
+	}
+}
+
+func appendPlanReferenceOutput(output string, ref planReference) string {
+	output = strings.TrimRight(output, "\n")
+	if output != "" {
+		output += "\n\n"
+	}
+	return output + fmt.Sprintf("--- Plan Gate ---\nPlan hash: %s\nExpires: %s\n", ref.Hash, ref.ExpiresAt)
+}
+
+func planHash(projectPath, tool, env, connectionID, command, output string) string {
+	h := sha256.New()
+	writeHashField(h, "iac-studio-plan-gate-v1")
+	writeHashField(h, tool)
+	writeHashField(h, env)
+	writeHashField(h, connectionID)
+	writeHashField(h, command)
+	writeHashField(h, output)
+	for _, name := range []string{savedTerraformPlanFile, savedPlanJSONFile} {
+		data, err := os.ReadFile(filepath.Join(projectPath, name))
+		if err != nil {
+			continue
+		}
+		writeHashField(h, name)
+		_, _ = h.Write(data)
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func writeHashField(w io.Writer, value string) {
+	_, _ = io.WriteString(w, value)
+	_, _ = w.Write([]byte{0})
+}

--- a/internal/api/plan_gate.go
+++ b/internal/api/plan_gate.go
@@ -111,8 +111,23 @@ func hasPlan(projectPath string) bool {
 
 func validatePlanForCommand(projectPath, tool, env, connectionID, command, providedHash string) (*planReference, *planGateRejection) {
 	planGate.mu.Lock()
+	defer planGate.mu.Unlock()
+	return validatePlanForCommandLocked(projectPath, tool, env, connectionID, command, providedHash)
+}
+
+func consumePlanForCommand(projectPath, tool, env, connectionID, command, providedHash string) (*planReference, *planGateRejection) {
+	planGate.mu.Lock()
+	defer planGate.mu.Unlock()
+	ref, rejection := validatePlanForCommandLocked(projectPath, tool, env, connectionID, command, providedHash)
+	if rejection != nil {
+		return nil, rejection
+	}
+	delete(planGate.plans, projectPath)
+	return ref, nil
+}
+
+func validatePlanForCommandLocked(projectPath, tool, env, connectionID, command, providedHash string) (*planReference, *planGateRejection) {
 	record, ok := planGate.plans[projectPath]
-	planGate.mu.Unlock()
 	if !ok || time.Since(record.createdAt) >= planGateTTL {
 		return nil, &planGateRejection{
 			Error:  "plan_required",

--- a/internal/api/plan_gate.go
+++ b/internal/api/plan_gate.go
@@ -78,22 +78,22 @@ func recordPlan(projectPath string) string {
 }
 
 func recordCommandPlan(projectPath, tool, env, connectionID, command, output string) planReference {
-	return recordCommandPlanAt(projectPath, tool, env, connectionID, command, output, time.Now().UTC())
+	return recordCommandPlanAt(projectPath, tool, env, connectionID, command, output, time.Now())
 }
 
 func recordCommandPlanAt(projectPath, tool, env, connectionID, command, output string, now time.Time) planReference {
 	if now.IsZero() {
-		now = time.Now().UTC()
+		now = time.Now()
 	}
-	now = now.UTC()
+	displayTime := now.UTC()
 	ref := planReference{
 		Hash:         planHash(projectPath, tool, env, connectionID, command, output),
 		Tool:         tool,
 		Env:          env,
 		ConnectionID: connectionID,
 		PlanCommand:  command,
-		CreatedAt:    now.Format(time.RFC3339),
-		ExpiresAt:    now.Add(planGateTTL).Format(time.RFC3339),
+		CreatedAt:    displayTime.Format(time.RFC3339),
+		ExpiresAt:    displayTime.Add(planGateTTL).Format(time.RFC3339),
 	}
 
 	planGate.mu.Lock()
@@ -189,12 +189,13 @@ func planHash(projectPath, tool, env, connectionID, command, output string) stri
 	writeHashField(h, command)
 	writeHashField(h, output)
 	for _, name := range []string{savedTerraformPlanFile, savedPlanJSONFile} {
-		data, err := os.ReadFile(filepath.Join(projectPath, name))
+		file, err := os.Open(filepath.Join(projectPath, name))
 		if err != nil {
 			continue
 		}
 		writeHashField(h, name)
-		_, _ = h.Write(data)
+		_, _ = io.Copy(h, file)
+		_ = file.Close()
 	}
 	return hex.EncodeToString(h.Sum(nil))
 }

--- a/internal/api/plan_gate_test.go
+++ b/internal/api/plan_gate_test.go
@@ -1,0 +1,140 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPlanGateRejectsStalePlan(t *testing.T) {
+	projectDir := t.TempDir()
+	t.Cleanup(func() { invalidatePlan(projectDir) })
+
+	ref := recordCommandPlanAt(projectDir, "terraform", "", "", "plan", "old plan", time.Now().Add(-2*time.Hour))
+	if _, rejection := validatePlanForCommand(projectDir, "terraform", "", "", "apply", ref.Hash); rejection == nil || rejection.Error != "plan_required" {
+		t.Fatalf("expected stale plan_required rejection, got %#v", rejection)
+	}
+}
+
+func TestPlanGateRejectsDifferentCommand(t *testing.T) {
+	projectDir := t.TempDir()
+	t.Cleanup(func() { invalidatePlan(projectDir) })
+
+	ref := recordCommandPlan(projectDir, "terraform", "", "", "check", "syntax only")
+	if _, rejection := validatePlanForCommand(projectDir, "terraform", "", "", "apply", ref.Hash); rejection == nil || rejection.Error != "plan_hash_mismatch" {
+		t.Fatalf("expected command mismatch rejection, got %#v", rejection)
+	}
+}
+
+func TestPlanGateRejectsDifferentEnvironment(t *testing.T) {
+	projectDir := t.TempDir()
+	t.Cleanup(func() { invalidatePlan(projectDir) })
+
+	ref := recordCommandPlan(projectDir, "terraform", "dev", "", "plan", "dev plan")
+	if _, rejection := validatePlanForCommand(projectDir, "terraform", "prod", "", "apply", ref.Hash); rejection == nil || rejection.Error != "plan_hash_mismatch" {
+		t.Fatalf("expected environment mismatch rejection, got %#v", rejection)
+	}
+}
+
+func TestPlanGateRejectsDifferentConnection(t *testing.T) {
+	projectDir := t.TempDir()
+	t.Cleanup(func() { invalidatePlan(projectDir) })
+
+	ref := recordCommandPlan(projectDir, "terraform", "", "aws-dev", "plan", "dev account plan")
+	if _, rejection := validatePlanForCommand(projectDir, "terraform", "", "aws-prod", "apply", ref.Hash); rejection == nil || rejection.Error != "plan_hash_mismatch" {
+		t.Fatalf("expected connection mismatch rejection, got %#v", rejection)
+	}
+}
+
+func TestPlanGateAcceptsMatchingPlanHash(t *testing.T) {
+	projectDir := t.TempDir()
+	t.Cleanup(func() { invalidatePlan(projectDir) })
+
+	ref := recordCommandPlan(projectDir, "terraform", "dev", "aws-dev", "plan", "dev plan")
+	if matched, rejection := validatePlanForCommand(projectDir, "terraform", "dev", "aws-dev", "apply", ref.Hash); rejection != nil {
+		t.Fatalf("expected matching plan to pass, got %#v", rejection)
+	} else if matched.Hash != ref.Hash {
+		t.Fatalf("matched hash = %q, want %q", matched.Hash, ref.Hash)
+	}
+}
+
+func TestPlanGateInvalidatesChangedLayeredFile(t *testing.T) {
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "demo")
+	envDir := filepath.Join(projectDir, "environments", "dev")
+	if err := os.MkdirAll(envDir, 0o755); err != nil {
+		t.Fatalf("mkdir env: %v", err)
+	}
+	t.Cleanup(func() { invalidatePlan(projectDir, envDir) })
+	recordPlan(projectDir)
+	recordPlan(envDir)
+
+	invalidatePlanForChangedFile(root, filepath.Join(envDir, "main.tf"))
+
+	if hasPlan(projectDir) {
+		t.Fatal("root plan gate should be invalidated after watched file change")
+	}
+	if hasPlan(envDir) {
+		t.Fatal("env plan gate should be invalidated after watched env file change")
+	}
+}
+
+func TestRunCommandRequiresSubmittedPlanHash(t *testing.T) {
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "demo")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	t.Cleanup(func() { invalidatePlan(projectDir) })
+	_ = recordCommandPlan(projectDir, "terraform", "", "", "plan", "safe plan")
+
+	srv := httptest.NewServer(fullRouterForTest(t, root))
+	defer srv.Close()
+
+	resp, err := http.Post(
+		srv.URL+"/api/projects/demo/run",
+		"application/json",
+		strings.NewReader(`{"tool":"terraform","command":"apply","approved":true}`),
+	)
+	if err != nil {
+		t.Fatalf("POST run apply: %v", err)
+	}
+	defer closeBody(resp.Body)
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("apply status = %d, want 409", resp.StatusCode)
+	}
+	assertResponseBodyContains(t, resp, "plan_hash_required")
+}
+
+func TestRunCommandAcceptsMatchingPlanHash(t *testing.T) {
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "demo")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, savedPlanJSONFile), []byte(`{"resource_changes":[]}`), 0o600); err != nil {
+		t.Fatalf("write safe plan json: %v", err)
+	}
+	t.Cleanup(func() { invalidatePlan(projectDir) })
+	ref := recordCommandPlan(projectDir, "terraform", "", "", "plan", "safe plan")
+
+	srv := httptest.NewServer(fullRouterForTest(t, root))
+	defer srv.Close()
+
+	resp, err := http.Post(
+		srv.URL+"/api/projects/demo/run",
+		"application/json",
+		strings.NewReader(`{"tool":"terraform","command":"apply","approved":true,"plan_hash":"`+ref.Hash+`"}`),
+	)
+	if err != nil {
+		t.Fatalf("POST run apply: %v", err)
+	}
+	defer closeBody(resp.Body)
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("apply status = %d, want 202", resp.StatusCode)
+	}
+}

--- a/internal/api/plan_gate_test.go
+++ b/internal/api/plan_gate_test.go
@@ -62,6 +62,38 @@ func TestPlanGateAcceptsMatchingPlanHash(t *testing.T) {
 	}
 }
 
+func TestConsumePlanRejectsPlanInvalidatedAfterValidation(t *testing.T) {
+	projectDir := t.TempDir()
+	t.Cleanup(func() { invalidatePlan(projectDir) })
+
+	ref := recordCommandPlan(projectDir, "terraform", "dev", "aws-dev", "plan", "dev plan")
+	if _, rejection := validatePlanForCommand(projectDir, "terraform", "dev", "aws-dev", "apply", ref.Hash); rejection != nil {
+		t.Fatalf("expected initial validation to pass, got %#v", rejection)
+	}
+
+	invalidatePlan(projectDir)
+
+	if _, rejection := consumePlanForCommand(projectDir, "terraform", "dev", "aws-dev", "apply", ref.Hash); rejection == nil || rejection.Error != "plan_required" {
+		t.Fatalf("expected invalidated plan_required rejection, got %#v", rejection)
+	}
+}
+
+func TestConsumePlanAllowsSingleUse(t *testing.T) {
+	projectDir := t.TempDir()
+	t.Cleanup(func() { invalidatePlan(projectDir) })
+
+	ref := recordCommandPlan(projectDir, "terraform", "", "", "plan", "safe plan")
+	if _, rejection := consumePlanForCommand(projectDir, "terraform", "", "", "apply", ref.Hash); rejection != nil {
+		t.Fatalf("expected first consume to pass, got %#v", rejection)
+	}
+	if hasPlan(projectDir) {
+		t.Fatal("plan gate should be removed after consume")
+	}
+	if _, rejection := consumePlanForCommand(projectDir, "terraform", "", "", "apply", ref.Hash); rejection == nil || rejection.Error != "plan_required" {
+		t.Fatalf("expected second consume to fail, got %#v", rejection)
+	}
+}
+
 func TestPlanGateInvalidatesChangedLayeredFile(t *testing.T) {
 	root := t.TempDir()
 	projectDir := filepath.Join(root, "demo")
@@ -137,4 +169,31 @@ func TestRunCommandAcceptsMatchingPlanHash(t *testing.T) {
 	if resp.StatusCode != http.StatusAccepted {
 		t.Fatalf("apply status = %d, want 202", resp.StatusCode)
 	}
+}
+
+func TestRunCommandRequiresSubmittedPlanHashForAnsiblePlaybook(t *testing.T) {
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "demo")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	t.Cleanup(func() { invalidatePlan(projectDir) })
+	_ = recordCommandPlan(projectDir, "ansible", "", "", "check", "safe check")
+
+	srv := httptest.NewServer(fullRouterForTest(t, root))
+	defer srv.Close()
+
+	resp, err := http.Post(
+		srv.URL+"/api/projects/demo/run",
+		"application/json",
+		strings.NewReader(`{"tool":"ansible","command":"playbook","approved":true}`),
+	)
+	if err != nil {
+		t.Fatalf("POST run playbook: %v", err)
+	}
+	defer closeBody(resp.Body)
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("playbook status = %d, want 409", resp.StatusCode)
+	}
+	assertResponseBodyContains(t, resp, "plan_hash_required")
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1568,6 +1568,24 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 		// a request-scoped context and kill the command. SafeRunner applies its
 		// own per-command timeout (init=5m, plan=10m, apply=30m).
 		go func() {
+			if run.RequiresApproval(req.Command) {
+				if _, planGateErr := consumePlanForCommand(runPath, effectiveTool, req.Env, req.ConnectionID, req.Command, req.PlanHash); planGateErr != nil {
+					msg := map[string]interface{}{
+						"type":    "terminal",
+						"project": name,
+						"status":  req.Command,
+						"output":  "",
+						"error":   "apply gate invalidated before execution: " + planGateErr.Detail,
+					}
+					data, marshalErr := json.Marshal(msg)
+					if marshalErr != nil {
+						log.Printf("marshal terminal invalidation message: %v", marshalErr)
+						return
+					}
+					hub.Broadcast(data)
+					return
+				}
+			}
 			var result *runner.ExecutionResult
 			var err error
 			if scopedConnection {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -812,14 +812,6 @@ func simpleRelativeFileName(target string) bool {
 	return target != "" && !filepath.IsAbs(target) && !strings.ContainsAny(target, `/\`)
 }
 
-func invalidatePlan(projectPaths ...string) {
-	planGate.mu.Lock()
-	defer planGate.mu.Unlock()
-	for _, projectPath := range projectPaths {
-		delete(planGate.plans, projectPath)
-	}
-}
-
 func planInvalidationPaths(projectPath string, targets ...string) []string {
 	seen := map[string]bool{projectPath: true}
 	paths := []string{projectPath}
@@ -938,28 +930,6 @@ func handlePulumiSync(w http.ResponseWriter, fw *watcher.FileWatcher, projectPat
 	})
 }
 
-// planGate tracks which projects have had a recent plan run.
-// Apply/destroy is only allowed after a plan has been run for the same project.
-var planGate = struct {
-	mu    sync.Mutex
-	plans map[string]time.Time // projectPath -> last plan time
-}{plans: make(map[string]time.Time)}
-
-// recordPlan marks that a plan was run for a project.
-func recordPlan(projectPath string) {
-	planGate.mu.Lock()
-	planGate.plans[projectPath] = time.Now()
-	planGate.mu.Unlock()
-}
-
-// hasPlan checks that a plan was run for a project within the last hour.
-func hasPlan(projectPath string) bool {
-	planGate.mu.Lock()
-	defer planGate.mu.Unlock()
-	t, ok := planGate.plans[projectPath]
-	return ok && time.Since(t) < time.Hour
-}
-
 // maxRequestBody is the maximum allowed request body size (1MB).
 // Prevents clients from sending oversized payloads to exhaust memory.
 const maxRequestBody = 1 << 20
@@ -984,6 +954,11 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 // NewRouterWithOptions creates the HTTP router with explicit service options.
 func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runner.SafeRunner, projectsDir string, opts RouterOptions) *http.ServeMux {
 	mux := http.NewServeMux()
+	if fw != nil {
+		fw.OnChange(func(file, _ string) {
+			invalidatePlanForChangedFile(projectsDir, file)
+		})
+	}
 
 	// Health
 	mux.HandleFunc("GET /api/health", func(w http.ResponseWriter, r *http.Request) {
@@ -1446,6 +1421,9 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 			// the audit trail can distinguish plan semantics from policy
 			// violations.
 			RiskAcknowledged bool `json:"risk_acknowledged"`
+			// PlanHash binds approval to the exact latest successful
+			// plan/preview/check artifact emitted by the server.
+			PlanHash string `json:"plan_hash,omitempty"`
 			// Env names the environment subdirectory to execute in for
 			// layered-v1 projects (environments/<env>/...). Empty runs
 			// commands at the project root (flat layout). Validated as a
@@ -1513,17 +1491,19 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 		}
 
 		// Block apply/destroy unless:
-		// 1. A plan was run for this project within the last hour (server-verified)
+		// 1. The caller submits the exact latest plan_hash for this
+		//    project/environment/tool/connection/command context.
 		// 2. The client explicitly confirms (approved:true)
 		// 3. No error-severity policy findings exist, OR the client sets
 		//    acknowledged:true after reading the findings.
 		if run.RequiresApproval(req.Command) {
-			if !hasPlan(runPath) {
+			_, planGateErr := validatePlanForCommand(runPath, effectiveTool, req.Env, req.ConnectionID, req.Command, req.PlanHash)
+			if planGateErr != nil {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusConflict)
 				_ = json.NewEncoder(w).Encode(map[string]string{
-					"error":  "plan_required",
-					"detail": "run plan first — no plan has been run for this project recently",
+					"error":  planGateErr.Error,
+					"detail": planGateErr.Detail,
 				})
 				return
 			}
@@ -1532,7 +1512,7 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 				w.WriteHeader(http.StatusConflict)
 				_ = json.NewEncoder(w).Encode(map[string]string{
 					"error":  "approval_required",
-					"detail": "plan exists — re-submit with approved:true to proceed",
+					"detail": "plan hash matches — re-submit with approved:true to proceed",
 				})
 				return
 			}
@@ -1597,6 +1577,7 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 			}
 			var classification *iacplan.ClassificationResult
 			var snapshot *recovery.StateSnapshot
+			var planRef *planReference
 			var snapshotErr error
 			// Only record a successful plan — failed/cancelled plans don't count.
 			// 'preview' is Pulumi's equivalent of terraform plan; without it
@@ -1629,7 +1610,15 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 						result.Output = appendPlanClassificationOutput(result.Output, classification)
 					}
 				}
-				recordPlan(runPath)
+				output := ""
+				if result != nil {
+					output = result.Output
+				}
+				recordedPlan := recordCommandPlan(runPath, effectiveTool, req.Env, req.ConnectionID, req.Command, output)
+				planRef = &recordedPlan
+				if result != nil {
+					result.Output = appendPlanReferenceOutput(result.Output, recordedPlan)
+				}
 			}
 			if err == nil && commandRecordsSnapshot(req.Command) {
 				recorded, recordErr := recovery.RecordSnapshot(projectRoot, runPath, recovery.SnapshotInput{
@@ -1651,6 +1640,9 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 			}
 			if classification != nil {
 				msg["plan_classification"] = classification
+			}
+			if planRef != nil {
+				msg["plan"] = planRef
 			}
 			if snapshot != nil {
 				msg["state_snapshot"] = snapshot

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -192,12 +192,13 @@ func TestBuildArgs_PulumiPassesStack(t *testing.T) {
 func TestRequiresApproval_CoversPulumiUp(t *testing.T) {
 	sr := NewSafeRunner(DefaultSafetyConfig())
 	cases := map[string]bool{
-		"plan":    false,
-		"preview": false,
-		"apply":   true,
-		"up":      true,
-		"destroy": true,
-		"refresh": true, // state-mutating — gated alongside apply/destroy
+		"plan":     false,
+		"preview":  false,
+		"apply":    true,
+		"playbook": true,
+		"up":       true,
+		"destroy":  true,
+		"refresh":  true, // state-mutating — gated alongside apply/destroy
 	}
 	for cmd, want := range cases {
 		if got := sr.RequiresApproval(cmd); got != want {

--- a/internal/runner/safe_runner.go
+++ b/internal/runner/safe_runner.go
@@ -547,7 +547,7 @@ func (sr *SafeRunner) RequiresApproval(command string) bool {
 		return false
 	}
 	switch command {
-	case "apply", "up", "destroy", "refresh":
+	case "apply", "playbook", "up", "destroy", "refresh":
 		return true
 	}
 	return false

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -16,12 +16,16 @@ type Broadcaster interface {
 	Broadcast(msg []byte)
 }
 
+type FileChangeHook func(file, dir string)
+
 // FileWatcher monitors project directories and notifies the UI of changes.
 type FileWatcher struct {
 	watcher    *fsnotify.Watcher
 	hub        Broadcaster
 	paused     map[string]bool
 	mu         sync.RWMutex
+	hookMu     sync.RWMutex
+	onChange   FileChangeHook
 	debounce   map[string]*time.Timer
 	debounceMu sync.Mutex
 }
@@ -47,6 +51,12 @@ func New(hub Broadcaster) *FileWatcher {
 func (fw *FileWatcher) Watch(dir string) error {
 	log.Printf("Watching: %s", dir)
 	return fw.watcher.Add(dir)
+}
+
+func (fw *FileWatcher) OnChange(hook FileChangeHook) {
+	fw.hookMu.Lock()
+	defer fw.hookMu.Unlock()
+	fw.onChange = hook
 }
 
 // Pause temporarily stops notifications for a directory (used during UI → disk writes).
@@ -148,4 +158,11 @@ func (fw *FileWatcher) notify(file, dir string) {
 
 	log.Printf("File changed: %s", file)
 	fw.hub.Broadcast(data)
+
+	fw.hookMu.RLock()
+	hook := fw.onChange
+	fw.hookMu.RUnlock()
+	if hook != nil {
+		hook(file, dir)
+	}
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
-import { api, Resource, ToolInfo, CatalogResource, Suggestion, type CloudConnection } from './api';
+import { api, Resource, ToolInfo, CatalogResource, Suggestion, type CloudConnection, type PlanReference } from './api';
 import { useWebSocket, WSMessage } from './useWebSocket';
 import { useHistory } from './useHistory';
 import { useKeyboardShortcuts } from './useKeyboardShortcuts';
@@ -58,6 +58,7 @@ export default function App() {
   const [activeEnvironment, setActiveEnvironment] = useState<string | null>(null);
   const [canvasMode, setCanvasMode] = useState<CanvasMode>('freeform');
   const [selectedCloudConnection, setSelectedCloudConnection] = useState<CloudConnection | null>(null);
+  const [latestPlan, setLatestPlan] = useState<PlanReference | null>(null);
 
   const [terminalOutput, setTerminalOutput] = useState<string[]>([]);
   const [dragging, setDragging] = useState<{ id: string; ox: number; oy: number } | null>(null);
@@ -160,6 +161,7 @@ export default function App() {
     projectId,
     activeEnv,
     selectedCloudConnection,
+    latestPlanHash: latestPlan?.hash,
     activeResourceFile,
     unresolvedHybridEnv,
     nodes,
@@ -190,6 +192,7 @@ export default function App() {
   const { detectProvider, saveCodeToDisk: saveCodeWithContext } = actions;
 
   const saveCodeToDisk = useCallback((value: string) => {
+    setLatestPlan(null);
     saveCodeWithContext(value, { setCodeSaving, isSyncing, showNotification });
   }, [saveCodeWithContext, showNotification]);
 
@@ -231,10 +234,23 @@ export default function App() {
     }
   }, [tool, rightTab]);
 
+  useEffect(() => {
+    setLatestPlan(null);
+  }, [activeEnv, concreteTool, projectId, selectedCloudConnection?.id]);
+
   // WebSocket for live sync
   const handleWSMessage = useCallback((msg: WSMessage) => {
     if (msg.type === 'terminal' && msg.output) {
       setTerminalOutput(prev => [...prev, ...msg.output!.split('\n')]);
+      if (
+        msg.project === projectId &&
+        msg.plan &&
+        msg.plan.tool === concreteTool &&
+        (msg.plan.env || '') === (activeEnv || '') &&
+        (msg.plan.connection_id || '') === (selectedCloudConnection?.id || '')
+      ) {
+        setLatestPlan(msg.plan);
+      }
       if (msg.error) {
         setTerminalOutput(prev => [...prev, `ERROR: ${msg.error}`]);
         // Capture the error for "Fix with AI" — include last command output
@@ -263,6 +279,9 @@ export default function App() {
       }
     }
     if (msg.type === 'file_changed') {
+      if (msg.project === projectId) {
+        setLatestPlan(null);
+      }
       // Skip ALL file_changed events from our own operations:
       // - Our sync writes (isSyncing flag)
       // - Scaffold creation (hasCreatedProject is true but we just started)
@@ -273,7 +292,7 @@ export default function App() {
       // re-open the project or use the import feature.
       showNotification(`File updated: ${msg.file?.split('/').pop()}`);
     }
-  }, [clearNotification, setImportLoading, setImportPreview, showNotification, showPersistentNotification, topologyProvider]);
+  }, [activeEnv, clearNotification, concreteTool, projectId, selectedCloudConnection?.id, setImportLoading, setImportPreview, showNotification, showPersistentNotification, topologyProvider]);
 
   const { connected } = useWebSocket(handleWSMessage);
 

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -262,6 +262,37 @@ describe('api.runCommand', () => {
       }),
     });
   });
+
+  it('sends plan_hash for approved mutating commands', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ status: 'running' }), {
+        status: 202,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await api.runCommand('demo', 'terraform', 'apply', {
+      approved: true,
+      env: 'prod',
+      planHash: 'plan_abc123',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/projects/demo/run', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        tool: 'terraform',
+        command: 'apply',
+        approved: true,
+        env: 'prod',
+        acknowledged: false,
+        risk_acknowledged: false,
+        connection_id: undefined,
+        plan_hash: 'plan_abc123',
+      }),
+    });
+  });
 });
 
 describe('api.runDrift', () => {

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -217,6 +217,16 @@ export interface PlanClassification {
   markdown?: string;
 }
 
+export interface PlanReference {
+  hash: string;
+  tool: string;
+  env?: string;
+  connection_id?: string;
+  plan_command: string;
+  created_at: string;
+  expires_at: string;
+}
+
 export interface DriftField {
   path: string;
   code_value?: unknown;
@@ -636,7 +646,7 @@ export const api = {
     projectName: string,
     tool: string,
     command: string,
-    opts: { approved?: boolean; env?: string; acknowledged?: boolean; riskAcknowledged?: boolean; connectionId?: string | null } = {},
+    opts: { approved?: boolean; env?: string; acknowledged?: boolean; riskAcknowledged?: boolean; connectionId?: string | null; planHash?: string | null } = {},
   ): Promise<{ status: string; connection?: CloudConnection }> {
     const res = await fetch(`${BASE}/api/projects/${projectName}/run`, {
       method: 'POST',
@@ -649,6 +659,7 @@ export const api = {
         acknowledged: opts.acknowledged ?? false,
         risk_acknowledged: opts.riskAcknowledged ?? false,
         connection_id: opts.connectionId || undefined,
+        plan_hash: opts.planHash || undefined,
       }),
     });
     return (await check(res)).json();

--- a/web/src/app/useWorkspaceActions.ts
+++ b/web/src/app/useWorkspaceActions.ts
@@ -52,6 +52,7 @@ export interface UseWorkspaceActionsInput {
   projectId: string;
   activeEnv: string | null;
   selectedCloudConnection: CloudConnection | null;
+  latestPlanHash?: string | null;
   activeResourceFile?: string;
   unresolvedHybridEnv: boolean;
   nodes: AppResource[];
@@ -86,6 +87,7 @@ export function useWorkspaceActions({
   projectId,
   activeEnv,
   selectedCloudConnection,
+  latestPlanHash,
   activeResourceFile,
   unresolvedHybridEnv,
   nodes,
@@ -373,6 +375,7 @@ export function useWorkspaceActions({
         acknowledged: true,
         riskAcknowledged,
         connectionId: selectedCloudConnection?.id,
+        planHash: needsApproval ? latestPlanHash : undefined,
       }).catch(overrideErr => {
         setTerminalOutput(prev => [...prev, `Error: ${overrideErr.message}`]);
       });
@@ -382,6 +385,7 @@ export function useWorkspaceActions({
       approved: needsApproval,
       env: activeEnv,
       connectionId: selectedCloudConnection?.id,
+      planHash: needsApproval ? latestPlanHash : undefined,
     }).catch(err => {
       if (needsApproval && isPlanRiskBlockedError(err)) {
         const summary = summarizePlanClassification(err.payload?.classification);
@@ -399,6 +403,7 @@ export function useWorkspaceActions({
           env: activeEnv,
           riskAcknowledged: true,
           connectionId: selectedCloudConnection?.id,
+          planHash: latestPlanHash,
         }).catch(overrideErr => {
           if (needsApproval && isPolicyBlockedError(overrideErr)) {
             handlePolicyBlock(overrideErr, true);
@@ -414,7 +419,7 @@ export function useWorkspaceActions({
       }
       setTerminalOutput(prev => [...prev, `Error: ${err.message}`]);
     });
-  }, [activeEnv, projectId, selectedCloudConnection, setTerminalOutput, tool, unresolvedHybridEnv]);
+  }, [activeEnv, latestPlanHash, projectId, selectedCloudConnection, setTerminalOutput, tool, unresolvedHybridEnv]);
 
   const fixLastError = useCallback(async () => {
     if (!lastCmdError || !tool) return;

--- a/web/src/app/useWorkspaceActions.ts
+++ b/web/src/app/useWorkspaceActions.ts
@@ -348,7 +348,7 @@ export function useWorkspaceActions({
       setTerminalOutput(prev => [...prev, `Error: environment "${activeEnv}" has no configured IaC tool`]);
       return;
     }
-    const needsApproval = command === 'apply' || command === 'destroy';
+    const needsApproval = command === 'apply' || command === 'playbook' || command === 'destroy';
     if (needsApproval && !confirm(`Are you sure you want to run "${command}"? This will modify real infrastructure.`)) {
       return;
     }

--- a/web/src/useWebSocket.ts
+++ b/web/src/useWebSocket.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useCallback, useState } from 'react';
 
-import type { PlanClassification } from './api';
+import type { PlanClassification, PlanReference } from './api';
 
 export interface WSMessage {
   type: 'file_changed' | 'terminal' | 'error' | 'ai_progress' | 'ai_topology_result';
@@ -13,6 +13,7 @@ export interface WSMessage {
   message?: string;
   resources?: any[];
   plan_classification?: PlanClassification;
+  plan?: PlanReference;
 }
 
 export function useWebSocket(onMessage: (msg: WSMessage) => void) {


### PR DESCRIPTION
## Summary
- Replace the time-only apply gate with a saved plan hash gate keyed by project, tool, environment, connection, and command context.
- Emit the plan reference through terminal WebSocket messages and include the hash in terminal output after successful plan/preview/check runs.
- Thread the latest plan hash through the frontend apply, risk-acknowledged, and policy-acknowledged flows.
- Invalidate saved plan approval on sync/resource writes and watched file changes.

## Security impact
Mutating commands now require the exact plan_hash returned by the latest successful plan context, reducing the chance of approving one plan and applying another.

## Validation
- GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/api
- GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/... *(rerun outside sandbox after httptest bind was blocked in sandbox)*
- npm test -- --run
- npm run build
- npm run lint *(0 errors; existing warnings only)*