### PR TITLE
Coerce project state responses to arrays

### DIFF
--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -214,6 +214,46 @@ describe('api.mcpAirlock', () => {
   });
 });
 
+describe('api.listProjectStates', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns project state arrays unchanged', async () => {
+    const states = [{ name: 'demo', tool: 'terraform' }];
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(states), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    ));
+
+    await expect(api.listProjectStates()).resolves.toEqual(states);
+  });
+
+  it('coerces null project state responses to an empty array', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response('null', {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    ));
+
+    await expect(api.listProjectStates()).resolves.toEqual([]);
+  });
+
+  it('coerces malformed project state responses to an empty array', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ states: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    ));
+
+    await expect(api.listProjectStates()).resolves.toEqual([]);
+  });
+});
+
 describe('api.runCommand', () => {
   afterEach(() => {
     vi.unstubAllGlobals();

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -636,7 +636,8 @@ export const api = {
   // List all projects with their state
   async listProjectStates(): Promise<any[]> {
     const res = await fetch(`${BASE}/api/projects/states`);
-    return (await check(res)).json();
+    const states = await (await check(res)).json();
+    return Array.isArray(states) ? states : [];
   },
 
   // Health check


### PR DESCRIPTION
## Summary
- make the frontend project-state API helper return [] for null or non-array payloads
- preserve valid array responses unchanged
- add focused API client regression tests

## Scope
This is the frontend-only defensive guard for issue #85. The backend empty-slice contract was fixed separately in #84.

Closes #85

## Tests
- npm test -- --run src/api.test.ts