### PR TITLE
Harden JSON mutating API content types

### DIFF
--- a/internal/api/agent.go
+++ b/internal/api/agent.go
@@ -99,6 +99,9 @@ func registerAgentRoutes(
 	// the project. Returns the specialist used and the final text.
 	mux.HandleFunc("POST /api/projects/{name}/ai/agent", func(w http.ResponseWriter, r *http.Request) {
 		limitBody(w, r)
+		if !requireJSONContentType(w, r) {
+			return
+		}
 		name := r.PathValue("name")
 		projectPath, err := safeProjectPath(projectsDir, name)
 		if err != nil {

--- a/internal/api/modules.go
+++ b/internal/api/modules.go
@@ -169,6 +169,9 @@ func registerModuleRoutes(mux *http.ServeMux, projectsDir string, reg *registry.
 	// Body: {"module_name": "networking", "resource_ids": ["aws_vpc.main", ...]}
 	mux.HandleFunc("POST /api/projects/{name}/promote-to-module", func(w http.ResponseWriter, r *http.Request) {
 		limitBody(w, r)
+		if !requireJSONContentType(w, r) {
+			return
+		}
 		name := r.PathValue("name")
 		projectPath, err := safeProjectPath(projectsDir, name)
 		if err != nil {

--- a/internal/api/plan_classification.go
+++ b/internal/api/plan_classification.go
@@ -27,6 +27,9 @@ type planClassifyRequest struct {
 func registerPlanClassificationRoutes(mux *http.ServeMux, projectsDir string) {
 	mux.HandleFunc("POST /api/projects/{name}/plan/classify", func(w http.ResponseWriter, r *http.Request) {
 		r.Body = http.MaxBytesReader(w, r.Body, maxPlanClassifyRequestBody)
+		if !requireOptionalJSONContentType(w, r) {
+			return
+		}
 		name := r.PathValue("name")
 		projectPath, err := safeProjectPath(projectsDir, name)
 		if err != nil {

--- a/internal/api/policy.go
+++ b/internal/api/policy.go
@@ -84,6 +84,9 @@ func registerPolicyRoutes(mux *http.ServeMux, projectsDir string) {
 	// and returns a unified findings feed.
 	mux.HandleFunc("POST /api/projects/{name}/policy/run", func(w http.ResponseWriter, r *http.Request) {
 		limitBody(w, r)
+		if !requireOptionalJSONContentType(w, r) {
+			return
+		}
 		name := r.PathValue("name")
 		projectPath, err := safeProjectPath(projectsDir, name)
 		if err != nil {

--- a/internal/api/rag.go
+++ b/internal/api/rag.go
@@ -57,6 +57,9 @@ func registerRAGRoutes(mux *http.ServeMux, projectsDir string, aiClient *ai.Clie
 	// call basis (useful for CI benchmarks). Returns the new Stats.
 	mux.HandleFunc("POST /api/projects/{name}/ai/index", func(w http.ResponseWriter, r *http.Request) {
 		limitBody(w, r)
+		if !requireOptionalJSONContentType(w, r) {
+			return
+		}
 		name := r.PathValue("name")
 		projectPath, err := safeProjectPath(projectsDir, name)
 		if err != nil {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"mime"
 	"net"
 	"net/http"
 	"os"
@@ -940,6 +941,34 @@ func limitBody(w http.ResponseWriter, r *http.Request) {
 	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBody)
 }
 
+func requireJSONContentType(w http.ResponseWriter, r *http.Request) bool {
+	contentType := strings.TrimSpace(r.Header.Get("Content-Type"))
+	if contentType == "" {
+		http.Error(w, "content type must be application/json", http.StatusUnsupportedMediaType)
+		return false
+	}
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil || !strings.EqualFold(mediaType, "application/json") {
+		http.Error(w, "content type must be application/json", http.StatusUnsupportedMediaType)
+		return false
+	}
+	return true
+}
+
+func requestHasBody(r *http.Request) bool {
+	return r.Body != nil && r.Body != http.NoBody && r.ContentLength != 0
+}
+
+func requireOptionalJSONContentType(w http.ResponseWriter, r *http.Request) bool {
+	if strings.TrimSpace(r.Header.Get("Content-Type")) != "" {
+		return requireJSONContentType(w, r)
+	}
+	if requestHasBody(r) {
+		return requireJSONContentType(w, r)
+	}
+	return true
+}
+
 // RouterOptions allows callers to provide long-lived services that need
 // explicit lifecycle management outside the router.
 type RouterOptions struct {
@@ -1009,6 +1038,9 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 	// Create project
 	mux.HandleFunc("POST /api/projects", func(w http.ResponseWriter, r *http.Request) {
 		limitBody(w, r)
+		if !requireJSONContentType(w, r) {
+			return
+		}
 		var req struct {
 			Name string `json:"name"`
 			Tool string `json:"tool"` // terraform | opentofu | ansible
@@ -1082,6 +1114,9 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 	// is auto-filled from "name" when not explicitly set.
 	mux.HandleFunc("POST /api/blueprints/{id}/render", func(w http.ResponseWriter, r *http.Request) {
 		limitBody(w, r)
+		if !requireJSONContentType(w, r) {
+			return
+		}
 		id := r.PathValue("id")
 		bp, ok := scaffold.Default.Get(id)
 		if !ok {
@@ -1189,6 +1224,9 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 			return
 		}
 		limitBody(w, r)
+		if !requireJSONContentType(w, r) {
+			return
+		}
 		var body syncRequest
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			http.Error(w, "invalid request body", 400)
@@ -1407,6 +1445,9 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 		projectRoot := projectPath
 
 		limitBody(w, r)
+		if !requireJSONContentType(w, r) {
+			return
+		}
 		var req struct {
 			Tool     string `json:"tool"`
 			Command  string `json:"command"`  // init | plan | apply | check | playbook
@@ -1717,6 +1758,9 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 		// A missing body (EOF) is fine — kill defaults to the project
 		// root. Any other decode failure is a client error; treating
 		// it as "no env" would silently target the wrong execution.
+		if !requireOptionalJSONContentType(w, r) {
+			return
+		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
 			http.Error(w, "invalid request body: "+err.Error(), 400)
 			return
@@ -1740,6 +1784,9 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 	// AI chat
 	mux.HandleFunc("POST /api/ai/chat", func(w http.ResponseWriter, r *http.Request) {
 		limitBody(w, r)
+		if !requireJSONContentType(w, r) {
+			return
+		}
 		var req ai.ChatRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			http.Error(w, "invalid request", 400)
@@ -1779,6 +1826,9 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 	// clients keep working; new clients should prefer this endpoint.
 	mux.HandleFunc("POST /api/ai/chat/stream", func(w http.ResponseWriter, r *http.Request) {
 		limitBody(w, r)
+		if !requireJSONContentType(w, r) {
+			return
+		}
 		var req ai.ChatRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			http.Error(w, "invalid request", 400)
@@ -1867,6 +1917,9 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 	// Smart resource suggestions based on canvas state
 	mux.HandleFunc("POST /api/ai/suggest", func(w http.ResponseWriter, r *http.Request) {
 		limitBody(w, r)
+		if !requireJSONContentType(w, r) {
+			return
+		}
 		var req struct {
 			Tool     string              `json:"tool"`
 			Provider string              `json:"provider"`
@@ -1883,6 +1936,9 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 	// Analyze plan/apply output and suggest fixes
 	mux.HandleFunc("POST /api/ai/fix", func(w http.ResponseWriter, r *http.Request) {
 		limitBody(w, r)
+		if !requireJSONContentType(w, r) {
+			return
+		}
 		var req ai.PlanFixRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			http.Error(w, "invalid request", 400)
@@ -1963,6 +2019,9 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 
 	mux.HandleFunc("POST /api/mcp-airlock/servers/{id}/tools/evaluate", func(w http.ResponseWriter, r *http.Request) {
 		limitBody(w, r)
+		if !requireJSONContentType(w, r) {
+			return
+		}
 		var req struct {
 			ToolName string `json:"tool_name"`
 			Project  string `json:"project,omitempty"`
@@ -1990,6 +2049,9 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 
 	mux.HandleFunc("POST /api/mcp-airlock/servers/{id}/tools/allowlist", func(w http.ResponseWriter, r *http.Request) {
 		limitBody(w, r)
+		if !requireJSONContentType(w, r) {
+			return
+		}
 		var req struct {
 			ToolName string `json:"tool_name"`
 			Project  string `json:"project,omitempty"`
@@ -2053,6 +2115,9 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 
 	mux.HandleFunc("POST /api/cloud/connections", func(w http.ResponseWriter, r *http.Request) {
 		limitBody(w, r)
+		if !requireJSONContentType(w, r) {
+			return
+		}
 		var req cloudconnections.Connection
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			http.Error(w, "invalid request", 400)
@@ -2070,6 +2135,9 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 
 	mux.HandleFunc("PUT /api/cloud/connections/{id}", func(w http.ResponseWriter, r *http.Request) {
 		limitBody(w, r)
+		if !requireJSONContentType(w, r) {
+			return
+		}
 		id := r.PathValue("id")
 		if _, err := cloudConnections.Get(id); err != nil {
 			if errors.Is(err, os.ErrNotExist) {
@@ -2156,6 +2224,9 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 			return
 		}
 		limitBody(w, r)
+		if !requireJSONContentType(w, r) {
+			return
+		}
 		var state project.State
 		if err := json.NewDecoder(r.Body).Decode(&state); err != nil {
 			http.Error(w, "invalid request", 400)
@@ -2276,6 +2347,9 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 
 	mux.HandleFunc("PUT /api/ai/settings", func(w http.ResponseWriter, r *http.Request) {
 		limitBody(w, r)
+		if !requireJSONContentType(w, r) {
+			return
+		}
 		var req ai.ProviderConfig
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			http.Error(w, "invalid request", 400)
@@ -2368,6 +2442,9 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 	// Scan and import an existing project directory
 	mux.HandleFunc("POST /api/import", func(w http.ResponseWriter, r *http.Request) {
 		limitBody(w, r)
+		if !requireJSONContentType(w, r) {
+			return
+		}
 		var req struct {
 			Path string `json:"path"`
 		}
@@ -2395,6 +2472,9 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 	// AI topology builder — runs async, sends progress via WebSocket, returns result via HTTP
 	mux.HandleFunc("POST /api/ai/topology", func(w http.ResponseWriter, r *http.Request) {
 		limitBody(w, r)
+		if !requireJSONContentType(w, r) {
+			return
+		}
 		var req ai.TopologyRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			http.Error(w, "invalid request", 400)
@@ -2457,6 +2537,9 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 	// Security scan from canvas resources (no project dir needed)
 	mux.HandleFunc("POST /api/security/scan", func(w http.ResponseWriter, r *http.Request) {
 		limitBody(w, r)
+		if !requireJSONContentType(w, r) {
+			return
+		}
 		var resources []parser.Resource
 		if err := json.NewDecoder(r.Body).Decode(&resources); err != nil {
 			http.Error(w, "invalid request", 400)
@@ -2511,6 +2594,9 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 		var req struct {
 			Env string `json:"env,omitempty"`
 		}
+		if !requireOptionalJSONContentType(w, r) {
+			return
+		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
 			http.Error(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
 			return
@@ -2539,6 +2625,9 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 		var req struct {
 			Env      string                     `json:"env,omitempty"`
 			Proposal *recovery.RollbackProposal `json:"proposal,omitempty"`
+		}
+		if !requireOptionalJSONContentType(w, r) {
+			return
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
 			http.Error(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
@@ -2587,6 +2676,9 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 		var req struct {
 			Env      string                     `json:"env,omitempty"`
 			Proposal *recovery.RollbackProposal `json:"proposal,omitempty"`
+		}
+		if !requireOptionalJSONContentType(w, r) {
+			return
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
 			http.Error(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
@@ -2655,6 +2747,9 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 			ConnectionID string `json:"connection_id,omitempty"`
 		}
 		if r.Method == http.MethodPost {
+			if !requireOptionalJSONContentType(w, r) {
+				return
+			}
 			if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
 				http.Error(w, "invalid request body: "+err.Error(), 400)
 				return
@@ -2692,6 +2787,9 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 			Env          string `json:"env,omitempty"`
 			ConnectionID string `json:"connection_id,omitempty"`
 			Mode         string `json:"mode"`
+		}
+		if !requireOptionalJSONContentType(w, r) {
+			return
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
 			http.Error(w, "invalid request body: "+err.Error(), 400)
@@ -2734,6 +2832,9 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 			ConnectionID string                     `json:"connection_id,omitempty"`
 			Mode         string                     `json:"mode"`
 			Proposal     *drift.RemediationProposal `json:"proposal,omitempty"`
+		}
+		if !requireOptionalJSONContentType(w, r) {
+			return
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
 			http.Error(w, "invalid request body: "+err.Error(), 400)
@@ -2798,6 +2899,9 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 			ConnectionID string                     `json:"connection_id,omitempty"`
 			Mode         string                     `json:"mode"`
 			Proposal     *drift.RemediationProposal `json:"proposal,omitempty"`
+		}
+		if !requireOptionalJSONContentType(w, r) {
+			return
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
 			http.Error(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
@@ -2886,6 +2990,9 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 
 	mux.HandleFunc("POST /api/export", func(w http.ResponseWriter, r *http.Request) {
 		limitBody(w, r)
+		if !requireJSONContentType(w, r) {
+			return
+		}
 		var req struct {
 			Format    string            `json:"format"`
 			Resources []parser.Resource `json:"resources"`

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -956,7 +957,40 @@ func requireJSONContentType(w http.ResponseWriter, r *http.Request) bool {
 }
 
 func requestHasBody(r *http.Request) bool {
-	return r.Body != nil && r.Body != http.NoBody && r.ContentLength != 0
+	if r.Body == nil || r.Body == http.NoBody || r.ContentLength == 0 {
+		return false
+	}
+	if r.ContentLength > 0 {
+		return true
+	}
+
+	var first [1]byte
+	n, err := r.Body.Read(first[:])
+	if n > 0 {
+		r.Body = prependBody(r.Body, first[:n])
+		return true
+	}
+	return err != nil && !errors.Is(err, io.EOF)
+}
+
+type prependReadCloser struct {
+	reader io.Reader
+	closer io.Closer
+}
+
+func (p prependReadCloser) Read(buf []byte) (int, error) {
+	return p.reader.Read(buf)
+}
+
+func (p prependReadCloser) Close() error {
+	return p.closer.Close()
+}
+
+func prependBody(body io.ReadCloser, prefix []byte) io.ReadCloser {
+	return prependReadCloser{
+		reader: io.MultiReader(bytes.NewReader(prefix), body),
+		closer: body,
+	}
 }
 
 func requireOptionalJSONContentType(w http.ResponseWriter, r *http.Request) bool {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -960,9 +960,6 @@ func requestHasBody(r *http.Request) bool {
 }
 
 func requireOptionalJSONContentType(w http.ResponseWriter, r *http.Request) bool {
-	if strings.TrimSpace(r.Header.Get("Content-Type")) != "" {
-		return requireJSONContentType(w, r)
-	}
 	if requestHasBody(r) {
 		return requireJSONContentType(w, r)
 	}

--- a/internal/api/router_security_test.go
+++ b/internal/api/router_security_test.go
@@ -33,6 +33,16 @@ func fullRouterForTest(t *testing.T, projectsDir string) *http.ServeMux {
 	)
 }
 
+func canonicalTempDir(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	resolved, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return root
+	}
+	return resolved
+}
+
 func assertResponseBodyContains(t *testing.T, resp *http.Response, want ...string) {
 	t.Helper()
 	data, err := io.ReadAll(resp.Body)
@@ -129,6 +139,83 @@ func TestInitAllowedOriginsFormatsIPv6LoopbackOrigin(t *testing.T) {
 	}
 	if IsAllowedOrigin("http://::1:3000") {
 		t.Fatal("IPv6 origins should not use unbracketed host syntax")
+	}
+}
+
+func TestJSONMutationRejectsMissingContentType(t *testing.T) {
+	root := canonicalTempDir(t)
+	router := fullRouterForTest(t, root)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/security/scan", strings.NewReader(`[]`))
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnsupportedMediaType {
+		t.Fatalf("missing content type should 415, got %d", rec.Code)
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "application/json") {
+		t.Fatalf("response body %q does not contain application/json", body)
+	}
+}
+
+func TestJSONMutationRejectsWrongContentType(t *testing.T) {
+	root := canonicalTempDir(t)
+	router := fullRouterForTest(t, root)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/security/scan", strings.NewReader(`[]`))
+	req.Header.Set("Content-Type", "text/plain")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnsupportedMediaType {
+		t.Fatalf("text/plain content type should 415, got %d", rec.Code)
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "application/json") {
+		t.Fatalf("response body %q does not contain application/json", body)
+	}
+}
+
+func TestJSONMutationAllowsContentTypeParameters(t *testing.T) {
+	root := canonicalTempDir(t)
+	router := fullRouterForTest(t, root)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/security/scan", strings.NewReader(`[]`))
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("application/json with charset should 200, got %d", rec.Code)
+	}
+}
+
+func TestOptionalJSONBodyAllowsEmptyRequestWithoutContentType(t *testing.T) {
+	root := canonicalTempDir(t)
+	router := fullRouterForTest(t, root)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/projects/demo/kill", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusUnsupportedMediaType {
+		t.Fatalf("empty optional body should not require content type")
+	}
+}
+
+func TestOptionalJSONBodyRejectsWrongContentTypeWhenBodyPresent(t *testing.T) {
+	root := canonicalTempDir(t)
+	router := fullRouterForTest(t, root)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/projects/demo/kill", strings.NewReader(`{"env":"dev"}`))
+	req.Header.Set("Content-Type", "text/plain")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnsupportedMediaType {
+		t.Fatalf("optional JSON body with text/plain should 415, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "application/json") {
+		t.Fatalf("response body %q does not contain application/json", body)
 	}
 }
 

--- a/internal/api/router_security_test.go
+++ b/internal/api/router_security_test.go
@@ -281,6 +281,88 @@ func TestOptionalJSONBodyRestoresPeekedUnknownLengthBody(t *testing.T) {
 	}
 }
 
+func TestRegisteredMandatoryJSONRoutesRejectWrongContentType(t *testing.T) {
+	root := canonicalTempDir(t)
+	router := fullRouterForTest(t, root)
+
+	tests := []struct {
+		name string
+		path string
+		body string
+	}{
+		{
+			name: "module promotion",
+			path: "/api/projects/demo/promote-to-module",
+			body: `{"module_name":"networking","resource_ids":[]}`,
+		},
+		{
+			name: "agent run",
+			path: "/api/projects/demo/ai/agent",
+			body: `{"prompt":"summarize this project"}`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, tc.path, strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "text/plain")
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusUnsupportedMediaType {
+				t.Fatalf("%s should reject text/plain with 415, got %d: %s", tc.path, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestRegisteredOptionalJSONRoutesAllowEmptyWrongContentType(t *testing.T) {
+	root := canonicalTempDir(t)
+	router := fullRouterForTest(t, root)
+
+	paths := []string{
+		"/api/projects/demo/policy/run",
+		"/api/projects/demo/security/scanners/run",
+		"/api/projects/demo/ai/index",
+		"/api/projects/demo/plan/classify",
+	}
+	for _, path := range paths {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, path, nil)
+			req.Header.Set("Content-Type", "text/plain")
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			if rec.Code == http.StatusUnsupportedMediaType {
+				t.Fatalf("%s should allow empty optional body despite text/plain", path)
+			}
+		})
+	}
+}
+
+func TestRegisteredOptionalJSONRoutesRejectWrongContentTypeWhenBodyPresent(t *testing.T) {
+	root := canonicalTempDir(t)
+	router := fullRouterForTest(t, root)
+
+	paths := []string{
+		"/api/projects/demo/policy/run",
+		"/api/projects/demo/security/scanners/run",
+		"/api/projects/demo/ai/index",
+		"/api/projects/demo/plan/classify",
+	}
+	for _, path := range paths {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(`{}`))
+			req.Header.Set("Content-Type", "text/plain")
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusUnsupportedMediaType {
+				t.Fatalf("%s should reject text/plain body with 415, got %d: %s", path, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
 func TestStateRoutesRejectTraversalProjectName(t *testing.T) {
 	root := t.TempDir()
 	srv := httptest.NewServer(fullRouterForTest(t, root))

--- a/internal/api/router_security_test.go
+++ b/internal/api/router_security_test.go
@@ -202,6 +202,20 @@ func TestOptionalJSONBodyAllowsEmptyRequestWithoutContentType(t *testing.T) {
 	}
 }
 
+func TestOptionalJSONBodyAllowsEmptyRequestWithNonJSONContentType(t *testing.T) {
+	root := canonicalTempDir(t)
+	router := fullRouterForTest(t, root)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/projects/demo/kill", nil)
+	req.Header.Set("Content-Type", "text/plain")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusUnsupportedMediaType {
+		t.Fatalf("empty optional body should not require JSON content type")
+	}
+}
+
 func TestOptionalJSONBodyRejectsWrongContentTypeWhenBodyPresent(t *testing.T) {
 	root := canonicalTempDir(t)
 	router := fullRouterForTest(t, root)

--- a/internal/api/router_security_test.go
+++ b/internal/api/router_security_test.go
@@ -216,6 +216,21 @@ func TestOptionalJSONBodyAllowsEmptyRequestWithNonJSONContentType(t *testing.T) 
 	}
 }
 
+func TestOptionalJSONBodyAllowsEmptyUnknownLengthRequestWithNonJSONContentType(t *testing.T) {
+	root := canonicalTempDir(t)
+	router := fullRouterForTest(t, root)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/projects/demo/kill", strings.NewReader(""))
+	req.ContentLength = -1
+	req.Header.Set("Content-Type", "text/plain")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusUnsupportedMediaType {
+		t.Fatalf("empty unknown-length optional body should not require JSON content type")
+	}
+}
+
 func TestOptionalJSONBodyRejectsWrongContentTypeWhenBodyPresent(t *testing.T) {
 	root := canonicalTempDir(t)
 	router := fullRouterForTest(t, root)
@@ -230,6 +245,39 @@ func TestOptionalJSONBodyRejectsWrongContentTypeWhenBodyPresent(t *testing.T) {
 	}
 	if body := rec.Body.String(); !strings.Contains(body, "application/json") {
 		t.Fatalf("response body %q does not contain application/json", body)
+	}
+}
+
+func TestOptionalJSONBodyRejectsWrongContentTypeWhenUnknownLengthBodyPresent(t *testing.T) {
+	root := canonicalTempDir(t)
+	router := fullRouterForTest(t, root)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/projects/demo/kill", strings.NewReader(`{"env":"dev"}`))
+	req.ContentLength = -1
+	req.Header.Set("Content-Type", "text/plain")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnsupportedMediaType {
+		t.Fatalf("unknown-length optional JSON body with text/plain should 415, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "application/json") {
+		t.Fatalf("response body %q does not contain application/json", body)
+	}
+}
+
+func TestOptionalJSONBodyRestoresPeekedUnknownLengthBody(t *testing.T) {
+	root := canonicalTempDir(t)
+	router := fullRouterForTest(t, root)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/projects/demo/kill", strings.NewReader(`{}`))
+	req.ContentLength = -1
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusBadRequest && strings.Contains(rec.Body.String(), "invalid request body") {
+		t.Fatalf("peeked unknown-length body was not restored before JSON decode: %s", rec.Body.String())
 	}
 }
 

--- a/internal/api/scanners.go
+++ b/internal/api/scanners.go
@@ -68,6 +68,9 @@ func registerScannerRoutes(mux *http.ServeMux, projectsDir string) {
 	// and returns a unified Findings feed.
 	mux.HandleFunc("POST /api/projects/{name}/security/scanners/run", func(w http.ResponseWriter, r *http.Request) {
 		limitBody(w, r)
+		if !requireOptionalJSONContentType(w, r) {
+			return
+		}
 		name := r.PathValue("name")
 		projectPath, err := safeProjectPath(projectsDir, name)
 		if err != nil {


### PR DESCRIPTION
## Summary
- require `Content-Type: application/json` before decoding mutating JSON API requests
- allow `application/json` media-type parameters such as `charset=utf-8`
- preserve empty-body behavior for optional JSON endpoints while rejecting non-JSON bodies when present

## Tests
- `GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/api`
- `GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/...`

Closes #81