### PR TITLE
Encrypt Cloud Connection secrets at rest

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -163,9 +163,10 @@ Use them like this:
 6. Confirm the selected target appears in the header before running `Plan` or `Apply`.
 
 Secret fields are encrypted locally before they are written to
-`.iac-studio-connections.json`. By default IaC Studio creates a
+`.iac-studio-connections.json`. When a saved connection contains secret fields
+and `IAC_STUDIO_CONNECTIONS_KEY` is not set, IaC Studio creates a
 `.iac-studio-connections.key` file next to the connections file with `0600`
-permissions; set `IAC_STUDIO_CONNECTIONS_KEY` if you need a stable key for
+permissions. Set `IAC_STUDIO_CONNECTIONS_KEY` if you need a stable key for
 container redeploys or backups. API responses, WebSocket terminal messages, and
 generated IaC files do not echo secret values.
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -162,8 +162,11 @@ Use them like this:
 5. Click **Use for runs**.
 6. Confirm the selected target appears in the header before running `Plan` or `Apply`.
 
-Secrets are stored locally under your configured projects directory in
-`.iac-studio-connections.json`. API responses, WebSocket terminal messages, and
+Secret fields are encrypted locally before they are written to
+`.iac-studio-connections.json`. By default IaC Studio creates a
+`.iac-studio-connections.key` file next to the connections file with `0600`
+permissions; set `IAC_STUDIO_CONNECTIONS_KEY` if you need a stable key for
+container redeploys or backups. API responses, WebSocket terminal messages, and
 generated IaC files do not echo secret values.
 
 For local auth flows, make sure the provider CLI is already logged in:

--- a/README.md
+++ b/README.md
@@ -203,12 +203,14 @@ IaC Studio runs locally and is designed to be secure by default:
 - **Review-branch handoff** — drift and rollback PR workflows create local branches that commit only generated `.iac-studio/remediations` or `.iac-studio/rollbacks` artifacts, reject unrelated dirty source files, and return explicit `git push` / `gh pr create` commands instead of collecting GitHub tokens
 - **MCP approval and audit** — AI clients can inspect and propose, while mutating or high-risk MCP tools require explicit approval and are logged to `.iac-studio/mcp-audit.jsonl`
 - **Cloud target checks** — selected Cloud Connections are tested before command execution
-- **Secret redaction** — static credentials are not echoed in API responses, terminal messages, or generated IaC
+- **Encrypted local secrets** — Cloud Connection secret fields are encrypted at rest and never echoed in API responses, terminal messages, or generated IaC
 - **No telemetry** — zero data collection, no phone-home
 
 Cloud Connections support AWS profiles and SSO, Azure CLI login, and gcloud auth
 as the preferred paths. Static AWS keys, Azure service principals, and GCP
