### PR TITLE
Add local encrypted secret store adapter

### DIFF
--- a/internal/cloudconnections/connections.go
+++ b/internal/cloudconnections/connections.go
@@ -1,6 +1,7 @@
 package cloudconnections
 
 import (
+	"context"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
@@ -355,7 +356,7 @@ func (m *Manager) loadUnlockedWithMigrationFlag() ([]Connection, bool, error) {
 	if err := json.Unmarshal(data, &connections); err != nil {
 		return nil, false, fmt.Errorf("parse cloud connections: %w", err)
 	}
-	needsMigration, err := m.decryptConnectionSecrets(connections)
+	needsMigration, err := m.loadConnectionSecrets(connections)
 	if err != nil {
 		return nil, false, err
 	}
@@ -369,7 +370,7 @@ func (m *Manager) saveUnlocked(connections []Connection) error {
 	if err := os.MkdirAll(filepath.Dir(m.path), 0o755); err != nil {
 		return fmt.Errorf("create cloud connections directory: %w", err)
 	}
-	persisted, err := m.encryptConnectionSecrets(connections)
+	persisted, err := m.storeConnectionSecrets(connections)
 	if err != nil {
 		return err
 	}
@@ -383,62 +384,74 @@ func (m *Manager) saveUnlocked(connections []Connection) error {
 	return nil
 }
 
-func (m *Manager) encryptConnectionSecrets(connections []Connection) ([]Connection, error) {
+func (m *Manager) storeConnectionSecrets(connections []Connection) ([]Connection, error) {
 	out := make([]Connection, 0, len(connections))
-	var key []byte
+	store := m.localSecretStore()
 	for _, connection := range connections {
 		next := connection
 		next.Metadata = cloneMap(connection.Metadata)
 		next.Secrets = cloneMap(connection.Secrets)
 		next.SecretRefs = cloneMap(connection.SecretRefs)
-		for name, value := range next.Secrets {
-			if strings.TrimSpace(value) == "" {
-				continue
+		if next.SecretStore != "" && next.SecretStore != store.Kind() {
+			if len(next.Secrets) != 0 {
+				return nil, fmt.Errorf("unsupported secret store %q cannot persist local secret values", next.SecretStore)
 			}
-			if key == nil {
-				loaded, err := m.encryptionKeyForEncrypt()
-				if err != nil {
-					return nil, err
-				}
-				key = loaded
-			}
-			encrypted, err := encryptSecretValue(key, value)
-			if err != nil {
-				return nil, fmt.Errorf("encrypt cloud connection secret %q: %w", name, err)
-			}
-			next.Secrets[name] = encrypted
+			out = append(out, next)
+			continue
+		}
+		if len(next.Secrets) == 0 {
+			out = append(out, next)
+			continue
+		}
+		stored, err := store.Save(context.Background(), secretScope(next), next.Secrets)
+		if err != nil {
+			return nil, err
+		}
+		next.Secrets = stored.Values
+		next.SecretRefs = stored.Refs
+		if len(next.Secrets) > 0 {
+			next.SecretStore = store.Kind()
 		}
 		out = append(out, next)
 	}
 	return out, nil
 }
 
-func (m *Manager) decryptConnectionSecrets(connections []Connection) (bool, error) {
-	var key []byte
+func (m *Manager) loadConnectionSecrets(connections []Connection) (bool, error) {
 	needsMigration := false
+	store := m.localSecretStore()
 	for index := range connections {
-		for name, value := range connections[index].Secrets {
-			if !isEncryptedSecret(value) {
-				if strings.TrimSpace(value) != "" {
-					needsMigration = true
-				}
-				continue
-			}
-			if key == nil {
-				loaded, err := m.encryptionKeyForDecrypt()
-				if err != nil {
-					return false, err
-				}
-				key = loaded
-			}
-			plaintext, err := decryptSecretValue(key, value)
-			if err != nil {
-				return false, fmt.Errorf("decrypt cloud connection secret %q: %w", name, err)
-			}
-			connections[index].Secrets[name] = plaintext
+		if connections[index].SecretStore != "" && connections[index].SecretStore != store.Kind() {
+			continue
+		}
+		if len(connections[index].Secrets) == 0 {
+			continue
+		}
+		loaded, err := store.Load(context.Background(), secretScope(connections[index]), StoredSecrets{
+			Values: connections[index].Secrets,
+			Refs:   connections[index].SecretRefs,
+		})
+		if err != nil {
+			return false, err
+		}
+		connections[index].Secrets = loaded.Values
+		if loaded.NeedsMigration {
+			needsMigration = true
 		}
 	}
 	return needsMigration, nil
+}
+
+func (m *Manager) localSecretStore() SecretStore {
+	return newLocalEncryptedSecretStore(m.encryptionKeyForEncrypt, m.encryptionKeyForDecrypt)
+}
+
+func secretScope(connection Connection) SecretScope {
+	return SecretScope{
+		ConnectionID: connection.ID,
+		Provider:     connection.Provider,
+		AuthMethod:   connection.AuthMethod,
+	}
 }
 
 func (m *Manager) encryptionKeyForEncrypt() ([]byte, error) {

--- a/internal/cloudconnections/connections.go
+++ b/internal/cloudconnections/connections.go
@@ -392,6 +392,7 @@ func (m *Manager) storeConnectionSecrets(connections []Connection) ([]Connection
 		next.Metadata = cloneMap(connection.Metadata)
 		next.Secrets = cloneMap(connection.Secrets)
 		next.SecretRefs = cloneMap(connection.SecretRefs)
+		next.SecretStore = strings.TrimSpace(next.SecretStore)
 		if next.SecretStore != "" && next.SecretStore != store.Kind() {
 			if hasNonEmptySecrets(next.Secrets) {
 				return nil, fmt.Errorf("unsupported secret store %q cannot persist local secret values", next.SecretStore)
@@ -421,6 +422,7 @@ func (m *Manager) loadConnectionSecrets(connections []Connection) (bool, error) 
 	needsMigration := false
 	store := m.localSecretStore()
 	for index := range connections {
+		connections[index].SecretStore = strings.TrimSpace(connections[index].SecretStore)
 		if connections[index].SecretStore != "" && connections[index].SecretStore != store.Kind() {
 			if hasNonEmptySecrets(connections[index].Secrets) {
 				return false, fmt.Errorf("unsupported secret store %q cannot persist local secret values", connections[index].SecretStore)

--- a/internal/cloudconnections/connections.go
+++ b/internal/cloudconnections/connections.go
@@ -393,7 +393,7 @@ func (m *Manager) storeConnectionSecrets(connections []Connection) ([]Connection
 		next.Secrets = cloneMap(connection.Secrets)
 		next.SecretRefs = cloneMap(connection.SecretRefs)
 		if next.SecretStore != "" && next.SecretStore != store.Kind() {
-			if len(next.Secrets) != 0 {
+			if hasNonEmptySecrets(next.Secrets) {
 				return nil, fmt.Errorf("unsupported secret store %q cannot persist local secret values", next.SecretStore)
 			}
 			out = append(out, next)
@@ -422,6 +422,9 @@ func (m *Manager) loadConnectionSecrets(connections []Connection) (bool, error) 
 	store := m.localSecretStore()
 	for index := range connections {
 		if connections[index].SecretStore != "" && connections[index].SecretStore != store.Kind() {
+			if hasNonEmptySecrets(connections[index].Secrets) {
+				return false, fmt.Errorf("unsupported secret store %q cannot persist local secret values", connections[index].SecretStore)
+			}
 			continue
 		}
 		if len(connections[index].Secrets) == 0 {
@@ -879,6 +882,15 @@ func mergeSecrets(existing, submitted map[string]string) map[string]string {
 		return nil
 	}
 	return out
+}
+
+func hasNonEmptySecrets(secrets map[string]string) bool {
+	for _, value := range secrets {
+		if strings.TrimSpace(value) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func validateReadiness(connection Connection) []Check {

--- a/internal/cloudconnections/connections.go
+++ b/internal/cloudconnections/connections.go
@@ -395,7 +395,7 @@ func (m *Manager) storeConnectionSecrets(connections []Connection) ([]Connection
 		next.SecretStore = strings.TrimSpace(next.SecretStore)
 		if next.SecretStore != "" && next.SecretStore != store.Kind() {
 			if hasNonEmptySecrets(next.Secrets) {
-				return nil, fmt.Errorf("unsupported secret store %q cannot persist local secret values", next.SecretStore)
+				return nil, fmt.Errorf("connection %s uses unsupported secret store %q with local secret values", connectionLabel(next), next.SecretStore)
 			}
 			out = append(out, next)
 			continue
@@ -425,7 +425,7 @@ func (m *Manager) loadConnectionSecrets(connections []Connection) (bool, error) 
 		connections[index].SecretStore = strings.TrimSpace(connections[index].SecretStore)
 		if connections[index].SecretStore != "" && connections[index].SecretStore != store.Kind() {
 			if hasNonEmptySecrets(connections[index].Secrets) {
-				return false, fmt.Errorf("unsupported secret store %q cannot persist local secret values", connections[index].SecretStore)
+				return false, fmt.Errorf("connection %s uses unsupported secret store %q with local secret values", connectionLabel(connections[index]), connections[index].SecretStore)
 			}
 			continue
 		}
@@ -457,6 +457,21 @@ func secretScope(connection Connection) SecretScope {
 		Provider:     connection.Provider,
 		AuthMethod:   connection.AuthMethod,
 	}
+}
+
+func connectionLabel(connection Connection) string {
+	id := strings.TrimSpace(connection.ID)
+	name := strings.TrimSpace(connection.Name)
+	if id == "" && name == "" {
+		return "<unknown>"
+	}
+	if id == "" {
+		return fmt.Sprintf("%q", name)
+	}
+	if name == "" || name == id {
+		return fmt.Sprintf("%q", id)
+	}
+	return fmt.Sprintf("%q (%s)", id, name)
 }
 
 func (m *Manager) encryptionKeyForEncrypt() ([]byte, error) {

--- a/internal/cloudconnections/connections_test.go
+++ b/internal/cloudconnections/connections_test.go
@@ -98,6 +98,26 @@ func TestManagerRejectsUnsupportedSecretStore(t *testing.T) {
 	}
 }
 
+func TestManagerRejectsExternalStoreWithLocalSecretValuesDuringPersistence(t *testing.T) {
+	manager := NewManager(t.TempDir())
+
+	err := manager.saveUnlocked([]Connection{{
+		ID:          "conn_external",
+		Name:        "external",
+		Provider:    ProviderAWS,
+		AuthMethod:  "aws_static",
+		SecretStore: "vault",
+		SecretRefs:  map[string]string{"secret_access_key": "vault://secret/data/iac/prod#secret_access_key"},
+		Secrets:     map[string]string{"secret_access_key": "must-not-persist"},
+	}})
+	if err == nil {
+		t.Fatal("external stores should fail closed when local secret values are present")
+	}
+	if !strings.Contains(err.Error(), "cannot persist local secret values") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestManagerPreservesExternalSecretRefsOnLoad(t *testing.T) {
 	dir := t.TempDir()
 	manager := NewManager(dir)

--- a/internal/cloudconnections/connections_test.go
+++ b/internal/cloudconnections/connections_test.go
@@ -118,6 +118,32 @@ func TestManagerRejectsExternalStoreWithLocalSecretValuesDuringPersistence(t *te
 	}
 }
 
+func TestManagerRejectsExternalStoreWithLocalSecretValuesOnLoad(t *testing.T) {
+	dir := t.TempDir()
+	manager := NewManager(dir)
+	record := `[{
+		"id":"conn_external",
+		"name":"external",
+		"provider":"aws",
+		"auth_method":"aws_static",
+		"metadata":{"access_key_id":"AKIAEXAMPLE"},
+		"secret_store":"vault",
+		"secret_refs":{"secret_access_key":"vault://secret/data/iac/prod#secret_access_key"},
+		"secrets":{"secret_access_key":"must-not-load"},
+		"created_at":"2026-06-18T00:00:00Z",
+		"updated_at":"2026-06-18T00:00:00Z"
+	}]`
+	if err := os.WriteFile(manager.path, []byte(record), 0o600); err != nil {
+		t.Fatalf("write external store record: %v", err)
+	}
+
+	if _, err := manager.Get("conn_external"); err == nil {
+		t.Fatal("Get should reject unsupported external stores that persisted local secret values")
+	} else if !strings.Contains(err.Error(), "cannot persist local secret values") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestManagerPreservesExternalSecretRefsOnLoad(t *testing.T) {
 	dir := t.TempDir()
 	manager := NewManager(dir)

--- a/internal/cloudconnections/connections_test.go
+++ b/internal/cloudconnections/connections_test.go
@@ -113,7 +113,10 @@ func TestManagerRejectsExternalStoreWithLocalSecretValuesDuringPersistence(t *te
 	if err == nil {
 		t.Fatal("external stores should fail closed when local secret values are present")
 	}
-	if !strings.Contains(err.Error(), "cannot persist local secret values") {
+	if !strings.Contains(err.Error(), "conn_external") ||
+		!strings.Contains(err.Error(), "external") ||
+		!strings.Contains(err.Error(), `secret store "vault"`) ||
+		!strings.Contains(err.Error(), "local secret values") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -139,7 +142,10 @@ func TestManagerRejectsExternalStoreWithLocalSecretValuesOnLoad(t *testing.T) {
 
 	if _, err := manager.Get("conn_external"); err == nil {
 		t.Fatal("Get should reject unsupported external stores that persisted local secret values")
-	} else if !strings.Contains(err.Error(), "cannot persist local secret values") {
+	} else if !strings.Contains(err.Error(), "conn_external") ||
+		!strings.Contains(err.Error(), "external") ||
+		!strings.Contains(err.Error(), `secret store "vault"`) ||
+		!strings.Contains(err.Error(), "local secret values") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/internal/cloudconnections/connections_test.go
+++ b/internal/cloudconnections/connections_test.go
@@ -144,6 +144,85 @@ func TestManagerRejectsExternalStoreWithLocalSecretValuesOnLoad(t *testing.T) {
 	}
 }
 
+func TestManagerNormalizesLocalSecretStoreDuringPersistence(t *testing.T) {
+	manager := NewManager(t.TempDir())
+
+	err := manager.saveUnlocked([]Connection{{
+		ID:          "conn_local",
+		Name:        "local",
+		Provider:    ProviderAWS,
+		AuthMethod:  "aws_static",
+		SecretStore: " local_encrypted ",
+		Metadata:    map[string]string{"access_key_id": "AKIAEXAMPLE"},
+		Secrets:     map[string]string{"secret_access_key": "super-secret"},
+	}})
+	if err != nil {
+		t.Fatalf("save local encrypted record with whitespace store: %v", err)
+	}
+
+	stored, err := manager.Get("conn_local")
+	if err != nil {
+		t.Fatalf("Get normalized local encrypted record: %v", err)
+	}
+	if got := stored.SecretStore; got != SecretStoreLocalEncrypted {
+		t.Fatalf("local encrypted secret store should be normalized, got %q", got)
+	}
+	if got := stored.Secrets["secret_access_key"]; got != "super-secret" {
+		t.Fatalf("local encrypted secret should decrypt after normalized persistence, got %q", got)
+	}
+
+	data, err := os.ReadFile(manager.path)
+	if err != nil {
+		t.Fatalf("read persisted local encrypted record: %v", err)
+	}
+	if contains(string(data), `"secret_store": " local_encrypted "`) {
+		t.Fatalf("persisted local secret store should be normalized: %s", string(data))
+	}
+}
+
+func TestManagerNormalizesLocalSecretStoreDuringLoad(t *testing.T) {
+	dir := t.TempDir()
+	manager := NewManager(dir)
+
+	if _, err := manager.Save(Connection{
+		Name:       "local",
+		Provider:   ProviderAWS,
+		AuthMethod: "aws_static",
+		Metadata:   map[string]string{"access_key_id": "AKIAEXAMPLE"},
+		Secrets:    map[string]string{"secret_access_key": "super-secret"},
+	}); err != nil {
+		t.Fatalf("Save local encrypted record: %v", err)
+	}
+
+	data, err := os.ReadFile(manager.path)
+	if err != nil {
+		t.Fatalf("read local encrypted record: %v", err)
+	}
+	data = []byte(strings.Replace(string(data), `"secret_store": "local_encrypted"`, `"secret_store": " local_encrypted "`, 1))
+	if err := os.WriteFile(manager.path, data, 0o600); err != nil {
+		t.Fatalf("write local encrypted record with whitespace store: %v", err)
+	}
+
+	listed, err := manager.List()
+	if err != nil {
+		t.Fatalf("List normalized local encrypted record: %v", err)
+	}
+	if len(listed) != 1 {
+		t.Fatalf("expected one local encrypted record, got %d", len(listed))
+	}
+	if got := listed[0].SecretStore; got != SecretStoreLocalEncrypted {
+		t.Fatalf("public local encrypted secret store should be normalized, got %q", got)
+	}
+
+	stored, err := manager.Get(listed[0].ID)
+	if err != nil {
+		t.Fatalf("Get normalized local encrypted record: %v", err)
+	}
+	if got := stored.Secrets["secret_access_key"]; got != "super-secret" {
+		t.Fatalf("local encrypted secret should decrypt after normalized load, got %q", got)
+	}
+}
+
 func TestManagerPreservesExternalSecretRefsOnLoad(t *testing.T) {
 	dir := t.TempDir()
 	manager := NewManager(dir)

--- a/internal/cloudconnections/local_encrypted_store.go
+++ b/internal/cloudconnections/local_encrypted_store.go
@@ -4,11 +4,18 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 )
 
 type localEncryptedSecretStore struct {
 	keyForEncrypt func() ([]byte, error)
 	keyForDecrypt func() ([]byte, error)
+	encryptOnce   sync.Once
+	encryptKey    []byte
+	encryptErr    error
+	decryptOnce   sync.Once
+	decryptKey    []byte
+	decryptErr    error
 }
 
 func newLocalEncryptedSecretStore(keyForEncrypt, keyForDecrypt func() ([]byte, error)) *localEncryptedSecretStore {
@@ -35,7 +42,7 @@ func (s *localEncryptedSecretStore) Save(ctx context.Context, scope SecretScope,
 			continue
 		}
 		if key == nil {
-			loaded, err := s.keyForEncrypt()
+			loaded, err := s.encryptionKey()
 			if err != nil {
 				return StoredSecrets{}, err
 			}
@@ -75,7 +82,7 @@ func (s *localEncryptedSecretStore) Load(ctx context.Context, _ SecretScope, sto
 			continue
 		}
 		if key == nil {
-			loaded, err := s.keyForDecrypt()
+			loaded, err := s.decryptionKey()
 			if err != nil {
 				return LoadedSecrets{}, err
 			}
@@ -98,4 +105,18 @@ func (s *localEncryptedSecretStore) Load(ctx context.Context, _ SecretScope, sto
 
 func (s *localEncryptedSecretStore) Delete(ctx context.Context, _ SecretScope, _ StoredSecrets) error {
 	return ctx.Err()
+}
+
+func (s *localEncryptedSecretStore) encryptionKey() ([]byte, error) {
+	s.encryptOnce.Do(func() {
+		s.encryptKey, s.encryptErr = s.keyForEncrypt()
+	})
+	return s.encryptKey, s.encryptErr
+}
+
+func (s *localEncryptedSecretStore) decryptionKey() ([]byte, error) {
+	s.decryptOnce.Do(func() {
+		s.decryptKey, s.decryptErr = s.keyForDecrypt()
+	})
+	return s.decryptKey, s.decryptErr
 }

--- a/internal/cloudconnections/local_encrypted_store.go
+++ b/internal/cloudconnections/local_encrypted_store.go
@@ -1,0 +1,101 @@
+package cloudconnections
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+type localEncryptedSecretStore struct {
+	keyForEncrypt func() ([]byte, error)
+	keyForDecrypt func() ([]byte, error)
+}
+
+func newLocalEncryptedSecretStore(keyForEncrypt, keyForDecrypt func() ([]byte, error)) *localEncryptedSecretStore {
+	return &localEncryptedSecretStore{
+		keyForEncrypt: keyForEncrypt,
+		keyForDecrypt: keyForDecrypt,
+	}
+}
+
+func (s *localEncryptedSecretStore) Kind() string {
+	return SecretStoreLocalEncrypted
+}
+
+func (s *localEncryptedSecretStore) Save(ctx context.Context, scope SecretScope, secrets map[string]string) (StoredSecrets, error) {
+	if err := ctx.Err(); err != nil {
+		return StoredSecrets{}, err
+	}
+
+	values := map[string]string{}
+	var key []byte
+	for name, value := range secrets {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if key == nil {
+			loaded, err := s.keyForEncrypt()
+			if err != nil {
+				return StoredSecrets{}, err
+			}
+			key = loaded
+		}
+		encrypted, err := encryptSecretValue(key, value)
+		if err != nil {
+			return StoredSecrets{}, fmt.Errorf("encrypt cloud connection secret %q: %w", name, err)
+		}
+		values[name] = encrypted
+	}
+	if len(values) == 0 {
+		return StoredSecrets{}, nil
+	}
+	return StoredSecrets{
+		Values: values,
+		Refs:   localEncryptedSecretRefs(scope.ConnectionID, scope.AuthMethod, values),
+	}, nil
+}
+
+func (s *localEncryptedSecretStore) Load(ctx context.Context, _ SecretScope, stored StoredSecrets) (LoadedSecrets, error) {
+	if err := ctx.Err(); err != nil {
+		return LoadedSecrets{}, err
+	}
+
+	values := map[string]string{}
+	needsMigration := false
+	var key []byte
+	for name, value := range stored.Values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if !isEncryptedSecret(value) {
+			needsMigration = true
+			values[name] = value
+			continue
+		}
+		if key == nil {
+			loaded, err := s.keyForDecrypt()
+			if err != nil {
+				return LoadedSecrets{}, err
+			}
+			key = loaded
+		}
+		plaintext, err := decryptSecretValue(key, value)
+		if err != nil {
+			return LoadedSecrets{}, fmt.Errorf("decrypt cloud connection secret %q: %w", name, err)
+		}
+		values[name] = plaintext
+	}
+	if len(values) == 0 {
+		values = nil
+	}
+	return LoadedSecrets{
+		Values:         values,
+		NeedsMigration: needsMigration,
+	}, nil
+}
+
+func (s *localEncryptedSecretStore) Delete(ctx context.Context, _ SecretScope, _ StoredSecrets) error {
+	return ctx.Err()
+}

--- a/internal/cloudconnections/local_encrypted_store.go
+++ b/internal/cloudconnections/local_encrypted_store.go
@@ -37,8 +37,7 @@ func (s *localEncryptedSecretStore) Save(ctx context.Context, scope SecretScope,
 	values := map[string]string{}
 	var key []byte
 	for name, value := range secrets {
-		value = strings.TrimSpace(value)
-		if value == "" {
+		if strings.TrimSpace(value) == "" {
 			continue
 		}
 		if key == nil {
@@ -72,8 +71,7 @@ func (s *localEncryptedSecretStore) Load(ctx context.Context, _ SecretScope, sto
 	needsMigration := false
 	var key []byte
 	for name, value := range stored.Values {
-		value = strings.TrimSpace(value)
-		if value == "" {
+		if strings.TrimSpace(value) == "" {
 			continue
 		}
 		if !isEncryptedSecret(value) {

--- a/internal/cloudconnections/local_encrypted_store_test.go
+++ b/internal/cloudconnections/local_encrypted_store_test.go
@@ -20,7 +20,7 @@ func TestLocalEncryptedSecretStoreRoundTrip(t *testing.T) {
 
 	stored, err := store.Save(context.Background(), scope, map[string]string{
 		"secret_access_key": "super-secret",
-		"session_token":     "session-secret",
+		"session_token":     "  session-secret  ",
 	})
 	if err != nil {
 		t.Fatalf("Save: %v", err)
@@ -42,7 +42,7 @@ func TestLocalEncryptedSecretStoreRoundTrip(t *testing.T) {
 	if got := loaded.Values["secret_access_key"]; got != "super-secret" {
 		t.Fatalf("secret_access_key should round trip, got %q", got)
 	}
-	if got := loaded.Values["session_token"]; got != "session-secret" {
+	if got := loaded.Values["session_token"]; got != "  session-secret  " {
 		t.Fatalf("session_token should round trip, got %q", got)
 	}
 }
@@ -60,7 +60,7 @@ func TestLocalEncryptedSecretStoreMarksPlaintextForMigration(t *testing.T) {
 	}
 
 	loaded, err := store.Load(context.Background(), scope, StoredSecrets{
-		Values: map[string]string{"secret_access_key": "legacy-secret"},
+		Values: map[string]string{"secret_access_key": "  legacy-secret  "},
 	})
 	if err != nil {
 		t.Fatalf("Load legacy plaintext: %v", err)
@@ -68,7 +68,7 @@ func TestLocalEncryptedSecretStoreMarksPlaintextForMigration(t *testing.T) {
 	if !loaded.NeedsMigration {
 		t.Fatal("plaintext local secret should be marked for migration")
 	}
-	if got := loaded.Values["secret_access_key"]; got != "legacy-secret" {
+	if got := loaded.Values["secret_access_key"]; got != "  legacy-secret  " {
 		t.Fatalf("plaintext local secret should remain usable before migration, got %q", got)
 	}
 }

--- a/internal/cloudconnections/local_encrypted_store_test.go
+++ b/internal/cloudconnections/local_encrypted_store_test.go
@@ -1,0 +1,74 @@
+package cloudconnections
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+func TestLocalEncryptedSecretStoreRoundTrip(t *testing.T) {
+	keyPath := filepath.Join(t.TempDir(), connectionsKeyFileName)
+	store := newLocalEncryptedSecretStore(
+		func() ([]byte, error) { return loadOrCreateLocalKey(keyPath) },
+		func() ([]byte, error) { return loadExistingLocalKey(keyPath) },
+	)
+	scope := SecretScope{
+		ConnectionID: "conn_test",
+		Provider:     ProviderAWS,
+		AuthMethod:   "aws_static",
+	}
+
+	stored, err := store.Save(context.Background(), scope, map[string]string{
+		"secret_access_key": "super-secret",
+		"session_token":     "session-secret",
+	})
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if got := stored.Values["secret_access_key"]; got == "" || got == "super-secret" || !isEncryptedSecret(got) {
+		t.Fatalf("secret should be stored as encrypted envelope, got %q", got)
+	}
+	if got := stored.Refs["secret_access_key"]; got != "local://connections/conn_test/secret_access_key" {
+		t.Fatalf("unexpected local secret ref: %q", got)
+	}
+
+	loaded, err := store.Load(context.Background(), scope, stored)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded.NeedsMigration {
+		t.Fatal("encrypted local secrets should not need migration")
+	}
+	if got := loaded.Values["secret_access_key"]; got != "super-secret" {
+		t.Fatalf("secret_access_key should round trip, got %q", got)
+	}
+	if got := loaded.Values["session_token"]; got != "session-secret" {
+		t.Fatalf("session_token should round trip, got %q", got)
+	}
+}
+
+func TestLocalEncryptedSecretStoreMarksPlaintextForMigration(t *testing.T) {
+	keyPath := filepath.Join(t.TempDir(), connectionsKeyFileName)
+	store := newLocalEncryptedSecretStore(
+		func() ([]byte, error) { return loadOrCreateLocalKey(keyPath) },
+		func() ([]byte, error) { return loadExistingLocalKey(keyPath) },
+	)
+	scope := SecretScope{
+		ConnectionID: "conn_legacy",
+		Provider:     ProviderAWS,
+		AuthMethod:   "aws_static",
+	}
+
+	loaded, err := store.Load(context.Background(), scope, StoredSecrets{
+		Values: map[string]string{"secret_access_key": "legacy-secret"},
+	})
+	if err != nil {
+		t.Fatalf("Load legacy plaintext: %v", err)
+	}
+	if !loaded.NeedsMigration {
+		t.Fatal("plaintext local secret should be marked for migration")
+	}
+	if got := loaded.Values["secret_access_key"]; got != "legacy-secret" {
+		t.Fatalf("plaintext local secret should remain usable before migration, got %q", got)
+	}
+}

--- a/internal/cloudconnections/local_encrypted_store_test.go
+++ b/internal/cloudconnections/local_encrypted_store_test.go
@@ -72,3 +72,46 @@ func TestLocalEncryptedSecretStoreMarksPlaintextForMigration(t *testing.T) {
 		t.Fatalf("plaintext local secret should remain usable before migration, got %q", got)
 	}
 }
+
+func TestLocalEncryptedSecretStoreMemoizesKeysPerInstance(t *testing.T) {
+	key := []byte("0123456789abcdef0123456789abcdef")
+	encryptLoads := 0
+	decryptLoads := 0
+	store := newLocalEncryptedSecretStore(
+		func() ([]byte, error) {
+			encryptLoads++
+			return key, nil
+		},
+		func() ([]byte, error) {
+			decryptLoads++
+			return key, nil
+		},
+	)
+	scope := SecretScope{
+		ConnectionID: "conn_test",
+		Provider:     ProviderAWS,
+		AuthMethod:   "aws_static",
+	}
+
+	storedA, err := store.Save(context.Background(), scope, map[string]string{"secret_access_key": "secret-a"})
+	if err != nil {
+		t.Fatalf("Save A: %v", err)
+	}
+	storedB, err := store.Save(context.Background(), scope, map[string]string{"secret_access_key": "secret-b"})
+	if err != nil {
+		t.Fatalf("Save B: %v", err)
+	}
+	if encryptLoads != 1 {
+		t.Fatalf("encryption key should load once per store instance, got %d loads", encryptLoads)
+	}
+
+	if _, err := store.Load(context.Background(), scope, storedA); err != nil {
+		t.Fatalf("Load A: %v", err)
+	}
+	if _, err := store.Load(context.Background(), scope, storedB); err != nil {
+		t.Fatalf("Load B: %v", err)
+	}
+	if decryptLoads != 1 {
+		t.Fatalf("decryption key should load once per store instance, got %d loads", decryptLoads)
+	}
+}

--- a/internal/cloudconnections/secret_store.go
+++ b/internal/cloudconnections/secret_store.go
@@ -10,13 +10,27 @@ type SecretScope struct {
 	AuthMethod   string
 }
 
+// StoredSecrets is the persisted output of a SecretStore save operation.
+// Values are backend-specific persisted values. For local encrypted storage
+// these are encrypted envelopes; for external stores this will usually be nil.
+type StoredSecrets struct {
+	Values map[string]string
+	Refs   map[string]string
+}
+
+// LoadedSecrets is the resolved output of a SecretStore load operation.
+type LoadedSecrets struct {
+	Values         map[string]string
+	NeedsMigration bool
+}
+
 // SecretStore is the backend contract for storing cloud credential fields
 // outside public connection metadata. Implementations return opaque refs that
 // can be persisted in Connection.SecretRefs and resolved only for runner or MCP
 // workflows that need credentials.
 type SecretStore interface {
 	Kind() string
-	Save(ctx context.Context, scope SecretScope, secrets map[string]string) (map[string]string, error)
-	Load(ctx context.Context, refs map[string]string) (map[string]string, error)
-	Delete(ctx context.Context, refs map[string]string) error
+	Save(ctx context.Context, scope SecretScope, secrets map[string]string) (StoredSecrets, error)
+	Load(ctx context.Context, scope SecretScope, stored StoredSecrets) (LoadedSecrets, error)
+	Delete(ctx context.Context, scope SecretScope, stored StoredSecrets) error
 }


### PR DESCRIPTION
## Summary
- Add a local encrypted SecretStore adapter with persisted encrypted values and local secret refs.
- Route Cloud Connections save/load through the adapter while preserving the existing encrypted file format and legacy plaintext migration behavior.
- Fail closed if an unsupported external secret store record tries to persist local secret values.

## Tests
- GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/cloudconnections ./internal/api
- GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/...

Closes #96
Part of #91