### PR TITLE
Add Cloud Connections secret refs model

### DIFF
--- a/internal/api/cloud_connections_test.go
+++ b/internal/api/cloud_connections_test.go
@@ -38,6 +38,7 @@ func TestCloudConnectionRoutesRedactSecrets(t *testing.T) {
 		ID           string            `json:"id"`
 		Metadata     map[string]string `json:"metadata"`
 		SecretFields []string          `json:"secret_fields"`
+		SecretStore  string            `json:"secret_store"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
 		t.Fatalf("decode create: %v", err)
@@ -47,6 +48,9 @@ func TestCloudConnectionRoutesRedactSecrets(t *testing.T) {
 	}
 	if got := created.Metadata["access_key_id"]; got != "AKIAEXAMPLE" {
 		t.Fatalf("public metadata should include access key id, got %q", got)
+	}
+	if got := created.SecretStore; got != "local_encrypted" {
+		t.Fatalf("public response should include local encrypted secret store, got %q", got)
 	}
 
 	resp, err = http.Get(srv.URL + "/api/cloud/connections")

--- a/internal/cloudconnections/connections.go
+++ b/internal/cloudconnections/connections.go
@@ -718,7 +718,7 @@ func normalizeAndValidate(connection *Connection) error {
 }
 
 func publicConnection(connection Connection) PublicConnection {
-	secretStore := connection.SecretStore
+	secretStore := strings.TrimSpace(connection.SecretStore)
 	if secretStore == "" && len(connection.Secrets) > 0 {
 		secretStore = SecretStoreLocalEncrypted
 	}
@@ -747,14 +747,19 @@ func applySecretReferenceDefaultsToAll(connections []Connection) bool {
 }
 
 func preserveExistingExternalSecretRefs(input *Connection, existing Connection) {
-	if existing.SecretStore == "" || existing.SecretStore == SecretStoreLocalEncrypted {
+	secretStore := strings.TrimSpace(existing.SecretStore)
+	if secretStore == "" || secretStore == SecretStoreLocalEncrypted {
 		return
 	}
 	if input.SecretStore != "" || len(input.SecretRefs) != 0 || len(input.Secrets) != 0 {
 		return
 	}
-	input.SecretStore = existing.SecretStore
-	input.SecretRefs = cloneMap(existing.SecretRefs)
+	secretRefs := trimMap(existing.SecretRefs)
+	if len(secretRefs) == 0 {
+		return
+	}
+	input.SecretStore = secretStore
+	input.SecretRefs = secretRefs
 }
 
 func applySecretReferenceDefaults(connection *Connection) bool {

--- a/internal/cloudconnections/connections.go
+++ b/internal/cloudconnections/connections.go
@@ -236,6 +236,7 @@ func (m *Manager) Save(input Connection) (PublicConnection, error) {
 			if existing.ID == input.ID {
 				input.CreatedAt = existing.CreatedAt
 				input.Secrets = mergeSecrets(existing.Secrets, input.Secrets)
+				preserveExistingExternalSecretRefs(&input, existing)
 				break
 			}
 		}
@@ -743,6 +744,17 @@ func applySecretReferenceDefaultsToAll(connections []Connection) bool {
 		}
 	}
 	return changed
+}
+
+func preserveExistingExternalSecretRefs(input *Connection, existing Connection) {
+	if existing.SecretStore == "" || existing.SecretStore == SecretStoreLocalEncrypted {
+		return
+	}
+	if input.SecretStore != "" || len(input.SecretRefs) != 0 || len(input.Secrets) != 0 {
+		return
+	}
+	input.SecretStore = existing.SecretStore
+	input.SecretRefs = cloneMap(existing.SecretRefs)
 }
 
 func applySecretReferenceDefaults(connection *Connection) bool {

--- a/internal/cloudconnections/connections.go
+++ b/internal/cloudconnections/connections.go
@@ -728,7 +728,7 @@ func publicConnection(connection Connection) PublicConnection {
 		AuthMethod:   connection.AuthMethod,
 		Region:       connection.Region,
 		Metadata:     publicMetadata(connection.AuthMethod, connection.Metadata),
-		SecretFields: presentSecretFields(connection.AuthMethod, connection.Secrets),
+		SecretFields: presentSecretFields(connection.AuthMethod, connection.Secrets, connection.SecretRefs),
 		SecretStore:  secretStore,
 		CreatedAt:    connection.CreatedAt,
 		UpdatedAt:    connection.UpdatedAt,
@@ -825,10 +825,10 @@ func secretMetadata(authMethod string, secrets map[string]string) map[string]str
 	return out
 }
 
-func presentSecretFields(authMethod string, secrets map[string]string) []string {
+func presentSecretFields(authMethod string, secrets, secretRefs map[string]string) []string {
 	out := []string{}
 	for _, key := range secretFieldsByMethod[authMethod] {
-		if strings.TrimSpace(secrets[key]) != "" {
+		if strings.TrimSpace(secrets[key]) != "" || strings.TrimSpace(secretRefs[key]) != "" {
 			out = append(out, key)
 		}
 	}

--- a/internal/cloudconnections/connections.go
+++ b/internal/cloudconnections/connections.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -23,6 +24,8 @@ const (
 	ProviderAWS   = "aws"
 	ProviderAzure = "azure"
 	ProviderGCP   = "gcp"
+
+	SecretStoreLocalEncrypted = "local_encrypted"
 
 	connectionsFileName       = ".iac-studio-connections.json"
 	connectionsKeyFileName    = ".iac-studio-connections.key"
@@ -65,15 +68,17 @@ var requiredFieldsByMethod = map[string][]string{
 // Connection is the persisted form. Secrets are intentionally isolated from
 // public metadata so route handlers can return redacted PublicConnection views.
 type Connection struct {
-	ID         string            `json:"id"`
-	Name       string            `json:"name"`
-	Provider   string            `json:"provider"`
-	AuthMethod string            `json:"auth_method"`
-	Region     string            `json:"region,omitempty"`
-	Metadata   map[string]string `json:"metadata,omitempty"`
-	Secrets    map[string]string `json:"secrets,omitempty"`
-	CreatedAt  time.Time         `json:"created_at"`
-	UpdatedAt  time.Time         `json:"updated_at"`
+	ID          string            `json:"id"`
+	Name        string            `json:"name"`
+	Provider    string            `json:"provider"`
+	AuthMethod  string            `json:"auth_method"`
+	Region      string            `json:"region,omitempty"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+	Secrets     map[string]string `json:"secrets,omitempty"`
+	SecretStore string            `json:"secret_store,omitempty"`
+	SecretRefs  map[string]string `json:"secret_refs,omitempty"`
+	CreatedAt   time.Time         `json:"created_at"`
+	UpdatedAt   time.Time         `json:"updated_at"`
 }
 
 type PublicConnection struct {
@@ -84,6 +89,7 @@ type PublicConnection struct {
 	Region       string            `json:"region,omitempty"`
 	Metadata     map[string]string `json:"metadata,omitempty"`
 	SecretFields []string          `json:"secret_fields,omitempty"`
+	SecretStore  string            `json:"secret_store,omitempty"`
 	CreatedAt    time.Time         `json:"created_at"`
 	UpdatedAt    time.Time         `json:"updated_at"`
 }
@@ -200,6 +206,7 @@ func (m *Manager) Get(id string) (*Connection, error) {
 			connectionCopy := connection
 			connectionCopy.Metadata = cloneMap(connection.Metadata)
 			connectionCopy.Secrets = cloneMap(connection.Secrets)
+			connectionCopy.SecretRefs = cloneMap(connection.SecretRefs)
 			return &connectionCopy, nil
 		}
 	}