-service account JSON are available as explicit fallback paths. See
+service account JSON are available as explicit fallback paths; their secret
+fields are encrypted in `.iac-studio-connections.json` using a local key file
+or `IAC_STUDIO_CONNECTIONS_KEY` when you need a stable deployment key. See
 [QUICKSTART.md](QUICKSTART.md#cloud-connections) and the
 [published docs](https://olandodeflexy.github.io/IaCStudio/#cloud-connections)
 for the full workflow.

--- a/docs/index.html
+++ b/docs/index.html
@@ -528,9 +528,10 @@ gcloud config set project my-platform-dev</code></pre>
               <p>
                 Connections are saved under the configured projects directory in
                 <code>.iac-studio-connections.json</code>. Secret fields are encrypted before
-                they are written; IaC Studio creates a local <code>.iac-studio-connections.key</code>
-                file by default, or you can set <code>IAC_STUDIO_CONNECTIONS_KEY</code> for a
-                stable deployment key.
+                they are written. When a connection contains secret fields and
+                <code>IAC_STUDIO_CONNECTIONS_KEY</code> is not set, IaC Studio creates a local
+                <code>.iac-studio-connections.key</code> file; set
+                <code>IAC_STUDIO_CONNECTIONS_KEY</code> for a stable deployment key.
               </p>
             </article>
             <article>
@@ -1113,7 +1114,7 @@ ollama pull qwen2.5-coder:7b</code></pre>
             </details>
             <details>
               <summary>Where are cloud connection credentials stored?</summary>
-              <p>Named connections are stored locally in <code>.iac-studio-connections.json</code> under your configured projects directory. Secret fields are encrypted before write, using a local <code>.iac-studio-connections.key</code> file by default or <code>IAC_STUDIO_CONNECTIONS_KEY</code> when you need a stable key. API responses redact secret values.</p>
+              <p>Named connections are stored locally in <code>.iac-studio-connections.json</code> under your configured projects directory. Secret fields are encrypted before write. IaC Studio creates a local <code>.iac-studio-connections.key</code> file only when a saved connection has secret fields and <code>IAC_STUDIO_CONNECTIONS_KEY</code> is not set; use <code>IAC_STUDIO_CONNECTIONS_KEY</code> when you need a stable key. API responses redact secret values.</p>
             </details>
             <details>
               <summary>Does it send telemetry?</summary>

--- a/docs/index.html
+++ b/docs/index.html
@@ -524,11 +524,13 @@ gcloud config set project my-platform-dev</code></pre>
           <h3>Secret handling</h3>
           <div class="feature-grid compact">
             <article>
-              <h3>Stored locally</h3>
+              <h3>Encrypted locally</h3>
               <p>
                 Connections are saved under the configured projects directory in
-                <code>.iac-studio-connections.json</code>. Treat this as a local secret file
-                when static credentials or service account JSON are used.
+                <code>.iac-studio-connections.json</code>. Secret fields are encrypted before
+                they are written; IaC Studio creates a local <code>.iac-studio-connections.key</code>
+                file by default, or you can set <code>IAC_STUDIO_CONNECTIONS_KEY</code> for a
+                stable deployment key.
               </p>
             </article>
             <article>
@@ -1111,7 +1113,7 @@ ollama pull qwen2.5-coder:7b</code></pre>
             </details>
             <details>
               <summary>Where are cloud connection credentials stored?</summary>
-              <p>Named connections are stored locally in <code>.iac-studio-connections.json</code> under your configured projects directory. API responses redact secret values.</p>
+              <p>Named connections are stored locally in <code>.iac-studio-connections.json</code> under your configured projects directory. Secret fields are encrypted before write, using a local <code>.iac-studio-connections.key</code> file by default or <code>IAC_STUDIO_CONNECTIONS_KEY</code> when you need a stable key. API responses redact secret values.</p>
             </details>
             <details>
               <summary>Does it send telemetry?</summary>

--- a/internal/cloudconnections/connections.go
+++ b/internal/cloudconnections/connections.go
@@ -511,7 +511,6 @@ func writeNewLocalKey(path string, key []byte) (err error) {
 		return err
 	}
 	syncDirBestEffort(filepath.Dir(path))
-	cleanup = false
 	return nil
 }
 

--- a/internal/cloudconnections/connections.go
+++ b/internal/cloudconnections/connections.go
@@ -383,7 +383,7 @@ func (m *Manager) encryptConnectionSecrets(connections []Connection) ([]Connecti
 				continue
 			}
 			if key == nil {
-				loaded, err := m.encryptionKey()
+				loaded, err := m.encryptionKeyForEncrypt()
 				if err != nil {
 					return nil, err
 				}
@@ -412,7 +412,7 @@ func (m *Manager) decryptConnectionSecrets(connections []Connection) (bool, erro
 				continue
 			}
 			if key == nil {
-				loaded, err := m.encryptionKey()
+				loaded, err := m.encryptionKeyForDecrypt()
 				if err != nil {
 					return false, err
 				}
@@ -428,25 +428,35 @@ func (m *Manager) decryptConnectionSecrets(connections []Connection) (bool, erro
 	return needsMigration, nil
 }
 
-func (m *Manager) encryptionKey() ([]byte, error) {
-	if passphrase := strings.TrimSpace(os.Getenv(connectionsKeyEnv)); passphrase != "" {
-		sum := sha256.Sum256([]byte(passphrase))
-		return sum[:], nil
+func (m *Manager) encryptionKeyForEncrypt() ([]byte, error) {
+	if key, ok := environmentEncryptionKey(); ok {
+		return key, nil
 	}
 	return loadOrCreateLocalKey(m.keyPath)
+}
+
+func (m *Manager) encryptionKeyForDecrypt() ([]byte, error) {
+	if key, ok := environmentEncryptionKey(); ok {
+		return key, nil
+	}
+	return loadExistingLocalKey(m.keyPath)
+}
+
+func environmentEncryptionKey() ([]byte, bool) {
+	passphrase := strings.TrimSpace(os.Getenv(connectionsKeyEnv))
+	if passphrase == "" {
+		return nil, false
+	}
+	sum := sha256.Sum256([]byte(passphrase))
+	key := make([]byte, len(sum))
+	copy(key, sum[:])
+	return key, true
 }
 
 func loadOrCreateLocalKey(path string) ([]byte, error) {
 	data, err := os.ReadFile(path)
 	if err == nil {
-		if err := ensureLocalKeyFileMode(path); err != nil {
-			return nil, err
-		}
-		decoded, decodeErr := hex.DecodeString(strings.TrimSpace(string(data)))
-		if decodeErr != nil || len(decoded) != generatedSecretKeyByteLen {
-			return nil, fmt.Errorf("read cloud connections key: invalid key material")
-		}
-		return decoded, nil
+		return decodeLocalKey(path, data)
 	}
 	if !os.IsNotExist(err) {
 		return nil, fmt.Errorf("read cloud connections key: %w", err)
@@ -463,6 +473,28 @@ func loadOrCreateLocalKey(path string) ([]byte, error) {
 		return nil, fmt.Errorf("write cloud connections key: %w", err)
 	}
 	return key, nil
+}
+
+func loadExistingLocalKey(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("read cloud connections key: missing key material; set %s or restore %s before reading encrypted cloud connections", connectionsKeyEnv, connectionsKeyFileName)
+		}
+		return nil, fmt.Errorf("read cloud connections key: %w", err)
+	}
+	return decodeLocalKey(path, data)
+}
+
+func decodeLocalKey(path string, data []byte) ([]byte, error) {
+	if err := ensureLocalKeyFileMode(path); err != nil {
+		return nil, err
+	}
+	decoded, decodeErr := hex.DecodeString(strings.TrimSpace(string(data)))
+	if decodeErr != nil || len(decoded) != generatedSecretKeyByteLen {
+		return nil, fmt.Errorf("read cloud connections key: invalid key material")
+	}
+	return decoded, nil
 }
 
 func ensureLocalKeyFileMode(path string) error {

--- a/internal/cloudconnections/connections.go
+++ b/internal/cloudconnections/connections.go
@@ -1,11 +1,16 @@
 package cloudconnections
 
 import (
+	"crypto/aes"
+	"crypto/cipher"
 	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"slices"
@@ -18,6 +23,13 @@ const (
 	ProviderAWS   = "aws"
 	ProviderAzure = "azure"
 	ProviderGCP   = "gcp"
+
+	connectionsFileName       = ".iac-studio-connections.json"
+	connectionsKeyFileName    = ".iac-studio-connections.key"
+	connectionsKeyEnv         = "IAC_STUDIO_CONNECTIONS_KEY"
+	encryptedSecretPrefix     = "iacstudio:v1:"
+	encryptedSecretNonceSize  = 12
+	generatedSecretKeyByteLen = 32
 )
 
 var providerAuthMethods = map[string][]string{
@@ -90,12 +102,16 @@ type Check struct {
 }
 
 type Manager struct {
-	path string
-	mu   sync.RWMutex
+	path    string
+	keyPath string
+	mu      sync.RWMutex
 }
 
 func NewManager(projectsDir string) *Manager {
-	return &Manager{path: filepath.Join(projectsDir, ".iac-studio-connections.json")}
+	return &Manager{
+		path:    filepath.Join(projectsDir, connectionsFileName),
+		keyPath: filepath.Join(projectsDir, connectionsKeyFileName),
+	}
 }
 
 func SupportedAuthMethods(provider string) []string {
@@ -288,31 +304,53 @@ func (m *Manager) Test(id string) (TestResult, error) {
 }
 
 func (m *Manager) load() ([]Connection, error) {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	return m.loadUnlocked()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	connections, needsMigration, err := m.loadUnlockedWithMigrationFlag()
+	if err != nil {
+		return nil, err
+	}
+	if needsMigration {
+		if err := m.saveUnlocked(connections); err != nil {
+			return nil, err
+		}
+	}
+	return connections, nil
 }
 
 func (m *Manager) loadUnlocked() ([]Connection, error) {
+	connections, _, err := m.loadUnlockedWithMigrationFlag()
+	return connections, err
+}
+
+func (m *Manager) loadUnlockedWithMigrationFlag() ([]Connection, bool, error) {
 	data, err := os.ReadFile(m.path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return []Connection{}, nil
+			return []Connection{}, false, nil
 		}
-		return nil, fmt.Errorf("read cloud connections: %w", err)
+		return nil, false, fmt.Errorf("read cloud connections: %w", err)
 	}
 	var connections []Connection
 	if err := json.Unmarshal(data, &connections); err != nil {
-		return nil, fmt.Errorf("parse cloud connections: %w", err)
+		return nil, false, fmt.Errorf("parse cloud connections: %w", err)
 	}
-	return connections, nil
+	needsMigration, err := m.decryptConnectionSecrets(connections)
+	if err != nil {
+		return nil, false, err
+	}
+	return connections, needsMigration, nil
 }
 
 func (m *Manager) saveUnlocked(connections []Connection) error {
 	if err := os.MkdirAll(filepath.Dir(m.path), 0o755); err != nil {
 		return fmt.Errorf("create cloud connections directory: %w", err)
 	}
-	data, err := json.MarshalIndent(connections, "", "  ")
+	persisted, err := m.encryptConnectionSecrets(connections)
+	if err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(persisted, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal cloud connections: %w", err)
 	}
@@ -320,6 +358,152 @@ func (m *Manager) saveUnlocked(connections []Connection) error {
 		return fmt.Errorf("write cloud connections: %w", err)
 	}
 	return nil
+}
+
+func (m *Manager) encryptConnectionSecrets(connections []Connection) ([]Connection, error) {
+	out := make([]Connection, 0, len(connections))
+	var key []byte
+	for _, connection := range connections {
+		next := connection
+		next.Metadata = cloneMap(connection.Metadata)
+		next.Secrets = cloneMap(connection.Secrets)
+		for name, value := range next.Secrets {
+			if strings.TrimSpace(value) == "" || isEncryptedSecret(value) {
+				continue
+			}
+			if key == nil {
+				loaded, err := m.encryptionKey()
+				if err != nil {
+					return nil, err
+				}
+				key = loaded
+			}
+			encrypted, err := encryptSecretValue(key, value)
+			if err != nil {
+				return nil, fmt.Errorf("encrypt cloud connection secret %q: %w", name, err)
+			}
+			next.Secrets[name] = encrypted
+		}
+		out = append(out, next)
+	}
+	return out, nil
+}
+
+func (m *Manager) decryptConnectionSecrets(connections []Connection) (bool, error) {
+	var key []byte
+	needsMigration := false
+	for index := range connections {
+		for name, value := range connections[index].Secrets {
+			if !isEncryptedSecret(value) {
+				if strings.TrimSpace(value) != "" {
+					needsMigration = true
+				}
+				continue
+			}
+			if key == nil {
+				loaded, err := m.encryptionKey()
+				if err != nil {
+					return false, err
+				}
+				key = loaded
+			}
+			plaintext, err := decryptSecretValue(key, value)
+			if err != nil {
+				return false, fmt.Errorf("decrypt cloud connection secret %q: %w", name, err)
+			}
+			connections[index].Secrets[name] = plaintext
+		}
+	}
+	return needsMigration, nil
+}
+
+func (m *Manager) encryptionKey() ([]byte, error) {
+	if passphrase := strings.TrimSpace(os.Getenv(connectionsKeyEnv)); passphrase != "" {
+		sum := sha256.Sum256([]byte(passphrase))
+		return sum[:], nil
+	}
+	return loadOrCreateLocalKey(m.keyPath)
+}
+
+func loadOrCreateLocalKey(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if err == nil {
+		decoded, decodeErr := hex.DecodeString(strings.TrimSpace(string(data)))
+		if decodeErr != nil || len(decoded) != generatedSecretKeyByteLen {
+			return nil, fmt.Errorf("read cloud connections key: invalid key material")
+		}
+		return decoded, nil
+	}
+	if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("read cloud connections key: %w", err)
+	}
+
+	key := make([]byte, generatedSecretKeyByteLen)
+	if _, err := io.ReadFull(rand.Reader, key); err != nil {
+		return nil, fmt.Errorf("generate cloud connections key: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, fmt.Errorf("create cloud connections key directory: %w", err)
+	}
+	if err := writeFileAtomic(path, []byte(hex.EncodeToString(key)+"\n"), 0o600); err != nil {
+		return nil, fmt.Errorf("write cloud connections key: %w", err)
+	}
+	return key, nil
+}
+
+func isEncryptedSecret(value string) bool {
+	return strings.HasPrefix(value, encryptedSecretPrefix)
+}
+
+func encryptSecretValue(key []byte, plaintext string) (string, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+	nonce := make([]byte, encryptedSecretNonceSize)
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", err
+	}
+	ciphertext := gcm.Seal(nil, nonce, []byte(plaintext), nil)
+	return encryptedSecretPrefix +
+		base64.RawURLEncoding.EncodeToString(nonce) + ":" +
+		base64.RawURLEncoding.EncodeToString(ciphertext), nil
+}
+
+func decryptSecretValue(key []byte, value string) (string, error) {
+	encoded := strings.TrimPrefix(value, encryptedSecretPrefix)
+	nonceText, ciphertextText, ok := strings.Cut(encoded, ":")
+	if !ok {
+		return "", errors.New("invalid encrypted secret envelope")
+	}
+	nonce, err := base64.RawURLEncoding.DecodeString(nonceText)
+	if err != nil {
+		return "", fmt.Errorf("decode nonce: %w", err)
+	}
+	if len(nonce) != encryptedSecretNonceSize {
+		return "", errors.New("invalid nonce length")
+	}
+	ciphertext, err := base64.RawURLEncoding.DecodeString(ciphertextText)
+	if err != nil {
+		return "", fmt.Errorf("decode ciphertext: %w", err)
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return "", errors.New("authentication failed")
+	}
+	return string(plaintext), nil
 }
 
 func writeFileAtomic(path string, data []byte, mode os.FileMode) error {

--- a/internal/cloudconnections/connections.go
+++ b/internal/cloudconnections/connections.go
@@ -519,7 +519,22 @@ func ensureLocalKeyFileMode(path string) error {
 }
 
 func isEncryptedSecret(value string) bool {
-	return strings.HasPrefix(value, encryptedSecretPrefix)
+	if !strings.HasPrefix(value, encryptedSecretPrefix) {
+		return false
+	}
+	encoded := strings.TrimPrefix(value, encryptedSecretPrefix)
+	nonceText, ciphertextText, ok := strings.Cut(encoded, ":")
+	if !ok || nonceText == "" || ciphertextText == "" {
+		return false
+	}
+	nonce, err := base64.RawURLEncoding.DecodeString(nonceText)
+	if err != nil || len(nonce) != encryptedSecretNonceSize {
+		return false
+	}
+	if _, err := base64.RawURLEncoding.DecodeString(ciphertextText); err != nil {
+		return false
+	}
+	return true
 }
 
 func encryptSecretValue(key []byte, plaintext string) (string, error) {

--- a/internal/cloudconnections/connections.go
+++ b/internal/cloudconnections/connections.go
@@ -379,7 +379,7 @@ func (m *Manager) encryptConnectionSecrets(connections []Connection) ([]Connecti
 		next.Metadata = cloneMap(connection.Metadata)
 		next.Secrets = cloneMap(connection.Secrets)
 		for name, value := range next.Secrets {
-			if strings.TrimSpace(value) == "" || isEncryptedSecret(value) {
+			if strings.TrimSpace(value) == "" {
 				continue
 			}
 			if key == nil {

--- a/internal/cloudconnections/connections.go
+++ b/internal/cloudconnections/connections.go
@@ -513,7 +513,7 @@ func ensureLocalKeyFileMode(path string) error {
 		return nil
 	}
 	if err := os.Chmod(path, 0o600); err != nil {
-		return fmt.Errorf("cloud connections key permissions are too broad (%o); set %s to 0600: %w", info.Mode().Perm(), connectionsKeyFileName, err)
+		return fmt.Errorf("cloud connections key permissions are too broad (%o); tighten %s permissions to 0600: %w", info.Mode().Perm(), connectionsKeyFileName, err)
 	}
 	return nil
 }

--- a/internal/cloudconnections/connections.go
+++ b/internal/cloudconnections/connections.go
@@ -304,16 +304,27 @@ func (m *Manager) Test(id string) (TestResult, error) {
 }
 
 func (m *Manager) load() ([]Connection, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	m.mu.RLock()
 	connections, needsMigration, err := m.loadUnlockedWithMigrationFlag()
+	m.mu.RUnlock()
 	if err != nil {
 		return nil, err
 	}
-	if needsMigration {
-		if err := m.saveUnlocked(connections); err != nil {
-			return nil, err
-		}
+	if !needsMigration {
+		return connections, nil
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	connections, needsMigration, err = m.loadUnlockedWithMigrationFlag()
+	if err != nil {
+		return nil, err
+	}
+	if !needsMigration {
+		return connections, nil
+	}
+	if err := m.saveUnlocked(connections); err != nil {
+		return nil, err
 	}
 	return connections, nil
 }
@@ -428,6 +439,9 @@ func (m *Manager) encryptionKey() ([]byte, error) {
 func loadOrCreateLocalKey(path string) ([]byte, error) {
 	data, err := os.ReadFile(path)
 	if err == nil {
+		if err := ensureLocalKeyFileMode(path); err != nil {
+			return nil, err
+		}
 		decoded, decodeErr := hex.DecodeString(strings.TrimSpace(string(data)))
 		if decodeErr != nil || len(decoded) != generatedSecretKeyByteLen {
 			return nil, fmt.Errorf("read cloud connections key: invalid key material")
@@ -449,6 +463,23 @@ func loadOrCreateLocalKey(path string) ([]byte, error) {
 		return nil, fmt.Errorf("write cloud connections key: %w", err)
 	}
 	return key, nil
+}
+
+func ensureLocalKeyFileMode(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat cloud connections key: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("cloud connections key must be a regular file")
+	}
+	if info.Mode().Perm()&0o077 == 0 {
+		return nil
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		return fmt.Errorf("cloud connections key permissions are too broad (%o); set %s to 0600: %w", info.Mode().Perm(), connectionsKeyFileName, err)
+	}
+	return nil
 }
 
 func isEncryptedSecret(value string) bool {

--- a/internal/cloudconnections/connections.go
+++ b/internal/cloudconnections/connections.go
@@ -501,7 +501,7 @@ func decryptSecretValue(key []byte, value string) (string, error) {
 	}
 	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
 	if err != nil {
-		return "", errors.New("authentication failed")
+		return "", errors.New("encrypted secret authentication failed; verify " + connectionsKeyEnv + " or " + connectionsKeyFileName + " matches the key used to encrypt this connections file")
 	}
 	return string(plaintext), nil
 }

--- a/internal/cloudconnections/connections.go
+++ b/internal/cloudconnections/connections.go
@@ -454,12 +454,12 @@ func environmentEncryptionKey() ([]byte, bool) {
 }
 
 func loadOrCreateLocalKey(path string) ([]byte, error) {
-	data, err := os.ReadFile(path)
+	err := ensureLocalKeyFileMode(path)
 	if err == nil {
-		return decodeLocalKey(path, data)
+		return readLocalKey(path)
 	}
-	if !os.IsNotExist(err) {
-		return nil, fmt.Errorf("read cloud connections key: %w", err)
+	if !errors.Is(err, os.ErrNotExist) {
+		return nil, err
 	}
 
 	key := make([]byte, generatedSecretKeyByteLen)
@@ -476,19 +476,20 @@ func loadOrCreateLocalKey(path string) ([]byte, error) {
 }
 
 func loadExistingLocalKey(path string) ([]byte, error) {
-	data, err := os.ReadFile(path)
+	err := ensureLocalKeyFileMode(path)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return nil, fmt.Errorf("read cloud connections key: missing key material; set %s or restore %s before reading encrypted cloud connections", connectionsKeyEnv, connectionsKeyFileName)
 		}
-		return nil, fmt.Errorf("read cloud connections key: %w", err)
+		return nil, err
 	}
-	return decodeLocalKey(path, data)
+	return readLocalKey(path)
 }
 
-func decodeLocalKey(path string, data []byte) ([]byte, error) {
-	if err := ensureLocalKeyFileMode(path); err != nil {
-		return nil, err
+func readLocalKey(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read cloud connections key: %w", err)
 	}
 	decoded, decodeErr := hex.DecodeString(strings.TrimSpace(string(data)))
 	if decodeErr != nil || len(decoded) != generatedSecretKeyByteLen {
@@ -498,9 +499,12 @@ func decodeLocalKey(path string, data []byte) ([]byte, error) {
 }
 
 func ensureLocalKeyFileMode(path string) error {
-	info, err := os.Stat(path)
+	info, err := os.Lstat(path)
 	if err != nil {
 		return fmt.Errorf("stat cloud connections key: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("cloud connections key must not be a symlink")
 	}
 	if !info.Mode().IsRegular() {
 		return fmt.Errorf("cloud connections key must be a regular file")

--- a/internal/cloudconnections/connections.go
+++ b/internal/cloudconnections/connections.go
@@ -469,10 +469,50 @@ func loadOrCreateLocalKey(path string) ([]byte, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return nil, fmt.Errorf("create cloud connections key directory: %w", err)
 	}
-	if err := writeFileAtomic(path, []byte(hex.EncodeToString(key)+"\n"), 0o600); err != nil {
+	if err := writeNewLocalKey(path, key); err != nil {
+		if errors.Is(err, os.ErrExist) {
+			if err := ensureLocalKeyFileMode(path); err != nil {
+				return nil, err
+			}
+			return readLocalKey(path)
+		}
 		return nil, fmt.Errorf("write cloud connections key: %w", err)
 	}
 	return key, nil
+}
+
+func writeNewLocalKey(path string, key []byte) (err error) {
+	dir := filepath.Dir(path)
+	file, err := os.CreateTemp(dir, filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := file.Name()
+	cleanup := true
+	defer func() {
+		if closeErr := file.Close(); err == nil && closeErr != nil {
+			err = closeErr
+		}
+		if cleanup {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if err = file.Chmod(0o600); err != nil {
+		return err
+	}
+	if _, err = file.WriteString(hex.EncodeToString(key) + "\n"); err != nil {
+		return err
+	}
+	if err = file.Sync(); err != nil {
+		return err
+	}
+	if err = os.Link(tmpPath, path); err != nil {
+		return err
+	}
+	syncDirBestEffort(filepath.Dir(path))
+	cleanup = false
+	return nil
 }
 
 func loadExistingLocalKey(path string) ([]byte, error) {

--- a/internal/cloudconnections/connections_test.go
+++ b/internal/cloudconnections/connections_test.go
@@ -46,7 +46,7 @@ func TestManagerRedactsStaticSecrets(t *testing.T) {
 		t.Fatal("secret_access_key leaked into public metadata")
 	}
 
-	data, err := os.ReadFile(filepath.Join(filepath.Dir(manager.path), ".iac-studio-connections.json"))
+	data, err := os.ReadFile(manager.path)
 	if err != nil {
 		t.Fatalf("read persisted file: %v", err)
 	}

--- a/internal/cloudconnections/connections_test.go
+++ b/internal/cloudconnections/connections_test.go
@@ -66,6 +66,38 @@ func TestManagerRedactsStaticSecrets(t *testing.T) {
 	}
 }
 
+func TestManagerEncryptsUserSecretWithEnvelopePrefix(t *testing.T) {
+	manager := NewManager(t.TempDir())
+	plaintext := encryptedSecretPrefix + "user-supplied-secret"
+
+	created, err := manager.Save(Connection{
+		Name:       "prefixed-secret",
+		Provider:   ProviderAWS,
+		AuthMethod: "aws_static",
+		Metadata:   map[string]string{"access_key_id": "AKIAEXAMPLE"},
+		Secrets:    map[string]string{"secret_access_key": plaintext},
+	})
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	data, err := os.ReadFile(manager.path)
+	if err != nil {
+		t.Fatalf("read persisted file: %v", err)
+	}
+	if contains(string(data), plaintext) {
+		t.Fatal("secret with envelope prefix should still be encrypted at rest")
+	}
+
+	stored, err := manager.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got := stored.Secrets["secret_access_key"]; got != plaintext {
+		t.Fatalf("prefixed secret should decrypt to original value, got %q", got)
+	}
+}
+
 func TestManagerReadsLegacyPlaintextSecrets(t *testing.T) {
 	dir := t.TempDir()
 	manager := NewManager(dir)

--- a/internal/cloudconnections/connections_test.go
+++ b/internal/cloudconnections/connections_test.go
@@ -161,6 +161,37 @@ func TestManagerCanUseEnvironmentEncryptionKey(t *testing.T) {
 	}
 }
 
+func TestManagerWrongEncryptionKeyReturnsRemediation(t *testing.T) {
+	t.Setenv(connectionsKeyEnv, "original-deployment-key")
+	dir := t.TempDir()
+	manager := NewManager(dir)
+
+	created, err := manager.Save(Connection{
+		Name:       "prod-admin",
+		Provider:   ProviderAWS,
+		AuthMethod: "aws_static",
+		Metadata:   map[string]string{"access_key_id": "AKIAEXAMPLE"},
+		Secrets:    map[string]string{"secret_access_key": "super-secret"},
+	})
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	t.Setenv(connectionsKeyEnv, "rotated-deployment-key")
+	reloaded := NewManager(dir)
+	_, err = reloaded.Get(created.ID)
+	if err == nil {
+		t.Fatal("expected wrong encryption key to fail closed")
+	}
+	message := err.Error()
+	if !strings.Contains(message, connectionsKeyEnv) || !strings.Contains(message, connectionsKeyFileName) {
+		t.Fatalf("expected key remediation in decrypt error, got %q", message)
+	}
+	if strings.Contains(message, "super-secret") {
+		t.Fatalf("decrypt error leaked plaintext secret: %q", message)
+	}
+}
+
 func TestManagerKeepsExistingSecretOnMaskedUpdate(t *testing.T) {
 	manager := NewManager(t.TempDir())
 

--- a/internal/cloudconnections/connections_test.go
+++ b/internal/cloudconnections/connections_test.go
@@ -189,6 +189,36 @@ func TestManagerTightensExistingConnectionKeyFileMode(t *testing.T) {
 	}
 }
 
+func TestManagerRejectsSymlinkedConnectionKey(t *testing.T) {
+	dir := t.TempDir()
+	manager := NewManager(dir)
+	targetPath := filepath.Join(dir, "target-key")
+	if err := os.WriteFile(targetPath, []byte(strings.Repeat("ab", generatedSecretKeyByteLen)+"\n"), 0o600); err != nil {
+		t.Fatalf("write target key: %v", err)
+	}
+	if err := os.Chmod(targetPath, 0o644); err != nil {
+		t.Fatalf("chmod target key: %v", err)
+	}
+	if err := os.Symlink(targetPath, manager.keyPath); err != nil {
+		t.Skipf("symlinks are not available on this platform: %v", err)
+	}
+
+	_, err := loadOrCreateLocalKey(manager.keyPath)
+	if err == nil {
+		t.Fatal("expected symlinked key path to be rejected")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("expected symlink rejection, got %q", err.Error())
+	}
+	info, err := os.Stat(targetPath)
+	if err != nil {
+		t.Fatalf("stat target key: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o644 {
+		t.Fatalf("symlink target should not be chmodded, got %o", got)
+	}
+}
+
 func TestManagerCanUseEnvironmentEncryptionKey(t *testing.T) {
 	t.Setenv(connectionsKeyEnv, "stable-deployment-key")
 	dir := t.TempDir()

--- a/internal/cloudconnections/connections_test.go
+++ b/internal/cloudconnections/connections_test.go
@@ -249,6 +249,41 @@ func TestManagerWrongEncryptionKeyReturnsRemediation(t *testing.T) {
 	}
 }
 
+func TestManagerMissingLocalKeyDoesNotCreateReplacementOnDecrypt(t *testing.T) {
+	dir := t.TempDir()
+	manager := NewManager(dir)
+
+	created, err := manager.Save(Connection{
+		Name:       "prod-admin",
+		Provider:   ProviderAWS,
+		AuthMethod: "aws_static",
+		Metadata:   map[string]string{"access_key_id": "AKIAEXAMPLE"},
+		Secrets:    map[string]string{"secret_access_key": "super-secret"},
+	})
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if err := os.Remove(manager.keyPath); err != nil {
+		t.Fatalf("remove local key file: %v", err)
+	}
+
+	reloaded := NewManager(dir)
+	_, err = reloaded.Get(created.ID)
+	if err == nil {
+		t.Fatal("expected missing local encryption key to fail closed")
+	}
+	message := err.Error()
+	if !strings.Contains(message, connectionsKeyEnv) || !strings.Contains(message, connectionsKeyFileName) {
+		t.Fatalf("expected missing key remediation in decrypt error, got %q", message)
+	}
+	if strings.Contains(message, "super-secret") {
+		t.Fatalf("decrypt error leaked plaintext secret: %q", message)
+	}
+	if _, err := os.Stat(reloaded.keyPath); !os.IsNotExist(err) {
+		t.Fatalf("decrypt should not create a replacement local key file, stat err=%v", err)
+	}
+}
+
 func TestManagerKeepsExistingSecretOnMaskedUpdate(t *testing.T) {
 	manager := NewManager(t.TempDir())
 

--- a/internal/cloudconnections/connections_test.go
+++ b/internal/cloudconnections/connections_test.go
@@ -49,8 +49,115 @@ func TestManagerRedactsStaticSecrets(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read persisted file: %v", err)
 	}
-	if !contains(string(data), "super-secret") {
-		t.Fatal("expected secret to persist for later runner use")
+	if contains(string(data), "super-secret") {
+		t.Fatal("secret should be encrypted at rest, but plaintext was found")
+	}
+	if !contains(string(data), encryptedSecretPrefix) {
+		t.Fatalf("expected encrypted secret envelope in persisted file: %s", string(data))
+	}
+
+	stored, err := manager.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got := stored.Secrets["secret_access_key"]; got != "super-secret" {
+		t.Fatalf("stored secret should decrypt for runner use, got %q", got)
+	}
+}
+
+func TestManagerReadsLegacyPlaintextSecrets(t *testing.T) {
+	dir := t.TempDir()
+	manager := NewManager(dir)
+	legacy := `[{
+		"id":"conn_legacy",
+		"name":"legacy",
+		"provider":"aws",
+		"auth_method":"aws_static",
+		"metadata":{"access_key_id":"AKIAEXAMPLE"},
+		"secrets":{"secret_access_key":"legacy-secret"},
+		"created_at":"2026-06-18T00:00:00Z",
+		"updated_at":"2026-06-18T00:00:00Z"
+	}]`
+	if err := os.WriteFile(manager.path, []byte(legacy), 0o600); err != nil {
+		t.Fatalf("write legacy file: %v", err)
+	}
+
+	stored, err := manager.Get("conn_legacy")
+	if err != nil {
+		t.Fatalf("Get legacy: %v", err)
+	}
+	if got := stored.Secrets["secret_access_key"]; got != "legacy-secret" {
+		t.Fatalf("legacy plaintext secret should remain readable, got %q", got)
+	}
+
+	data, err := os.ReadFile(manager.path)
+	if err != nil {
+		t.Fatalf("read migrated file: %v", err)
+	}
+	if contains(string(data), "legacy-secret") {
+		t.Fatal("legacy plaintext secret should be migrated to encrypted storage after read")
+	}
+	if !contains(string(data), encryptedSecretPrefix) {
+		t.Fatalf("migrated file should contain encrypted envelope: %s", string(data))
+	}
+}
+
+func TestManagerConnectionKeyFileMode(t *testing.T) {
+	dir := t.TempDir()
+	manager := NewManager(dir)
+
+	if _, err := manager.Save(Connection{
+		Name:       "prod-admin",
+		Provider:   ProviderAWS,
+		AuthMethod: "aws_static",
+		Metadata:   map[string]string{"access_key_id": "AKIAEXAMPLE"},
+		Secrets:    map[string]string{"secret_access_key": "super-secret"},
+	}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	info, err := os.Stat(manager.keyPath)
+	if err != nil {
+		t.Fatalf("stat key file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("connection key file mode should be 0600, got %o", got)
+	}
+	keyData, err := os.ReadFile(manager.keyPath)
+	if err != nil {
+		t.Fatalf("read key file: %v", err)
+	}
+	if len(strings.TrimSpace(string(keyData))) != generatedSecretKeyByteLen*2 {
+		t.Fatalf("key file should contain hex encoded 256-bit key, got %q", string(keyData))
+	}
+}
+
+func TestManagerCanUseEnvironmentEncryptionKey(t *testing.T) {
+	t.Setenv(connectionsKeyEnv, "stable-deployment-key")
+	dir := t.TempDir()
+	manager := NewManager(dir)
+
+	created, err := manager.Save(Connection{
+		Name:       "prod-admin",
+		Provider:   ProviderAWS,
+		AuthMethod: "aws_static",
+		Metadata:   map[string]string{"access_key_id": "AKIAEXAMPLE"},
+		Secrets:    map[string]string{"secret_access_key": "super-secret"},
+	})
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if _, err := os.Stat(manager.keyPath); !os.IsNotExist(err) {
+		t.Fatalf("env-key mode should not create local key file, err=%v", err)
+	}
+
+	reloaded := NewManager(dir)
+	stored, err := reloaded.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get with env key: %v", err)
+	}
+	if got := stored.Secrets["secret_access_key"]; got != "super-secret" {
+		t.Fatalf("env key should decrypt stored secret, got %q", got)
 	}
 }
 

--- a/internal/cloudconnections/connections_test.go
+++ b/internal/cloudconnections/connections_test.go
@@ -204,6 +204,29 @@ func TestManagerConnectionKeyFileMode(t *testing.T) {
 	}
 }
 
+func TestManagerConnectionKeyCreationCleansTempFiles(t *testing.T) {
+	dir := t.TempDir()
+	manager := NewManager(dir)
+
+	if _, err := manager.Save(Connection{
+		Name:       "prod-admin",
+		Provider:   ProviderAWS,
+		AuthMethod: "aws_static",
+		Metadata:   map[string]string{"access_key_id": "AKIAEXAMPLE"},
+		Secrets:    map[string]string{"secret_access_key": "super-secret"},
+	}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	tmpFiles, err := filepath.Glob(filepath.Join(dir, connectionsKeyFileName+".*.tmp"))
+	if err != nil {
+		t.Fatalf("glob key temp files: %v", err)
+	}
+	if len(tmpFiles) != 0 {
+		t.Fatalf("key temp files should be cleaned up: %#v", tmpFiles)
+	}
+}
+
 func TestManagerListUsesReadLockWhenNoMigrationNeeded(t *testing.T) {
 	manager := NewManager(t.TempDir())
 	if _, err := manager.Save(Connection{

--- a/internal/cloudconnections/connections_test.go
+++ b/internal/cloudconnections/connections_test.go
@@ -135,6 +135,44 @@ func TestManagerReadsLegacyPlaintextSecrets(t *testing.T) {
 	}
 }
 
+func TestManagerMigratesLegacyPlaintextSecretWithEnvelopePrefix(t *testing.T) {
+	dir := t.TempDir()
+	manager := NewManager(dir)
+	plaintext := encryptedSecretPrefix + "legacy-prefix-collision"
+	legacy := `[{
+		"id":"conn_legacy",
+		"name":"legacy",
+		"provider":"aws",
+		"auth_method":"aws_static",
+		"metadata":{"access_key_id":"AKIAEXAMPLE"},
+		"secrets":{"secret_access_key":"` + plaintext + `"},
+		"created_at":"2026-06-18T00:00:00Z",
+		"updated_at":"2026-06-18T00:00:00Z"
+	}]`
+	if err := os.WriteFile(manager.path, []byte(legacy), 0o600); err != nil {
+		t.Fatalf("write legacy file: %v", err)
+	}
+
+	stored, err := manager.Get("conn_legacy")
+	if err != nil {
+		t.Fatalf("Get legacy: %v", err)
+	}
+	if got := stored.Secrets["secret_access_key"]; got != plaintext {
+		t.Fatalf("legacy plaintext secret with envelope prefix should remain readable, got %q", got)
+	}
+
+	data, err := os.ReadFile(manager.path)
+	if err != nil {
+		t.Fatalf("read migrated file: %v", err)
+	}
+	if contains(string(data), plaintext) {
+		t.Fatal("legacy plaintext secret with envelope prefix should be migrated to encrypted storage")
+	}
+	if !contains(string(data), encryptedSecretPrefix) {
+		t.Fatalf("migrated file should contain encrypted envelope: %s", string(data))
+	}
+}
+
 func TestManagerConnectionKeyFileMode(t *testing.T) {
 	dir := t.TempDir()
 	manager := NewManager(dir)
@@ -190,7 +228,7 @@ func TestManagerListUsesReadLockWhenNoMigrationNeeded(t *testing.T) {
 		if err != nil {
 			t.Fatalf("List: %v", err)
 		}
-	case <-time.After(500 * time.Millisecond):
+	case <-time.After(2 * time.Second):
 		t.Fatal("List blocked behind an existing read lock")
 	}
 }

--- a/internal/cloudconnections/connections_test.go
+++ b/internal/cloudconnections/connections_test.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestManagerRedactsStaticSecrets(t *testing.T) {
@@ -129,6 +130,62 @@ func TestManagerConnectionKeyFileMode(t *testing.T) {
 	}
 	if len(strings.TrimSpace(string(keyData))) != generatedSecretKeyByteLen*2 {
 		t.Fatalf("key file should contain hex encoded 256-bit key, got %q", string(keyData))
+	}
+}
+
+func TestManagerListUsesReadLockWhenNoMigrationNeeded(t *testing.T) {
+	manager := NewManager(t.TempDir())
+	if _, err := manager.Save(Connection{
+		Name:       "profile-only",
+		Provider:   ProviderAWS,
+		AuthMethod: "aws_profile",
+		Metadata:   map[string]string{"profile": "default"},
+	}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	manager.mu.RLock()
+	defer manager.mu.RUnlock()
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := manager.List()
+		errCh <- err
+	}()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("List: %v", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("List blocked behind an existing read lock")
+	}
+}
+
+func TestManagerTightensExistingConnectionKeyFileMode(t *testing.T) {
+	dir := t.TempDir()
+	manager := NewManager(dir)
+	if err := os.MkdirAll(filepath.Dir(manager.keyPath), 0o755); err != nil {
+		t.Fatalf("mkdir key dir: %v", err)
+	}
+	if err := os.WriteFile(manager.keyPath, []byte(strings.Repeat("ab", generatedSecretKeyByteLen)+"\n"), 0o644); err != nil {
+		t.Fatalf("write loose key file: %v", err)
+	}
+
+	key, err := loadOrCreateLocalKey(manager.keyPath)
+	if err != nil {
+		t.Fatalf("load existing key: %v", err)
+	}
+	if len(key) != generatedSecretKeyByteLen {
+		t.Fatalf("expected %d key bytes, got %d", generatedSecretKeyByteLen, len(key))
+	}
+	info, err := os.Stat(manager.keyPath)
+	if err != nil {
+		t.Fatalf("stat key file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("connection key file mode should be tightened to 0600, got %o", got)
 	}
 }
 

--- a/internal/cloudconnections/connections_test.go
+++ b/internal/cloudconnections/connections_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -286,6 +287,50 @@ func TestManagerRejectsSymlinkedConnectionKey(t *testing.T) {
 	}
 	if got := info.Mode().Perm(); got != 0o644 {
 		t.Fatalf("symlink target should not be chmodded, got %o", got)
+	}
+}
+
+func TestLoadOrCreateLocalKeyReturnsSingleKeyAcrossConcurrentCreators(t *testing.T) {
+	for attempt := 0; attempt < 20; attempt++ {
+		dir := t.TempDir()
+		keyPath := filepath.Join(dir, connectionsKeyFileName)
+		const workers = 8
+		start := make(chan struct{})
+		results := make(chan string, workers)
+		errs := make(chan error, workers)
+		var wg sync.WaitGroup
+		wg.Add(workers)
+		for i := 0; i < workers; i++ {
+			go func() {
+				defer wg.Done()
+				<-start
+				key, err := loadOrCreateLocalKey(keyPath)
+				if err != nil {
+					errs <- err
+					return
+				}
+				results <- string(key)
+			}()
+		}
+		close(start)
+		wg.Wait()
+		close(results)
+		close(errs)
+
+		for err := range errs {
+			t.Fatalf("loadOrCreateLocalKey: %v", err)
+		}
+
+		var first string
+		for key := range results {
+			if first == "" {
+				first = key
+				continue
+			}
+			if key != first {
+				t.Fatal("concurrent key creators should all return the same key material")
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- encrypt Cloud Connection secret fields before writing `.iac-studio-connections.json`
- add transparent decryption for runner/API use and automatic migration for legacy plaintext connection files on read
- support `IAC_STUDIO_CONNECTIONS_KEY` for stable container/backup deployments, otherwise generate a local `0600` `.iac-studio-connections.key`
- update README, quickstart, and GitHub Pages docs for the new storage model

## Security posture

- API responses remain redacted and unchanged
- static AWS keys, Azure service principal secrets, and GCP service account JSON are no longer stored as plaintext in the connections JSON
- legacy plaintext files remain readable and are rewritten encrypted after read
- local key material is written with `0600`; deployments that need stable key material can supply `IAC_STUDIO_CONNECTIONS_KEY`

Part of #63 and addresses the Cloud Connections plaintext-at-rest finding from `CODE_REVIEW.md`.

## Validation

- `GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/cloudconnections ./internal/api`
- `GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/...`
- `GOCACHE=/private/tmp/iacstudio-go-cache go test ./cmd/...`
- `git diff --check`