### PR TITLE
Return empty project state lists

### DIFF
--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -149,7 +149,7 @@ func (m *Manager) ListAll() ([]*State, error) {
 		return nil, err
 	}
 
-	var states []*State
+	states := make([]*State, 0)
 	for _, e := range entries {
 		if !e.IsDir() {
 			continue

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -2,10 +2,33 @@ package project
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 )
+
+func TestListAllEmptyWorkspaceReturnsEmptySlice(t *testing.T) {
+	manager := NewManager(t.TempDir())
+
+	states, err := manager.ListAll()
+	if err != nil {
+		t.Fatalf("list all: %v", err)
+	}
+	if states == nil {
+		t.Fatal("expected empty workspace to return a non-nil slice")
+	}
+	if len(states) != 0 {
+		t.Fatalf("expected no project states, got %d", len(states))
+	}
+	encoded, err := json.Marshal(states)
+	if err != nil {
+		t.Fatalf("marshal states: %v", err)
+	}
+	if string(encoded) != "[]" {
+		t.Fatalf("empty project states encoded as %s, want []", encoded)
+	}
+}
 
 func TestLoadAndSavePreservesLayeredMetadata(t *testing.T) {
 	root := t.TempDir()


### PR DESCRIPTION
## Summary
- make project.Manager.ListAll return a non-nil empty slice for empty workspaces
- add a regression test that verifies empty project state lists encode as [], not null

## Scope
This is the backend-only slice contract fix for issue #83. Frontend defensive coercion is intentionally left for a separate smaller PR.

Closes #83

## Tests
- GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/project