### PR TITLE
Use configured health version

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -103,7 +103,10 @@ func main() {
 	}()
 
 	// Build router
-	router := api.NewRouterWithOptions(hub, fw, aiClient, safeRun, *projectsDir, api.RouterOptions{MCPAirlock: mcpAirlock})
+	router := api.NewRouterWithOptions(hub, fw, aiClient, safeRun, *projectsDir, api.RouterOptions{
+		MCPAirlock: mcpAirlock,
+		Version:    AppVersion,
+	})
 
 	// Serve embedded frontend
 	frontendContent, _ := fs.Sub(frontendFS, "frontend/dist")

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -104,7 +104,7 @@ func main() {
 	// Build router
 	router := api.NewRouterWithOptions(hub, fw, aiClient, safeRun, *projectsDir, api.RouterOptions{
 		MCPAirlock: mcpAirlock,
-		Version:    AppVersion,
+		AppVersion: AppVersion,
 	})
 
 	// Serve embedded frontend

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -22,10 +22,9 @@ import (
 	"github.com/iac-studio/iac-studio/internal/watcher"
 )
 
-const (
-	AppName    = "iac-studio"
-	AppVersion = "0.1.0"
-)
+const AppName = "iac-studio"
+
+var AppVersion = "0.1.0"
 
 // frontendFS holds the built React frontend. The directory is created by
 // `make build-frontend` (or `cd web && npm run build`) before the Go

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1035,15 +1035,15 @@ func requireOptionalJSONContentType(w http.ResponseWriter, r *http.Request) bool
 // explicit ownership outside the router.
 type RouterOptions struct {
 	MCPAirlock *mcpairlock.Manager
-	Version    string
+	AppVersion string
 }
 
-const defaultRouterVersion = "0.1.0"
+const defaultAppVersion = "0.1.0"
 
-func (opts RouterOptions) version() string {
-	version := strings.TrimSpace(opts.Version)
+func (opts RouterOptions) appVersion() string {
+	version := strings.TrimSpace(opts.AppVersion)
 	if version == "" {
-		return defaultRouterVersion
+		return defaultAppVersion
 	}
 	return version
 }
@@ -1056,7 +1056,7 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 // NewRouterWithOptions creates the HTTP router with explicit service options.
 func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runner.SafeRunner, projectsDir string, opts RouterOptions) *http.ServeMux {
 	mux := http.NewServeMux()
-	version := opts.version()
+	appVersion := opts.appVersion()
 	if fw != nil {
 		fw.OnChange(func(file, _ string) {
 			invalidatePlanForChangedFile(projectsDir, file)
@@ -1065,7 +1065,7 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 
 	// Health
 	mux.HandleFunc("GET /api/health", func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok", "version": version})
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok", "version": appVersion})
 	})
 
 	// List available IaC tools detected on this machine

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1035,6 +1035,17 @@ func requireOptionalJSONContentType(w http.ResponseWriter, r *http.Request) bool
 // explicit lifecycle management outside the router.
 type RouterOptions struct {
 	MCPAirlock *mcpairlock.Manager
+	Version    string
+}
+
+const defaultRouterVersion = "0.1.0"
+
+func (opts RouterOptions) version() string {
+	version := strings.TrimSpace(opts.Version)
+	if version == "" {
+		return defaultRouterVersion
+	}
+	return version
 }
 
 // NewRouter creates the HTTP router with all endpoints.
@@ -1045,6 +1056,7 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 // NewRouterWithOptions creates the HTTP router with explicit service options.
 func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runner.SafeRunner, projectsDir string, opts RouterOptions) *http.ServeMux {
 	mux := http.NewServeMux()
+	version := opts.version()
 	if fw != nil {
 		fw.OnChange(func(file, _ string) {
 			invalidatePlanForChangedFile(projectsDir, file)
@@ -1053,7 +1065,7 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 
 	// Health
 	mux.HandleFunc("GET /api/health", func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok", "version": "0.1.0"})
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok", "version": version})
 	})
 
 	// List available IaC tools detected on this machine

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1031,8 +1031,8 @@ func requireOptionalJSONContentType(w http.ResponseWriter, r *http.Request) bool
 	return true
 }
 
-// RouterOptions allows callers to provide long-lived services that need
-// explicit lifecycle management outside the router.
+// RouterOptions allows callers to provide services and configuration that need
+// explicit ownership outside the router.
 type RouterOptions struct {
 	MCPAirlock *mcpairlock.Manager
 	Version    string

--- a/internal/api/router_security_test.go
+++ b/internal/api/router_security_test.go
@@ -43,6 +43,41 @@ func canonicalTempDir(t *testing.T) string {
 	return resolved
 }
 
+func TestHealthEndpointUsesConfiguredVersion(t *testing.T) {
+	root := canonicalTempDir(t)
+	hub := NewHub()
+	go hub.Run()
+	t.Cleanup(hub.Close)
+	fw := watcher.New(hub)
+	t.Cleanup(fw.Close)
+	router := NewRouterWithOptions(
+		hub,
+		fw,
+		ai.NewClient("http://127.0.0.1:1", "ignored"),
+		runner.NewSafeRunner(runner.DefaultSafetyConfig()),
+		root,
+		RouterOptions{Version: "9.8.7-test"},
+	)
+	req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected health request to return 200, got %d", rec.Code)
+	}
+	var body map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode health response: %v", err)
+	}
+	if body["status"] != "ok" {
+		t.Fatalf("expected health status ok, got %q", body["status"])
+	}
+	if body["version"] != "9.8.7-test" {
+		t.Fatalf("expected configured version, got %q", body["version"])
+	}
+}
+
 func assertResponseBodyContains(t *testing.T, resp *http.Response, want ...string) {
 	t.Helper()
 	data, err := io.ReadAll(resp.Body)

--- a/internal/api/router_security_test.go
+++ b/internal/api/router_security_test.go
@@ -56,7 +56,7 @@ func TestHealthEndpointUsesConfiguredVersion(t *testing.T) {
 		ai.NewClient("http://127.0.0.1:1", "ignored"),
 		runner.NewSafeRunner(runner.DefaultSafetyConfig()),
 		root,
-		RouterOptions{Version: "9.8.7-test"},
+		RouterOptions{AppVersion: "9.8.7-test"},
 	)
 	req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
 	rec := httptest.NewRecorder()


### PR DESCRIPTION
Closes #92

## Summary
- Add a defaulted router version option for the health endpoint.
- Pass cmd/server AppVersion into the API router.
- Cover the health response with a focused backend test.

## Validation
- GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/api -run TestHealthEndpointUsesConfiguredVersion -count=1
- GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/api