@@ -236,6 +243,7 @@ func (m *Manager) Save(input Connection) (PublicConnection, error) {
 	input.UpdatedAt = now
 	input.Metadata = publicMetadata(input.AuthMethod, input.Metadata)
 	input.Secrets = secretMetadata(input.AuthMethod, input.Secrets)
+	applySecretReferenceDefaults(&input)
 
 	replaced := false
 	for index, existing := range connections {
@@ -350,6 +358,9 @@ func (m *Manager) loadUnlockedWithMigrationFlag() ([]Connection, bool, error) {
 	if err != nil {
 		return nil, false, err
 	}
+	if applySecretReferenceDefaultsToAll(connections) {
+		needsMigration = true
+	}
 	return connections, needsMigration, nil
 }
 
@@ -378,6 +389,7 @@ func (m *Manager) encryptConnectionSecrets(connections []Connection) ([]Connecti
 		next := connection
 		next.Metadata = cloneMap(connection.Metadata)
 		next.Secrets = cloneMap(connection.Secrets)
+		next.SecretRefs = cloneMap(connection.SecretRefs)
 		for name, value := range next.Secrets {
 			if strings.TrimSpace(value) == "" {
 				continue
@@ -683,6 +695,7 @@ func normalizeAndValidate(connection *Connection) error {
 	connection.Provider = strings.TrimSpace(connection.Provider)
 	connection.AuthMethod = strings.TrimSpace(connection.AuthMethod)
 	connection.Region = strings.TrimSpace(connection.Region)
+	connection.SecretStore = strings.TrimSpace(connection.SecretStore)
 
 	if connection.Name == "" {
 		return errors.New("connection name is required")
@@ -696,10 +709,18 @@ func normalizeAndValidate(connection *Connection) error {
 	}
 	connection.Metadata = trimMap(connection.Metadata)
 	connection.Secrets = trimMap(connection.Secrets)
+	connection.SecretRefs = trimMap(connection.SecretRefs)
+	if connection.SecretStore != "" && connection.SecretStore != SecretStoreLocalEncrypted {
+		return fmt.Errorf("unsupported secret store %q", connection.SecretStore)
+	}
 	return nil
 }
 
 func publicConnection(connection Connection) PublicConnection {
+	secretStore := connection.SecretStore
+	if secretStore == "" && len(connection.Secrets) > 0 {
+		secretStore = SecretStoreLocalEncrypted
+	}
 	return PublicConnection{
 		ID:           connection.ID,
 		Name:         connection.Name,
@@ -708,9 +729,60 @@ func publicConnection(connection Connection) PublicConnection {
 		Region:       connection.Region,
 		Metadata:     publicMetadata(connection.AuthMethod, connection.Metadata),
 		SecretFields: presentSecretFields(connection.AuthMethod, connection.Secrets),
+		SecretStore:  secretStore,
 		CreatedAt:    connection.CreatedAt,
 		UpdatedAt:    connection.UpdatedAt,
 	}
+}
+
+func applySecretReferenceDefaultsToAll(connections []Connection) bool {
+	changed := false
+	for index := range connections {
+		if applySecretReferenceDefaults(&connections[index]) {
+			changed = true
+		}
+	}
+	return changed
+}
+
+func applySecretReferenceDefaults(connection *Connection) bool {
+	refs := localEncryptedSecretRefs(connection.ID, connection.AuthMethod, connection.Secrets)
+	if len(refs) == 0 {
+		changed := connection.SecretStore != "" || len(connection.SecretRefs) != 0
+		connection.SecretStore = ""
+		connection.SecretRefs = nil
+		return changed
+	}
+
+	changed := false
+	if connection.SecretStore == "" {
+		connection.SecretStore = SecretStoreLocalEncrypted
+		changed = true
+	}
+	if connection.SecretStore != SecretStoreLocalEncrypted {
+		return changed
+	}
+	if !maps.Equal(connection.SecretRefs, refs) {
+		connection.SecretRefs = refs
+		changed = true
+	}
+	return changed
+}
+
+func localEncryptedSecretRefs(connectionID, authMethod string, secrets map[string]string) map[string]string {
+	if strings.TrimSpace(connectionID) == "" {
+		return nil
+	}
+	out := map[string]string{}
+	for _, key := range secretFieldsByMethod[authMethod] {
+		if strings.TrimSpace(secrets[key]) != "" {
+			out[key] = "local://connections/" + connectionID + "/" + key
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func publicMetadata(authMethod string, metadata map[string]string) map[string]string {

--- a/internal/cloudconnections/connections.go
+++ b/internal/cloudconnections/connections.go
@@ -746,6 +746,10 @@ func applySecretReferenceDefaultsToAll(connections []Connection) bool {
 }
 
 func applySecretReferenceDefaults(connection *Connection) bool {
+	if connection.SecretStore != "" && connection.SecretStore != SecretStoreLocalEncrypted {
+		return false
+	}
+
 	refs := localEncryptedSecretRefs(connection.ID, connection.AuthMethod, connection.Secrets)
 	if len(refs) == 0 {
 		changed := connection.SecretStore != "" || len(connection.SecretRefs) != 0

--- a/internal/cloudconnections/connections_test.go
+++ b/internal/cloudconnections/connections_test.go
@@ -139,6 +139,30 @@ func TestManagerPreservesExternalSecretRefsOnLoad(t *testing.T) {
 		t.Fatalf("public secret fields should include referenced secret field: %#v", listed[0].SecretFields)
 	}
 
+	if _, err := manager.Save(Connection{
+		ID:         "conn_external",
+		Name:       "external-renamed",
+		Provider:   ProviderAWS,
+		AuthMethod: "aws_static",
+		Region:     "us-west-2",
+		Metadata:   map[string]string{"access_key_id": "AKIARENAMED"},
+	}); err != nil {
+		t.Fatalf("Save external store metadata update: %v", err)
+	}
+	updated, err := manager.Get("conn_external")
+	if err != nil {
+		t.Fatalf("Get updated external store record: %v", err)
+	}
+	if got := updated.SecretStore; got != "vault" {
+		t.Fatalf("external secret store should survive metadata update, got %q", got)
+	}
+	if got := updated.SecretRefs["secret_access_key"]; got != ref {
+		t.Fatalf("external secret ref should survive metadata update, got %q", got)
+	}
+	if got := updated.Region; got != "us-west-2" {
+		t.Fatalf("metadata update should still apply, got region %q", got)
+	}
+
 	data, err := os.ReadFile(manager.path)
 	if err != nil {
 		t.Fatalf("read external store record: %v", err)

--- a/internal/cloudconnections/connections_test.go
+++ b/internal/cloudconnections/connections_test.go
@@ -35,6 +35,9 @@ func TestManagerRedactsStaticSecrets(t *testing.T) {
 	if slices.Contains(created.SecretFields, "secret_access_key") == false {
 		t.Fatalf("secret field presence should be exposed without value: %#v", created.SecretFields)
 	}
+	if created.SecretStore != SecretStoreLocalEncrypted {
+		t.Fatalf("secret store should report local encrypted storage, got %q", created.SecretStore)
+	}
 
 	listed, err := manager.List()
 	if err != nil {
@@ -57,6 +60,12 @@ func TestManagerRedactsStaticSecrets(t *testing.T) {
 	if !contains(string(data), encryptedSecretPrefix) {
 		t.Fatalf("expected encrypted secret envelope in persisted file: %s", string(data))
 	}
+	if !contains(string(data), `"secret_store": "local_encrypted"`) {
+		t.Fatalf("expected persisted secret store metadata: %s", string(data))
+	}
+	if !contains(string(data), `"secret_refs"`) || !contains(string(data), `local://connections/`) {
+		t.Fatalf("expected persisted local secret refs: %s", string(data))
+	}
 
 	stored, err := manager.Get(created.ID)
 	if err != nil {
@@ -64,6 +73,28 @@ func TestManagerRedactsStaticSecrets(t *testing.T) {
 	}
 	if got := stored.Secrets["secret_access_key"]; got != "super-secret" {
 		t.Fatalf("stored secret should decrypt for runner use, got %q", got)
+	}
+	if got := stored.SecretRefs["secret_access_key"]; got != "local://connections/"+created.ID+"/secret_access_key" {
+		t.Fatalf("stored secret ref should point at local encrypted store, got %q", got)
+	}
+}
+
+func TestManagerRejectsUnsupportedSecretStore(t *testing.T) {
+	manager := NewManager(t.TempDir())
+
+	_, err := manager.Save(Connection{
+		Name:        "prod-admin",
+		Provider:    ProviderAWS,
+		AuthMethod:  "aws_static",
+		Metadata:    map[string]string{"access_key_id": "AKIAEXAMPLE"},
+		Secrets:     map[string]string{"secret_access_key": "super-secret"},
+		SecretStore: "vault",
+	})
+	if err == nil {
+		t.Fatal("Save should reject unsupported secret stores until an adapter is registered")
+	}
+	if !strings.Contains(err.Error(), "unsupported secret store") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/internal/cloudconnections/connections_test.go
+++ b/internal/cloudconnections/connections_test.go
@@ -128,6 +128,17 @@ func TestManagerPreservesExternalSecretRefsOnLoad(t *testing.T) {
 		t.Fatalf("external secret ref should be preserved, got %q", got)
 	}
 
+	listed, err := manager.List()
+	if err != nil {
+		t.Fatalf("List external store record: %v", err)
+	}
+	if len(listed) != 1 {
+		t.Fatalf("expected one external store record, got %d", len(listed))
+	}
+	if !slices.Contains(listed[0].SecretFields, "secret_access_key") {
+		t.Fatalf("public secret fields should include referenced secret field: %#v", listed[0].SecretFields)
+	}
+
 	data, err := os.ReadFile(manager.path)
 	if err != nil {
 		t.Fatalf("read external store record: %v", err)

--- a/internal/cloudconnections/connections_test.go
+++ b/internal/cloudconnections/connections_test.go
@@ -98,6 +98,48 @@ func TestManagerRejectsUnsupportedSecretStore(t *testing.T) {
 	}
 }
 
+func TestManagerPreservesExternalSecretRefsOnLoad(t *testing.T) {
+	dir := t.TempDir()
+	manager := NewManager(dir)
+	ref := "vault://secret/data/iac/prod#secret_access_key"
+	record := `[{
+		"id":"conn_external",
+		"name":"external",
+		"provider":"aws",
+		"auth_method":"aws_static",
+		"metadata":{"access_key_id":"AKIAEXAMPLE"},
+		"secret_store":"vault",
+		"secret_refs":{"secret_access_key":"` + ref + `"},
+		"created_at":"2026-06-18T00:00:00Z",
+		"updated_at":"2026-06-18T00:00:00Z"
+	}]`
+	if err := os.WriteFile(manager.path, []byte(record), 0o600); err != nil {
+		t.Fatalf("write external store record: %v", err)
+	}
+
+	stored, err := manager.Get("conn_external")
+	if err != nil {
+		t.Fatalf("Get external store record: %v", err)
+	}
+	if got := stored.SecretStore; got != "vault" {
+		t.Fatalf("external secret store should be preserved, got %q", got)
+	}
+	if got := stored.SecretRefs["secret_access_key"]; got != ref {
+		t.Fatalf("external secret ref should be preserved, got %q", got)
+	}
+
+	data, err := os.ReadFile(manager.path)
+	if err != nil {
+		t.Fatalf("read external store record: %v", err)
+	}
+	if !contains(string(data), ref) {
+		t.Fatalf("external secret ref should not be overwritten: %s", string(data))
+	}
+	if contains(string(data), "local://connections/") {
+		t.Fatalf("external secret store should not receive local refs: %s", string(data))
+	}
+}
+
 func TestManagerEncryptsUserSecretWithEnvelopePrefix(t *testing.T) {
 	manager := NewManager(t.TempDir())
 	plaintext := encryptedSecretPrefix + "user-supplied-secret"

--- a/internal/cloudconnections/connections_test.go
+++ b/internal/cloudconnections/connections_test.go
@@ -108,8 +108,8 @@ func TestManagerPreservesExternalSecretRefsOnLoad(t *testing.T) {
 		"provider":"aws",
 		"auth_method":"aws_static",
 		"metadata":{"access_key_id":"AKIAEXAMPLE"},
-		"secret_store":"vault",
-		"secret_refs":{"secret_access_key":"` + ref + `"},
+		"secret_store":" vault ",
+		"secret_refs":{"secret_access_key":" ` + ref + ` ","session_token":"   "},
 		"created_at":"2026-06-18T00:00:00Z",
 		"updated_at":"2026-06-18T00:00:00Z"
 	}]`
@@ -121,10 +121,10 @@ func TestManagerPreservesExternalSecretRefsOnLoad(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get external store record: %v", err)
 	}
-	if got := stored.SecretStore; got != "vault" {
+	if got := strings.TrimSpace(stored.SecretStore); got != "vault" {
 		t.Fatalf("external secret store should be preserved, got %q", got)
 	}
-	if got := stored.SecretRefs["secret_access_key"]; got != ref {
+	if got := strings.TrimSpace(stored.SecretRefs["secret_access_key"]); got != ref {
 		t.Fatalf("external secret ref should be preserved, got %q", got)
 	}
 
@@ -137,6 +137,9 @@ func TestManagerPreservesExternalSecretRefsOnLoad(t *testing.T) {
 	}
 	if !slices.Contains(listed[0].SecretFields, "secret_access_key") {
 		t.Fatalf("public secret fields should include referenced secret field: %#v", listed[0].SecretFields)
+	}
+	if got := listed[0].SecretStore; got != "vault" {
+		t.Fatalf("public secret store should be normalized, got %q", got)
 	}
 
 	if _, err := manager.Save(Connection{
@@ -159,6 +162,9 @@ func TestManagerPreservesExternalSecretRefsOnLoad(t *testing.T) {
 	if got := updated.SecretRefs["secret_access_key"]; got != ref {
 		t.Fatalf("external secret ref should survive metadata update, got %q", got)
 	}
+	if _, ok := updated.SecretRefs["session_token"]; ok {
+		t.Fatalf("empty external secret ref should be dropped: %#v", updated.SecretRefs)
+	}
 	if got := updated.Region; got != "us-west-2" {
 		t.Fatalf("metadata update should still apply, got region %q", got)
 	}
@@ -169,6 +175,9 @@ func TestManagerPreservesExternalSecretRefsOnLoad(t *testing.T) {
 	}
 	if !contains(string(data), ref) {
 		t.Fatalf("external secret ref should not be overwritten: %s", string(data))
+	}
+	if contains(string(data), `"secret_store": " vault "`) || contains(string(data), `"session_token": "   "`) {
+		t.Fatalf("external secret refs should be normalized on update: %s", string(data))
 	}
 	if contains(string(data), "local://connections/") {
 		t.Fatalf("external secret store should not receive local refs: %s", string(data))

--- a/internal/cloudconnections/secret_store.go
+++ b/internal/cloudconnections/secret_store.go
@@ -1,0 +1,22 @@
+package cloudconnections
+
+import "context"
+
+// SecretScope identifies the connection context a SecretStore uses when saving
+// or resolving provider credential fields.
+type SecretScope struct {
+	ConnectionID string
+	Provider     string
+	AuthMethod   string
+}
+
+// SecretStore is the backend contract for storing cloud credential fields
+// outside public connection metadata. Implementations return opaque refs that
+// can be persisted in Connection.SecretRefs and resolved only for runner or MCP
+// workflows that need credentials.
+type SecretStore interface {
+	Kind() string
+	Save(ctx context.Context, scope SecretScope, secrets map[string]string) (map[string]string, error)
+	Load(ctx context.Context, refs map[string]string) (map[string]string, error)
+	Delete(ctx context.Context, refs map[string]string) error
+}

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -101,6 +101,8 @@ export interface CatalogResource {
 
 export type CloudProvider = 'aws' | 'azure' | 'gcp';
 
+export type CloudSecretStore = 'local_encrypted';
+
 export type CloudAuthMethod =
   | 'aws_profile'
   | 'aws_sso'
@@ -118,6 +120,7 @@ export interface CloudConnection {
   region?: string;
   metadata?: Record<string, string>;
   secret_fields?: string[];
+  secret_store?: CloudSecretStore;
   created_at?: string;
   updated_at?: string;
 }

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -101,7 +101,8 @@ export interface CatalogResource {
 
 export type CloudProvider = 'aws' | 'azure' | 'gcp';
 
-export type CloudSecretStore = 'local_encrypted';
+export type KnownCloudSecretStore = 'local_encrypted';
+export type CloudSecretStore = KnownCloudSecretStore | (string & Record<never, never>);
 
 export type CloudAuthMethod =
   | 'aws_profile'


### PR DESCRIPTION
## Summary
- Add a Cloud Connections `SecretStore` interface for future secret backends.
- Persist `secret_store` and `secret_refs` metadata for encrypted local cloud connection secrets.
- Keep existing encrypted local storage as the only supported backend for this slice.
- Preserve and normalize forward-compatible non-local `secret_store` / `secret_refs` metadata on load and metadata-only updates so unsupported external-store records fail closed without being clobbered.
- Surface `secret_store` and configured `secret_fields` in public connection responses without exposing secret values, including records backed only by `secret_refs`.
- Widen frontend `CloudSecretStore` typing to allow forward-compatible store kinds while keeping `local_encrypted` as a known literal.

## Validation
- `GOCACHE=/tmp/iacstudio-go-cache go test ./internal/cloudconnections ./internal/api`
- `cd web && npm test -- --run src/components/CloudConnections/CloudConnectionsPanel.test.tsx`