### PR TITLE
Add MCP Airlock tool firewall

### DIFF
--- a/cmd/server/frontend/dist/index.html
+++ b/cmd/server/frontend/dist/index.html
@@ -13,8 +13,8 @@
       ::-webkit-scrollbar-track { background: transparent; }
       ::-webkit-scrollbar-thumb { background: #2a2a3e; border-radius: 3px; }
     </style>
-    <script type="module" crossorigin src="/assets/index-z8RqkAUi.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-Cc11d1M6.css">
+    <script type="module" crossorigin src="/assets/index-nyWuLdOj.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-BNkEi-_k.css">
   </head>
   <body>
     <div id="root"></div>

--- a/internal/api/mcp_airlock_test.go
+++ b/internal/api/mcp_airlock_test.go
@@ -3,9 +3,11 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -229,6 +231,147 @@ func TestMCPAirlockToolRoutesDiscoverAndEvaluateFirewall(t *testing.T) {
 	}
 	if allowed.Decision.Status != "approval_required" || !allowed.Decision.Allowlisted || !allowed.Decision.ApprovalRequired {
 		t.Fatalf("expected allowlisted mutation to require approval, got %+v", allowed)
+	}
+}
+
+func TestMCPAirlockToolRoutesReturnArrayJSONForEmptyInventory(t *testing.T) {
+	root := t.TempDir()
+	manager := mcpairlock.NewManager(root,
+		mcpairlock.WithDefinitions([]mcpairlock.ServerDefinition{{
+			ID:              "terraform",
+			Name:            "Terraform",
+			Command:         apiTestExecutable(t),
+			Transport:       "stdio",
+			Trusted:         true,
+			ReadOnlyDefault: true,
+			CredentialMode:  "none",
+		}}),
+	)
+	srv := httptest.NewServer(fullRouterForTestWithAirlock(t, root, manager))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/mcp-airlock/servers/terraform/tools")
+	if err != nil {
+		t.Fatalf("GET inventory: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var payload struct {
+		Tools  []any `json:"tools"`
+		Checks []any `json:"checks"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode inventory: %v", err)
+	}
+	if payload.Tools == nil {
+		t.Fatal("expected tools to decode from [] rather than null")
+	}
+	if payload.Checks == nil {
+		t.Fatal("expected checks to decode from [] rather than null")
+	}
+}
+
+func TestMCPAirlockToolRoutesSanitizeInternalErrors(t *testing.T) {
+	root := t.TempDir()
+	manager := mcpairlock.NewManager(root,
+		mcpairlock.WithDefinitions([]mcpairlock.ServerDefinition{{
+			ID:              "terraform",
+			Name:            "Terraform",
+			Command:         apiTestExecutable(t),
+			Transport:       "stdio",
+			Trusted:         true,
+			ReadOnlyDefault: true,
+			CredentialMode:  "none",
+		}}),
+	)
+	if err := os.MkdirAll(filepath.Join(root, ".iac-studio"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".iac-studio", "mcp-airlock-tools.json"), []byte("{"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	srv := httptest.NewServer(fullRouterForTestWithAirlock(t, root, manager))
+	defer srv.Close()
+
+	resp, err := http.Post(
+		srv.URL+"/api/mcp-airlock/servers/terraform/tools/evaluate",
+		"application/json",
+		strings.NewReader(`{"tool_name":"list_modules"}`),
+	)
+	if err != nil {
+		t.Fatalf("POST evaluate: %v", err)
+	}
+	body, readErr := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if readErr != nil {
+		t.Fatalf("ReadAll evaluate body: %v", readErr)
+	}
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", resp.StatusCode)
+	}
+	if got := string(body); !strings.Contains(got, "mcp airlock tool evaluation failed") || strings.Contains(got, ".iac-studio") {
+		t.Fatalf("expected sanitized evaluate error, got %q", got)
+	}
+
+	resp, err = http.Post(
+		srv.URL+"/api/mcp-airlock/servers/terraform/tools/allowlist",
+		"application/json",
+		strings.NewReader(`{"tool_name":"list_modules","allowed":true}`),
+	)
+	if err != nil {
+		t.Fatalf("POST allowlist: %v", err)
+	}
+	body, readErr = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if readErr != nil {
+		t.Fatalf("ReadAll allowlist body: %v", readErr)
+	}
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", resp.StatusCode)
+	}
+	if got := string(body); !strings.Contains(got, "mcp airlock allowlist update failed") || strings.Contains(got, ".iac-studio") {
+		t.Fatalf("expected sanitized allowlist error, got %q", got)
+	}
+}
+
+func TestMCPAirlockToolRoutesValidateToolName(t *testing.T) {
+	root := t.TempDir()
+	manager := mcpairlock.NewManager(root,
+		mcpairlock.WithDefinitions([]mcpairlock.ServerDefinition{{
+			ID:              "terraform",
+			Name:            "Terraform",
+			Command:         apiTestExecutable(t),
+			Transport:       "stdio",
+			Trusted:         true,
+			ReadOnlyDefault: true,
+			CredentialMode:  "none",
+		}}),
+	)
+	srv := httptest.NewServer(fullRouterForTestWithAirlock(t, root, manager))
+	defer srv.Close()
+
+	for _, path := range []string{
+		"/api/mcp-airlock/servers/terraform/tools/evaluate",
+		"/api/mcp-airlock/servers/terraform/tools/allowlist",
+	} {
+		resp, err := http.Post(srv.URL+path, "application/json", strings.NewReader(`{"tool_name":"   ","allowed":true}`))
+		if err != nil {
+			t.Fatalf("POST %s: %v", path, err)
+		}
+		body, readErr := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if readErr != nil {
+			t.Fatalf("ReadAll %s body: %v", path, readErr)
+		}
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("expected 400 for %s, got %d", path, resp.StatusCode)
+		}
+		if got := string(body); !strings.Contains(got, "tool_name is required") {
+			t.Fatalf("expected validation error for %s, got %q", path, got)
+		}
 	}
 }
 

--- a/internal/api/mcp_airlock_test.go
+++ b/internal/api/mcp_airlock_test.go
@@ -234,6 +234,44 @@ func TestMCPAirlockToolRoutesDiscoverAndEvaluateFirewall(t *testing.T) {
 	}
 }
 
+func TestMCPAirlockDiscoverRouteRejectsOversizedBody(t *testing.T) {
+	root := t.TempDir()
+	called := false
+	manager := mcpairlock.NewManager(root,
+		mcpairlock.WithDefinitions([]mcpairlock.ServerDefinition{{
+			ID:              "terraform",
+			Name:            "Terraform",
+			Command:         apiTestExecutable(t),
+			Transport:       "stdio",
+			Trusted:         true,
+			ReadOnlyDefault: true,
+			CredentialMode:  "none",
+		}}),
+		mcpairlock.WithToolDiscoverer(func(context.Context, mcpairlock.ServerDefinition, time.Duration) mcpairlock.DiscoveryProbeResult {
+			called = true
+			return mcpairlock.DiscoveryProbeResult{}
+		}),
+	)
+	srv := httptest.NewServer(fullRouterForTestWithAirlock(t, root, manager))
+	defer srv.Close()
+
+	resp, err := http.Post(
+		srv.URL+"/api/mcp-airlock/servers/terraform/tools/discover",
+		"application/json",
+		strings.NewReader(strings.Repeat("x", maxRequestBody+1)),
+	)
+	if err != nil {
+		t.Fatalf("POST discover oversized: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413, got %d", resp.StatusCode)
+	}
+	if called {
+		t.Fatal("expected oversized body to be rejected before tool discovery")
+	}
+}
+
 func TestMCPAirlockToolRoutesReturnArrayJSONForEmptyInventory(t *testing.T) {
 	root := t.TempDir()
 	manager := mcpairlock.NewManager(root,

--- a/internal/api/mcp_airlock_test.go
+++ b/internal/api/mcp_airlock_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -120,6 +121,114 @@ func TestMCPAirlockStartStopRoutesUseLifecycle(t *testing.T) {
 	}
 	if stopped.Running || stopped.State != "stopped" || !handle.stopped {
 		t.Fatalf("expected stopped response, got response=%+v stopped=%v", stopped, handle.stopped)
+	}
+}
+
+func TestMCPAirlockToolRoutesDiscoverAndEvaluateFirewall(t *testing.T) {
+	root := t.TempDir()
+	manager := mcpairlock.NewManager(root,
+		mcpairlock.WithDefinitions([]mcpairlock.ServerDefinition{{
+			ID:              "terraform",
+			Name:            "Terraform",
+			Command:         apiTestExecutable(t),
+			Transport:       "stdio",
+			Trusted:         true,
+			ReadOnlyDefault: true,
+			CredentialMode:  "none",
+		}}),
+		mcpairlock.WithToolDiscoverer(func(context.Context, mcpairlock.ServerDefinition, time.Duration) mcpairlock.DiscoveryProbeResult {
+			return mcpairlock.DiscoveryProbeResult{Tools: []mcpairlock.DiscoveredTool{
+				{
+					Name:        "list_modules",
+					Description: "List Terraform registry modules.",
+					InputSchema: map[string]any{"type": "object"},
+					Annotations: map[string]any{"readOnlyHint": true},
+				},
+				{
+					Name:        "apply_workspace",
+					Description: "Apply a Terraform workspace.",
+					InputSchema: map[string]any{"type": "object"},
+				},
+			}}
+		}),
+	)
+	srv := httptest.NewServer(fullRouterForTestWithAirlock(t, root, manager))
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/api/mcp-airlock/servers/terraform/tools/discover", "application/json", nil)
+	if err != nil {
+		t.Fatalf("POST discover: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	var inventory struct {
+		Tools []struct {
+			Name     string `json:"name"`
+			Risk     string `json:"risk"`
+			Decision struct {
+				Status  string `json:"status"`
+				Allowed bool   `json:"allowed"`
+			} `json:"decision"`
+		} `json:"tools"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&inventory); err != nil {
+		t.Fatalf("decode inventory: %v", err)
+	}
+	if len(inventory.Tools) != 2 {
+		t.Fatalf("expected 2 tools, got %+v", inventory)
+	}
+
+	resp, err = http.Post(
+		srv.URL+"/api/mcp-airlock/servers/terraform/tools/evaluate",
+		"application/json",
+		strings.NewReader(`{"tool_name":"apply_workspace"}`),
+	)
+	if err != nil {
+		t.Fatalf("POST evaluate: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	var evaluated struct {
+		Risk     string `json:"risk"`
+		Decision struct {
+			Status string `json:"status"`
+		} `json:"decision"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&evaluated); err != nil {
+		t.Fatalf("decode evaluation: %v", err)
+	}
+	if evaluated.Risk != "cloud_mutation" || evaluated.Decision.Status != "blocked" {
+		t.Fatalf("expected blocked cloud mutation, got %+v", evaluated)
+	}
+
+	resp, err = http.Post(
+		srv.URL+"/api/mcp-airlock/servers/terraform/tools/allowlist",
+		"application/json",
+		strings.NewReader(`{"tool_name":"apply_workspace","project":"demo","allowed":true}`),
+	)
+	if err != nil {
+		t.Fatalf("POST allowlist: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	var allowed struct {
+		Decision struct {
+			Status           string `json:"status"`
+			Allowlisted      bool   `json:"allowlisted"`
+			ApprovalRequired bool   `json:"approval_required"`
+		} `json:"decision"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&allowed); err != nil {
+		t.Fatalf("decode allowlist response: %v", err)
+	}
+	if allowed.Decision.Status != "approval_required" || !allowed.Decision.Allowlisted || !allowed.Decision.ApprovalRequired {
+		t.Fatalf("expected allowlisted mutation to require approval, got %+v", allowed)
 	}
 }
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1966,13 +1966,18 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 			http.Error(w, "invalid request", http.StatusBadRequest)
 			return
 		}
+		req.ToolName = strings.TrimSpace(req.ToolName)
+		if req.ToolName == "" {
+			http.Error(w, "tool_name is required", http.StatusBadRequest)
+			return
+		}
 		entry, err := mcpAirlock.EvaluateTool(r.PathValue("id"), req.Project, req.ToolName)
 		if err != nil {
 			if errors.Is(err, mcpairlock.ErrUnknownServer) {
 				http.Error(w, "mcp airlock server not found", http.StatusNotFound)
 				return
 			}
-			http.Error(w, err.Error(), http.StatusBadRequest)
+			http.Error(w, "mcp airlock tool evaluation failed", http.StatusInternalServerError)
 			return
 		}
 		_ = json.NewEncoder(w).Encode(entry)
@@ -1989,13 +1994,18 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 			http.Error(w, "invalid request", http.StatusBadRequest)
 			return
 		}
