### PR TITLE
Warn about encrypted local cloud secret storage

### DIFF
--- a/web/src/components/CloudConnections/CloudConnectionsPanel.test.tsx
+++ b/web/src/components/CloudConnections/CloudConnectionsPanel.test.tsx
@@ -54,7 +54,8 @@ describe('CloudConnectionsPanel', () => {
     const client = makeClient();
     render(<CloudConnectionsPanel client={client} />);
 
-    expect(await screen.findByText(/Secrets are stored locally on this machine/)).toBeInTheDocument();
+    expect(screen.getByText(/Secrets are encrypted and stored locally on this machine/)).toBeInTheDocument();
+    await screen.findByText('0 connections');
   });
 
   it('creates an AWS profile connection and refreshes the list', async () => {

--- a/web/src/components/CloudConnections/CloudConnectionsPanel.test.tsx
+++ b/web/src/components/CloudConnections/CloudConnectionsPanel.test.tsx
@@ -50,6 +50,13 @@ function makeClient(initial: CloudConnection[] = []) {
 }
 
 describe('CloudConnectionsPanel', () => {
+  it('shows the local secret storage warning', async () => {
+    const client = makeClient();
+    render(<CloudConnectionsPanel client={client} />);
+
+    expect(await screen.findByText(/Secrets are stored locally on this machine/)).toBeInTheDocument();
+  });
+
   it('creates an AWS profile connection and refreshes the list', async () => {
     const client = makeClient();
     render(<CloudConnectionsPanel client={client} />);

--- a/web/src/components/CloudConnections/CloudConnectionsPanel.tsx
+++ b/web/src/components/CloudConnections/CloudConnectionsPanel.tsx
@@ -238,6 +238,10 @@ export function CloudConnectionsPanel({
       )}
 
       <section className="grid gap-2">
+        <div className="rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-100">
+          Secrets are stored locally on this machine in the IaC Studio projects directory. Use scoped, revocable credentials.
+        </div>
+
         <label className="grid gap-1 text-xs text-muted-foreground">
           Name
           <input

--- a/web/src/components/CloudConnections/CloudConnectionsPanel.tsx
+++ b/web/src/components/CloudConnections/CloudConnectionsPanel.tsx
@@ -239,7 +239,7 @@ export function CloudConnectionsPanel({
 
       <section className="grid gap-2">
         <div className="rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-100">
-          Secrets are stored locally on this machine in the IaC Studio projects directory. Use scoped, revocable credentials.
+          Secrets are encrypted and stored locally on this machine in the IaC Studio projects directory. Use scoped, revocable credentials.
         </div>
 
         <label className="grid gap-1 text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary
- add a visible Cloud Connections warning that secrets are encrypted and stored locally on this machine, accurately reflecting the AES-GCM local storage model
- recommend scoped, revocable credentials before users save provider secrets
- add focused component coverage for the warning, using `getByText` for the synchronous assertion and `findByText` only for the async connection count

## Scope
This is the UI awareness fix for issue #89. Backend storage format, OS keychain integration, and broader secret-store design are intentionally out of scope for this small PR (tracked separately in #91).

## Tests
- npm test -- --run src/components/CloudConnections/CloudConnectionsPanel.test.tsx