### PR TITLE
Handle symlinked project roots

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -59,13 +59,13 @@ func safeProjectPath(projectsDir, name string) (string, error) {
 		}
 	}
 	resolved := filepath.Join(projectsDir, name)
-	// Resolve symlinks so a symlink at ~/iac-projects/evil -> /etc/ is caught
-	// (and so macOS's /var/folders -> /private/var/folders symlink doesn't
-	// cause httptest-based tests to trip the escape check below).
+	// Resolve symlinks so a symlink at ~/iac-projects/evil -> /etc/ is caught.
+	// For missing project paths, resolve the deepest existing parent first so a
+	// symlinked projects root can still create new project directories.
 	//
 	// filepath.Abs errors surface explicitly — a failure would leave an
 	// empty absProjects, which would then let any resolved path pass the
-	// HasPrefix check and weaken the symlink-escape protection.
+	// containment check and weaken the symlink-escape protection.
 	absProjects, err := filepath.Abs(projectsDir)
 	if err != nil {
 		return "", fmt.Errorf("resolve projects dir: %w", err)
@@ -73,20 +73,51 @@ func safeProjectPath(projectsDir, name string) (string, error) {
 	if evalProjects, err := filepath.EvalSymlinks(absProjects); err == nil {
 		absProjects = evalProjects
 	}
-	absResolved, err := filepath.Abs(resolved)
+	absResolved, err := resolveExistingPathForContainment(resolved)
 	if err != nil {
 		return "", fmt.Errorf("resolve project path: %w", err)
 	}
-	// If the directory already exists, resolve symlinks in the actual path.
-	if evalResolved, err := filepath.EvalSymlinks(resolved); err == nil {
-		if absEval, absErr := filepath.Abs(evalResolved); absErr == nil {
-			absResolved = absEval
-		}
-	}
-	if !strings.HasPrefix(absResolved, absProjects+string(filepath.Separator)) {
+	rel, err := filepath.Rel(absProjects, absResolved)
+	if err != nil || rel == "." || rel == ".." || filepath.IsAbs(rel) || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 		return "", fmt.Errorf("project path escapes root: %q", name)
 	}
 	return resolved, nil
+}
+
+func resolveExistingPathForContainment(path string) (string, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	if evalPath, err := filepath.EvalSymlinks(absPath); err == nil {
+		return filepath.Abs(evalPath)
+	}
+
+	existing := absPath
+	missing := make([]string, 0)
+	for {
+		if _, err := os.Lstat(existing); err == nil {
+			break
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return "", err
+		}
+		parent := filepath.Dir(existing)
+		if parent == existing {
+			return absPath, nil
+		}
+		missing = append([]string{filepath.Base(existing)}, missing...)
+		existing = parent
+	}
+
+	evalExisting, err := filepath.EvalSymlinks(existing)
+	if err != nil {
+		return "", err
+	}
+	resolved := evalExisting
+	for _, part := range missing {
+		resolved = filepath.Join(resolved, part)
+	}
+	return filepath.Abs(resolved)
 }
 
 // safeSubdir resolves a subdirectory beneath projectPath while

--- a/internal/api/router_security_test.go
+++ b/internal/api/router_security_test.go
@@ -379,6 +379,41 @@ func TestStateRoutesRejectTraversalProjectName(t *testing.T) {
 	}
 }
 
+func TestSafeProjectPathAllowsMissingProjectUnderSymlinkedRoot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink permissions vary on Windows")
+	}
+	realRoot := t.TempDir()
+	linkRoot := filepath.Join(t.TempDir(), "projects-link")
+	if err := os.Symlink(realRoot, linkRoot); err != nil {
+		t.Fatalf("create symlinked projects root: %v", err)
+	}
+
+	got, err := safeProjectPath(linkRoot, "demo")
+	if err != nil {
+		t.Fatalf("safeProjectPath should allow missing project under symlinked root: %v", err)
+	}
+	if got != filepath.Join(linkRoot, "demo") {
+		t.Fatalf("safeProjectPath returned %q, want %q", got, filepath.Join(linkRoot, "demo"))
+	}
+}
+
+func TestSafeProjectPathRejectsExistingProjectSymlinkEscape(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink permissions vary on Windows")
+	}
+	root := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(root, "escape")); err != nil {
+		t.Fatalf("create escaping project symlink: %v", err)
+	}
+
+	_, err := safeProjectPath(root, "escape")
+	if err == nil || !strings.Contains(err.Error(), "project path escapes root") {
+		t.Fatalf("expected escaping project symlink rejection, got %v", err)
+	}
+}
+
 func TestSyncRejectsResourceFileOutsideProject(t *testing.T) {
 	root := t.TempDir()
 	projectDir := filepath.Join(root, "demo")


### PR DESCRIPTION
## Summary
- resolve the deepest existing project path ancestor before API containment checks
- allow new projects beneath a symlinked projects root
- keep existing project symlinks that escape the root rejected
- replace string-prefix containment with filepath.Rel containment

## Scope
This is the API-only path containment fix for issue #87. MCP path handling is intentionally out of scope.

Closes #87

## Tests
- GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/api -run 'TestSafeProjectPath' -count=1
- GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/api