+		req.ToolName = strings.TrimSpace(req.ToolName)
+		if req.ToolName == "" {
+			http.Error(w, "tool_name is required", http.StatusBadRequest)
+			return
+		}
 		entry, err := mcpAirlock.SetToolAllowlist(r.PathValue("id"), req.Project, req.ToolName, req.Allowed)
 		if err != nil {
 			if errors.Is(err, mcpairlock.ErrUnknownServer) {
 				http.Error(w, "mcp airlock server not found", http.StatusNotFound)
 				return
 			}
-			http.Error(w, err.Error(), http.StatusBadRequest)
+			http.Error(w, "mcp airlock allowlist update failed", http.StatusInternalServerError)
 			return
 		}
 		_ = json.NewEncoder(w).Encode(entry)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1944,6 +1944,11 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 	})
 
 	mux.HandleFunc("POST /api/mcp-airlock/servers/{id}/tools/discover", func(w http.ResponseWriter, r *http.Request) {
+		limitBody(w, r)
+		if _, err := io.Copy(io.Discard, r.Body); err != nil {
+			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+			return
+		}
 		inventory, err := mcpAirlock.DiscoverTools(r.Context(), r.PathValue("id"))
 		if err != nil {
 			if errors.Is(err, mcpairlock.ErrUnknownServer) {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1930,6 +1930,77 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 		_ = json.NewEncoder(w).Encode(status)
 	})
 
+	mux.HandleFunc("GET /api/mcp-airlock/servers/{id}/tools", func(w http.ResponseWriter, r *http.Request) {
+		inventory, err := mcpAirlock.Inventory(r.PathValue("id"))
+		if err != nil {
+			if errors.Is(err, mcpairlock.ErrUnknownServer) {
+				http.Error(w, "mcp airlock server not found", http.StatusNotFound)
+				return
+			}
+			http.Error(w, "mcp airlock inventory failed", http.StatusInternalServerError)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(inventory)
+	})
+
+	mux.HandleFunc("POST /api/mcp-airlock/servers/{id}/tools/discover", func(w http.ResponseWriter, r *http.Request) {
+		inventory, err := mcpAirlock.DiscoverTools(r.Context(), r.PathValue("id"))
+		if err != nil {
+			if errors.Is(err, mcpairlock.ErrUnknownServer) {
+				http.Error(w, "mcp airlock server not found", http.StatusNotFound)
+				return
+			}
+			http.Error(w, "mcp airlock tool discovery failed", http.StatusInternalServerError)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(inventory)
+	})
+
+	mux.HandleFunc("POST /api/mcp-airlock/servers/{id}/tools/evaluate", func(w http.ResponseWriter, r *http.Request) {
+		limitBody(w, r)
+		var req struct {
+			ToolName string `json:"tool_name"`
+			Project  string `json:"project,omitempty"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+		entry, err := mcpAirlock.EvaluateTool(r.PathValue("id"), req.Project, req.ToolName)
+		if err != nil {
+			if errors.Is(err, mcpairlock.ErrUnknownServer) {
+				http.Error(w, "mcp airlock server not found", http.StatusNotFound)
+				return
+			}
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(entry)
+	})
+
+	mux.HandleFunc("POST /api/mcp-airlock/servers/{id}/tools/allowlist", func(w http.ResponseWriter, r *http.Request) {
+		limitBody(w, r)
+		var req struct {
+			ToolName string `json:"tool_name"`
+			Project  string `json:"project,omitempty"`
+			Allowed  bool   `json:"allowed"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+		entry, err := mcpAirlock.SetToolAllowlist(r.PathValue("id"), req.Project, req.ToolName, req.Allowed)
+		if err != nil {
+			if errors.Is(err, mcpairlock.ErrUnknownServer) {
+				http.Error(w, "mcp airlock server not found", http.StatusNotFound)
+				return
+			}
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(entry)
+	})
+
 	mux.HandleFunc("POST /api/mcp-airlock/servers/{id}/start", func(w http.ResponseWriter, r *http.Request) {
 		status, err := mcpAirlock.Start(r.Context(), r.PathValue("id"))
 		if err != nil {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -274,6 +274,56 @@ func TestMCPAirlockCallRefusesBlockedExternalTool(t *testing.T) {
 	}
 }
 
+func TestMCPAirlockCallRefusesNewReadOnlyToolUntilRediscovered(t *testing.T) {
+	server := newTestServer(t)
+	command, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	server.mcpAirlock = mcpairlock.NewManager(server.projectsDir,
+		mcpairlock.WithDefinitions([]mcpairlock.ServerDefinition{{
+			ID:              "terraform",
+			Name:            "Terraform",
+			Command:         command,
+			Transport:       "stdio",
+			Trusted:         true,
+			ReadOnlyDefault: true,
+			CredentialMode:  "none",
+		}}),
+		mcpairlock.WithToolDiscoverer(func(context.Context, mcpairlock.ServerDefinition, time.Duration) mcpairlock.DiscoveryProbeResult {
+			return mcpairlock.DiscoveryProbeResult{Tools: []mcpairlock.DiscoveredTool{{
+				Name:        "list_modules",
+				Description: "List Terraform registry modules.",
+				InputSchema: map[string]any{"type": "object"},
+				Annotations: map[string]any{"readOnlyHint": true},
+			}}}
+		}),
+	)
+	if _, err := server.mcpAirlock.DiscoverTools(context.Background(), "terraform"); err != nil {
+		t.Fatalf("DiscoverTools: %v", err)
+	}
+
+	result := callTool(t, server, "call_mcp_airlock_tool", map[string]any{
+		"server_id": "terraform",
+		"tool_name": "list_modules",
+	})
+
+	if !result.IsError {
+		t.Fatalf("expected new read-only external tool call to be blocked pending schema review: %+v", result)
+	}
+	var payload struct {
+		Status   string `json:"status"`
+		Decision struct {
+			Status string `json:"status"`
+			Reason string `json:"reason"`
+		} `json:"decision"`
+	}
+	mustRemarshal(t, result.StructuredContent, &payload)
+	if payload.Status != "blocked" || payload.Decision.Status != "blocked" || !strings.Contains(payload.Decision.Reason, "new external MCP tool schemas") {
+		t.Fatalf("unexpected schema-review block payload: %+v", payload)
+	}
+}
+
 func TestSanitizeExecutionResultRedactsCredentialValues(t *testing.T) {
 	result := sanitizeExecutionResult(&runner.ExecutionResult{
 		ID:       "plan-1",

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -324,6 +324,81 @@ func TestMCPAirlockCallRefusesNewReadOnlyToolUntilRediscovered(t *testing.T) {
 	}
 }
 
+func TestMCPAirlockApprovalRequiredIncludesExternalToolContext(t *testing.T) {
+	server := newTestServer(t)
+	command, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	server.mcpAirlock = mcpairlock.NewManager(server.projectsDir,
+		mcpairlock.WithDefinitions([]mcpairlock.ServerDefinition{{
+			ID:              "terraform",
+			Name:            "Terraform",
+			Command:         command,
+			Transport:       "stdio",
+			Trusted:         true,
+			ReadOnlyDefault: true,
+			CredentialMode:  "none",
+		}}),
+		mcpairlock.WithToolDiscoverer(func(context.Context, mcpairlock.ServerDefinition, time.Duration) mcpairlock.DiscoveryProbeResult {
+			return mcpairlock.DiscoveryProbeResult{Tools: []mcpairlock.DiscoveredTool{{
+				Name:        "apply_workspace",
+				Description: "Apply a Terraform workspace.",
+				InputSchema: map[string]any{"type": "object"},
+			}}}
+		}),
+	)
+	if _, err := server.mcpAirlock.DiscoverTools(context.Background(), "terraform"); err != nil {
+		t.Fatalf("DiscoverTools: %v", err)
+	}
+	if _, err := server.mcpAirlock.SetToolAllowlist("terraform", "", "apply_workspace", true); err != nil {
+		t.Fatalf("SetToolAllowlist: %v", err)
+	}
+
+	result := callTool(t, server, "call_mcp_airlock_tool", map[string]any{
+		"server_id": "terraform",
+		"tool_name": "apply_workspace",
+	})
+
+	if result.IsError {
+		t.Fatalf("approval_required should be a structured gate, not an MCP error: %s", result.Content[0].Text)
+	}
+	var payload struct {
+		Status           string `json:"status"`
+		Tool             string `json:"tool"`
+		Server           string `json:"server"`
+		ServerID         string `json:"server_id"`
+		ToolName         string `json:"tool_name"`
+		ApprovalRequired bool   `json:"approval_required"`
+		ExternalTool     struct {
+			ServerID string `json:"server_id"`
+			Name     string `json:"name"`
+			Decision struct {
+				Status           string `json:"status"`
+				ApprovalRequired bool   `json:"approval_required"`
+			} `json:"decision"`
+		} `json:"external_tool"`
+		Decision struct {
+			Status           string `json:"status"`
+			ApprovalRequired bool   `json:"approval_required"`
+		} `json:"decision"`
+	}
+	mustRemarshal(t, result.StructuredContent, &payload)
+	if payload.Status != "approval_required" || !payload.ApprovalRequired || payload.Tool != "call_mcp_airlock_tool" {
+		t.Fatalf("unexpected approval payload status: %+v", payload)
+	}
+	if payload.Server != "terraform" || payload.ServerID != "terraform" || payload.ToolName != "apply_workspace" {
+		t.Fatalf("approval payload did not include external request context: %+v", payload)
+	}
+	if payload.ExternalTool.ServerID != "terraform" || payload.ExternalTool.Name != "apply_workspace" {
+		t.Fatalf("approval payload did not include evaluated external tool: %+v", payload.ExternalTool)
+	}
+	if payload.Decision.Status != "approval_required" || !payload.Decision.ApprovalRequired ||
+		payload.ExternalTool.Decision.Status != "approval_required" || !payload.ExternalTool.Decision.ApprovalRequired {
+		t.Fatalf("approval payload did not include evaluated decision: %+v", payload)
+	}
+}
+
 func TestSanitizeExecutionResultRedactsCredentialValues(t *testing.T) {
 	result := sanitizeExecutionResult(&runner.ExecutionResult{
 		ID:       "plan-1",

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/iac-studio/iac-studio/internal/cloudconnections"
+	"github.com/iac-studio/iac-studio/internal/mcpairlock"
 	"github.com/iac-studio/iac-studio/internal/runner"
 )
 
@@ -58,7 +59,7 @@ func TestServerLifecycleAndToolList(t *testing.T) {
 	if err := json.Unmarshal([]byte(lines[1]), &listResp); err != nil {
 		t.Fatalf("decode tools/list response: %v", err)
 	}
-	for _, name := range []string{"list_projects", "inspect_project", "list_mcp_airlock_servers", "check_mcp_airlock_server", "classify_plan", "scan_drift", "open_remediation_pr", "apply"} {
+	for _, name := range []string{"list_projects", "inspect_project", "list_mcp_airlock_servers", "check_mcp_airlock_server", "discover_mcp_airlock_tools", "evaluate_mcp_airlock_tool", "call_mcp_airlock_tool", "classify_plan", "scan_drift", "open_remediation_pr", "apply"} {
 		if !containsTool(listResp.Result.Tools, name) {
 			t.Fatalf("tools/list missing %s", name)
 		}
@@ -221,6 +222,55 @@ func TestMCPAirlockToolsExposeTrustedReadOnlyStatus(t *testing.T) {
 	mustRemarshal(t, checkResult.StructuredContent, &checkPayload)
 	if checkPayload.Server.State != "not_configured" || checkPayload.Server.Configured {
 		t.Fatalf("expected AWS built-in to require explicit local command config, got %+v", checkPayload.Server)
+	}
+}
+
+func TestMCPAirlockCallRefusesBlockedExternalTool(t *testing.T) {
+	server := newTestServer(t)
+	command, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	server.mcpAirlock = mcpairlock.NewManager(server.projectsDir,
+		mcpairlock.WithDefinitions([]mcpairlock.ServerDefinition{{
+			ID:              "terraform",
+			Name:            "Terraform",
+			Command:         command,
+			Transport:       "stdio",
+			Trusted:         true,
+			ReadOnlyDefault: true,
+			CredentialMode:  "none",
+		}}),
+		mcpairlock.WithToolDiscoverer(func(context.Context, mcpairlock.ServerDefinition, time.Duration) mcpairlock.DiscoveryProbeResult {
+			return mcpairlock.DiscoveryProbeResult{Tools: []mcpairlock.DiscoveredTool{{
+				Name:        "apply_workspace",
+				Description: "Apply a Terraform workspace.",
+				InputSchema: map[string]any{"type": "object"},
+			}}}
+		}),
+	)
+	if _, err := server.mcpAirlock.DiscoverTools(context.Background(), "terraform"); err != nil {
+		t.Fatalf("DiscoverTools: %v", err)
+	}
+
+	result := callTool(t, server, "call_mcp_airlock_tool", map[string]any{
+		"server_id": "terraform",
+		"tool_name": "apply_workspace",
+	})
+
+	if !result.IsError {
+		t.Fatalf("expected blocked external tool call to return an MCP tool error: %+v", result)
+	}
+	var payload struct {
+		Status   string `json:"status"`
+		Error    string `json:"error"`
+		Decision struct {
+			Status string `json:"status"`
+		} `json:"decision"`
+	}
+	mustRemarshal(t, result.StructuredContent, &payload)
+	if payload.Status != "blocked" || payload.Error != "mcp_airlock_tool_blocked" || payload.Decision.Status != "blocked" {
+		t.Fatalf("unexpected block payload: %+v", payload)
 	}
 }
 

--- a/internal/mcp/service.go
+++ b/internal/mcp/service.go
@@ -193,6 +193,116 @@ func (s *Server) handleCheckMCPAirlockServer(ctx context.Context, raw json.RawMe
 	}
 }
 
+func (s *Server) handleDiscoverMCPAirlockTools(ctx context.Context, raw json.RawMessage) toolResponse {
+	var args struct {
+		ServerID string `json:"server_id"`
+	}
+	if err := decode(raw, &args); err != nil {
+		return errResponse("discover_mcp_airlock_tools", err, AuditDecision{Tool: "discover_mcp_airlock_tools"})
+	}
+	if err := requireNonEmpty("server_id", args.ServerID); err != nil {
+		return errResponse("discover_mcp_airlock_tools", err, AuditDecision{Tool: "discover_mcp_airlock_tools"})
+	}
+	inventory, err := s.mcpAirlock.DiscoverTools(ctx, args.ServerID)
+	if err != nil {
+		if errors.Is(err, mcpairlock.ErrUnknownServer) {
+			return errResponse("discover_mcp_airlock_tools", err, AuditDecision{Tool: "discover_mcp_airlock_tools", Decision: "blocked"})
+		}
+		return errResponse("discover_mcp_airlock_tools", err, AuditDecision{Tool: "discover_mcp_airlock_tools"})
+	}
+	return toolResponse{
+		Result: structuredResult(map[string]any{
+			"inventory": inventory,
+			"scope":     "External tool output is inventoried as untrusted data. Unknown or risky tools are blocked or approval-gated before invocation.",
+		}),
+		Audit: AuditDecision{Tool: "discover_mcp_airlock_tools", Decision: "allowed"},
+	}
+}
+
+func (s *Server) handleEvaluateMCPAirlockTool(_ context.Context, raw json.RawMessage) toolResponse {
+	var args struct {
+		ServerID string `json:"server_id"`
+		ToolName string `json:"tool_name"`
+		Project  string `json:"project,omitempty"`
+	}
+	if err := decode(raw, &args); err != nil {
+		return errResponse("evaluate_mcp_airlock_tool", err, AuditDecision{Tool: "evaluate_mcp_airlock_tool"})
+	}
+	if err := firstErr(requireNonEmpty("server_id", args.ServerID), requireNonEmpty("tool_name", args.ToolName)); err != nil {
+		return errResponse("evaluate_mcp_airlock_tool", err, AuditDecision{Tool: "evaluate_mcp_airlock_tool"})
+	}
+	entry, err := s.mcpAirlock.EvaluateTool(args.ServerID, args.Project, args.ToolName)
+	if err != nil {
+		if errors.Is(err, mcpairlock.ErrUnknownServer) {
+			return errResponse("evaluate_mcp_airlock_tool", err, AuditDecision{Tool: "evaluate_mcp_airlock_tool", Project: args.Project, Decision: "blocked"})
+		}
+		return errResponse("evaluate_mcp_airlock_tool", err, AuditDecision{Tool: "evaluate_mcp_airlock_tool", Project: args.Project})
+	}
+	return toolResponse{
+		Result: structuredResult(map[string]any{"tool": entry}),
+		Audit:  AuditDecision{Tool: "evaluate_mcp_airlock_tool", Project: args.Project, Decision: "allowed"},
+	}
+}
+
+func (s *Server) handleCallMCPAirlockTool(_ context.Context, raw json.RawMessage) toolResponse {
+	var args struct {
+		ServerID      string `json:"server_id"`
+		ToolName      string `json:"tool_name"`
+		Project       string `json:"project,omitempty"`
+		ArgumentsJSON string `json:"arguments_json,omitempty"`
+		ApprovalToken string `json:"approval_token,omitempty"`
+	}
+	if err := decode(raw, &args); err != nil {
+		return errResponse("call_mcp_airlock_tool", err, AuditDecision{Tool: "call_mcp_airlock_tool"})
+	}
+	if err := firstErr(requireNonEmpty("server_id", args.ServerID), requireNonEmpty("tool_name", args.ToolName)); err != nil {
+		return errResponse("call_mcp_airlock_tool", err, AuditDecision{Tool: "call_mcp_airlock_tool"})
+	}
+	entry, err := s.mcpAirlock.EvaluateTool(args.ServerID, args.Project, args.ToolName)
+	if err != nil {
+		return errResponse("call_mcp_airlock_tool", err, AuditDecision{Tool: "call_mcp_airlock_tool", Project: args.Project, Decision: "blocked"})
+	}
+	audit := AuditDecision{
+		Tool:             "call_mcp_airlock_tool",
+		Project:          args.Project,
+		ApprovalRequired: entry.Decision.ApprovalRequired,
+		Decision:         "blocked",
+	}
+	if entry.Decision.Status == "blocked" {
+		audit.Error = entry.Decision.Reason
+		return toolResponse{
+			Result: errorResult("external MCP tool blocked by Airlock firewall", map[string]any{
+				"status":   "blocked",
+				"error":    "mcp_airlock_tool_blocked",
+				"server":   args.ServerID,
+				"tool":     entry,
+				"decision": entry.Decision,
+			}),
+			Audit: audit,
+		}
+	}
+	if entry.Decision.ApprovalRequired && !s.approved(args.ApprovalToken) {
+		audit.Decision = "approval_required"
+		return toolResponse{
+			Result: approvalRequiredResult("call_mcp_airlock_tool", entry.Decision.Reason),
+			Audit:  audit,
+		}
+	}
+	if entry.Decision.ApprovalRequired {
+		audit.Approved = true
+	}
+	return toolResponse{
+		Result: structuredResult(map[string]any{
+			"status":    "firewall_allowed",
+			"server":    args.ServerID,
+			"tool":      entry,
+			"arguments": "withheld",
+			"next_step": "External execution is intentionally deferred until the Cloud Connections credential broker is active.",
+		}),
+		Audit: AuditDecision{Tool: "call_mcp_airlock_tool", Project: args.Project, ApprovalRequired: entry.Decision.ApprovalRequired, Approved: audit.Approved, Decision: "allowed"},
+	}
+}
+
 func (s *Server) handleGeneratePlan(ctx context.Context, raw json.RawMessage) toolResponse {
 	var args projectArgs
 	if err := decode(raw, &args); err != nil {

--- a/internal/mcp/service.go
+++ b/internal/mcp/service.go
@@ -291,6 +291,7 @@ func (s *Server) handleCallMCPAirlockTool(_ context.Context, raw json.RawMessage
 	if entry.Decision.ApprovalRequired {
 		audit.Approved = true
 	}
+	audit.Decision = "allowed"
 	return toolResponse{
 		Result: structuredResult(map[string]any{
 			"status":    "firewall_allowed",
@@ -299,7 +300,7 @@ func (s *Server) handleCallMCPAirlockTool(_ context.Context, raw json.RawMessage
 			"arguments": "withheld",
 			"next_step": "External execution is intentionally deferred until the Cloud Connections credential broker is active.",
 		}),
-		Audit: AuditDecision{Tool: "call_mcp_airlock_tool", Project: args.Project, ApprovalRequired: entry.Decision.ApprovalRequired, Approved: audit.Approved, Decision: "allowed"},
+		Audit: audit,
 	}
 }
 

--- a/internal/mcp/service.go
+++ b/internal/mcp/service.go
@@ -284,8 +284,19 @@ func (s *Server) handleCallMCPAirlockTool(_ context.Context, raw json.RawMessage
 	if entry.Decision.ApprovalRequired && !s.approved(args.ApprovalToken) {
 		audit.Decision = "approval_required"
 		return toolResponse{
-			Result: approvalRequiredResult("call_mcp_airlock_tool", entry.Decision.Reason),
-			Audit:  audit,
+			Result: structuredResult(map[string]any{
+				"status":            "approval_required",
+				"tool":              "call_mcp_airlock_tool",
+				"server":            args.ServerID,
+				"server_id":         args.ServerID,
+				"tool_name":         args.ToolName,
+				"external_tool":     entry,
+				"decision":          entry.Decision,
+				"reason":            entry.Decision.Reason,
+				"approval_required": true,
+				"next_step":         "Approve the action through IaC Studio or retry with the configured local approval token.",
+			}),
+			Audit: audit,
 		}
 	}
 	if entry.Decision.ApprovalRequired {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -16,6 +16,21 @@ func (s *Server) buildTools() ([]Tool, map[string]toolHandler) {
 		readTool("check_mcp_airlock_server", "Check MCP Airlock Server", "Run a bounded local health check for one trusted external MCP server using a sanitized environment.", objectSchema(map[string]any{
 			"server_id": stringProp("Trusted Airlock server ID."),
 		}, []string{"server_id"})),
+		readTool("discover_mcp_airlock_tools", "Discover MCP Airlock Tools", "Run a bounded tools/list probe against one trusted external MCP server and persist schema fingerprints for firewall review.", objectSchema(map[string]any{
+			"server_id": stringProp("Trusted Airlock server ID."),
+		}, []string{"server_id"})),
+		readTool("evaluate_mcp_airlock_tool", "Evaluate MCP Airlock Tool", "Evaluate the fail-closed Airlock firewall decision for one discovered external MCP tool.", objectSchema(map[string]any{
+			"server_id": stringProp("Trusted Airlock server ID."),
+			"tool_name": stringProp("External MCP tool name."),
+			"project":   stringProp("Optional IaC Studio project for project-scoped allowlist checks."),
+		}, []string{"server_id", "tool_name"})),
+		proposalTool("call_mcp_airlock_tool", "Call MCP Airlock Tool", "Ask Airlock to route an external MCP tool call. Blocked or unapproved tools are refused before any external server is invoked.", objectSchema(map[string]any{
+			"server_id":      stringProp("Trusted Airlock server ID."),
+			"tool_name":      stringProp("External MCP tool name."),
+			"project":        stringProp("Optional IaC Studio project for project-scoped allowlist checks."),
+			"arguments_json": stringProp("JSON-encoded external tool arguments. Not forwarded unless the firewall permits execution."),
+			"approval_token": stringProp("Configured local approval token required for approval-gated tools."),
+		}, []string{"server_id", "tool_name"})),
 		readTool("generate_plan", "Generate Plan", "Run a local plan/preview command through the IaC Studio safe runner. This reads provider state and may write local plan artifacts, but does not apply changes.", objectSchema(projectExecutionProps(), []string{"project"})),
 		readTool("classify_plan", "Classify Plan", "Classify Terraform/OpenTofu plan JSON into safe, risky, destructive, and unknown changes.", objectSchema(map[string]any{
 			"plan_json": stringProp("Raw terraform show -json output. Use this for direct classification."),
@@ -76,6 +91,9 @@ func (s *Server) buildTools() ([]Tool, map[string]toolHandler) {
 		"inspect_connection_scope":   s.handleInspectConnectionScope,
 		"list_mcp_airlock_servers":   s.handleListMCPAirlockServers,
 		"check_mcp_airlock_server":   s.handleCheckMCPAirlockServer,
+		"discover_mcp_airlock_tools": s.handleDiscoverMCPAirlockTools,
+		"evaluate_mcp_airlock_tool":  s.handleEvaluateMCPAirlockTool,
+		"call_mcp_airlock_tool":      s.handleCallMCPAirlockTool,
 		"generate_plan":              s.handleGeneratePlan,
 		"classify_plan":              s.handleClassifyPlan,
 		"run_policy_check":           s.handleRunPolicyCheck,

--- a/internal/mcpairlock/atomic_replace_unix.go
+++ b/internal/mcpairlock/atomic_replace_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package mcpairlock
+
+import "os"
+
+func replaceFileAtomic(src, dst string) error {
+	return os.Rename(src, dst)
+}

--- a/internal/mcpairlock/atomic_replace_windows.go
+++ b/internal/mcpairlock/atomic_replace_windows.go
@@ -1,0 +1,42 @@
+//go:build windows
+
+package mcpairlock
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+const (
+	moveFileReplaceExisting = 0x1
+	moveFileWriteThrough    = 0x8
+)
+
+var (
+	kernel32        = syscall.NewLazyDLL("kernel32.dll")
+	procMoveFileExW = kernel32.NewProc("MoveFileExW")
+)
+
+func replaceFileAtomic(src, dst string) error {
+	from, err := syscall.UTF16PtrFromString(src)
+	if err != nil {
+		return err
+	}
+	to, err := syscall.UTF16PtrFromString(dst)
+	if err != nil {
+		return err
+	}
+	result, _, callErr := syscall.SyscallN(
+		procMoveFileExW.Addr(),
+		uintptr(unsafe.Pointer(from)),
+		uintptr(unsafe.Pointer(to)),
+		uintptr(moveFileReplaceExisting|moveFileWriteThrough),
+	)
+	if result == 0 {
+		if callErr != syscall.Errno(0) {
+			return callErr
+		}
+		return syscall.EINVAL
+	}
+	return nil
+}

--- a/internal/mcpairlock/registry.go
+++ b/internal/mcpairlock/registry.go
@@ -106,9 +106,10 @@ type Manager struct {
 	lifecycle     *lifecycleStore
 }
 
-// NewManager creates an Airlock registry. projectsDir is accepted for future
-// per-project allowlists, but the first slice only serves built-in trusted
-// definitions and optional process environment command overrides.
+// NewManager creates an Airlock registry. When projectsDir is set, Airlock
+// persists tool inventory and allowlists under the project's .iac-studio
+// directory. Definitions remain limited to trusted built-ins and explicit
+// process environment command overrides.
 func NewManager(projectsDir string, opts ...Option) *Manager {
 	m := &Manager{
 		definitions:   builtInDefinitions(),

--- a/internal/mcpairlock/registry.go
+++ b/internal/mcpairlock/registry.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -84,29 +85,40 @@ type ProbeResult struct {
 // with a constrained environment and timeout.
 type ProbeFunc func(ctx context.Context, command string, args []string, timeout time.Duration) ProbeResult
 
+// ToolDiscoveryFunc discovers external MCP tools without forwarding cloud
+// credentials. Production speaks a bounded tools/list flow over stdio.
+type ToolDiscoveryFunc func(ctx context.Context, definition ServerDefinition, timeout time.Duration) DiscoveryProbeResult
+
 // Option configures a Manager.
 type Option func(*Manager)
 
 // Manager owns trusted MCP Airlock server definitions and read-only checks.
 type Manager struct {
-	definitions []ServerDefinition
-	timeout     time.Duration
-	probe       ProbeFunc
-	launcher    LauncherFunc
-	lifecycle   *lifecycleStore
+	definitions   []ServerDefinition
+	projectsDir   string
+	inventoryPath string
+	allowlist     ToolAllowlist
+	inventoryMu   sync.Mutex
+	timeout       time.Duration
+	probe         ProbeFunc
+	discoverer    ToolDiscoveryFunc
+	launcher      LauncherFunc
+	lifecycle     *lifecycleStore
 }
 
 // NewManager creates an Airlock registry. projectsDir is accepted for future
 // per-project allowlists, but the first slice only serves built-in trusted
 // definitions and optional process environment command overrides.
 func NewManager(projectsDir string, opts ...Option) *Manager {
-	_ = projectsDir
 	m := &Manager{
-		definitions: builtInDefinitions(),
-		timeout:     defaultHealthTimeout,
-		probe:       defaultProbe,
-		launcher:    defaultLauncher,
-		lifecycle:   newLifecycleStore(),
+		definitions:   builtInDefinitions(),
+		projectsDir:   projectsDir,
+		inventoryPath: inventoryPath(projectsDir),
+		timeout:       defaultHealthTimeout,
+		probe:         defaultProbe,
+		discoverer:    defaultToolDiscoverer,
+		launcher:      defaultLauncher,
+		lifecycle:     newLifecycleStore(),
 	}
 	for _, opt := range opts {
 		opt(m)

--- a/internal/mcpairlock/tools.go
+++ b/internal/mcpairlock/tools.go
@@ -152,14 +152,17 @@ func (m *Manager) DiscoverTools(ctx context.Context, id string) (ToolInventory, 
 	}
 
 	now := time.Now().UTC()
-	previous, err := m.loadInventory()
+	m.inventoryMu.Lock()
+	defer m.inventoryMu.Unlock()
+	previous, err := m.loadInventoryUnlocked()
 	if err != nil {
 		inventory.Checks = append(inventory.Checks, Check{Name: "inventory", Status: "warn", Message: err.Error()})
-		previous = persistedToolInventory{Servers: map[string]persistedServerTools{}}
+		return inventory, nil
 	}
 	inventory.DiscoveredAt = now.Format(time.RFC3339)
 	inventory.Tools = make([]ToolInventoryEntry, 0, len(result.Tools))
 	seen := map[string]persistedToolRecord{}
+	allowlist := m.mergedAllowlist(previous.Allowlist)
 	for _, tool := range result.Tools {
 		name := strings.TrimSpace(tool.Name)
 		if name == "" {
@@ -175,7 +178,7 @@ func (m *Manager) DiscoverTools(ctx context.Context, id string) (ToolInventory, 
 				state = "changed"
 			}
 		}
-		decision := m.DecideTool(id, "", name, risk, state)
+		decision := decideToolWithAllowlist(id, "", name, risk, state, allowlist)
 		entry := ToolInventoryEntry{
 			ServerID:        id,
 			Name:            name,
@@ -206,8 +209,9 @@ func (m *Manager) DiscoverTools(ctx context.Context, id string) (ToolInventory, 
 		DiscoveredAt: inventory.DiscoveredAt,
 		Tools:        seen,
 	}
-	if err := m.saveInventory(previous); err != nil {
+	if err := m.saveInventoryUnlocked(previous); err != nil {
 		inventory.Checks = append(inventory.Checks, Check{Name: "inventory", Status: "warn", Message: err.Error()})
+		return inventory, nil
 	}
 	return inventory, nil
 }
@@ -222,6 +226,7 @@ func (m *Manager) Inventory(id string) (ToolInventory, error) {
 		return ToolInventory{ServerID: id, Checks: []Check{{Name: "inventory", Status: "warn", Message: err.Error()}}}, nil
 	}
 	server := snapshot.Servers[id]
+	allowlist := m.mergedAllowlist(snapshot.Allowlist)
 	inventory := ToolInventory{
 		ServerID:     id,
 		DiscoveredAt: server.DiscoveredAt,
@@ -240,7 +245,7 @@ func (m *Manager) Inventory(id string) (ToolInventory, error) {
 			LastSeenAt:      record.LastSeenAt,
 			SchemaState:     normalizedSchemaState(record.SchemaState),
 			Risk:            risk,
-			Decision:        m.DecideTool(id, "", name, risk, normalizedSchemaState(record.SchemaState)),
+			Decision:        decideToolWithAllowlist(id, "", name, risk, normalizedSchemaState(record.SchemaState), allowlist),
 		}
 		inventory.Tools = append(inventory.Tools, entry)
 	}
@@ -260,24 +265,11 @@ func (m *Manager) EvaluateTool(serverID, project, toolName string) (ToolInventor
 	if toolName == "" {
 		return ToolInventoryEntry{}, errors.New("tool_name is required")
 	}
-	inventory, err := m.Inventory(serverID)
+	snapshot, err := m.loadInventory()
 	if err != nil {
 		return ToolInventoryEntry{}, err
 	}
-	for _, entry := range inventory.Tools {
-		if entry.Name == toolName {
-			entry.Decision = m.DecideTool(serverID, project, toolName, entry.Risk, entry.SchemaState)
-			return entry, nil
-		}
-	}
-	risk := RiskUnknown
-	return ToolInventoryEntry{
-		ServerID:    serverID,
-		Name:        toolName,
-		SchemaState: "unknown",
-		Risk:        risk,
-		Decision:    m.DecideTool(serverID, project, toolName, risk, "unknown"),
-	}, nil
+	return m.evaluateToolFromSnapshot(snapshot, serverID, project, toolName), nil
 }
 
 // SetToolAllowlist updates the persisted server or project allowlist for one
@@ -290,7 +282,9 @@ func (m *Manager) SetToolAllowlist(serverID, project, toolName string, allowed b
 	if toolName == "" {
 		return ToolInventoryEntry{}, errors.New("tool_name is required")
 	}
-	snapshot, err := m.loadInventory()
+	m.inventoryMu.Lock()
+	defer m.inventoryMu.Unlock()
+	snapshot, err := m.loadInventoryUnlocked()
 	if err != nil {
 		return ToolInventoryEntry{}, err
 	}
@@ -300,19 +294,27 @@ func (m *Manager) SetToolAllowlist(serverID, project, toolName string, allowed b
 	} else {
 		removeAllowlistTool(&snapshot.Allowlist, serverID, project, toolName)
 	}
-	if err := m.saveInventory(snapshot); err != nil {
+	if err := m.saveInventoryUnlocked(snapshot); err != nil {
 		return ToolInventoryEntry{}, err
 	}
-	return m.EvaluateTool(serverID, project, toolName)
+	return m.evaluateToolFromSnapshot(snapshot, serverID, project, toolName), nil
 }
 
 // DecideTool applies Airlock's fail-closed firewall policy.
 func (m *Manager) DecideTool(serverID, project, toolName string, risk ToolRisk, schemaState string) ToolDecision {
+	allowlist := copyAllowlist(m.allowlist)
+	if snapshot, err := m.loadInventory(); err == nil {
+		mergeAllowlist(&allowlist, snapshot.Allowlist)
+	}
+	return decideToolWithAllowlist(serverID, project, toolName, risk, schemaState, allowlist)
+}
+
+func decideToolWithAllowlist(serverID, project, toolName string, risk ToolRisk, schemaState string, allowlist ToolAllowlist) ToolDecision {
 	if risk == "" {
 		risk = RiskUnknown
 	}
 	schemaState = normalizedSchemaState(schemaState)
-	allowlisted := m.isAllowlisted(serverID, project, toolName)
+	allowlisted := isToolAllowlisted(allowlist, serverID, project, toolName)
 	decision := ToolDecision{
 		Risk:            risk,
 		Allowlisted:     allowlisted,
@@ -363,6 +365,44 @@ func (m *Manager) DecideTool(serverID, project, toolName string, risk ToolRisk, 
 		}
 	}
 	return decision
+}
+
+func (m *Manager) mergedAllowlist(persisted ToolAllowlist) ToolAllowlist {
+	allowlist := copyAllowlist(m.allowlist)
+	mergeAllowlist(&allowlist, persisted)
+	return allowlist
+}
+
+func (m *Manager) evaluateToolFromSnapshot(snapshot persistedToolInventory, serverID, project, toolName string) ToolInventoryEntry {
+	allowlist := m.mergedAllowlist(snapshot.Allowlist)
+	for name, record := range snapshot.Servers[serverID].Tools {
+		if name != toolName {
+			continue
+		}
+		risk := record.Risk
+		if risk == "" {
+			risk = RiskUnknown
+		}
+		schemaState := normalizedSchemaState(record.SchemaState)
+		return ToolInventoryEntry{
+			ServerID:        serverID,
+			Name:            name,
+			Description:     record.Description,
+			InputSchemaHash: record.InputSchemaHash,
+			LastSeenAt:      record.LastSeenAt,
+			SchemaState:     schemaState,
+			Risk:            risk,
+			Decision:        decideToolWithAllowlist(serverID, project, toolName, risk, schemaState, allowlist),
+		}
+	}
+	risk := RiskUnknown
+	return ToolInventoryEntry{
+		ServerID:    serverID,
+		Name:        toolName,
+		SchemaState: "unknown",
+		Risk:        risk,
+		Decision:    decideToolWithAllowlist(serverID, project, toolName, risk, "unknown", allowlist),
+	}
 }
 
 // ClassifyTool assigns a conservative risk class from MCP metadata.
@@ -425,7 +465,7 @@ func defaultToolDiscoverer(ctx context.Context, definition ServerDefinition, tim
 
 	encoder := json.NewEncoder(stdin)
 	encoder.SetEscapeHTML(false)
-	_ = encoder.Encode(map[string]any{
+	if err := encoder.Encode(map[string]any{
 		"jsonrpc": "2.0",
 		"id":      1,
 		"method":  "initialize",
@@ -434,10 +474,26 @@ func defaultToolDiscoverer(ctx context.Context, definition ServerDefinition, tim
 			"capabilities":    map[string]any{},
 			"clientInfo":      map[string]any{"name": "iac-studio-airlock", "version": "0"},
 		},
-	})
-	_ = encoder.Encode(map[string]any{"jsonrpc": "2.0", "method": "notifications/initialized"})
-	_ = encoder.Encode(map[string]any{"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": map[string]any{}})
-	_ = stdin.Close()
+	}); err != nil {
+		cancel()
+		waitErr := <-doneErr
+		return DiscoveryProbeResult{Output: stderrBuf.String(), Err: errors.Join(fmt.Errorf("write initialize request: %w", err), waitErr)}
+	}
+	if err := encoder.Encode(map[string]any{"jsonrpc": "2.0", "method": "notifications/initialized"}); err != nil {
+		cancel()
+		waitErr := <-doneErr
+		return DiscoveryProbeResult{Output: stderrBuf.String(), Err: errors.Join(fmt.Errorf("write initialized notification: %w", err), waitErr)}
+	}
+	if err := encoder.Encode(map[string]any{"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": map[string]any{}}); err != nil {
+		cancel()
+		waitErr := <-doneErr
+		return DiscoveryProbeResult{Output: stderrBuf.String(), Err: errors.Join(fmt.Errorf("write tools/list request: %w", err), waitErr)}
+	}
+	if err := stdin.Close(); err != nil {
+		cancel()
+		waitErr := <-doneErr
+		return DiscoveryProbeResult{Output: stderrBuf.String(), Err: errors.Join(fmt.Errorf("close discovery stdin: %w", err), waitErr)}
+	}
 
 	scanner := bufio.NewScanner(stdout)
 	scanner.Buffer(make([]byte, 0, 64*1024), 5*1024*1024)
@@ -522,6 +578,10 @@ func (m *Manager) loadInventoryUnlocked() (persistedToolInventory, error) {
 func (m *Manager) saveInventory(snapshot persistedToolInventory) error {
 	m.inventoryMu.Lock()
 	defer m.inventoryMu.Unlock()
+	return m.saveInventoryUnlocked(snapshot)
+}
+
+func (m *Manager) saveInventoryUnlocked(snapshot persistedToolInventory) error {
 	if strings.TrimSpace(m.inventoryPath) == "" {
 		return nil
 	}
@@ -597,14 +657,10 @@ func containsAny(value string, needles ...string) bool {
 	return false
 }
 
-func (m *Manager) isAllowlisted(serverID, project, toolName string) bool {
+func isToolAllowlisted(allowlist ToolAllowlist, serverID, project, toolName string) bool {
 	serverID = strings.TrimSpace(serverID)
 	project = strings.TrimSpace(project)
 	toolName = strings.TrimSpace(toolName)
-	allowlist := copyAllowlist(m.allowlist)
-	if snapshot, err := m.loadInventory(); err == nil {
-		mergeAllowlist(&allowlist, snapshot.Allowlist)
-	}
 	if containsString(allowlist.ServerTools[serverID], toolName) {
 		return true
 	}

--- a/internal/mcpairlock/tools.go
+++ b/internal/mcpairlock/tools.go
@@ -682,7 +682,17 @@ func writeFileAtomic(path string, data []byte) error {
 		return fmt.Errorf("replace inventory file: %w", err)
 	}
 	keepTemp = false
+	syncDirBestEffort(dir)
 	return nil
+}
+
+func syncDirBestEffort(dir string) {
+	handle, err := os.Open(dir)
+	if err != nil {
+		return
+	}
+	defer func() { _ = handle.Close() }()
+	_ = handle.Sync()
 }
 
 func inventoryPath(projectsDir string) string {

--- a/internal/mcpairlock/tools.go
+++ b/internal/mcpairlock/tools.go
@@ -1,0 +1,714 @@
+package mcpairlock
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const toolInventoryName = "mcp-airlock-tools.json"
+
+// ToolRisk is the Airlock risk class for one external MCP tool.
+type ToolRisk string
+
+const (
+	RiskReadOnly        ToolRisk = "read_only"
+	RiskGenerateCode    ToolRisk = "generate_code"
+	RiskModifyWorkspace ToolRisk = "modify_workspace"
+	RiskCloudMutation   ToolRisk = "cloud_mutation"
+	RiskSecretSensitive ToolRisk = "secret_sensitive"
+	RiskDestructive     ToolRisk = "destructive"
+	RiskUnknown         ToolRisk = "unknown"
+)
+
+// ToolAllowlist stores explicit external MCP tool exceptions. Project entries
+// are scoped more narrowly than server entries.
+type ToolAllowlist struct {
+	ServerTools  map[string][]string            `json:"server_tools,omitempty"`
+	ProjectTools map[string]map[string][]string `json:"project_tools,omitempty"`
+}
+
+// DiscoveredTool is one raw MCP tool returned by tools/list.
+type DiscoveredTool struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description,omitempty"`
+	InputSchema map[string]any `json:"inputSchema,omitempty"`
+	Annotations map[string]any `json:"annotations,omitempty"`
+}
+
+// DiscoveryProbeResult is the sanitized result from a tools/list probe.
+type DiscoveryProbeResult struct {
+	Tools    []DiscoveredTool
+	Output   string
+	Err      error
+	TimedOut bool
+}
+
+// ToolDecision is the fail-closed firewall decision for one external MCP tool.
+type ToolDecision struct {
+	Status           string   `json:"status"`
+	Allowed          bool     `json:"allowed"`
+	ApprovalRequired bool     `json:"approval_required"`
+	Risk             ToolRisk `json:"risk"`
+	Reason           string   `json:"reason"`
+	Allowlisted      bool     `json:"allowlisted"`
+	UntrustedOutput  bool     `json:"untrusted_output"`
+}
+
+// ToolInventoryEntry is the public inventory row shown in the UI and MCP tools.
+type ToolInventoryEntry struct {
+	ServerID        string       `json:"server_id"`
+	Name            string       `json:"name"`
+	Description     string       `json:"description,omitempty"`
+	InputSchemaHash string       `json:"input_schema_hash"`
+	LastSeenAt      string       `json:"last_seen_at"`
+	SchemaState     string       `json:"schema_state"`
+	Risk            ToolRisk     `json:"risk"`
+	Decision        ToolDecision `json:"decision"`
+}
+
+// ToolInventory is a snapshot of discovered tools for one server.
+type ToolInventory struct {
+	ServerID     string               `json:"server_id"`
+	DiscoveredAt string               `json:"discovered_at,omitempty"`
+	Tools        []ToolInventoryEntry `json:"tools"`
+	Checks       []Check              `json:"checks"`
+}
+
+type persistedToolInventory struct {
+	Allowlist ToolAllowlist                   `json:"allowlist,omitempty"`
+	Servers   map[string]persistedServerTools `json:"servers"`
+}
+
+type persistedServerTools struct {
+	DiscoveredAt string                         `json:"discovered_at,omitempty"`
+	Tools        map[string]persistedToolRecord `json:"tools"`
+}
+
+type persistedToolRecord struct {
+	Description     string   `json:"description,omitempty"`
+	InputSchemaHash string   `json:"input_schema_hash"`
+	LastSeenAt      string   `json:"last_seen_at"`
+	Risk            ToolRisk `json:"risk"`
+}
+
+func WithToolDiscoverer(discoverer ToolDiscoveryFunc) Option {
+	return func(m *Manager) {
+		if discoverer != nil {
+			m.discoverer = discoverer
+		}
+	}
+}
+
+func WithToolAllowlist(allowlist ToolAllowlist) Option {
+	return func(m *Manager) {
+		m.allowlist = copyAllowlist(allowlist)
+	}
+}
+
+// DiscoverTools launches a bounded tools/list probe and persists the observed
+// tool schemas. Unknown or changed tools are visible and fail closed until
+// classified or explicitly allowed.
+func (m *Manager) DiscoverTools(ctx context.Context, id string) (ToolInventory, error) {
+	definition, ok := m.lookup(id)
+	if !ok {
+		return ToolInventory{}, ErrUnknownServer
+	}
+	status := m.passiveStatus(definition)
+	inventory := ToolInventory{
+		ServerID: id,
+		Checks:   append([]Check{}, status.Checks...),
+	}
+	if status.State != "available" {
+		inventory.Checks = append(inventory.Checks, Check{Name: "tool_discovery", Status: "error", Message: status.Summary})
+		return inventory, nil
+	}
+
+	result := m.discoverer(ctx, definition, m.timeout)
+	if result.TimedOut {
+		inventory.Checks = append(inventory.Checks, Check{Name: "tool_discovery", Status: "error", Message: "tools/list probe timed out"})
+		return inventory, nil
+	}
+	if result.Err != nil {
+		message := result.Err.Error()
+		if output := redactOutput(result.Output); output != "" {
+			message = fmt.Sprintf("%s: %s", message, output)
+		}
+		inventory.Checks = append(inventory.Checks, Check{Name: "tool_discovery", Status: "error", Message: message})
+		return inventory, nil
+	}
+
+	now := time.Now().UTC()
+	previous, err := m.loadInventory()
+	if err != nil {
+		inventory.Checks = append(inventory.Checks, Check{Name: "inventory", Status: "warn", Message: err.Error()})
+		previous = persistedToolInventory{Servers: map[string]persistedServerTools{}}
+	}
+	inventory.DiscoveredAt = now.Format(time.RFC3339)
+	inventory.Tools = make([]ToolInventoryEntry, 0, len(result.Tools))
+	seen := map[string]persistedToolRecord{}
+	for _, tool := range result.Tools {
+		name := strings.TrimSpace(tool.Name)
+		if name == "" {
+			continue
+		}
+		hash := schemaHash(tool.InputSchema)
+		risk := ClassifyTool(tool)
+		prior, hadPrior := previous.Servers[id].Tools[name]
+		state := "new"
+		if hadPrior {
+			state = "known"
+			if prior.InputSchemaHash != hash {
+				state = "changed"
+			}
+		}
+		decision := m.DecideTool(id, "", name, risk)
+		entry := ToolInventoryEntry{
+			ServerID:        id,
+			Name:            name,
+			Description:     strings.TrimSpace(tool.Description),
+			InputSchemaHash: hash,
+			LastSeenAt:      inventory.DiscoveredAt,
+			SchemaState:     state,
+			Risk:            risk,
+			Decision:        decision,
+		}
+		inventory.Tools = append(inventory.Tools, entry)
+		seen[name] = persistedToolRecord{
+			Description:     entry.Description,
+			InputSchemaHash: entry.InputSchemaHash,
+			LastSeenAt:      entry.LastSeenAt,
+			Risk:            entry.Risk,
+		}
+	}
+	sortToolEntries(inventory.Tools)
+	if len(inventory.Tools) == 0 {
+		inventory.Checks = append(inventory.Checks, Check{Name: "tool_discovery", Status: "warn", Message: "tools/list returned no tools"})
+	} else {
+		inventory.Checks = append(inventory.Checks, Check{Name: "tool_discovery", Status: "pass", Message: fmt.Sprintf("discovered %d external MCP tools", len(inventory.Tools))})
+	}
+
+	previous.Servers[id] = persistedServerTools{
+		DiscoveredAt: inventory.DiscoveredAt,
+		Tools:        seen,
+	}
+	if err := m.saveInventory(previous); err != nil {
+		inventory.Checks = append(inventory.Checks, Check{Name: "inventory", Status: "warn", Message: err.Error()})
+	}
+	return inventory, nil
+}
+
+// Inventory returns the last persisted inventory for one server.
+func (m *Manager) Inventory(id string) (ToolInventory, error) {
+	if _, ok := m.lookup(id); !ok {
+		return ToolInventory{}, ErrUnknownServer
+	}
+	snapshot, err := m.loadInventory()
+	if err != nil {
+		return ToolInventory{ServerID: id, Checks: []Check{{Name: "inventory", Status: "warn", Message: err.Error()}}}, nil
+	}
+	server := snapshot.Servers[id]
+	inventory := ToolInventory{
+		ServerID:     id,
+		DiscoveredAt: server.DiscoveredAt,
+		Tools:        make([]ToolInventoryEntry, 0, len(server.Tools)),
+	}
+	for name, record := range server.Tools {
+		risk := record.Risk
+		if risk == "" {
+			risk = RiskUnknown
+		}
+		entry := ToolInventoryEntry{
+			ServerID:        id,
+			Name:            name,
+			Description:     record.Description,
+			InputSchemaHash: record.InputSchemaHash,
+			LastSeenAt:      record.LastSeenAt,
+			SchemaState:     "known",
+			Risk:            risk,
+			Decision:        m.DecideTool(id, "", name, risk),
+		}
+		inventory.Tools = append(inventory.Tools, entry)
+	}
+	sortToolEntries(inventory.Tools)
+	if len(inventory.Tools) == 0 {
+		inventory.Checks = []Check{{Name: "inventory", Status: "warn", Message: "no tools have been discovered for this server"}}
+	}
+	return inventory, nil
+}
+
+// EvaluateTool returns the firewall decision for one discovered tool.
+func (m *Manager) EvaluateTool(serverID, project, toolName string) (ToolInventoryEntry, error) {
+	if _, ok := m.lookup(serverID); !ok {
+		return ToolInventoryEntry{}, ErrUnknownServer
+	}
+	toolName = strings.TrimSpace(toolName)
+	if toolName == "" {
+		return ToolInventoryEntry{}, errors.New("tool_name is required")
+	}
+	inventory, err := m.Inventory(serverID)
+	if err != nil {
+		return ToolInventoryEntry{}, err
+	}
+	for _, entry := range inventory.Tools {
+		if entry.Name == toolName {
+			entry.Decision = m.DecideTool(serverID, project, toolName, entry.Risk)
+			return entry, nil
+		}
+	}
+	risk := RiskUnknown
+	return ToolInventoryEntry{
+		ServerID:    serverID,
+		Name:        toolName,
+		SchemaState: "unknown",
+		Risk:        risk,
+		Decision:    m.DecideTool(serverID, project, toolName, risk),
+	}, nil
+}
+
+// SetToolAllowlist updates the persisted server or project allowlist for one
+// external tool and returns the resulting firewall decision.
+func (m *Manager) SetToolAllowlist(serverID, project, toolName string, allowed bool) (ToolInventoryEntry, error) {
+	if _, ok := m.lookup(serverID); !ok {
+		return ToolInventoryEntry{}, ErrUnknownServer
+	}
+	toolName = strings.TrimSpace(toolName)
+	if toolName == "" {
+		return ToolInventoryEntry{}, errors.New("tool_name is required")
+	}
+	snapshot, err := m.loadInventory()
+	if err != nil {
+		return ToolInventoryEntry{}, err
+	}
+	ensureAllowlist(&snapshot.Allowlist)
+	if allowed {
+		addAllowlistTool(&snapshot.Allowlist, serverID, project, toolName)
+	} else {
+		removeAllowlistTool(&snapshot.Allowlist, serverID, project, toolName)
+	}
+	if err := m.saveInventory(snapshot); err != nil {
+		return ToolInventoryEntry{}, err
+	}
+	return m.EvaluateTool(serverID, project, toolName)
+}
+
+// DecideTool applies Airlock's fail-closed firewall policy.
+func (m *Manager) DecideTool(serverID, project, toolName string, risk ToolRisk) ToolDecision {
+	if risk == "" {
+		risk = RiskUnknown
+	}
+	allowlisted := m.isAllowlisted(serverID, project, toolName)
+	decision := ToolDecision{
+		Risk:            risk,
+		Allowlisted:     allowlisted,
+		UntrustedOutput: true,
+	}
+	switch risk {
+	case RiskReadOnly:
+		decision.Status = "allowed"
+		decision.Allowed = true
+		decision.Reason = "read-only tools are allowed by default; output remains untrusted"
+	case RiskGenerateCode:
+		if allowlisted {
+			decision.Status = "allowed"
+			decision.Allowed = true
+			decision.Reason = "generate-code tool is explicitly allowlisted; output remains untrusted"
+		} else {
+			decision.Status = "blocked"
+			decision.Reason = "generate-code tools require an explicit server or project allowlist"
+		}
+	case RiskModifyWorkspace, RiskCloudMutation, RiskSecretSensitive, RiskDestructive:
+		if !allowlisted {
+			decision.Status = "blocked"
+			decision.Reason = string(risk) + " tools require an explicit server or project allowlist"
+		} else {
+			decision.Status = "approval_required"
+			decision.ApprovalRequired = true
+			decision.Reason = string(risk) + " tools require explicit user approval before execution"
+		}
+	default:
+		if !allowlisted {
+			decision.Status = "blocked"
+			decision.Reason = "unknown external MCP tools are blocked until classified or explicitly allowlisted"
+		} else {
+			decision.Status = "approval_required"
+			decision.ApprovalRequired = true
+			decision.Reason = "allowlisted unknown tools still require explicit approval"
+		}
+	}
+	return decision
+}
+
+// ClassifyTool assigns a conservative risk class from MCP metadata.
+func ClassifyTool(tool DiscoveredTool) ToolRisk {
+	schemaText := schemaText(tool.InputSchema)
+	text := strings.ToLower(strings.Join([]string{tool.Name, tool.Description, schemaText}, " "))
+	if containsAny(text, "destroy", "delete", "remove", "terminate", "drop ", "revoke", "detach", "decommission", "purge") {
+		return RiskDestructive
+	}
+	if containsAny(text, "secret", "token", "credential", "private_key", "private key", "session", "assume_role", "assume role", "client_secret", "access key") {
+		return RiskSecretSensitive
+	}
+	if containsAny(text, "apply", "deploy", "create", "update", "put ", "patch", "authorize", "ingress", "egress", "security group", "iam policy", "route table") {
+		return RiskCloudMutation
+	}
+	if containsAny(text, "write file", "workspace", "edit", "modify file", "commit", "pull request", "pr branch", "rename", "move file") {
+		return RiskModifyWorkspace
+	}
+	if containsAny(text, "generate", "template", "hcl", "terraform code", "rego", "policy code", "yaml", "json patch") {
+		return RiskGenerateCode
+	}
+	if readOnlyAnnotation(tool.Annotations) || strings.HasPrefix(strings.ToLower(tool.Name), "get") || strings.HasPrefix(strings.ToLower(tool.Name), "list") || strings.HasPrefix(strings.ToLower(tool.Name), "describe") {
+		return RiskReadOnly
+	}
+	if containsAny(text, "read", "lookup", "search", "show", "inspect", "query", "documentation", "docs", "registry", "provider", "module") {
+		return RiskReadOnly
+	}
+	return RiskUnknown
+}
+
+func defaultToolDiscoverer(ctx context.Context, definition ServerDefinition, timeout time.Duration) DiscoveryProbeResult {
+	probeCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(probeCtx, definition.Command, definition.Args...)
+	cmd.Dir = os.TempDir()
+	cmd.Env = minimalEnv()
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return DiscoveryProbeResult{Err: err}
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return DiscoveryProbeResult{Err: err}
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return DiscoveryProbeResult{Err: err}
+	}
+	if err := cmd.Start(); err != nil {
+		return DiscoveryProbeResult{Err: err}
+	}
+
+	var stderrBuf bytes.Buffer
+	doneErr := make(chan error, 1)
+	go func() {
+		_, _ = io.Copy(&limitedBuffer{buf: &stderrBuf, limit: 2048}, stderr)
+		doneErr <- cmd.Wait()
+	}()
+
+	encoder := json.NewEncoder(stdin)
+	encoder.SetEscapeHTML(false)
+	_ = encoder.Encode(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params": map[string]any{
+			"protocolVersion": "2025-06-18",
+			"capabilities":    map[string]any{},
+			"clientInfo":      map[string]any{"name": "iac-studio-airlock", "version": "0"},
+		},
+	})
+	_ = encoder.Encode(map[string]any{"jsonrpc": "2.0", "method": "notifications/initialized"})
+	_ = encoder.Encode(map[string]any{"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": map[string]any{}})
+	_ = stdin.Close()
+
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 0, 64*1024), 5*1024*1024)
+	for scanner.Scan() {
+		var response struct {
+			ID     int `json:"id"`
+			Result struct {
+				Tools []DiscoveredTool `json:"tools"`
+			} `json:"result"`
+			Error *struct {
+				Message string `json:"message"`
+				Data    any    `json:"data,omitempty"`
+			} `json:"error,omitempty"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &response); err != nil {
+			continue
+		}
+		if response.ID != 2 {
+			continue
+		}
+		if response.Error != nil {
+			cancel()
+			<-doneErr
+			return DiscoveryProbeResult{Output: stderrBuf.String(), Err: fmt.Errorf("tools/list failed: %s", response.Error.Message)}
+		}
+		cancel()
+		<-doneErr
+		return DiscoveryProbeResult{Tools: response.Result.Tools, Output: stderrBuf.String()}
+	}
+	if err := scanner.Err(); err != nil {
+		cancel()
+		<-doneErr
+		return DiscoveryProbeResult{Output: stderrBuf.String(), Err: err, TimedOut: errors.Is(probeCtx.Err(), context.DeadlineExceeded)}
+	}
+	err = <-doneErr
+	if errors.Is(probeCtx.Err(), context.DeadlineExceeded) {
+		return DiscoveryProbeResult{Output: stderrBuf.String(), Err: err, TimedOut: true}
+	}
+	if err != nil {
+		return DiscoveryProbeResult{Output: stderrBuf.String(), Err: err}
+	}
+	return DiscoveryProbeResult{Output: stderrBuf.String(), Err: errors.New("tools/list response not received")}
+}
+
+func (m *Manager) loadInventory() (persistedToolInventory, error) {
+	m.inventoryMu.Lock()
+	defer m.inventoryMu.Unlock()
+	return m.loadInventoryUnlocked()
+}
+
+func (m *Manager) loadInventoryUnlocked() (persistedToolInventory, error) {
+	snapshot := persistedToolInventory{Servers: map[string]persistedServerTools{}}
+	if strings.TrimSpace(m.inventoryPath) == "" {
+		return snapshot, nil
+	}
+	data, err := os.ReadFile(m.inventoryPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return snapshot, nil
+		}
+		return snapshot, fmt.Errorf("read Airlock tool inventory: %w", err)
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return snapshot, nil
+	}
+	if err := json.Unmarshal(data, &snapshot); err != nil {
+		return snapshot, fmt.Errorf("decode Airlock tool inventory: %w", err)
+	}
+	if snapshot.Servers == nil {
+		snapshot.Servers = map[string]persistedServerTools{}
+	}
+	ensureAllowlist(&snapshot.Allowlist)
+	for id, server := range snapshot.Servers {
+		if server.Tools == nil {
+			server.Tools = map[string]persistedToolRecord{}
+			snapshot.Servers[id] = server
+		}
+	}
+	return snapshot, nil
+}
+
+func (m *Manager) saveInventory(snapshot persistedToolInventory) error {
+	m.inventoryMu.Lock()
+	defer m.inventoryMu.Unlock()
+	if strings.TrimSpace(m.inventoryPath) == "" {
+		return nil
+	}
+	data, err := json.MarshalIndent(snapshot, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal Airlock tool inventory: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(m.inventoryPath), 0o755); err != nil {
+		return fmt.Errorf("create Airlock inventory directory: %w", err)
+	}
+	if err := os.WriteFile(m.inventoryPath, append(data, '\n'), 0o600); err != nil {
+		return fmt.Errorf("write Airlock tool inventory: %w", err)
+	}
+	return nil
+}
+
+func inventoryPath(projectsDir string) string {
+	projectsDir = strings.TrimSpace(projectsDir)
+	if projectsDir == "" {
+		return ""
+	}
+	return filepath.Join(projectsDir, ".iac-studio", toolInventoryName)
+}
+
+func schemaHash(schema map[string]any) string {
+	data, err := json.Marshal(schema)
+	if err != nil {
+		data = []byte(fmt.Sprintf("%v", schema))
+	}
+	sum := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func schemaText(schema map[string]any) string {
+	data, err := json.Marshal(schema)
+	if err != nil {
+		return fmt.Sprintf("%v", schema)
+	}
+	return string(data)
+}
+
+func readOnlyAnnotation(annotations map[string]any) bool {
+	if annotations == nil {
+		return false
+	}
+	value, ok := annotations["readOnlyHint"]
+	if !ok {
+		return false
+	}
+	hint, ok := value.(bool)
+	return ok && hint
+}
+
+func containsAny(value string, needles ...string) bool {
+	for _, needle := range needles {
+		if strings.Contains(value, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *Manager) isAllowlisted(serverID, project, toolName string) bool {
+	serverID = strings.TrimSpace(serverID)
+	project = strings.TrimSpace(project)
+	toolName = strings.TrimSpace(toolName)
+	allowlist := copyAllowlist(m.allowlist)
+	if snapshot, err := m.loadInventory(); err == nil {
+		mergeAllowlist(&allowlist, snapshot.Allowlist)
+	}
+	if containsString(allowlist.ServerTools[serverID], toolName) {
+		return true
+	}
+	if project != "" {
+		if serverTools := allowlist.ProjectTools[project]; containsString(serverTools[serverID], toolName) {
+			return true
+		}
+	}
+	return false
+}
+
+func ensureAllowlist(allowlist *ToolAllowlist) {
+	if allowlist.ServerTools == nil {
+		allowlist.ServerTools = map[string][]string{}
+	}
+	if allowlist.ProjectTools == nil {
+		allowlist.ProjectTools = map[string]map[string][]string{}
+	}
+}
+
+func mergeAllowlist(dst *ToolAllowlist, src ToolAllowlist) {
+	ensureAllowlist(dst)
+	for server, tools := range src.ServerTools {
+		for _, tool := range tools {
+			addAllowlistTool(dst, server, "", tool)
+		}
+	}
+	for project, servers := range src.ProjectTools {
+		for server, tools := range servers {
+			for _, tool := range tools {
+				addAllowlistTool(dst, server, project, tool)
+			}
+		}
+	}
+}
+
+func addAllowlistTool(allowlist *ToolAllowlist, serverID, project, toolName string) {
+	ensureAllowlist(allowlist)
+	serverID = strings.TrimSpace(serverID)
+	project = strings.TrimSpace(project)
+	toolName = strings.TrimSpace(toolName)
+	if toolName == "" {
+		return
+	}
+	if project == "" {
+		if !containsString(allowlist.ServerTools[serverID], toolName) {
+			allowlist.ServerTools[serverID] = append(allowlist.ServerTools[serverID], toolName)
+		}
+		return
+	}
+	if allowlist.ProjectTools[project] == nil {
+		allowlist.ProjectTools[project] = map[string][]string{}
+	}
+	if !containsString(allowlist.ProjectTools[project][serverID], toolName) {
+		allowlist.ProjectTools[project][serverID] = append(allowlist.ProjectTools[project][serverID], toolName)
+	}
+}
+
+func removeAllowlistTool(allowlist *ToolAllowlist, serverID, project, toolName string) {
+	ensureAllowlist(allowlist)
+	serverID = strings.TrimSpace(serverID)
+	project = strings.TrimSpace(project)
+	toolName = strings.TrimSpace(toolName)
+	if project == "" {
+		allowlist.ServerTools[serverID] = removeString(allowlist.ServerTools[serverID], toolName)
+		return
+	}
+	if allowlist.ProjectTools[project] == nil {
+		return
+	}
+	allowlist.ProjectTools[project][serverID] = removeString(allowlist.ProjectTools[project][serverID], toolName)
+}
+
+func copyAllowlist(in ToolAllowlist) ToolAllowlist {
+	out := ToolAllowlist{
+		ServerTools:  map[string][]string{},
+		ProjectTools: map[string]map[string][]string{},
+	}
+	for server, tools := range in.ServerTools {
+		out.ServerTools[server] = append([]string{}, tools...)
+	}
+	for project, servers := range in.ProjectTools {
+		out.ProjectTools[project] = map[string][]string{}
+		for server, tools := range servers {
+			out.ProjectTools[project][server] = append([]string{}, tools...)
+		}
+	}
+	return out
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if strings.TrimSpace(value) == target {
+			return true
+		}
+	}
+	return false
+}
+
+func removeString(values []string, target string) []string {
+	out := values[:0]
+	for _, value := range values {
+		if strings.TrimSpace(value) != target {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+func sortToolEntries(entries []ToolInventoryEntry) {
+	sort.SliceStable(entries, func(i, j int) bool {
+		if entries[i].Risk != entries[j].Risk {
+			return entries[i].Risk < entries[j].Risk
+		}
+		return entries[i].Name < entries[j].Name
+	})
+}
+
+type limitedBuffer struct {
+	buf   *bytes.Buffer
+	limit int
+}
+
+func (w *limitedBuffer) Write(p []byte) (int, error) {
+	remaining := w.limit - w.buf.Len()
+	if remaining > 0 {
+		if len(p) > remaining {
+			_, _ = w.buf.Write(p[:remaining])
+		} else {
+			_, _ = w.buf.Write(p)
+		}
+	}
+	return len(p), nil
+}

--- a/internal/mcpairlock/tools.go
+++ b/internal/mcpairlock/tools.go
@@ -154,7 +154,15 @@ func (m *Manager) DiscoverTools(ctx context.Context, id string) (ToolInventory, 
 
 	now := time.Now().UTC()
 	inventory.DiscoveredAt = now.Format(time.RFC3339)
-	if err := m.updateInventoryAtomically(func(previous *persistedToolInventory, loadErr error) error {
+	if err := m.persistDiscoveredTools(id, result, &inventory); err != nil {
+		inventory.Checks = append(inventory.Checks, Check{Name: "inventory", Status: "warn", Message: m.publicInventoryWarning(err)})
+		return inventory, nil
+	}
+	return inventory, nil
+}
+
+func (m *Manager) persistDiscoveredTools(id string, result DiscoveryProbeResult, inventory *ToolInventory) error {
+	return m.updateInventoryAtomically(func(previous *persistedToolInventory, loadErr error) error {
 		if loadErr != nil {
 			inventory.Checks = append(inventory.Checks, Check{Name: "inventory", Status: "warn", Message: m.publicInventoryWarning(loadErr)})
 			*previous = persistedToolInventory{Servers: map[string]persistedServerTools{}}
@@ -209,11 +217,7 @@ func (m *Manager) DiscoverTools(ctx context.Context, id string) (ToolInventory, 
 			Tools:        seen,
 		}
 		return nil
-	}); err != nil {
-		inventory.Checks = append(inventory.Checks, Check{Name: "inventory", Status: "warn", Message: m.publicInventoryWarning(err)})
-		return inventory, nil
-	}
-	return inventory, nil
+	})
 }
 
 // Inventory returns the last persisted inventory for one server.

--- a/internal/mcpairlock/tools.go
+++ b/internal/mcpairlock/tools.go
@@ -154,7 +154,7 @@ func (m *Manager) DiscoverTools(ctx context.Context, id string) (ToolInventory, 
 
 	now := time.Now().UTC()
 	inventory.DiscoveredAt = now.Format(time.RFC3339)
-	if err := m.updateInventory(func(previous *persistedToolInventory, loadErr error) error {
+	if err := m.updateInventoryAtomically(func(previous *persistedToolInventory, loadErr error) error {
 		if loadErr != nil {
 			inventory.Checks = append(inventory.Checks, Check{Name: "inventory", Status: "warn", Message: m.publicInventoryWarning(loadErr)})
 			*previous = persistedToolInventory{Servers: map[string]persistedServerTools{}}
@@ -288,7 +288,7 @@ func (m *Manager) SetToolAllowlist(serverID, project, toolName string, allowed b
 		return ToolInventoryEntry{}, errors.New("tool_name is required")
 	}
 	var snapshot persistedToolInventory
-	if err := m.updateInventory(func(next *persistedToolInventory, loadErr error) error {
+	if err := m.updateInventoryAtomically(func(next *persistedToolInventory, loadErr error) error {
 		if loadErr != nil {
 			return loadErr
 		}
@@ -551,9 +551,10 @@ func (m *Manager) loadInventory() (persistedToolInventory, error) {
 	return m.loadInventoryUnlocked()
 }
 
-// updateInventory holds one lock across load, mutation, and save so overlapping
-// discovery and allowlist updates cannot drop each other's persisted changes.
-func (m *Manager) updateInventory(update func(*persistedToolInventory, error) error) error {
+// updateInventoryAtomically holds one lock across load, mutation, and save so
+// overlapping discovery and allowlist updates cannot drop each other's
+// persisted changes.
+func (m *Manager) updateInventoryAtomically(update func(*persistedToolInventory, error) error) error {
 	m.inventoryMu.Lock()
 	defer m.inventoryMu.Unlock()
 

--- a/internal/mcpairlock/tools.go
+++ b/internal/mcpairlock/tools.go
@@ -575,12 +575,6 @@ func (m *Manager) loadInventoryUnlocked() (persistedToolInventory, error) {
 	return snapshot, nil
 }
 
-func (m *Manager) saveInventory(snapshot persistedToolInventory) error {
-	m.inventoryMu.Lock()
-	defer m.inventoryMu.Unlock()
-	return m.saveInventoryUnlocked(snapshot)
-}
-
 func (m *Manager) saveInventoryUnlocked(snapshot persistedToolInventory) error {
 	if strings.TrimSpace(m.inventoryPath) == "" {
 		return nil

--- a/internal/mcpairlock/tools.go
+++ b/internal/mcpairlock/tools.go
@@ -158,7 +158,7 @@ func (m *Manager) DiscoverTools(ctx context.Context, id string) (ToolInventory, 
 	previous, err := m.loadInventoryUnlocked()
 	if err != nil {
 		inventory.Checks = append(inventory.Checks, Check{Name: "inventory", Status: "warn", Message: err.Error()})
-		return inventory, nil
+		previous = persistedToolInventory{Servers: map[string]persistedServerTools{}}
 	}
 	inventory.DiscoveredAt = now.Format(time.RFC3339)
 	inventory.Tools = make([]ToolInventoryEntry, 0, len(result.Tools))

--- a/internal/mcpairlock/tools.go
+++ b/internal/mcpairlock/tools.go
@@ -130,6 +130,7 @@ func (m *Manager) DiscoverTools(ctx context.Context, id string) (ToolInventory, 
 	status := m.passiveStatus(definition)
 	inventory := ToolInventory{
 		ServerID: id,
+		Tools:    []ToolInventoryEntry{},
 		Checks:   append([]Check{}, status.Checks...),
 	}
 	if status.State != "available" {
@@ -223,7 +224,11 @@ func (m *Manager) Inventory(id string) (ToolInventory, error) {
 	}
 	snapshot, err := m.loadInventory()
 	if err != nil {
-		return ToolInventory{ServerID: id, Checks: []Check{{Name: "inventory", Status: "warn", Message: err.Error()}}}, nil
+		return ToolInventory{
+			ServerID: id,
+			Tools:    []ToolInventoryEntry{},
+			Checks:   []Check{{Name: "inventory", Status: "warn", Message: err.Error()}},
+		}, nil
 	}
 	server := snapshot.Servers[id]
 	allowlist := m.mergedAllowlist(snapshot.Allowlist)
@@ -231,6 +236,7 @@ func (m *Manager) Inventory(id string) (ToolInventory, error) {
 		ServerID:     id,
 		DiscoveredAt: server.DiscoveredAt,
 		Tools:        make([]ToolInventoryEntry, 0, len(server.Tools)),
+		Checks:       []Check{},
 	}
 	for name, record := range server.Tools {
 		risk := record.Risk

--- a/internal/mcpairlock/tools.go
+++ b/internal/mcpairlock/tools.go
@@ -593,9 +593,41 @@ func (m *Manager) saveInventoryUnlocked(snapshot persistedToolInventory) error {
 	if err := os.MkdirAll(filepath.Dir(m.inventoryPath), 0o755); err != nil {
 		return fmt.Errorf("create Airlock inventory directory: %w", err)
 	}
-	if err := os.WriteFile(m.inventoryPath, append(data, '\n'), 0o600); err != nil {
+	if err := writeFileAtomic(m.inventoryPath, append(data, '\n')); err != nil {
 		return fmt.Errorf("write Airlock tool inventory: %w", err)
 	}
+	return nil
+}
+
+func writeFileAtomic(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temporary file: %w", err)
+	}
+	tmpName := tmp.Name()
+	keepTemp := true
+	defer func() {
+		if keepTemp {
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temporary file: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync temporary file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temporary file: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("replace inventory file: %w", err)
+	}
+	keepTemp = false
 	return nil
 }
 

--- a/internal/mcpairlock/tools.go
+++ b/internal/mcpairlock/tools.go
@@ -762,6 +762,9 @@ func containsString(values []string, target string) bool {
 }
 
 func removeString(values []string, target string) []string {
+	if len(values) == 0 {
+		return values
+	}
 	out := values[:0]
 	for _, value := range values {
 		if strings.TrimSpace(value) != target {

--- a/internal/mcpairlock/tools.go
+++ b/internal/mcpairlock/tools.go
@@ -157,7 +157,7 @@ func (m *Manager) DiscoverTools(ctx context.Context, id string) (ToolInventory, 
 	defer m.inventoryMu.Unlock()
 	previous, err := m.loadInventoryUnlocked()
 	if err != nil {
-		inventory.Checks = append(inventory.Checks, Check{Name: "inventory", Status: "warn", Message: err.Error()})
+		inventory.Checks = append(inventory.Checks, Check{Name: "inventory", Status: "warn", Message: m.publicInventoryWarning(err)})
 		previous = persistedToolInventory{Servers: map[string]persistedServerTools{}}
 	}
 	inventory.DiscoveredAt = now.Format(time.RFC3339)
@@ -211,7 +211,7 @@ func (m *Manager) DiscoverTools(ctx context.Context, id string) (ToolInventory, 
 		Tools:        seen,
 	}
 	if err := m.saveInventoryUnlocked(previous); err != nil {
-		inventory.Checks = append(inventory.Checks, Check{Name: "inventory", Status: "warn", Message: err.Error()})
+		inventory.Checks = append(inventory.Checks, Check{Name: "inventory", Status: "warn", Message: m.publicInventoryWarning(err)})
 		return inventory, nil
 	}
 	return inventory, nil
@@ -227,7 +227,7 @@ func (m *Manager) Inventory(id string) (ToolInventory, error) {
 		return ToolInventory{
 			ServerID: id,
 			Tools:    []ToolInventoryEntry{},
-			Checks:   []Check{{Name: "inventory", Status: "warn", Message: err.Error()}},
+			Checks:   []Check{{Name: "inventory", Status: "warn", Message: m.publicInventoryWarning(err)}},
 		}, nil
 	}
 	server := snapshot.Servers[id]
@@ -329,12 +329,12 @@ func decideToolWithAllowlist(serverID, project, toolName string, risk ToolRisk, 
 	if schemaReviewRequired(schemaState) {
 		if !allowlisted {
 			decision.Status = "blocked"
-			decision.Reason = schemaState + " external MCP tool schemas are blocked until re-reviewed or explicitly allowlisted"
+			decision.Reason = schemaState + " external MCP tool schemas are blocked until a later discovery confirms the same schema, or until explicitly allowlisted"
 			return decision
 		}
 		decision.Status = "approval_required"
 		decision.ApprovalRequired = true
-		decision.Reason = "allowlisted " + schemaState + " external MCP tool schemas still require explicit approval"
+		decision.Reason = "allowlisted " + schemaState + " external MCP tool schemas require explicit user approval before execution"
 		return decision
 	}
 	switch risk {
@@ -580,6 +580,56 @@ func (m *Manager) loadInventoryUnlocked() (persistedToolInventory, error) {
 		}
 	}
 	return snapshot, nil
+}
+
+func (m *Manager) publicInventoryWarning(err error) string {
+	if err == nil {
+		return "Airlock tool inventory warning"
+	}
+	var pathErr *os.PathError
+	if errors.As(err, &pathErr) {
+		return "Airlock tool inventory filesystem access failed: " + publicInventoryErrorDetail(pathErr.Err)
+	}
+	var linkErr *os.LinkError
+	if errors.As(err, &linkErr) {
+		return "Airlock tool inventory replacement failed: " + publicInventoryErrorDetail(linkErr.Err)
+	}
+	message := redactOutput(err.Error())
+	message = redactInventoryLocation(message, m.inventoryPath)
+	if message == "" {
+		return "Airlock tool inventory warning"
+	}
+	return message
+}
+
+func publicInventoryErrorDetail(err error) string {
+	if err == nil {
+		return "filesystem operation failed"
+	}
+	message := redactOutput(err.Error())
+	if message == "" {
+		return "filesystem operation failed"
+	}
+	return message
+}
+
+func redactInventoryLocation(message, path string) string {
+	path = strings.TrimSpace(path)
+	if message == "" || path == "" {
+		return message
+	}
+	candidates := []string{path, filepath.Clean(path)}
+	dir := filepath.Dir(path)
+	if dir != "." {
+		candidates = append(candidates, dir, filepath.Clean(dir))
+	}
+	for _, candidate := range candidates {
+		if candidate == "" || candidate == "." {
+			continue
+		}
+		message = strings.ReplaceAll(message, candidate, "[airlock-inventory]")
+	}
+	return message
 }
 
 func (m *Manager) saveInventoryUnlocked(snapshot persistedToolInventory) error {

--- a/internal/mcpairlock/tools.go
+++ b/internal/mcpairlock/tools.go
@@ -101,6 +101,7 @@ type persistedToolRecord struct {
 	Description     string   `json:"description,omitempty"`
 	InputSchemaHash string   `json:"input_schema_hash"`
 	LastSeenAt      string   `json:"last_seen_at"`
+	SchemaState     string   `json:"schema_state,omitempty"`
 	Risk            ToolRisk `json:"risk"`
 }
 
@@ -174,7 +175,7 @@ func (m *Manager) DiscoverTools(ctx context.Context, id string) (ToolInventory, 
 				state = "changed"
 			}
 		}
-		decision := m.DecideTool(id, "", name, risk)
+		decision := m.DecideTool(id, "", name, risk, state)
 		entry := ToolInventoryEntry{
 			ServerID:        id,
 			Name:            name,
@@ -190,6 +191,7 @@ func (m *Manager) DiscoverTools(ctx context.Context, id string) (ToolInventory, 
 			Description:     entry.Description,
 			InputSchemaHash: entry.InputSchemaHash,
 			LastSeenAt:      entry.LastSeenAt,
+			SchemaState:     entry.SchemaState,
 			Risk:            entry.Risk,
 		}
 	}
@@ -236,9 +238,9 @@ func (m *Manager) Inventory(id string) (ToolInventory, error) {
 			Description:     record.Description,
 			InputSchemaHash: record.InputSchemaHash,
 			LastSeenAt:      record.LastSeenAt,
-			SchemaState:     "known",
+			SchemaState:     normalizedSchemaState(record.SchemaState),
 			Risk:            risk,
-			Decision:        m.DecideTool(id, "", name, risk),
+			Decision:        m.DecideTool(id, "", name, risk, normalizedSchemaState(record.SchemaState)),
 		}
 		inventory.Tools = append(inventory.Tools, entry)
 	}
@@ -264,7 +266,7 @@ func (m *Manager) EvaluateTool(serverID, project, toolName string) (ToolInventor
 	}
 	for _, entry := range inventory.Tools {
 		if entry.Name == toolName {
-			entry.Decision = m.DecideTool(serverID, project, toolName, entry.Risk)
+			entry.Decision = m.DecideTool(serverID, project, toolName, entry.Risk, entry.SchemaState)
 			return entry, nil
 		}
 	}
@@ -274,7 +276,7 @@ func (m *Manager) EvaluateTool(serverID, project, toolName string) (ToolInventor
 		Name:        toolName,
 		SchemaState: "unknown",
 		Risk:        risk,
-		Decision:    m.DecideTool(serverID, project, toolName, risk),
+		Decision:    m.DecideTool(serverID, project, toolName, risk, "unknown"),
 	}, nil
 }
 
@@ -305,15 +307,27 @@ func (m *Manager) SetToolAllowlist(serverID, project, toolName string, allowed b
 }
 
 // DecideTool applies Airlock's fail-closed firewall policy.
-func (m *Manager) DecideTool(serverID, project, toolName string, risk ToolRisk) ToolDecision {
+func (m *Manager) DecideTool(serverID, project, toolName string, risk ToolRisk, schemaState string) ToolDecision {
 	if risk == "" {
 		risk = RiskUnknown
 	}
+	schemaState = normalizedSchemaState(schemaState)
 	allowlisted := m.isAllowlisted(serverID, project, toolName)
 	decision := ToolDecision{
 		Risk:            risk,
 		Allowlisted:     allowlisted,
 		UntrustedOutput: true,
+	}
+	if schemaReviewRequired(schemaState) {
+		if !allowlisted {
+			decision.Status = "blocked"
+			decision.Reason = schemaState + " external MCP tool schemas are blocked until re-reviewed or explicitly allowlisted"
+			return decision
+		}
+		decision.Status = "approval_required"
+		decision.ApprovalRequired = true
+		decision.Reason = "allowlisted " + schemaState + " external MCP tool schemas still require explicit approval"
+		return decision
 	}
 	switch risk {
 	case RiskReadOnly:
@@ -321,13 +335,13 @@ func (m *Manager) DecideTool(serverID, project, toolName string, risk ToolRisk) 
 		decision.Allowed = true
 		decision.Reason = "read-only tools are allowed by default; output remains untrusted"
 	case RiskGenerateCode:
-		if allowlisted {
-			decision.Status = "allowed"
-			decision.Allowed = true
-			decision.Reason = "generate-code tool is explicitly allowlisted; output remains untrusted"
-		} else {
+		if !allowlisted {
 			decision.Status = "blocked"
 			decision.Reason = "generate-code tools require an explicit server or project allowlist"
+		} else {
+			decision.Status = "approval_required"
+			decision.ApprovalRequired = true
+			decision.Reason = "generate-code tools require explicit user approval before execution"
 		}
 	case RiskModifyWorkspace, RiskCloudMutation, RiskSecretSensitive, RiskDestructive:
 		if !allowlisted {
@@ -547,6 +561,19 @@ func schemaText(schema map[string]any) string {
 		return fmt.Sprintf("%v", schema)
 	}
 	return string(data)
+}
+
+func normalizedSchemaState(state string) string {
+	switch trimmed := strings.TrimSpace(state); trimmed {
+	case "new", "changed", "unknown":
+		return trimmed
+	default:
+		return "known"
+	}
+}
+
+func schemaReviewRequired(state string) bool {
+	return state == "new" || state == "changed"
 }
 
 func readOnlyAnnotation(annotations map[string]any) bool {

--- a/internal/mcpairlock/tools.go
+++ b/internal/mcpairlock/tools.go
@@ -624,7 +624,7 @@ func writeFileAtomic(path string, data []byte) error {
 	if err := tmp.Close(); err != nil {
 		return fmt.Errorf("close temporary file: %w", err)
 	}
-	if err := os.Rename(tmpName, path); err != nil {
+	if err := replaceFileAtomic(tmpName, path); err != nil {
 		return fmt.Errorf("replace inventory file: %w", err)
 	}
 	keepTemp = false

--- a/internal/mcpairlock/tools.go
+++ b/internal/mcpairlock/tools.go
@@ -708,15 +708,15 @@ func schemaText(schema map[string]any) string {
 
 func normalizedSchemaState(state string) string {
 	switch trimmed := strings.TrimSpace(state); trimmed {
-	case "new", "changed", "unknown":
+	case "known", "new", "changed", "unknown":
 		return trimmed
 	default:
-		return "known"
+		return "unknown"
 	}
 }
 
 func schemaReviewRequired(state string) bool {
-	return state == "new" || state == "changed"
+	return normalizedSchemaState(state) != "known"
 }
 
 func readOnlyAnnotation(annotations map[string]any) bool {

--- a/internal/mcpairlock/tools.go
+++ b/internal/mcpairlock/tools.go
@@ -153,64 +153,63 @@ func (m *Manager) DiscoverTools(ctx context.Context, id string) (ToolInventory, 
 	}
 
 	now := time.Now().UTC()
-	m.inventoryMu.Lock()
-	defer m.inventoryMu.Unlock()
-	previous, err := m.loadInventoryUnlocked()
-	if err != nil {
-		inventory.Checks = append(inventory.Checks, Check{Name: "inventory", Status: "warn", Message: m.publicInventoryWarning(err)})
-		previous = persistedToolInventory{Servers: map[string]persistedServerTools{}}
-	}
 	inventory.DiscoveredAt = now.Format(time.RFC3339)
-	inventory.Tools = make([]ToolInventoryEntry, 0, len(result.Tools))
-	seen := map[string]persistedToolRecord{}
-	allowlist := m.mergedAllowlist(previous.Allowlist)
-	for _, tool := range result.Tools {
-		name := strings.TrimSpace(tool.Name)
-		if name == "" {
-			continue
+	if err := m.updateInventory(func(previous *persistedToolInventory, loadErr error) error {
+		if loadErr != nil {
+			inventory.Checks = append(inventory.Checks, Check{Name: "inventory", Status: "warn", Message: m.publicInventoryWarning(loadErr)})
+			*previous = persistedToolInventory{Servers: map[string]persistedServerTools{}}
 		}
-		hash := schemaHash(tool.InputSchema)
-		risk := ClassifyTool(tool)
-		prior, hadPrior := previous.Servers[id].Tools[name]
-		state := "new"
-		if hadPrior {
-			state = "known"
-			if prior.InputSchemaHash != hash {
-				state = "changed"
+		inventory.Tools = make([]ToolInventoryEntry, 0, len(result.Tools))
+		seen := map[string]persistedToolRecord{}
+		allowlist := m.mergedAllowlist(previous.Allowlist)
+		for _, tool := range result.Tools {
+			name := strings.TrimSpace(tool.Name)
+			if name == "" {
+				continue
+			}
+			hash := schemaHash(tool.InputSchema)
+			risk := ClassifyTool(tool)
+			prior, hadPrior := previous.Servers[id].Tools[name]
+			state := "new"
+			if hadPrior {
+				state = "known"
+				if prior.InputSchemaHash != hash {
+					state = "changed"
+				}
+			}
+			decision := decideToolWithAllowlist(id, "", name, risk, state, allowlist)
+			entry := ToolInventoryEntry{
+				ServerID:        id,
+				Name:            name,
+				Description:     strings.TrimSpace(tool.Description),
+				InputSchemaHash: hash,
+				LastSeenAt:      inventory.DiscoveredAt,
+				SchemaState:     state,
+				Risk:            risk,
+				Decision:        decision,
+			}
+			inventory.Tools = append(inventory.Tools, entry)
+			seen[name] = persistedToolRecord{
+				Description:     entry.Description,
+				InputSchemaHash: entry.InputSchemaHash,
+				LastSeenAt:      entry.LastSeenAt,
+				SchemaState:     entry.SchemaState,
+				Risk:            entry.Risk,
 			}
 		}
-		decision := decideToolWithAllowlist(id, "", name, risk, state, allowlist)
-		entry := ToolInventoryEntry{
-			ServerID:        id,
-			Name:            name,
-			Description:     strings.TrimSpace(tool.Description),
-			InputSchemaHash: hash,
-			LastSeenAt:      inventory.DiscoveredAt,
-			SchemaState:     state,
-			Risk:            risk,
-			Decision:        decision,
+		sortToolEntries(inventory.Tools)
+		if len(inventory.Tools) == 0 {
+			inventory.Checks = append(inventory.Checks, Check{Name: "tool_discovery", Status: "warn", Message: "tools/list returned no tools"})
+		} else {
+			inventory.Checks = append(inventory.Checks, Check{Name: "tool_discovery", Status: "pass", Message: fmt.Sprintf("discovered %d external MCP tools", len(inventory.Tools))})
 		}
-		inventory.Tools = append(inventory.Tools, entry)
-		seen[name] = persistedToolRecord{
-			Description:     entry.Description,
-			InputSchemaHash: entry.InputSchemaHash,
-			LastSeenAt:      entry.LastSeenAt,
-			SchemaState:     entry.SchemaState,
-			Risk:            entry.Risk,
-		}
-	}
-	sortToolEntries(inventory.Tools)
-	if len(inventory.Tools) == 0 {
-		inventory.Checks = append(inventory.Checks, Check{Name: "tool_discovery", Status: "warn", Message: "tools/list returned no tools"})
-	} else {
-		inventory.Checks = append(inventory.Checks, Check{Name: "tool_discovery", Status: "pass", Message: fmt.Sprintf("discovered %d external MCP tools", len(inventory.Tools))})
-	}
 
-	previous.Servers[id] = persistedServerTools{
-		DiscoveredAt: inventory.DiscoveredAt,
-		Tools:        seen,
-	}
-	if err := m.saveInventoryUnlocked(previous); err != nil {
+		previous.Servers[id] = persistedServerTools{
+			DiscoveredAt: inventory.DiscoveredAt,
+			Tools:        seen,
+		}
+		return nil
+	}); err != nil {
 		inventory.Checks = append(inventory.Checks, Check{Name: "inventory", Status: "warn", Message: m.publicInventoryWarning(err)})
 		return inventory, nil
 	}
@@ -288,19 +287,20 @@ func (m *Manager) SetToolAllowlist(serverID, project, toolName string, allowed b
 	if toolName == "" {
 		return ToolInventoryEntry{}, errors.New("tool_name is required")
 	}
-	m.inventoryMu.Lock()
-	defer m.inventoryMu.Unlock()
-	snapshot, err := m.loadInventoryUnlocked()
-	if err != nil {
-		return ToolInventoryEntry{}, m.publicInventoryError(err)
-	}
-	ensureAllowlist(&snapshot.Allowlist)
-	if allowed {
-		addAllowlistTool(&snapshot.Allowlist, serverID, project, toolName)
-	} else {
-		removeAllowlistTool(&snapshot.Allowlist, serverID, project, toolName)
-	}
-	if err := m.saveInventoryUnlocked(snapshot); err != nil {
+	var snapshot persistedToolInventory
+	if err := m.updateInventory(func(next *persistedToolInventory, loadErr error) error {
+		if loadErr != nil {
+			return loadErr
+		}
+		ensureAllowlist(&next.Allowlist)
+		if allowed {
+			addAllowlistTool(&next.Allowlist, serverID, project, toolName)
+		} else {
+			removeAllowlistTool(&next.Allowlist, serverID, project, toolName)
+		}
+		snapshot = *next
+		return nil
+	}); err != nil {
 		return ToolInventoryEntry{}, m.publicInventoryError(err)
 	}
 	return m.evaluateToolFromSnapshot(snapshot, serverID, project, toolName), nil
@@ -549,6 +549,22 @@ func (m *Manager) loadInventory() (persistedToolInventory, error) {
 	m.inventoryMu.Lock()
 	defer m.inventoryMu.Unlock()
 	return m.loadInventoryUnlocked()
+}
+
+// updateInventory holds one lock across load, mutation, and save so overlapping
+// discovery and allowlist updates cannot drop each other's persisted changes.
+func (m *Manager) updateInventory(update func(*persistedToolInventory, error) error) error {
+	m.inventoryMu.Lock()
+	defer m.inventoryMu.Unlock()
+
+	snapshot, loadErr := m.loadInventoryUnlocked()
+	if err := update(&snapshot, loadErr); err != nil {
+		return err
+	}
+	if err := m.saveInventoryUnlocked(snapshot); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (m *Manager) loadInventoryUnlocked() (persistedToolInventory, error) {

--- a/internal/mcpairlock/tools.go
+++ b/internal/mcpairlock/tools.go
@@ -273,7 +273,7 @@ func (m *Manager) EvaluateTool(serverID, project, toolName string) (ToolInventor
 	}
 	snapshot, err := m.loadInventory()
 	if err != nil {
-		return ToolInventoryEntry{}, err
+		return ToolInventoryEntry{}, m.publicInventoryError(err)
 	}
 	return m.evaluateToolFromSnapshot(snapshot, serverID, project, toolName), nil
 }
@@ -292,7 +292,7 @@ func (m *Manager) SetToolAllowlist(serverID, project, toolName string, allowed b
 	defer m.inventoryMu.Unlock()
 	snapshot, err := m.loadInventoryUnlocked()
 	if err != nil {
-		return ToolInventoryEntry{}, err
+		return ToolInventoryEntry{}, m.publicInventoryError(err)
 	}
 	ensureAllowlist(&snapshot.Allowlist)
 	if allowed {
@@ -301,7 +301,7 @@ func (m *Manager) SetToolAllowlist(serverID, project, toolName string, allowed b
 		removeAllowlistTool(&snapshot.Allowlist, serverID, project, toolName)
 	}
 	if err := m.saveInventoryUnlocked(snapshot); err != nil {
-		return ToolInventoryEntry{}, err
+		return ToolInventoryEntry{}, m.publicInventoryError(err)
 	}
 	return m.evaluateToolFromSnapshot(snapshot, serverID, project, toolName), nil
 }
@@ -600,6 +600,10 @@ func (m *Manager) publicInventoryWarning(err error) string {
 		return "Airlock tool inventory warning"
 	}
 	return message
+}
+
+func (m *Manager) publicInventoryError(err error) error {
+	return errors.New(m.publicInventoryWarning(err))
 }
 
 func publicInventoryErrorDetail(err error) string {

--- a/internal/mcpairlock/tools.go
+++ b/internal/mcpairlock/tools.go
@@ -465,34 +465,10 @@ func defaultToolDiscoverer(ctx context.Context, definition ServerDefinition, tim
 
 	encoder := json.NewEncoder(stdin)
 	encoder.SetEscapeHTML(false)
-	if err := encoder.Encode(map[string]any{
-		"jsonrpc": "2.0",
-		"id":      1,
-		"method":  "initialize",
-		"params": map[string]any{
-			"protocolVersion": "2025-06-18",
-			"capabilities":    map[string]any{},
-			"clientInfo":      map[string]any{"name": "iac-studio-airlock", "version": "0"},
-		},
-	}); err != nil {
+	if err := writeToolDiscoveryRequests(encoder, stdin); err != nil {
 		cancel()
 		waitErr := <-doneErr
-		return DiscoveryProbeResult{Output: stderrBuf.String(), Err: errors.Join(fmt.Errorf("write initialize request: %w", err), waitErr)}
-	}
-	if err := encoder.Encode(map[string]any{"jsonrpc": "2.0", "method": "notifications/initialized"}); err != nil {
-		cancel()
-		waitErr := <-doneErr
-		return DiscoveryProbeResult{Output: stderrBuf.String(), Err: errors.Join(fmt.Errorf("write initialized notification: %w", err), waitErr)}
-	}
-	if err := encoder.Encode(map[string]any{"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": map[string]any{}}); err != nil {
-		cancel()
-		waitErr := <-doneErr
-		return DiscoveryProbeResult{Output: stderrBuf.String(), Err: errors.Join(fmt.Errorf("write tools/list request: %w", err), waitErr)}
-	}
-	if err := stdin.Close(); err != nil {
-		cancel()
-		waitErr := <-doneErr
-		return DiscoveryProbeResult{Output: stderrBuf.String(), Err: errors.Join(fmt.Errorf("close discovery stdin: %w", err), waitErr)}
+		return DiscoveryProbeResult{Output: stderrBuf.String(), Err: errors.Join(err, waitErr)}
 	}
 
 	scanner := bufio.NewScanner(stdout)
@@ -536,6 +512,31 @@ func defaultToolDiscoverer(ctx context.Context, definition ServerDefinition, tim
 		return DiscoveryProbeResult{Output: stderrBuf.String(), Err: err}
 	}
 	return DiscoveryProbeResult{Output: stderrBuf.String(), Err: errors.New("tools/list response not received")}
+}
+
+func writeToolDiscoveryRequests(encoder *json.Encoder, stdin io.Closer) error {
+	if err := encoder.Encode(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params": map[string]any{
+			"protocolVersion": "2025-06-18",
+			"capabilities":    map[string]any{},
+			"clientInfo":      map[string]any{"name": "iac-studio-airlock", "version": "0"},
+		},
+	}); err != nil {
+		return fmt.Errorf("write initialize request: %w", err)
+	}
+	if err := encoder.Encode(map[string]any{"jsonrpc": "2.0", "method": "notifications/initialized"}); err != nil {
+		return fmt.Errorf("write initialized notification: %w", err)
+	}
+	if err := encoder.Encode(map[string]any{"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": map[string]any{}}); err != nil {
+		return fmt.Errorf("write tools/list request: %w", err)
+	}
+	if err := stdin.Close(); err != nil {
+		return fmt.Errorf("close discovery stdin: %w", err)
+	}
+	return nil
 }
 
 func (m *Manager) loadInventory() (persistedToolInventory, error) {

--- a/internal/mcpairlock/tools_test.go
+++ b/internal/mcpairlock/tools_test.go
@@ -128,6 +128,27 @@ func TestDiscoverToolsPreservesPersistedAllowlist(t *testing.T) {
 	}
 }
 
+func TestSetToolAllowlistCanRemoveMissingEntries(t *testing.T) {
+	manager := NewManager(t.TempDir(),
+		WithDefinitions([]ServerDefinition{{
+			ID:              "aws",
+			Name:            "AWS",
+			Command:         testExecutable(t),
+			Transport:       "stdio",
+			Trusted:         true,
+			ReadOnlyDefault: true,
+			CredentialMode:  "none",
+		}}),
+	)
+
+	if _, err := manager.SetToolAllowlist("aws", "", "missing_tool", false); err != nil {
+		t.Fatalf("remove missing server allowlist entry: %v", err)
+	}
+	if _, err := manager.SetToolAllowlist("aws", "demo", "missing_tool", false); err != nil {
+		t.Fatalf("remove missing project allowlist entry: %v", err)
+	}
+}
+
 func TestToolFirewallBlocksUnknownAndApprovalGatesAllowlistedMutation(t *testing.T) {
 	manager := NewManager(t.TempDir(), WithToolAllowlist(ToolAllowlist{
 		ServerTools: map[string][]string{"aws": []string{"create_bucket"}},

--- a/internal/mcpairlock/tools_test.go
+++ b/internal/mcpairlock/tools_test.go
@@ -149,6 +149,46 @@ func TestSetToolAllowlistCanRemoveMissingEntries(t *testing.T) {
 	}
 }
 
+func TestSaveInventoryAtomicWriteFailurePreservesExistingInventory(t *testing.T) {
+	root := t.TempDir()
+	manager := NewManager(root)
+	inventoryDir := filepath.Join(root, ".iac-studio")
+	if err := os.MkdirAll(inventoryDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	original := []byte("{\"servers\":{}}\n")
+	if err := os.WriteFile(manager.inventoryPath, original, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := os.Chmod(inventoryDir, 0o500); err != nil {
+		t.Fatalf("Chmod read-only: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(inventoryDir, 0o700)
+	})
+
+	err := manager.saveInventoryUnlocked(persistedToolInventory{
+		Servers: map[string]persistedServerTools{
+			"aws": {
+				Tools: map[string]persistedToolRecord{
+					"create_bucket": {Description: "Create an S3 bucket"},
+				},
+			},
+		},
+	})
+	if err == nil {
+		t.Skip("directory permissions did not block inventory replacement on this platform")
+	}
+
+	got, readErr := os.ReadFile(manager.inventoryPath)
+	if readErr != nil {
+		t.Fatalf("ReadFile existing inventory: %v", readErr)
+	}
+	if !bytes.Equal(got, original) {
+		t.Fatalf("existing inventory changed after failed write: got %q want %q", got, original)
+	}
+}
+
 func TestToolFirewallBlocksUnknownAndApprovalGatesAllowlistedMutation(t *testing.T) {
 	manager := NewManager(t.TempDir(), WithToolAllowlist(ToolAllowlist{
 		ServerTools: map[string][]string{"aws": []string{"create_bucket"}},

--- a/internal/mcpairlock/tools_test.go
+++ b/internal/mcpairlock/tools_test.go
@@ -189,6 +189,25 @@ func TestSaveInventoryAtomicWriteFailurePreservesExistingInventory(t *testing.T)
 	}
 }
 
+func TestWriteFileAtomicReplacesExistingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "inventory.json")
+	if err := os.WriteFile(path, []byte("old\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile old: %v", err)
+	}
+
+	if err := writeFileAtomic(path, []byte("new\n")); err != nil {
+		t.Fatalf("writeFileAtomic: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !bytes.Equal(got, []byte("new\n")) {
+		t.Fatalf("unexpected replacement contents: got %q", got)
+	}
+}
+
 func TestToolFirewallBlocksUnknownAndApprovalGatesAllowlistedMutation(t *testing.T) {
 	manager := NewManager(t.TempDir(), WithToolAllowlist(ToolAllowlist{
 		ServerTools: map[string][]string{"aws": []string{"create_bucket"}},

--- a/internal/mcpairlock/tools_test.go
+++ b/internal/mcpairlock/tools_test.go
@@ -245,6 +245,52 @@ func TestSetToolAllowlistCanRemoveMissingEntries(t *testing.T) {
 	}
 }
 
+func TestInventoryMissingSchemaStateFailsClosed(t *testing.T) {
+	manager := NewManager(t.TempDir(),
+		WithDefinitions([]ServerDefinition{{
+			ID:              "aws",
+			Name:            "AWS",
+			Command:         testExecutable(t),
+			Transport:       "stdio",
+			Trusted:         true,
+			ReadOnlyDefault: true,
+			CredentialMode:  "none",
+		}}),
+	)
+	if err := manager.saveInventoryUnlocked(persistedToolInventory{
+		Servers: map[string]persistedServerTools{
+			"aws": {
+				DiscoveredAt: time.Now().UTC().Format(time.RFC3339),
+				Tools: map[string]persistedToolRecord{
+					"list_buckets": {
+						Description:     "List S3 buckets.",
+						InputSchemaHash: "sha256:legacy",
+						LastSeenAt:      time.Now().UTC().Format(time.RFC3339),
+						Risk:            RiskReadOnly,
+					},
+				},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("saveInventoryUnlocked: %v", err)
+	}
+
+	inventory, err := manager.Inventory("aws")
+	if err != nil {
+		t.Fatalf("Inventory: %v", err)
+	}
+	if len(inventory.Tools) != 1 {
+		t.Fatalf("expected one tool, got %+v", inventory.Tools)
+	}
+	tool := inventory.Tools[0]
+	if tool.SchemaState != "unknown" {
+		t.Fatalf("expected missing schema state to normalize to unknown, got %+v", tool)
+	}
+	if tool.Decision.Status != "blocked" || tool.Decision.Allowed {
+		t.Fatalf("missing schema state should fail closed, got %+v", tool.Decision)
+	}
+}
+
 func TestSaveInventoryAtomicWriteFailurePreservesExistingInventory(t *testing.T) {
 	root := t.TempDir()
 	manager := NewManager(root)
@@ -340,6 +386,16 @@ func TestToolFirewallBlocksUnknownAndApprovalGatesAllowlistedMutation(t *testing
 	changedReadOnly := manager.DecideTool("aws", "demo", "mystery_tool", RiskReadOnly, "changed")
 	if changedReadOnly.Status != "approval_required" || !changedReadOnly.ApprovalRequired || !changedReadOnly.Allowlisted {
 		t.Fatalf("allowlisted changed schemas should still require approval, got %+v", changedReadOnly)
+	}
+
+	missingStateReadOnly := manager.DecideTool("aws", "", "list_buckets", RiskReadOnly, "")
+	if missingStateReadOnly.Status != "blocked" || missingStateReadOnly.Allowed {
+		t.Fatalf("missing schema state should fail closed, got %+v", missingStateReadOnly)
+	}
+
+	invalidStateReadOnly := manager.DecideTool("aws", "", "list_buckets", RiskReadOnly, "unexpected")
+	if invalidStateReadOnly.Status != "blocked" || invalidStateReadOnly.Allowed {
+		t.Fatalf("invalid schema state should fail closed, got %+v", invalidStateReadOnly)
 	}
 }
 

--- a/internal/mcpairlock/tools_test.go
+++ b/internal/mcpairlock/tools_test.go
@@ -176,6 +176,74 @@ func TestDiscoverToolsDoesNotDropConcurrentAllowlistUpdate(t *testing.T) {
 	}
 }
 
+func TestDiscoverToolsDoesNotDropConcurrentServerInventory(t *testing.T) {
+	started := map[string]chan struct{}{
+		"aws":       make(chan struct{}),
+		"terraform": make(chan struct{}),
+	}
+	releaseDiscovery := make(chan struct{})
+	manager := NewManager(t.TempDir(),
+		WithDefinitions([]ServerDefinition{
+			{
+				ID:              "aws",
+				Name:            "AWS",
+				Command:         testExecutable(t),
+				Transport:       "stdio",
+				Trusted:         true,
+				ReadOnlyDefault: true,
+				CredentialMode:  "none",
+			},
+			{
+				ID:              "terraform",
+				Name:            "Terraform",
+				Command:         testExecutable(t),
+				Transport:       "stdio",
+				Trusted:         true,
+				ReadOnlyDefault: true,
+				CredentialMode:  "none",
+			},
+		}),
+		WithToolDiscoverer(func(_ context.Context, definition ServerDefinition, _ time.Duration) DiscoveryProbeResult {
+			close(started[definition.ID])
+			<-releaseDiscovery
+			return DiscoveryProbeResult{Tools: []DiscoveredTool{{
+				Name:        definition.ID + "_tool",
+				Description: "Read-only test tool",
+				InputSchema: map[string]any{"type": "object"},
+				Annotations: map[string]any{"readOnlyHint": true},
+			}}}
+		}),
+	)
+
+	errCh := make(chan error, 2)
+	for _, id := range []string{"aws", "terraform"} {
+		id := id
+		go func() {
+			_, err := manager.DiscoverTools(context.Background(), id)
+			errCh <- err
+		}()
+	}
+
+	<-started["aws"]
+	<-started["terraform"]
+	close(releaseDiscovery)
+	for range 2 {
+		if err := <-errCh; err != nil {
+			t.Fatalf("DiscoverTools: %v", err)
+		}
+	}
+
+	for _, id := range []string{"aws", "terraform"} {
+		inventory, err := manager.Inventory(id)
+		if err != nil {
+			t.Fatalf("Inventory %s: %v", id, err)
+		}
+		if len(inventory.Tools) != 1 || inventory.Tools[0].Name != id+"_tool" {
+			t.Fatalf("expected %s inventory to survive concurrent discovery, got %+v", id, inventory.Tools)
+		}
+	}
+}
+
 func TestDiscoverToolsRecoversFromCorruptInventory(t *testing.T) {
 	root := t.TempDir()
 	manager := NewManager(root,

--- a/internal/mcpairlock/tools_test.go
+++ b/internal/mcpairlock/tools_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -213,6 +215,79 @@ func TestDiscoverToolsUnknownServerFailsClosed(t *testing.T) {
 
 	if !errors.Is(err, ErrUnknownServer) {
 		t.Fatalf("expected ErrUnknownServer, got %v", err)
+	}
+}
+
+func TestDiscoverToolsReturnsEmptySlicesOnEarlyExit(t *testing.T) {
+	root := t.TempDir()
+	manager := NewManager(root,
+		WithDefinitions([]ServerDefinition{{
+			ID:              "terraform",
+			Name:            "Terraform",
+			Command:         testExecutable(t),
+			Transport:       "stdio",
+			Trusted:         true,
+			ReadOnlyDefault: true,
+			CredentialMode:  "none",
+		}}),
+		WithToolDiscoverer(func(context.Context, ServerDefinition, time.Duration) DiscoveryProbeResult {
+			return DiscoveryProbeResult{TimedOut: true}
+		}),
+	)
+
+	inventory, err := manager.DiscoverTools(context.Background(), "terraform")
+	if err != nil {
+		t.Fatalf("DiscoverTools: %v", err)
+	}
+	if inventory.Tools == nil {
+		t.Fatal("expected Tools to be an empty slice")
+	}
+	if inventory.Checks == nil {
+		t.Fatal("expected Checks to be an empty or populated slice")
+	}
+}
+
+func TestInventoryReturnsEmptySlicesWhenNothingDiscoveredOrLoadFails(t *testing.T) {
+	root := t.TempDir()
+	manager := NewManager(root,
+		WithDefinitions([]ServerDefinition{{
+			ID:              "terraform",
+			Name:            "Terraform",
+			Command:         testExecutable(t),
+			Transport:       "stdio",
+			Trusted:         true,
+			ReadOnlyDefault: true,
+			CredentialMode:  "none",
+		}}),
+	)
+
+	emptyInventory, err := manager.Inventory("terraform")
+	if err != nil {
+		t.Fatalf("Inventory empty: %v", err)
+	}
+	if emptyInventory.Tools == nil {
+		t.Fatal("expected empty inventory Tools to be []")
+	}
+	if emptyInventory.Checks == nil {
+		t.Fatal("expected empty inventory Checks to be []")
+	}
+
+	if err := os.MkdirAll(filepath.Join(root, ".iac-studio"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".iac-studio", toolInventoryName), []byte("{"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	invalidInventory, err := manager.Inventory("terraform")
+	if err != nil {
+		t.Fatalf("Inventory invalid: %v", err)
+	}
+	if invalidInventory.Tools == nil {
+		t.Fatal("expected invalid inventory Tools to be []")
+	}
+	if len(invalidInventory.Checks) != 1 {
+		t.Fatalf("expected one warning check, got %+v", invalidInventory.Checks)
 	}
 }
 

--- a/internal/mcpairlock/tools_test.go
+++ b/internal/mcpairlock/tools_test.go
@@ -179,6 +179,51 @@ func TestDiscoverToolsRecoversFromCorruptInventory(t *testing.T) {
 	}
 }
 
+func TestDiscoverToolsInventoryWarningsDoNotExposeInventoryPath(t *testing.T) {
+	root := t.TempDir()
+	manager := NewManager(root,
+		WithDefinitions([]ServerDefinition{{
+			ID:              "aws",
+			Name:            "AWS",
+			Command:         testExecutable(t),
+			Transport:       "stdio",
+			Trusted:         true,
+			ReadOnlyDefault: true,
+			CredentialMode:  "none",
+		}}),
+		WithToolDiscoverer(func(context.Context, ServerDefinition, time.Duration) DiscoveryProbeResult {
+			return DiscoveryProbeResult{Tools: []DiscoveredTool{{
+				Name:        "list_buckets",
+				Description: "List S3 buckets.",
+				InputSchema: map[string]any{"type": "object"},
+				Annotations: map[string]any{"readOnlyHint": true},
+			}}}
+		}),
+	)
+	inventoryDir := filepath.Join(root, ".iac-studio")
+	if err := os.MkdirAll(inventoryDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	manager.inventoryPath = inventoryDir
+
+	inventory, err := manager.DiscoverTools(context.Background(), "aws")
+	if err != nil {
+		t.Fatalf("DiscoverTools: %v", err)
+	}
+	if len(inventory.Tools) != 1 {
+		t.Fatalf("expected discovery to continue, got %+v", inventory.Tools)
+	}
+	messages := checkMessages(inventory.Checks, "inventory")
+	if len(messages) == 0 {
+		t.Fatalf("expected inventory warning checks, got %+v", inventory.Checks)
+	}
+	for _, message := range messages {
+		if strings.Contains(message, root) || strings.Contains(message, manager.inventoryPath) {
+			t.Fatalf("inventory warning leaked path %q in %q", root, message)
+		}
+	}
+}
+
 func TestSetToolAllowlistCanRemoveMissingEntries(t *testing.T) {
 	manager := NewManager(t.TempDir(),
 		WithDefinitions([]ServerDefinition{{
@@ -422,6 +467,51 @@ func TestInventoryReturnsEmptySlicesWhenNothingDiscoveredOrLoadFails(t *testing.
 	}
 }
 
+func TestInventoryWarningDoesNotExposeInventoryPath(t *testing.T) {
+	root := t.TempDir()
+	manager := NewManager(root,
+		WithDefinitions([]ServerDefinition{{
+			ID:              "terraform",
+			Name:            "Terraform",
+			Command:         testExecutable(t),
+			Transport:       "stdio",
+			Trusted:         true,
+			ReadOnlyDefault: true,
+			CredentialMode:  "none",
+		}}),
+	)
+	inventoryDir := filepath.Join(root, ".iac-studio")
+	if err := os.MkdirAll(inventoryDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	manager.inventoryPath = inventoryDir
+
+	inventory, err := manager.Inventory("terraform")
+	if err != nil {
+		t.Fatalf("Inventory: %v", err)
+	}
+	messages := checkMessages(inventory.Checks, "inventory")
+	if len(messages) == 0 {
+		t.Fatalf("expected inventory warning checks, got %+v", inventory.Checks)
+	}
+	for _, message := range messages {
+		if strings.Contains(message, root) || strings.Contains(message, manager.inventoryPath) {
+			t.Fatalf("inventory warning leaked path %q in %q", root, message)
+		}
+	}
+}
+
+func TestSchemaReviewReasonMatchesRediscoveryFlow(t *testing.T) {
+	decision := decideToolWithAllowlist("aws", "", "list_buckets", RiskReadOnly, "new", ToolAllowlist{})
+
+	if strings.Contains(decision.Reason, "re-reviewed") {
+		t.Fatalf("schema review reason mentions unavailable review flow: %q", decision.Reason)
+	}
+	if !strings.Contains(decision.Reason, "later discovery confirms the same schema") {
+		t.Fatalf("schema review reason does not explain stable rediscovery flow: %q", decision.Reason)
+	}
+}
+
 func TestWriteToolDiscoveryRequestsReturnsEncodeError(t *testing.T) {
 	errEncode := errors.New("encode failed")
 
@@ -459,6 +549,16 @@ func hasCheck(checks []Check, name, status string) bool {
 		}
 	}
 	return false
+}
+
+func checkMessages(checks []Check, name string) []string {
+	messages := []string{}
+	for _, check := range checks {
+		if check.Name == name {
+			messages = append(messages, check.Message)
+		}
+	}
+	return messages
 }
 
 type failingWriter struct {

--- a/internal/mcpairlock/tools_test.go
+++ b/internal/mcpairlock/tools_test.go
@@ -1,0 +1,152 @@
+package mcpairlock
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestDiscoverToolsPersistsInventoryAndDetectsSchemaChanges(t *testing.T) {
+	root := t.TempDir()
+	calls := 0
+	manager := NewManager(root,
+		WithDefinitions([]ServerDefinition{{
+			ID:              "terraform",
+			Name:            "Terraform",
+			Command:         testExecutable(t),
+			Transport:       "stdio",
+			Trusted:         true,
+			ReadOnlyDefault: true,
+			CredentialMode:  "none",
+		}}),
+		WithToolDiscoverer(func(context.Context, ServerDefinition, time.Duration) DiscoveryProbeResult {
+			calls++
+			schema := map[string]any{"type": "object", "properties": map[string]any{"query": map[string]any{"type": "string"}}}
+			if calls == 2 {
+				schema = map[string]any{"type": "object", "properties": map[string]any{"query": map[string]any{"type": "string"}, "limit": map[string]any{"type": "integer"}}}
+			}
+			return DiscoveryProbeResult{Tools: []DiscoveredTool{{
+				Name:        "list_modules",
+				Description: "List Terraform registry modules.",
+				InputSchema: schema,
+				Annotations: map[string]any{"readOnlyHint": true},
+			}}}
+		}),
+	)
+
+	first, err := manager.DiscoverTools(context.Background(), "terraform")
+	if err != nil {
+		t.Fatalf("DiscoverTools first: %v", err)
+	}
+	if len(first.Tools) != 1 || first.Tools[0].SchemaState != "new" || first.Tools[0].Risk != RiskReadOnly || !first.Tools[0].Decision.Allowed {
+		t.Fatalf("unexpected first discovery: %+v", first)
+	}
+
+	second, err := manager.DiscoverTools(context.Background(), "terraform")
+	if err != nil {
+		t.Fatalf("DiscoverTools second: %v", err)
+	}
+	if len(second.Tools) != 1 || second.Tools[0].SchemaState != "changed" {
+		t.Fatalf("expected changed schema state, got %+v", second)
+	}
+
+	stored, err := manager.Inventory("terraform")
+	if err != nil {
+		t.Fatalf("Inventory: %v", err)
+	}
+	if len(stored.Tools) != 1 || stored.Tools[0].SchemaState != "known" || stored.Tools[0].InputSchemaHash != second.Tools[0].InputSchemaHash {
+		t.Fatalf("inventory was not persisted: %+v", stored)
+	}
+}
+
+func TestDiscoveredToolDecodesMCPCamelCaseSchema(t *testing.T) {
+	var tool DiscoveredTool
+	if err := json.Unmarshal([]byte(`{"name":"list_modules","inputSchema":{"type":"object"}}`), &tool); err != nil {
+		t.Fatalf("decode tool: %v", err)
+	}
+	if tool.InputSchema["type"] != "object" {
+		t.Fatalf("expected inputSchema to decode, got %+v", tool.InputSchema)
+	}
+}
+
+func TestToolFirewallBlocksUnknownAndApprovalGatesAllowlistedMutation(t *testing.T) {
+	manager := NewManager(t.TempDir(), WithToolAllowlist(ToolAllowlist{
+		ServerTools: map[string][]string{"aws": []string{"create_bucket"}},
+		ProjectTools: map[string]map[string][]string{
+			"demo": map[string][]string{"aws": []string{"mystery_tool"}},
+		},
+	}))
+
+	unknown := manager.DecideTool("aws", "", "mystery_tool", RiskUnknown)
+	if unknown.Status != "blocked" || unknown.Allowed || unknown.ApprovalRequired {
+		t.Fatalf("unknown tools must fail closed, got %+v", unknown)
+	}
+
+	projectUnknown := manager.DecideTool("aws", "demo", "mystery_tool", RiskUnknown)
+	if projectUnknown.Status != "approval_required" || !projectUnknown.ApprovalRequired || !projectUnknown.Allowlisted {
+		t.Fatalf("project allowlisted unknown tool should require approval, got %+v", projectUnknown)
+	}
+
+	mutation := manager.DecideTool("aws", "", "create_bucket", RiskCloudMutation)
+	if mutation.Status != "approval_required" || !mutation.ApprovalRequired || mutation.Allowed {
+		t.Fatalf("allowlisted cloud mutation should require approval before execution, got %+v", mutation)
+	}
+
+	readOnly := manager.DecideTool("aws", "", "list_buckets", RiskReadOnly)
+	if readOnly.Status != "allowed" || !readOnly.Allowed || readOnly.ApprovalRequired {
+		t.Fatalf("read-only tools should be allowed by default, got %+v", readOnly)
+	}
+}
+
+func TestClassifyToolConservatively(t *testing.T) {
+	cases := []struct {
+		name string
+		tool DiscoveredTool
+		want ToolRisk
+	}{
+		{
+			name: "read-only annotation",
+			tool: DiscoveredTool{Name: "search_docs", Description: "Search provider documentation", Annotations: map[string]any{"readOnlyHint": true}},
+			want: RiskReadOnly,
+		},
+		{
+			name: "destructive",
+			tool: DiscoveredTool{Name: "delete_bucket", Description: "Delete an S3 bucket"},
+			want: RiskDestructive,
+		},
+		{
+			name: "secret sensitive",
+			tool: DiscoveredTool{Name: "assume_role", Description: "Return a session token"},
+			want: RiskSecretSensitive,
+		},
+		{
+			name: "workspace write",
+			tool: DiscoveredTool{Name: "edit_file", Description: "Modify file in workspace"},
+			want: RiskModifyWorkspace,
+		},
+		{
+			name: "unknown",
+			tool: DiscoveredTool{Name: "do_magic", Description: "Perform custom action"},
+			want: RiskUnknown,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ClassifyTool(tc.tool); got != tc.want {
+				t.Fatalf("ClassifyTool() = %s, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDiscoverToolsUnknownServerFailsClosed(t *testing.T) {
+	manager := NewManager(t.TempDir())
+
+	_, err := manager.DiscoverTools(context.Background(), "missing")
+
+	if !errors.Is(err, ErrUnknownServer) {
+		t.Fatalf("expected ErrUnknownServer, got %v", err)
+	}
+}

--- a/internal/mcpairlock/tools_test.go
+++ b/internal/mcpairlock/tools_test.go
@@ -224,6 +224,83 @@ func TestDiscoverToolsInventoryWarningsDoNotExposeInventoryPath(t *testing.T) {
 	}
 }
 
+func TestEvaluateToolErrorDoesNotExposeInventoryPath(t *testing.T) {
+	root := t.TempDir()
+	manager := NewManager(root,
+		WithDefinitions([]ServerDefinition{{
+			ID:              "aws",
+			Name:            "AWS",
+			Command:         testExecutable(t),
+			Transport:       "stdio",
+			Trusted:         true,
+			ReadOnlyDefault: true,
+			CredentialMode:  "none",
+		}}),
+	)
+	inventoryDir := filepath.Join(root, ".iac-studio")
+	if err := os.MkdirAll(inventoryDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	manager.inventoryPath = inventoryDir
+
+	_, err := manager.EvaluateTool("aws", "", "list_buckets")
+	if err == nil {
+		t.Fatal("expected inventory load error")
+	}
+	assertInventoryErrorSanitized(t, err, root, manager.inventoryPath)
+	if !strings.Contains(err.Error(), "Airlock tool inventory filesystem access failed") {
+		t.Fatalf("expected public inventory filesystem error, got %q", err.Error())
+	}
+}
+
+func TestSetToolAllowlistLoadErrorDoesNotExposeInventoryPath(t *testing.T) {
+	root := t.TempDir()
+	manager := NewManager(root,
+		WithDefinitions([]ServerDefinition{{
+			ID:              "aws",
+			Name:            "AWS",
+			Command:         testExecutable(t),
+			Transport:       "stdio",
+			Trusted:         true,
+			ReadOnlyDefault: true,
+			CredentialMode:  "none",
+		}}),
+	)
+	inventoryDir := filepath.Join(root, ".iac-studio")
+	if err := os.MkdirAll(inventoryDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	manager.inventoryPath = inventoryDir
+
+	_, err := manager.SetToolAllowlist("aws", "", "list_buckets", true)
+	if err == nil {
+		t.Fatal("expected inventory load error")
+	}
+	assertInventoryErrorSanitized(t, err, root, manager.inventoryPath)
+	if !strings.Contains(err.Error(), "Airlock tool inventory filesystem access failed") {
+		t.Fatalf("expected public inventory filesystem error, got %q", err.Error())
+	}
+}
+
+func TestPublicInventoryErrorDoesNotExposeSavePaths(t *testing.T) {
+	root := t.TempDir()
+	manager := NewManager(root)
+	manager.inventoryPath = filepath.Join(root, ".iac-studio", toolInventoryName)
+	rawErr := &os.LinkError{
+		Op:  "rename",
+		Old: manager.inventoryPath + ".tmp-123",
+		New: manager.inventoryPath,
+		Err: errors.New("permission denied"),
+	}
+
+	err := manager.publicInventoryError(rawErr)
+
+	assertInventoryErrorSanitized(t, err, root, manager.inventoryPath)
+	if !strings.Contains(err.Error(), "Airlock tool inventory replacement failed") {
+		t.Fatalf("expected public inventory replacement error, got %q", err.Error())
+	}
+}
+
 func TestSetToolAllowlistCanRemoveMissingEntries(t *testing.T) {
 	manager := NewManager(t.TempDir(),
 		WithDefinitions([]ServerDefinition{{
@@ -615,6 +692,19 @@ func checkMessages(checks []Check, name string) []string {
 		}
 	}
 	return messages
+}
+
+func assertInventoryErrorSanitized(t *testing.T, err error, sensitive ...string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	message := err.Error()
+	for _, value := range sensitive {
+		if value != "" && strings.Contains(message, value) {
+			t.Fatalf("inventory error leaked %q in %q", value, message)
+		}
+	}
 }
 
 type failingWriter struct {

--- a/internal/mcpairlock/tools_test.go
+++ b/internal/mcpairlock/tools_test.go
@@ -128,6 +128,54 @@ func TestDiscoverToolsPreservesPersistedAllowlist(t *testing.T) {
 	}
 }
 
+func TestDiscoverToolsDoesNotDropConcurrentAllowlistUpdate(t *testing.T) {
+	discoveryStarted := make(chan struct{})
+	releaseDiscovery := make(chan struct{})
+	manager := NewManager(t.TempDir(),
+		WithDefinitions([]ServerDefinition{{
+			ID:              "aws",
+			Name:            "AWS",
+			Command:         testExecutable(t),
+			Transport:       "stdio",
+			Trusted:         true,
+			ReadOnlyDefault: true,
+			CredentialMode:  "none",
+		}}),
+		WithToolDiscoverer(func(context.Context, ServerDefinition, time.Duration) DiscoveryProbeResult {
+			close(discoveryStarted)
+			<-releaseDiscovery
+			return DiscoveryProbeResult{Tools: []DiscoveredTool{{
+				Name:        "create_bucket",
+				Description: "Create an S3 bucket",
+				InputSchema: map[string]any{"type": "object"},
+			}}}
+		}),
+	)
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := manager.DiscoverTools(context.Background(), "aws")
+		errCh <- err
+	}()
+
+	<-discoveryStarted
+	if _, err := manager.SetToolAllowlist("aws", "demo", "create_bucket", true); err != nil {
+		t.Fatalf("SetToolAllowlist during discovery: %v", err)
+	}
+	close(releaseDiscovery)
+	if err := <-errCh; err != nil {
+		t.Fatalf("DiscoverTools: %v", err)
+	}
+
+	entry, err := manager.EvaluateTool("aws", "demo", "create_bucket")
+	if err != nil {
+		t.Fatalf("EvaluateTool: %v", err)
+	}
+	if !entry.Decision.Allowlisted || entry.Decision.Status != "approval_required" {
+		t.Fatalf("expected concurrent allowlist update to survive discovery, got %+v", entry.Decision)
+	}
+}
+
 func TestDiscoverToolsRecoversFromCorruptInventory(t *testing.T) {
 	root := t.TempDir()
 	manager := NewManager(root,

--- a/internal/mcpairlock/tools_test.go
+++ b/internal/mcpairlock/tools_test.go
@@ -24,7 +24,7 @@ func TestDiscoverToolsPersistsInventoryAndDetectsSchemaChanges(t *testing.T) {
 		WithToolDiscoverer(func(context.Context, ServerDefinition, time.Duration) DiscoveryProbeResult {
 			calls++
 			schema := map[string]any{"type": "object", "properties": map[string]any{"query": map[string]any{"type": "string"}}}
-			if calls == 2 {
+			if calls >= 2 {
 				schema = map[string]any{"type": "object", "properties": map[string]any{"query": map[string]any{"type": "string"}, "limit": map[string]any{"type": "integer"}}}
 			}
 			return DiscoveryProbeResult{Tools: []DiscoveredTool{{
@@ -40,7 +40,7 @@ func TestDiscoverToolsPersistsInventoryAndDetectsSchemaChanges(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DiscoverTools first: %v", err)
 	}
-	if len(first.Tools) != 1 || first.Tools[0].SchemaState != "new" || first.Tools[0].Risk != RiskReadOnly || !first.Tools[0].Decision.Allowed {
+	if len(first.Tools) != 1 || first.Tools[0].SchemaState != "new" || first.Tools[0].Risk != RiskReadOnly || first.Tools[0].Decision.Status != "blocked" {
 		t.Fatalf("unexpected first discovery: %+v", first)
 	}
 
@@ -48,7 +48,7 @@ func TestDiscoverToolsPersistsInventoryAndDetectsSchemaChanges(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DiscoverTools second: %v", err)
 	}
-	if len(second.Tools) != 1 || second.Tools[0].SchemaState != "changed" {
+	if len(second.Tools) != 1 || second.Tools[0].SchemaState != "changed" || second.Tools[0].Decision.Status != "blocked" {
 		t.Fatalf("expected changed schema state, got %+v", second)
 	}
 
@@ -56,8 +56,16 @@ func TestDiscoverToolsPersistsInventoryAndDetectsSchemaChanges(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Inventory: %v", err)
 	}
-	if len(stored.Tools) != 1 || stored.Tools[0].SchemaState != "known" || stored.Tools[0].InputSchemaHash != second.Tools[0].InputSchemaHash {
+	if len(stored.Tools) != 1 || stored.Tools[0].SchemaState != "changed" || stored.Tools[0].Decision.Status != "blocked" || stored.Tools[0].InputSchemaHash != second.Tools[0].InputSchemaHash {
 		t.Fatalf("inventory was not persisted: %+v", stored)
+	}
+
+	third, err := manager.DiscoverTools(context.Background(), "terraform")
+	if err != nil {
+		t.Fatalf("DiscoverTools third: %v", err)
+	}
+	if len(third.Tools) != 1 || third.Tools[0].SchemaState != "known" || !third.Tools[0].Decision.Allowed {
+		t.Fatalf("expected stable schema to become known and allowed, got %+v", third)
 	}
 }
 
@@ -79,24 +87,34 @@ func TestToolFirewallBlocksUnknownAndApprovalGatesAllowlistedMutation(t *testing
 		},
 	}))
 
-	unknown := manager.DecideTool("aws", "", "mystery_tool", RiskUnknown)
+	unknown := manager.DecideTool("aws", "", "mystery_tool", RiskUnknown, "unknown")
 	if unknown.Status != "blocked" || unknown.Allowed || unknown.ApprovalRequired {
 		t.Fatalf("unknown tools must fail closed, got %+v", unknown)
 	}
 
-	projectUnknown := manager.DecideTool("aws", "demo", "mystery_tool", RiskUnknown)
+	projectUnknown := manager.DecideTool("aws", "demo", "mystery_tool", RiskUnknown, "unknown")
 	if projectUnknown.Status != "approval_required" || !projectUnknown.ApprovalRequired || !projectUnknown.Allowlisted {
 		t.Fatalf("project allowlisted unknown tool should require approval, got %+v", projectUnknown)
 	}
 
-	mutation := manager.DecideTool("aws", "", "create_bucket", RiskCloudMutation)
+	mutation := manager.DecideTool("aws", "", "create_bucket", RiskCloudMutation, "known")
 	if mutation.Status != "approval_required" || !mutation.ApprovalRequired || mutation.Allowed {
 		t.Fatalf("allowlisted cloud mutation should require approval before execution, got %+v", mutation)
 	}
 
-	readOnly := manager.DecideTool("aws", "", "list_buckets", RiskReadOnly)
+	readOnly := manager.DecideTool("aws", "", "list_buckets", RiskReadOnly, "known")
 	if readOnly.Status != "allowed" || !readOnly.Allowed || readOnly.ApprovalRequired {
 		t.Fatalf("read-only tools should be allowed by default, got %+v", readOnly)
+	}
+
+	generateCode := manager.DecideTool("aws", "", "create_bucket", RiskGenerateCode, "known")
+	if generateCode.Status != "approval_required" || !generateCode.ApprovalRequired || generateCode.Allowed {
+		t.Fatalf("allowlisted generate-code tools should require approval, got %+v", generateCode)
+	}
+
+	changedReadOnly := manager.DecideTool("aws", "demo", "mystery_tool", RiskReadOnly, "changed")
+	if changedReadOnly.Status != "approval_required" || !changedReadOnly.ApprovalRequired || !changedReadOnly.Allowlisted {
+		t.Fatalf("allowlisted changed schemas should still require approval, got %+v", changedReadOnly)
 	}
 }
 

--- a/internal/mcpairlock/tools_test.go
+++ b/internal/mcpairlock/tools_test.go
@@ -128,6 +128,57 @@ func TestDiscoverToolsPreservesPersistedAllowlist(t *testing.T) {
 	}
 }
 
+func TestDiscoverToolsRecoversFromCorruptInventory(t *testing.T) {
+	root := t.TempDir()
+	manager := NewManager(root,
+		WithDefinitions([]ServerDefinition{{
+			ID:              "aws",
+			Name:            "AWS",
+			Command:         testExecutable(t),
+			Transport:       "stdio",
+			Trusted:         true,
+			ReadOnlyDefault: true,
+			CredentialMode:  "none",
+		}}),
+		WithToolDiscoverer(func(context.Context, ServerDefinition, time.Duration) DiscoveryProbeResult {
+			return DiscoveryProbeResult{Tools: []DiscoveredTool{{
+				Name:        "list_buckets",
+				Description: "List S3 buckets.",
+				InputSchema: map[string]any{"type": "object"},
+				Annotations: map[string]any{"readOnlyHint": true},
+			}}}
+		}),
+	)
+	if err := os.MkdirAll(filepath.Dir(manager.inventoryPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(manager.inventoryPath, []byte("{"), 0o600); err != nil {
+		t.Fatalf("WriteFile corrupt inventory: %v", err)
+	}
+
+	inventory, err := manager.DiscoverTools(context.Background(), "aws")
+	if err != nil {
+		t.Fatalf("DiscoverTools: %v", err)
+	}
+	if len(inventory.Tools) != 1 {
+		t.Fatalf("expected discovered tool despite corrupt inventory, got %+v", inventory.Tools)
+	}
+	if inventory.Tools[0].Name != "list_buckets" || inventory.Tools[0].SchemaState != "new" || inventory.Tools[0].Decision.Status != "blocked" {
+		t.Fatalf("expected fail-closed fresh discovery, got %+v", inventory.Tools[0])
+	}
+	if !hasCheck(inventory.Checks, "inventory", "warn") {
+		t.Fatalf("expected inventory warning check, got %+v", inventory.Checks)
+	}
+
+	stored, err := manager.Inventory("aws")
+	if err != nil {
+		t.Fatalf("Inventory after recovery: %v", err)
+	}
+	if len(stored.Tools) != 1 || stored.Tools[0].Name != "list_buckets" {
+		t.Fatalf("expected recovered inventory to be persisted, got %+v", stored.Tools)
+	}
+}
+
 func TestSetToolAllowlistCanRemoveMissingEntries(t *testing.T) {
 	manager := NewManager(t.TempDir(),
 		WithDefinitions([]ServerDefinition{{
@@ -399,6 +450,15 @@ func TestWriteToolDiscoveryRequestsReturnsCloseError(t *testing.T) {
 	if !strings.Contains(buf.String(), `"method":"tools/list"`) {
 		t.Fatalf("expected tools/list request to be written before close, got %q", buf.String())
 	}
+}
+
+func hasCheck(checks []Check, name, status string) bool {
+	for _, check := range checks {
+		if check.Name == name && check.Status == status {
+			return true
+		}
+	}
+	return false
 }
 
 type failingWriter struct {

--- a/internal/mcpairlock/tools_test.go
+++ b/internal/mcpairlock/tools_test.go
@@ -79,6 +79,51 @@ func TestDiscoveredToolDecodesMCPCamelCaseSchema(t *testing.T) {
 	}
 }
 
+func TestDiscoverToolsPreservesPersistedAllowlist(t *testing.T) {
+	manager := NewManager(t.TempDir(),
+		WithDefinitions([]ServerDefinition{{
+			ID:              "aws",
+			Name:            "AWS",
+			Command:         testExecutable(t),
+			Transport:       "stdio",
+			Trusted:         true,
+			ReadOnlyDefault: true,
+			CredentialMode:  "none",
+		}}),
+		WithToolDiscoverer(func(context.Context, ServerDefinition, time.Duration) DiscoveryProbeResult {
+			return DiscoveryProbeResult{Tools: []DiscoveredTool{{
+				Name:        "create_bucket",
+				Description: "Create an S3 bucket",
+				InputSchema: map[string]any{"type": "object"},
+			}}}
+		}),
+	)
+
+	if _, err := manager.SetToolAllowlist("aws", "", "create_bucket", true); err != nil {
+		t.Fatalf("SetToolAllowlist: %v", err)
+	}
+
+	inventory, err := manager.DiscoverTools(context.Background(), "aws")
+	if err != nil {
+		t.Fatalf("DiscoverTools: %v", err)
+	}
+	if len(inventory.Tools) != 1 {
+		t.Fatalf("expected one discovered tool, got %+v", inventory.Tools)
+	}
+	decision := inventory.Tools[0].Decision
+	if !decision.Allowlisted || decision.Status != "approval_required" {
+		t.Fatalf("expected persisted allowlist to survive discovery, got %+v", decision)
+	}
+
+	entry, err := manager.EvaluateTool("aws", "", "create_bucket")
+	if err != nil {
+		t.Fatalf("EvaluateTool: %v", err)
+	}
+	if !entry.Decision.Allowlisted || entry.Decision.Status != "approval_required" {
+		t.Fatalf("expected allowlist to remain persisted after discovery, got %+v", entry.Decision)
+	}
+}
+
 func TestToolFirewallBlocksUnknownAndApprovalGatesAllowlistedMutation(t *testing.T) {
 	manager := NewManager(t.TempDir(), WithToolAllowlist(ToolAllowlist{
 		ServerTools: map[string][]string{"aws": []string{"create_bucket"}},

--- a/internal/mcpairlock/tools_test.go
+++ b/internal/mcpairlock/tools_test.go
@@ -1,9 +1,11 @@
 package mcpairlock
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 )
@@ -212,4 +214,56 @@ func TestDiscoverToolsUnknownServerFailsClosed(t *testing.T) {
 	if !errors.Is(err, ErrUnknownServer) {
 		t.Fatalf("expected ErrUnknownServer, got %v", err)
 	}
+}
+
+func TestWriteToolDiscoveryRequestsReturnsEncodeError(t *testing.T) {
+	errEncode := errors.New("encode failed")
+
+	err := writeToolDiscoveryRequests(json.NewEncoder(failingWriter{err: errEncode}), noopCloser{})
+
+	if !errors.Is(err, errEncode) {
+		t.Fatalf("expected wrapped encode error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "write initialize request") {
+		t.Fatalf("expected write context in error, got %v", err)
+	}
+}
+
+func TestWriteToolDiscoveryRequestsReturnsCloseError(t *testing.T) {
+	errClose := errors.New("close failed")
+	var buf bytes.Buffer
+
+	err := writeToolDiscoveryRequests(json.NewEncoder(&buf), errorCloser{err: errClose})
+
+	if !errors.Is(err, errClose) {
+		t.Fatalf("expected wrapped close error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "close discovery stdin") {
+		t.Fatalf("expected close context in error, got %v", err)
+	}
+	if !strings.Contains(buf.String(), `"method":"tools/list"`) {
+		t.Fatalf("expected tools/list request to be written before close, got %q", buf.String())
+	}
+}
+
+type failingWriter struct {
+	err error
+}
+
+func (w failingWriter) Write([]byte) (int, error) {
+	return 0, w.err
+}
+
+type noopCloser struct{}
+
+func (noopCloser) Close() error {
+	return nil
+}
+
+type errorCloser struct {
+	err error
+}
+
+func (c errorCloser) Close() error {
+	return c.err
 }

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -150,6 +150,68 @@ describe('api.mcpAirlock', () => {
       method: 'POST',
     });
   });
+
+  it('calls MCP Airlock tool inventory and firewall endpoints', async () => {
+    const inventory = {
+      server_id: 'terraform-official',
+      tools: [{
+        server_id: 'terraform-official',
+        name: 'apply_workspace',
+        input_schema_hash: 'sha256:def',
+        last_seen_at: '2026-06-13T10:00:00Z',
+        schema_state: 'new',
+        risk: 'cloud_mutation',
+        decision: {
+          status: 'blocked',
+          allowed: false,
+          approval_required: false,
+          risk: 'cloud_mutation',
+          reason: 'requires allowlist',
+          allowlisted: false,
+          untrusted_output: true,
+        },
+      }],
+      checks: [],
+    };
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify(inventory), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(inventory), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(inventory.tools[0]), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(inventory.tools[0]), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(api.getMCPAirlockTools('terraform-official')).resolves.toEqual(inventory);
+    await expect(api.discoverMCPAirlockTools('terraform-official')).resolves.toEqual(inventory);
+    await expect(api.evaluateMCPAirlockTool('terraform-official', 'apply_workspace', 'demo')).resolves.toEqual(inventory.tools[0]);
+    await expect(api.setMCPAirlockToolAllowlist('terraform-official', 'apply_workspace', true, 'demo')).resolves.toEqual(inventory.tools[0]);
+
+    expect(fetchMock).toHaveBeenNthCalledWith(1, '/api/mcp-airlock/servers/terraform-official/tools');
+    expect(fetchMock).toHaveBeenNthCalledWith(2, '/api/mcp-airlock/servers/terraform-official/tools/discover', {
+      method: 'POST',
+    });
+    expect(fetchMock).toHaveBeenNthCalledWith(3, '/api/mcp-airlock/servers/terraform-official/tools/evaluate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tool_name: 'apply_workspace', project: 'demo' }),
+    });
+    expect(fetchMock).toHaveBeenNthCalledWith(4, '/api/mcp-airlock/servers/terraform-official/tools/allowlist', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tool_name: 'apply_workspace', project: 'demo', allowed: true }),
+    });
+  });
 });
 
 describe('api.runCommand', () => {

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -178,6 +178,43 @@ export interface MCPAirlockServerStatus {
   last_exit_reason?: string;
 }
 
+export type MCPAirlockToolRisk =
+  | 'read_only'
+  | 'generate_code'
+  | 'modify_workspace'
+  | 'cloud_mutation'
+  | 'secret_sensitive'
+  | 'destructive'
+  | 'unknown';
+
+export interface MCPAirlockToolDecision {
+  status: 'allowed' | 'blocked' | 'approval_required';
+  allowed: boolean;
+  approval_required: boolean;
+  risk: MCPAirlockToolRisk;
+  reason: string;
+  allowlisted: boolean;
+  untrusted_output: boolean;
+}
+
+export interface MCPAirlockToolEntry {
+  server_id: string;
+  name: string;
+  description?: string;
+  input_schema_hash: string;
+  last_seen_at: string;
+  schema_state: 'new' | 'known' | 'changed' | 'unknown';
+  risk: MCPAirlockToolRisk;
+  decision: MCPAirlockToolDecision;
+}
+
+export interface MCPAirlockToolInventory {
+  server_id: string;
+  discovered_at?: string;
+  tools: MCPAirlockToolEntry[];
+  checks: MCPAirlockCheck[];
+}
+
 export type PlanRiskLevel = 'safe' | 'risky' | 'destructive' | 'unknown';
 
 export interface PlanFieldChange {
@@ -434,6 +471,34 @@ export const api = {
 
   async stopMCPAirlockServer(id: string): Promise<MCPAirlockServerStatus> {
     const res = await fetch(`${BASE}/api/mcp-airlock/servers/${encodeURIComponent(id)}/stop`, { method: 'POST' });
+    return (await check(res)).json();
+  },
+
+  async getMCPAirlockTools(id: string): Promise<MCPAirlockToolInventory> {
+    const res = await fetch(`${BASE}/api/mcp-airlock/servers/${encodeURIComponent(id)}/tools`);
+    return (await check(res)).json();
+  },
+
+  async discoverMCPAirlockTools(id: string): Promise<MCPAirlockToolInventory> {
+    const res = await fetch(`${BASE}/api/mcp-airlock/servers/${encodeURIComponent(id)}/tools/discover`, { method: 'POST' });
+    return (await check(res)).json();
+  },
+
+  async evaluateMCPAirlockTool(id: string, toolName: string, project?: string): Promise<MCPAirlockToolEntry> {
+    const res = await fetch(`${BASE}/api/mcp-airlock/servers/${encodeURIComponent(id)}/tools/evaluate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tool_name: toolName, project }),
+    });
+    return (await check(res)).json();
+  },
+
+  async setMCPAirlockToolAllowlist(id: string, toolName: string, allowed: boolean, project?: string): Promise<MCPAirlockToolEntry> {
+    const res = await fetch(`${BASE}/api/mcp-airlock/servers/${encodeURIComponent(id)}/tools/allowlist`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tool_name: toolName, project, allowed }),
+    });
     return (await check(res)).json();
   },
 

--- a/web/src/components/MCPAirlock/MCPAirlockPanel.test.tsx
+++ b/web/src/components/MCPAirlock/MCPAirlockPanel.test.tsx
@@ -238,6 +238,31 @@ describe('MCPAirlockPanel', () => {
     });
   });
 
+  it('disables tool discovery when the command is unavailable', async () => {
+    const initial = server({
+      ready: true,
+      command_available: false,
+      state: 'ready',
+      summary: 'Configured command was removed from PATH.',
+    });
+    const client = {
+      listMCPAirlockServers: vi.fn(async () => [initial]),
+      checkMCPAirlockServer: vi.fn(async () => initial),
+      startMCPAirlockServer: vi.fn(async () => initial),
+      stopMCPAirlockServer: vi.fn(async () => initial),
+      getMCPAirlockTools: vi.fn(async () => ({ server_id: 'terraform-official', tools: [], checks: [] })),
+      discoverMCPAirlockTools: vi.fn(async () => ({ server_id: 'terraform-official', tools: [], checks: [] })),
+    };
+
+    render(<MCPAirlockPanel client={client} />);
+
+    const toolsButton = await screen.findByRole('button', { name: 'Tools' });
+    expect(toolsButton).toBeDisabled();
+
+    fireEvent.click(toolsButton);
+    expect(client.discoverMCPAirlockTools).not.toHaveBeenCalled();
+  });
+
   it('disables tool discovery while another server action is busy', async () => {
     const initial = server({
       ready: true,
@@ -274,6 +299,45 @@ describe('MCPAirlockPanel', () => {
     resolveCheck(initial);
     await waitFor(() => {
       expect(client.checkMCPAirlockServer).toHaveBeenCalledWith('terraform-official');
+    });
+  });
+
+  it('disables health checks while tool discovery is running', async () => {
+    const initial = server({
+      ready: true,
+      command_available: true,
+      state: 'ready',
+      summary: 'Health check completed without exposing cloud credentials.',
+    });
+    let resolveDiscovery!: (_inventory: { server_id: string; tools: []; checks: [] }) => void;
+    const client = {
+      listMCPAirlockServers: vi.fn(async () => [initial]),
+      checkMCPAirlockServer: vi.fn(async () => initial),
+      startMCPAirlockServer: vi.fn(async () => initial),
+      stopMCPAirlockServer: vi.fn(async () => initial),
+      getMCPAirlockTools: vi.fn(async () => ({ server_id: 'terraform-official', tools: [], checks: [] })),
+      discoverMCPAirlockTools: vi.fn(() => new Promise<{ server_id: string; tools: []; checks: [] }>(resolve => {
+        resolveDiscovery = resolve;
+      })),
+    };
+
+    render(<MCPAirlockPanel client={client} />);
+
+    const toolsButton = await screen.findByRole('button', { name: 'Tools' });
+    const checkButton = screen.getByRole('button', { name: 'Check' });
+
+    fireEvent.click(toolsButton);
+
+    await waitFor(() => {
+      expect(checkButton).toBeDisabled();
+    });
+
+    fireEvent.click(checkButton);
+    expect(client.checkMCPAirlockServer).not.toHaveBeenCalled();
+
+    resolveDiscovery({ server_id: 'terraform-official', tools: [], checks: [] });
+    await waitFor(() => {
+      expect(client.discoverMCPAirlockTools).toHaveBeenCalledWith('terraform-official');
     });
   });
 });

--- a/web/src/components/MCPAirlock/MCPAirlockPanel.test.tsx
+++ b/web/src/components/MCPAirlock/MCPAirlockPanel.test.tsx
@@ -238,6 +238,34 @@ describe('MCPAirlockPanel', () => {
     });
   });
 
+  it('allows tool discovery in non-ready lifecycle states when the command is available', async () => {
+    const initial = server({
+      command_available: true,
+      state: 'stopped',
+      summary: 'MCP server process stopped.',
+      last_exit_reason: 'stopped by user',
+    });
+    const client = {
+      listMCPAirlockServers: vi.fn(async () => [initial]),
+      checkMCPAirlockServer: vi.fn(async () => initial),
+      startMCPAirlockServer: vi.fn(async () => initial),
+      stopMCPAirlockServer: vi.fn(async () => initial),
+      getMCPAirlockTools: vi.fn(async () => ({ server_id: 'terraform-official', tools: [], checks: [] })),
+      discoverMCPAirlockTools: vi.fn(async () => ({ server_id: 'terraform-official', tools: [], checks: [] })),
+    };
+
+    render(<MCPAirlockPanel client={client} />);
+
+    const toolsButton = await screen.findByRole('button', { name: 'Tools' });
+    expect(toolsButton).toBeEnabled();
+
+    fireEvent.click(toolsButton);
+
+    await waitFor(() => {
+      expect(client.discoverMCPAirlockTools).toHaveBeenCalledWith('terraform-official');
+    });
+  });
+
   it('disables tool discovery when the command is unavailable', async () => {
     const initial = server({
       ready: true,

--- a/web/src/components/MCPAirlock/MCPAirlockPanel.test.tsx
+++ b/web/src/components/MCPAirlock/MCPAirlockPanel.test.tsx
@@ -340,4 +340,84 @@ describe('MCPAirlockPanel', () => {
       expect(client.discoverMCPAirlockTools).toHaveBeenCalledWith('terraform-official');
     });
   });
+
+  it('disables lifecycle actions while tool discovery is running', async () => {
+    const initial = server({
+      command_available: true,
+      state: 'available',
+      summary: 'Command is available.',
+    });
+    let resolveDiscovery!: (_inventory: { server_id: string; tools: []; checks: [] }) => void;
+    const client = {
+      listMCPAirlockServers: vi.fn(async () => [initial]),
+      checkMCPAirlockServer: vi.fn(async () => initial),
+      startMCPAirlockServer: vi.fn(async () => initial),
+      stopMCPAirlockServer: vi.fn(async () => initial),
+      getMCPAirlockTools: vi.fn(async () => ({ server_id: 'terraform-official', tools: [], checks: [] })),
+      discoverMCPAirlockTools: vi.fn(() => new Promise<{ server_id: string; tools: []; checks: [] }>(resolve => {
+        resolveDiscovery = resolve;
+      })),
+    };
+
+    render(<MCPAirlockPanel client={client} />);
+
+    const toolsButton = await screen.findByRole('button', { name: 'Tools' });
+    const startButton = screen.getByRole('button', { name: 'Start Terraform MCP Server' });
+    expect(startButton).toBeEnabled();
+
+    fireEvent.click(toolsButton);
+
+    await waitFor(() => {
+      expect(startButton).toBeDisabled();
+    });
+
+    fireEvent.click(startButton);
+    expect(client.startMCPAirlockServer).not.toHaveBeenCalled();
+
+    resolveDiscovery({ server_id: 'terraform-official', tools: [], checks: [] });
+    await waitFor(() => {
+      expect(client.discoverMCPAirlockTools).toHaveBeenCalledWith('terraform-official');
+    });
+  });
+
+  it('disables stop while tool discovery is running', async () => {
+    const initial = server({
+      ready: true,
+      running: true,
+      command_available: true,
+      state: 'running',
+      summary: 'MCP server process is running with cloud credentials withheld.',
+    });
+    let resolveDiscovery!: (_inventory: { server_id: string; tools: []; checks: [] }) => void;
+    const client = {
+      listMCPAirlockServers: vi.fn(async () => [initial]),
+      checkMCPAirlockServer: vi.fn(async () => initial),
+      startMCPAirlockServer: vi.fn(async () => initial),
+      stopMCPAirlockServer: vi.fn(async () => initial),
+      getMCPAirlockTools: vi.fn(async () => ({ server_id: 'terraform-official', tools: [], checks: [] })),
+      discoverMCPAirlockTools: vi.fn(() => new Promise<{ server_id: string; tools: []; checks: [] }>(resolve => {
+        resolveDiscovery = resolve;
+      })),
+    };
+
+    render(<MCPAirlockPanel client={client} />);
+
+    const toolsButton = await screen.findByRole('button', { name: 'Tools' });
+    const stopButton = screen.getByRole('button', { name: 'Stop Terraform MCP Server' });
+    expect(stopButton).toBeEnabled();
+
+    fireEvent.click(toolsButton);
+
+    await waitFor(() => {
+      expect(stopButton).toBeDisabled();
+    });
+
+    fireEvent.click(stopButton);
+    expect(client.stopMCPAirlockServer).not.toHaveBeenCalled();
+
+    resolveDiscovery({ server_id: 'terraform-official', tools: [], checks: [] });
+    await waitFor(() => {
+      expect(client.discoverMCPAirlockTools).toHaveBeenCalledWith('terraform-official');
+    });
+  });
 });

--- a/web/src/components/MCPAirlock/MCPAirlockPanel.test.tsx
+++ b/web/src/components/MCPAirlock/MCPAirlockPanel.test.tsx
@@ -189,12 +189,8 @@ describe('MCPAirlockPanel', () => {
     expect(screen.getByText('blocked')).toBeInTheDocument();
   });
 
-  it('disables tool discovery until the server is available', async () => {
-    const initial = server({
-      command_available: true,
-      state: 'ready',
-      summary: 'Health check completed without exposing cloud credentials.',
-    });
+  it('disables tool discovery when the server is unavailable', async () => {
+    const initial = server();
     const client = {
       listMCPAirlockServers: vi.fn(async () => [initial]),
       checkMCPAirlockServer: vi.fn(async () => initial),
@@ -212,5 +208,33 @@ describe('MCPAirlockPanel', () => {
     fireEvent.click(toolsButton);
 
     expect(client.discoverMCPAirlockTools).not.toHaveBeenCalled();
+  });
+
+  it('allows tool discovery after a successful health check', async () => {
+    const initial = server({
+      ready: true,
+      command_available: true,
+      state: 'ready',
+      summary: 'Health check completed without exposing cloud credentials.',
+    });
+    const client = {
+      listMCPAirlockServers: vi.fn(async () => [initial]),
+      checkMCPAirlockServer: vi.fn(async () => initial),
+      startMCPAirlockServer: vi.fn(async () => initial),
+      stopMCPAirlockServer: vi.fn(async () => initial),
+      getMCPAirlockTools: vi.fn(async () => ({ server_id: 'terraform-official', tools: [], checks: [] })),
+      discoverMCPAirlockTools: vi.fn(async () => ({ server_id: 'terraform-official', tools: [], checks: [] })),
+    };
+
+    render(<MCPAirlockPanel client={client} />);
+
+    const toolsButton = await screen.findByRole('button', { name: 'Tools' });
+    expect(toolsButton).toBeEnabled();
+
+    fireEvent.click(toolsButton);
+
+    await waitFor(() => {
+      expect(client.discoverMCPAirlockTools).toHaveBeenCalledWith('terraform-official');
+    });
   });
 });

--- a/web/src/components/MCPAirlock/MCPAirlockPanel.test.tsx
+++ b/web/src/components/MCPAirlock/MCPAirlockPanel.test.tsx
@@ -188,4 +188,29 @@ describe('MCPAirlockPanel', () => {
     expect(screen.getByText('cloud mutation')).toBeInTheDocument();
     expect(screen.getByText('blocked')).toBeInTheDocument();
   });
+
+  it('disables tool discovery until the server is available', async () => {
+    const initial = server({
+      command_available: true,
+      state: 'ready',
+      summary: 'Health check completed without exposing cloud credentials.',
+    });
+    const client = {
+      listMCPAirlockServers: vi.fn(async () => [initial]),
+      checkMCPAirlockServer: vi.fn(async () => initial),
+      startMCPAirlockServer: vi.fn(async () => initial),
+      stopMCPAirlockServer: vi.fn(async () => initial),
+      getMCPAirlockTools: vi.fn(async () => ({ server_id: 'terraform-official', tools: [], checks: [] })),
+      discoverMCPAirlockTools: vi.fn(async () => ({ server_id: 'terraform-official', tools: [], checks: [] })),
+    };
+
+    render(<MCPAirlockPanel client={client} />);
+
+    const toolsButton = await screen.findByRole('button', { name: 'Tools' });
+    expect(toolsButton).toBeDisabled();
+
+    fireEvent.click(toolsButton);
+
+    expect(client.discoverMCPAirlockTools).not.toHaveBeenCalled();
+  });
 });

--- a/web/src/components/MCPAirlock/MCPAirlockPanel.test.tsx
+++ b/web/src/components/MCPAirlock/MCPAirlockPanel.test.tsx
@@ -237,4 +237,43 @@ describe('MCPAirlockPanel', () => {
       expect(client.discoverMCPAirlockTools).toHaveBeenCalledWith('terraform-official');
     });
   });
+
+  it('disables tool discovery while another server action is busy', async () => {
+    const initial = server({
+      ready: true,
+      command_available: true,
+      state: 'ready',
+      summary: 'Health check completed without exposing cloud credentials.',
+    });
+    let resolveCheck!: (_status: MCPAirlockServerStatus) => void;
+    const client = {
+      listMCPAirlockServers: vi.fn(async () => [initial]),
+      checkMCPAirlockServer: vi.fn(() => new Promise<MCPAirlockServerStatus>(resolve => {
+        resolveCheck = resolve;
+      })),
+      startMCPAirlockServer: vi.fn(async () => initial),
+      stopMCPAirlockServer: vi.fn(async () => initial),
+      getMCPAirlockTools: vi.fn(async () => ({ server_id: 'terraform-official', tools: [], checks: [] })),
+      discoverMCPAirlockTools: vi.fn(async () => ({ server_id: 'terraform-official', tools: [], checks: [] })),
+    };
+
+    render(<MCPAirlockPanel client={client} />);
+
+    const toolsButton = await screen.findByRole('button', { name: 'Tools' });
+    expect(toolsButton).toBeEnabled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Check' }));
+
+    await waitFor(() => {
+      expect(toolsButton).toBeDisabled();
+    });
+
+    fireEvent.click(toolsButton);
+    expect(client.discoverMCPAirlockTools).not.toHaveBeenCalled();
+
+    resolveCheck(initial);
+    await waitFor(() => {
+      expect(client.checkMCPAirlockServer).toHaveBeenCalledWith('terraform-official');
+    });
+  });
 });

--- a/web/src/components/MCPAirlock/MCPAirlockPanel.test.tsx
+++ b/web/src/components/MCPAirlock/MCPAirlockPanel.test.tsx
@@ -51,6 +51,8 @@ describe('MCPAirlockPanel', () => {
       checkMCPAirlockServer: vi.fn(async () => checked),
       startMCPAirlockServer: vi.fn(async () => checked),
       stopMCPAirlockServer: vi.fn(async () => checked),
+      getMCPAirlockTools: vi.fn(async () => ({ server_id: 'terraform-official', tools: [], checks: [] })),
+      discoverMCPAirlockTools: vi.fn(async () => ({ server_id: 'terraform-official', tools: [], checks: [] })),
     };
 
     render(<MCPAirlockPanel client={client} />);
@@ -94,6 +96,8 @@ describe('MCPAirlockPanel', () => {
       checkMCPAirlockServer: vi.fn(async () => initial),
       startMCPAirlockServer: vi.fn(async () => running),
       stopMCPAirlockServer: vi.fn(async () => stopped),
+      getMCPAirlockTools: vi.fn(async () => ({ server_id: 'terraform-official', tools: [], checks: [] })),
+      discoverMCPAirlockTools: vi.fn(async () => ({ server_id: 'terraform-official', tools: [], checks: [] })),
     };
 
     render(<MCPAirlockPanel client={client} />);
@@ -111,5 +115,77 @@ describe('MCPAirlockPanel', () => {
       expect(client.stopMCPAirlockServer).toHaveBeenCalledWith('terraform-official');
     });
     expect(await screen.findByText('MCP server process stopped.')).toBeInTheDocument();
+  });
+
+  it('discovers tools and shows firewall decisions', async () => {
+    const initial = server({
+      command_available: true,
+      state: 'available',
+      summary: 'Command is available.',
+    });
+    const inventory = {
+      server_id: 'terraform-official',
+      discovered_at: '2026-06-13T10:00:00Z',
+      checks: [{ name: 'tool_discovery', status: 'pass' as const, message: 'discovered 2 external MCP tools' }],
+      tools: [
+        {
+          server_id: 'terraform-official',
+          name: 'list_modules',
+          description: 'List registry modules',
+          input_schema_hash: 'sha256:abc',
+          last_seen_at: '2026-06-13T10:00:00Z',
+          schema_state: 'new' as const,
+          risk: 'read_only' as const,
+          decision: {
+            status: 'allowed' as const,
+            allowed: true,
+            approval_required: false,
+            risk: 'read_only' as const,
+            reason: 'read-only',
+            allowlisted: false,
+            untrusted_output: true,
+          },
+        },
+        {
+          server_id: 'terraform-official',
+          name: 'apply_workspace',
+          description: 'Apply a Terraform workspace',
+          input_schema_hash: 'sha256:def',
+          last_seen_at: '2026-06-13T10:00:00Z',
+          schema_state: 'new' as const,
+          risk: 'cloud_mutation' as const,
+          decision: {
+            status: 'blocked' as const,
+            allowed: false,
+            approval_required: false,
+            risk: 'cloud_mutation' as const,
+            reason: 'requires allowlist',
+            allowlisted: false,
+            untrusted_output: true,
+          },
+        },
+      ],
+    };
+    const client = {
+      listMCPAirlockServers: vi.fn(async () => [initial]),
+      checkMCPAirlockServer: vi.fn(async () => initial),
+      startMCPAirlockServer: vi.fn(async () => initial),
+      stopMCPAirlockServer: vi.fn(async () => initial),
+      getMCPAirlockTools: vi.fn(async () => ({ server_id: 'terraform-official', tools: [], checks: [] })),
+      discoverMCPAirlockTools: vi.fn(async () => inventory),
+    };
+
+    render(<MCPAirlockPanel client={client} />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Tools' }));
+
+    await waitFor(() => {
+      expect(client.discoverMCPAirlockTools).toHaveBeenCalledWith('terraform-official');
+    });
+    expect(await screen.findByText('Tool Firewall')).toBeInTheDocument();
+    expect(screen.getByText('list_modules')).toBeInTheDocument();
+    expect(screen.getByText('apply_workspace')).toBeInTheDocument();
+    expect(screen.getByText('cloud mutation')).toBeInTheDocument();
+    expect(screen.getByText('blocked')).toBeInTheDocument();
   });
 });

--- a/web/src/components/MCPAirlock/MCPAirlockPanel.tsx
+++ b/web/src/components/MCPAirlock/MCPAirlockPanel.tsx
@@ -50,10 +50,6 @@ function decisionClass(status: string) {
   return 'text-destructive';
 }
 
-function canDiscoverTools(state: string) {
-  return state === 'available' || state === 'ready' || state === 'running';
-}
-
 export function MCPAirlockPanel({ client = api }: MCPAirlockPanelProps) {
   const [servers, setServers] = useState<MCPAirlockServerStatus[]>([]);
   const [toolsByServer, setToolsByServer] = useState<Record<string, MCPAirlockToolInventory>>({});
@@ -188,7 +184,7 @@ export function MCPAirlockPanel({ client = api }: MCPAirlockPanelProps) {
                 const checkDisabled = busy || discovering;
                 const startDisabled = busy || discovering || status.running || !status.command_available;
                 const stopDisabled = busy || discovering || !status.running;
-                const discoverDisabled = busy || discovering || !status.command_available || !canDiscoverTools(status.state);
+                const discoverDisabled = busy || discovering || !status.command_available;
                 return (
               <div className="flex items-start gap-2">
                 <div className="min-w-0 flex-1">

--- a/web/src/components/MCPAirlock/MCPAirlockPanel.tsx
+++ b/web/src/components/MCPAirlock/MCPAirlockPanel.tsx
@@ -50,6 +50,10 @@ function decisionClass(status: string) {
   return 'text-destructive';
 }
 
+function canDiscoverTools(state: string) {
+  return state === 'available' || state === 'ready' || state === 'running';
+}
+
 export function MCPAirlockPanel({ client = api }: MCPAirlockPanelProps) {
   const [servers, setServers] = useState<MCPAirlockServerStatus[]>([]);
   const [toolsByServer, setToolsByServer] = useState<Record<string, MCPAirlockToolInventory>>({});
@@ -183,7 +187,7 @@ export function MCPAirlockPanel({ client = api }: MCPAirlockPanelProps) {
                 const discovering = discoveringId === status.server.id;
                 const startDisabled = busy || status.running || !status.command_available;
                 const stopDisabled = busy || !status.running;
-                const discoverDisabled = discovering || status.state !== 'available';
+                const discoverDisabled = discovering || !canDiscoverTools(status.state);
                 return (
               <div className="flex items-start gap-2">
                 <div className="min-w-0 flex-1">

--- a/web/src/components/MCPAirlock/MCPAirlockPanel.tsx
+++ b/web/src/components/MCPAirlock/MCPAirlockPanel.tsx
@@ -186,8 +186,8 @@ export function MCPAirlockPanel({ client = api }: MCPAirlockPanelProps) {
                 const busy = busyId === status.server.id;
                 const discovering = discoveringId === status.server.id;
                 const checkDisabled = busy || discovering;
-                const startDisabled = busy || status.running || !status.command_available;
-                const stopDisabled = busy || !status.running;
+                const startDisabled = busy || discovering || status.running || !status.command_available;
+                const stopDisabled = busy || discovering || !status.running;
                 const discoverDisabled = busy || discovering || !status.command_available || !canDiscoverTools(status.state);
                 return (
               <div className="flex items-start gap-2">

--- a/web/src/components/MCPAirlock/MCPAirlockPanel.tsx
+++ b/web/src/components/MCPAirlock/MCPAirlockPanel.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from 'react';
 import { CheckCircle2, ExternalLink, Play, RefreshCw, ServerCog, ShieldCheck, Square, XCircle } from 'lucide-react';
 
-import { api, type MCPAirlockServerStatus } from '../../api';
+import { api, type MCPAirlockServerStatus, type MCPAirlockToolInventory, type MCPAirlockToolRisk } from '../../api';
 import { Button } from '../ui/button';
 
-type MCPAirlockClient = Pick<typeof api, 'listMCPAirlockServers' | 'checkMCPAirlockServer' | 'startMCPAirlockServer' | 'stopMCPAirlockServer'>;
+type MCPAirlockClient = Pick<typeof api, 'listMCPAirlockServers' | 'checkMCPAirlockServer' | 'startMCPAirlockServer' | 'stopMCPAirlockServer' | 'getMCPAirlockTools' | 'discoverMCPAirlockTools'>;
 
 export interface MCPAirlockPanelProps {
   client?: MCPAirlockClient;
@@ -36,17 +36,44 @@ function checkIcon(status: string) {
   return <XCircle className="h-3.5 w-3.5 text-destructive" />;
 }
 
+function riskClass(risk: MCPAirlockToolRisk) {
+  if (risk === 'read_only') return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300';
+  if (risk === 'generate_code') return 'border-primary/30 bg-primary/10 text-primary';
+  if (risk === 'modify_workspace') return 'border-yellow-500/30 bg-yellow-500/10 text-yellow-200';
+  if (risk === 'cloud_mutation' || risk === 'secret_sensitive') return 'border-orange-500/30 bg-orange-500/10 text-orange-200';
+  return 'border-destructive/40 bg-destructive/10 text-destructive';
+}
+
+function decisionClass(status: string) {
+  if (status === 'allowed') return 'text-emerald-300';
+  if (status === 'approval_required') return 'text-yellow-200';
+  return 'text-destructive';
+}
+
 export function MCPAirlockPanel({ client = api }: MCPAirlockPanelProps) {
   const [servers, setServers] = useState<MCPAirlockServerStatus[]>([]);
+  const [toolsByServer, setToolsByServer] = useState<Record<string, MCPAirlockToolInventory>>({});
   const [loading, setLoading] = useState(false);
   const [busyId, setBusyId] = useState<string | null>(null);
+  const [discoveringId, setDiscoveringId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const load = async () => {
     setLoading(true);
     setError(null);
     try {
-      setServers(await client.listMCPAirlockServers());
+      const nextServers = await client.listMCPAirlockServers();
+      setServers(nextServers);
+      const inventories = await Promise.all(
+        nextServers.map(async status => {
+          try {
+            return [status.server.id, await client.getMCPAirlockTools(status.server.id)] as const;
+          } catch {
+            return [status.server.id, null] as const;
+          }
+        }),
+      );
+      setToolsByServer(Object.fromEntries(inventories.filter((entry): entry is readonly [string, MCPAirlockToolInventory] => entry[1] !== null)));
     } catch (err) {
       setError(String(err));
     } finally {
@@ -97,6 +124,19 @@ export function MCPAirlockPanel({ client = api }: MCPAirlockPanelProps) {
     }
   };
 
+  const discover = async (id: string) => {
+    setDiscoveringId(id);
+    setError(null);
+    try {
+      const inventory = await client.discoverMCPAirlockTools(id);
+      setToolsByServer(current => ({ ...current, [id]: inventory }));
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setDiscoveringId(null);
+    }
+  };
+
   return (
     <div className="flex h-full flex-col gap-3 bg-background p-4">
       <header className="flex items-center gap-3">
@@ -140,6 +180,7 @@ export function MCPAirlockPanel({ client = api }: MCPAirlockPanelProps) {
             >
               {(() => {
                 const busy = busyId === status.server.id;
+                const discovering = discoveringId === status.server.id;
                 const startDisabled = busy || status.running || !status.command_available;
                 const stopDisabled = busy || !status.running;
                 return (
@@ -166,6 +207,15 @@ export function MCPAirlockPanel({ client = api }: MCPAirlockPanelProps) {
                     disabled={busy}
                   >
                     {busy ? '...' : 'Check'}
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    className="h-7 px-2 text-[10px]"
+                    onClick={() => discover(status.server.id)}
+                    disabled={discovering || !status.command_available}
+                  >
+                    {discovering ? '...' : 'Tools'}
                   </Button>
                   <Button
                     size="sm"
@@ -209,6 +259,52 @@ export function MCPAirlockPanel({ client = api }: MCPAirlockPanelProps) {
                   credentials: {status.server.credential_mode}
                 </span>
               </div>
+
+              {toolsByServer[status.server.id] && (
+                <div className="mt-3 rounded-md border border-border bg-background/70 p-2">
+                  <div className="flex items-center gap-2 text-[10px] uppercase tracking-widest text-muted-foreground">
+                    <ShieldCheck className="h-3.5 w-3.5 text-primary" />
+                    Tool Firewall
+                    <span className="ml-auto normal-case tracking-normal">
+                      {toolsByServer[status.server.id].tools.length} tools
+                    </span>
+                  </div>
+
+                  {toolsByServer[status.server.id].checks.length > 0 && (
+                    <div className="mt-2 grid gap-1">
+                      {toolsByServer[status.server.id].checks.slice(0, 2).map(check => (
+                        <div key={`${status.server.id}-tools-${check.name}`} className="flex items-start gap-1.5 text-[10px] leading-relaxed text-muted-foreground">
+                          {checkIcon(check.status)}
+                          <span>{check.message}</span>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+
+                  {toolsByServer[status.server.id].tools.length > 0 && (
+                    <div className="mt-2 grid gap-1.5">
+                      {toolsByServer[status.server.id].tools.slice(0, 5).map(tool => (
+                        <div key={`${status.server.id}-${tool.name}`} className="rounded border border-border/80 px-2 py-1.5">
+                          <div className="flex items-center gap-1.5">
+                            <span className="min-w-0 flex-1 truncate text-[11px] font-medium text-foreground">
+                              {tool.name}
+                            </span>
+                            <span className={`rounded border px-1.5 py-0.5 text-[9px] ${riskClass(tool.risk)}`}>
+                              {tool.risk.replace('_', ' ')}
+                            </span>
+                          </div>
+                          <div className="mt-1 flex items-center gap-2 text-[10px] text-muted-foreground">
+                            <span className={decisionClass(tool.decision.status)}>
+                              {tool.decision.status.replace('_', ' ')}
+                            </span>
+                            <span>{tool.schema_state}</span>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
 
               {status.server.install_hint && !status.command_available && (
                 <div className="mt-2 rounded-md border border-border bg-background px-2 py-1.5 text-[11px] leading-relaxed text-muted-foreground">

--- a/web/src/components/MCPAirlock/MCPAirlockPanel.tsx
+++ b/web/src/components/MCPAirlock/MCPAirlockPanel.tsx
@@ -187,7 +187,7 @@ export function MCPAirlockPanel({ client = api }: MCPAirlockPanelProps) {
                 const discovering = discoveringId === status.server.id;
                 const startDisabled = busy || status.running || !status.command_available;
                 const stopDisabled = busy || !status.running;
-                const discoverDisabled = discovering || !canDiscoverTools(status.state);
+                const discoverDisabled = busy || discovering || !canDiscoverTools(status.state);
                 return (
               <div className="flex items-start gap-2">
                 <div className="min-w-0 flex-1">

--- a/web/src/components/MCPAirlock/MCPAirlockPanel.tsx
+++ b/web/src/components/MCPAirlock/MCPAirlockPanel.tsx
@@ -183,6 +183,7 @@ export function MCPAirlockPanel({ client = api }: MCPAirlockPanelProps) {
                 const discovering = discoveringId === status.server.id;
                 const startDisabled = busy || status.running || !status.command_available;
                 const stopDisabled = busy || !status.running;
+                const discoverDisabled = discovering || status.state !== 'available';
                 return (
               <div className="flex items-start gap-2">
                 <div className="min-w-0 flex-1">
@@ -213,7 +214,7 @@ export function MCPAirlockPanel({ client = api }: MCPAirlockPanelProps) {
                     variant="secondary"
                     className="h-7 px-2 text-[10px]"
                     onClick={() => discover(status.server.id)}
-                    disabled={discovering || !status.command_available}
+                    disabled={discoverDisabled}
                   >
                     {discovering ? '...' : 'Tools'}
                   </Button>

--- a/web/src/components/MCPAirlock/MCPAirlockPanel.tsx
+++ b/web/src/components/MCPAirlock/MCPAirlockPanel.tsx
@@ -185,9 +185,10 @@ export function MCPAirlockPanel({ client = api }: MCPAirlockPanelProps) {
               {(() => {
                 const busy = busyId === status.server.id;
                 const discovering = discoveringId === status.server.id;
+                const checkDisabled = busy || discovering;
                 const startDisabled = busy || status.running || !status.command_available;
                 const stopDisabled = busy || !status.running;
-                const discoverDisabled = busy || discovering || !canDiscoverTools(status.state);
+                const discoverDisabled = busy || discovering || !status.command_available || !canDiscoverTools(status.state);
                 return (
               <div className="flex items-start gap-2">
                 <div className="min-w-0 flex-1">
@@ -209,7 +210,7 @@ export function MCPAirlockPanel({ client = api }: MCPAirlockPanelProps) {
                     variant="secondary"
                     className="h-7 px-2 text-[10px]"
                     onClick={() => check(status.server.id)}
-                    disabled={busy}
+                    disabled={checkDisabled}
                   >
                     {busy ? '...' : 'Check'}
                   </Button>


### PR DESCRIPTION
## Summary

- add bounded external MCP tools/list discovery with schema hashing and persisted inventory under .iac-studio/mcp-airlock-tools.json
- classify discovered tools into Airlock risk classes and fail closed for unknown, mutation, secret-sensitive, destructive, and workspace-modifying tools unless explicitly allowlisted
- add persisted server/project allowlist support and HTTP endpoints for inventory, discovery, evaluation, and allowlist updates
- expose discovery, evaluation, and guarded external call decisions through the local IaC Studio MCP server
- show discovered tool firewall status, risk badges, schema state, and decisions in the MCP Airlock panel

## Security posture

- discovery launches trusted stdio MCP servers with the existing sanitized minimal environment and no cloud credentials
- external MCP output is labeled untrusted in the decision model
- unknown tools are blocked by default
- risky allowlisted tools still require explicit approval before execution
- call_mcp_airlock_tool refuses blocked tools before any external server invocation, and allowed execution remains deferred until the Cloud Connections credential broker lands

## Validation

- GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/mcpairlock ./internal/mcp ./internal/api
- GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/api with local socket escalation
- GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/... with local socket escalation
- GOCACHE=/private/tmp/iacstudio-go-cache go test ./cmd/...
- npm --prefix web test -- --run MCPAirlockPanel api.test.ts
- npm --prefix web test -- --run
- npm --prefix web run build
- npm --prefix web run lint, passes with existing warnings
- git diff --check
- local Vite smoke check returned 200 OK at http://127.0.0.1:5174/

Closes #61