### PR TITLE
Show Cloud Connections secret storage status

### DIFF
--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -101,7 +101,14 @@ export interface CatalogResource {
 
 export type CloudProvider = 'aws' | 'azure' | 'gcp';
 
-export type KnownCloudSecretStore = 'local_encrypted';
+export type KnownCloudSecretStore =
+  | 'local_encrypted'
+  | 'os_keychain'
+  | 'vault'
+  | 'aws_secrets_manager'
+  | 'aws_ssm_parameter_store'
+  | 'azure_key_vault'
+  | 'gcp_secret_manager';
 export type CloudSecretStore = KnownCloudSecretStore | (string & Record<never, never>);
 
 export type CloudAuthMethod =

--- a/web/src/components/CloudConnections/CloudConnectionsPanel.test.tsx
+++ b/web/src/components/CloudConnections/CloudConnectionsPanel.test.tsx
@@ -17,6 +17,7 @@ function makeClient(initial: CloudConnection[] = []) {
         region: input.region,
         metadata: input.metadata,
         secret_fields: input.secrets && Object.keys(input.secrets).length > 0 ? Object.keys(input.secrets) : undefined,
+        secret_store: input.secrets && Object.keys(input.secrets).length > 0 ? 'local_encrypted' : undefined,
       };
       connections = [connection];
       return connection;
@@ -30,6 +31,7 @@ function makeClient(initial: CloudConnection[] = []) {
         region: input.region,
         metadata: input.metadata,
         secret_fields: initial.find(item => item.id === id)?.secret_fields,
+        secret_store: initial.find(item => item.id === id)?.secret_store,
       };
       connections = connections.map(item => item.id === id ? connection : item);
       return connection;
@@ -55,7 +57,76 @@ describe('CloudConnectionsPanel', () => {
     render(<CloudConnectionsPanel client={client} />);
 
     expect(screen.getByText(/Secrets are encrypted and stored locally on this machine/)).toBeInTheDocument();
+    expect(screen.getByText('No stored secrets')).toBeInTheDocument();
     await screen.findByText('0 connections');
+  });
+
+  it('shows storage badges for saved connection secret stores', async () => {
+    const client = makeClient([
+      {
+        id: 'conn_1',
+        name: 'break-glass',
+        provider: 'aws',
+        auth_method: 'aws_static',
+        metadata: { access_key_id: 'AKIAEXAMPLE' },
+        secret_fields: ['secret_access_key'],
+        secret_store: 'local_encrypted',
+      },
+      {
+        id: 'conn_2',
+        name: 'desktop',
+        provider: 'azure',
+        auth_method: 'azure_service_principal',
+        metadata: { tenant_id: 'tenant-1', client_id: 'client-1' },
+        secret_fields: ['client_secret'],
+        secret_store: 'os_keychain',
+      },
+      {
+        id: 'conn_3',
+        name: 'platform',
+        provider: 'gcp',
+        auth_method: 'gcp_service_account',
+        metadata: { project_id: 'prod' },
+        secret_fields: ['service_account_json'],
+        secret_store: 'vault',
+      },
+      {
+        id: 'conn_4',
+        name: 'future',
+        provider: 'aws',
+        auth_method: 'aws_static',
+        metadata: { access_key_id: 'AKIAFUTURE' },
+        secret_fields: ['secret_access_key'],
+        secret_store: 'custom_secret_store',
+      },
+    ]);
+    render(<CloudConnectionsPanel client={client} />);
+
+    await screen.findByText('break-glass');
+    expect(screen.getByText('Local encrypted')).toBeInTheDocument();
+    expect(screen.getByText('OS keychain')).toBeInTheDocument();
+    expect(screen.getByText('Vault')).toBeInTheDocument();
+    expect(screen.getByText('Custom Secret Store')).toBeInTheDocument();
+  });
+
+  it('shows the selected connection secret store near the form', async () => {
+    const client = makeClient([
+      {
+        id: 'conn_1',
+        name: 'prod-admin',
+        provider: 'aws',
+        auth_method: 'aws_static',
+        metadata: { access_key_id: 'AKIAEXAMPLE' },
+        secret_fields: ['secret_access_key'],
+        secret_store: 'aws_secrets_manager',
+      },
+    ]);
+    render(<CloudConnectionsPanel client={client} />);
+
+    await screen.findByText('prod-admin');
+    fireEvent.click(screen.getByText('prod-admin'));
+
+    expect(screen.getAllByText('AWS Secrets Manager').length).toBeGreaterThanOrEqual(1);
   });
 
   it('creates an AWS profile connection and refreshes the list', async () => {
@@ -95,6 +166,7 @@ describe('CloudConnectionsPanel', () => {
     render(<CloudConnectionsPanel client={client} />);
 
     await screen.findByText('break-glass');
+    expect(screen.getByText('Local encrypted')).toBeInTheDocument();
     fireEvent.click(screen.getByText('break-glass'));
 
     expect(screen.getByLabelText('Secret access key')).toHaveValue('');

--- a/web/src/components/CloudConnections/CloudConnectionsPanel.test.tsx
+++ b/web/src/components/CloudConnections/CloudConnectionsPanel.test.tsx
@@ -59,7 +59,7 @@ function makeClient(initial: CloudConnection[] = []) {
 }
 
 describe('CloudConnectionsPanel', () => {
-  it('shows the local secret storage warning', async () => {
+  it('shows the no-stored-secrets warning for a new connection', async () => {
     const client = makeClient();
     render(<CloudConnectionsPanel client={client} />);
 
@@ -107,6 +107,15 @@ describe('CloudConnectionsPanel', () => {
         secret_fields: ['secret_access_key'],
         secret_store: 'custom_secret_store',
       },
+      {
+        id: 'conn_5',
+        name: 'prototype-safe',
+        provider: 'aws',
+        auth_method: 'aws_static',
+        metadata: { access_key_id: 'AKIAPROTOTYPE' },
+        secret_fields: ['secret_access_key'],
+        secret_store: 'toString',
+      },
     ]);
     render(<CloudConnectionsPanel client={client} />);
 
@@ -115,6 +124,7 @@ describe('CloudConnectionsPanel', () => {
     expect(screen.getByText('OS keychain')).toBeInTheDocument();
     expect(screen.getByText('Vault')).toBeInTheDocument();
     expect(screen.getByText('Custom Secret Store')).toBeInTheDocument();
+    expect(screen.getByText('ToString')).toBeInTheDocument();
   });
 
   it('shows the selected connection secret store near the form', async () => {
@@ -183,6 +193,24 @@ describe('CloudConnectionsPanel', () => {
     });
     await screen.findByText('aws_static / us-west-2');
     expect(screen.getAllByText('Local encrypted').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('does not show local encrypted storage for cleared draft secret fields', async () => {
+    const client = makeClient();
+    render(<CloudConnectionsPanel client={client} />);
+
+    await screen.findByText('0 connections');
+    fireEvent.change(screen.getByLabelText('Auth'), { target: { value: 'aws_static' } });
+    fireEvent.change(screen.getByLabelText('Secret access key'), { target: { value: 'secret-value' } });
+
+    expect(screen.getByText(/Secrets are encrypted and stored locally/)).toBeInTheDocument();
+    expect(screen.getByText('Local encrypted')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Secret access key'), { target: { value: '   ' } });
+
+    expect(screen.getByText(/No secrets are stored for this connection yet/)).toBeInTheDocument();
+    expect(screen.getByText('No stored secrets')).toBeInTheDocument();
+    expect(screen.queryByText('Local encrypted')).not.toBeInTheDocument();
   });
 
   it('does not render stored secret values when editing', async () => {

--- a/web/src/components/CloudConnections/CloudConnectionsPanel.test.tsx
+++ b/web/src/components/CloudConnections/CloudConnectionsPanel.test.tsx
@@ -127,6 +127,7 @@ describe('CloudConnectionsPanel', () => {
     fireEvent.click(screen.getByText('prod-admin'));
 
     expect(screen.getAllByText('AWS Secrets Manager').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText(/Secrets are stored using this connection/)).toBeInTheDocument();
   });
 
   it('creates an AWS profile connection and refreshes the list', async () => {

--- a/web/src/components/CloudConnections/CloudConnectionsPanel.test.tsx
+++ b/web/src/components/CloudConnections/CloudConnectionsPanel.test.tsx
@@ -23,6 +23,11 @@ function makeClient(initial: CloudConnection[] = []) {
       return connection;
     }),
     updateCloudConnection: vi.fn(async (id: string, input: CloudConnectionInput) => {
+      const current = connections.find(item => item.id === id);
+      const inputSecretFields = input.secrets ? Object.keys(input.secrets) : [];
+      const nextSecretFields = inputSecretFields.length > 0
+        ? inputSecretFields
+        : current?.secret_fields;
       const connection: CloudConnection = {
         id,
         name: input.name,
@@ -30,8 +35,10 @@ function makeClient(initial: CloudConnection[] = []) {
         auth_method: input.auth_method,
         region: input.region,
         metadata: input.metadata,
-        secret_fields: initial.find(item => item.id === id)?.secret_fields,
-        secret_store: initial.find(item => item.id === id)?.secret_store,
+        secret_fields: nextSecretFields,
+        secret_store: inputSecretFields.length > 0
+          ? 'local_encrypted'
+          : current?.secret_store,
       };
       connections = connections.map(item => item.id === id ? connection : item);
       return connection;
@@ -56,7 +63,8 @@ describe('CloudConnectionsPanel', () => {
     const client = makeClient();
     render(<CloudConnectionsPanel client={client} />);
 
-    expect(screen.getByText(/Secrets are encrypted and stored locally on this machine/)).toBeInTheDocument();
+    expect(screen.getByText(/No secrets are stored for this connection yet/)).toBeInTheDocument();
+    expect(screen.queryByText(/Secrets are encrypted and stored locally on this machine/)).not.toBeInTheDocument();
     expect(screen.getByText('No stored secrets')).toBeInTheDocument();
     await screen.findByText('0 connections');
   });
@@ -151,6 +159,30 @@ describe('CloudConnectionsPanel', () => {
     await waitFor(() => {
       expect(screen.getByText('prod-admin')).toBeInTheDocument();
     });
+  });
+
+  it('preserves current secret storage metadata when updating a created connection', async () => {
+    const client = makeClient();
+    render(<CloudConnectionsPanel client={client} />);
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'break-glass' } });
+    fireEvent.change(screen.getByLabelText('Auth'), { target: { value: 'aws_static' } });
+    fireEvent.change(screen.getByLabelText('Access key ID'), { target: { value: 'AKIAEXAMPLE' } });
+    fireEvent.change(screen.getByLabelText('Secret access key'), { target: { value: 'secret-value' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save connection' }));
+
+    await screen.findByText('break-glass');
+    expect(screen.getAllByText('Local encrypted').length).toBeGreaterThanOrEqual(1);
+
+    fireEvent.click(screen.getByText('break-glass'));
+    fireEvent.change(screen.getByLabelText('Region'), { target: { value: 'us-west-2' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Update connection' }));
+
+    await waitFor(() => {
+      expect(client.updateCloudConnection).toHaveBeenCalled();
+    });
+    await screen.findByText('aws_static / us-west-2');
+    expect(screen.getAllByText('Local encrypted').length).toBeGreaterThanOrEqual(1);
   });
 
   it('does not render stored secret values when editing', async () => {

--- a/web/src/components/CloudConnections/CloudConnectionsPanel.tsx
+++ b/web/src/components/CloudConnections/CloudConnectionsPanel.tsx
@@ -6,6 +6,7 @@ import {
   type CloudAuthMethod,
   type CloudConnection,
   type CloudConnectionInput,
+  type CloudSecretStore,
   type CloudConnectionTestResult,
   type CloudProvider,
 } from '../../api';
@@ -88,6 +89,54 @@ const defaultInput = (): CloudConnectionInput => ({
   secrets: {},
 });
 
+const secretStoreLabels: Record<string, string> = {
+  local_encrypted: 'Local encrypted',
+  os_keychain: 'OS keychain',
+  vault: 'Vault',
+  aws_secrets_manager: 'AWS Secrets Manager',
+  aws_ssm_parameter_store: 'AWS SSM Parameter Store',
+  azure_key_vault: 'Azure Key Vault',
+  gcp_secret_manager: 'GCP Secret Manager',
+};
+
+function secretStoreLabel(store?: CloudSecretStore) {
+  const value = store?.trim();
+  if (!value) return 'No stored secrets';
+  return (
+    secretStoreLabels[value]
+    || value
+      .split(/[_-]+/)
+      .filter(Boolean)
+      .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(' ')
+  );
+}
+
+function secretStoreBadgeClass(store?: CloudSecretStore) {
+  const value = store?.trim();
+  if (!value) return 'border-border bg-muted/30 text-muted-foreground';
+  if (value === 'local_encrypted') return 'border-amber-500/40 bg-amber-500/10 text-amber-100';
+  return 'border-primary/40 bg-primary/10 text-primary';
+}
+
+function SecretStoreBadge({ store }: { store?: CloudSecretStore }) {
+  const label = secretStoreLabel(store);
+  return (
+    <span
+      className={`max-w-44 shrink-0 truncate rounded border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider ${secretStoreBadgeClass(store)}`}
+      title={label}
+    >
+      {label}
+    </span>
+  );
+}
+
+function connectionSecretStore(
+  connection?: Pick<CloudConnection, 'secret_fields' | 'secret_store'>,
+): CloudSecretStore | undefined {
+  return connection?.secret_store || (connection?.secret_fields?.length ? 'local_encrypted' : undefined);
+}
+
 function splitFields(input: CloudConnectionInput) {
   const metadata: Record<string, string> = {};
   const secrets: Record<string, string> = {};
@@ -130,6 +179,8 @@ export function CloudConnectionsPanel({
     () => connections.find(connection => connection.id === form.id),
     [connections, form.id],
   );
+  const formSecretStore = connectionSecretStore(selected)
+    || (Object.keys(form.secrets || {}).length > 0 ? 'local_encrypted' : undefined);
 
   const load = async () => {
     setLoading(true);
@@ -238,8 +289,11 @@ export function CloudConnectionsPanel({
       )}
 
       <section className="grid gap-2">
-        <div className="rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-100">
-          Secrets are encrypted and stored locally on this machine in the IaC Studio projects directory. Use scoped, revocable credentials.
+        <div className="flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-100">
+          <span className="min-w-0 flex-1">
+            Secrets are encrypted and stored locally on this machine in the IaC Studio projects directory. Use scoped, revocable credentials.
+          </span>
+          <SecretStoreBadge store={formSecretStore} />
         </div>
 
         <label className="grid gap-1 text-xs text-muted-foreground">
@@ -351,8 +405,11 @@ export function CloudConnectionsPanel({
                 <span className="min-w-0 flex-1 truncate text-sm font-semibold text-foreground">{connection.name}</span>
                 <span className="rounded bg-primary/10 px-2 py-0.5 font-mono text-[10px] uppercase text-primary">{connection.provider}</span>
               </button>
-              <div className="mb-3 font-mono text-[11px] text-muted-foreground">
-                {connection.auth_method}{connection.region ? ` / ${connection.region}` : ''}
+              <div className="mb-3 flex items-center gap-2">
+                <div className="min-w-0 flex-1 truncate font-mono text-[11px] text-muted-foreground">
+                  {connection.auth_method}{connection.region ? ` / ${connection.region}` : ''}
+                </div>
+                <SecretStoreBadge store={connectionSecretStore(connection)} />
               </div>
               <div className="flex gap-2">
                 <Button

--- a/web/src/components/CloudConnections/CloudConnectionsPanel.tsx
+++ b/web/src/components/CloudConnections/CloudConnectionsPanel.tsx
@@ -89,21 +89,21 @@ const defaultInput = (): CloudConnectionInput => ({
   secrets: {},
 });
 
-const secretStoreLabels: Record<string, string> = {
-  local_encrypted: 'Local encrypted',
-  os_keychain: 'OS keychain',
-  vault: 'Vault',
-  aws_secrets_manager: 'AWS Secrets Manager',
-  aws_ssm_parameter_store: 'AWS SSM Parameter Store',
-  azure_key_vault: 'Azure Key Vault',
-  gcp_secret_manager: 'GCP Secret Manager',
-};
+const secretStoreLabels = new Map<string, string>([
+  ['local_encrypted', 'Local encrypted'],
+  ['os_keychain', 'OS keychain'],
+  ['vault', 'Vault'],
+  ['aws_secrets_manager', 'AWS Secrets Manager'],
+  ['aws_ssm_parameter_store', 'AWS SSM Parameter Store'],
+  ['azure_key_vault', 'Azure Key Vault'],
+  ['gcp_secret_manager', 'GCP Secret Manager'],
+]);
 
 function secretStoreLabel(store?: CloudSecretStore) {
   const value = store?.trim();
   if (!value) return 'No stored secrets';
   return (
-    secretStoreLabels[value]
+    secretStoreLabels.get(value)
     || value
       .split(/[_-]+/)
       .filter(Boolean)
@@ -146,6 +146,10 @@ function connectionSecretStore(
   connection?: Pick<CloudConnection, 'secret_fields' | 'secret_store'>,
 ): CloudSecretStore | undefined {
   return connection?.secret_store || (connection?.secret_fields?.length ? 'local_encrypted' : undefined);
+}
+
+function hasDraftSecretValues(secrets?: Record<string, string>) {
+  return Object.values(secrets || {}).some(value => value?.trim());
 }
 
 function splitFields(input: CloudConnectionInput) {
@@ -191,7 +195,7 @@ export function CloudConnectionsPanel({
     [connections, form.id],
   );
   const formSecretStore = connectionSecretStore(selected)
-    || (Object.keys(form.secrets || {}).length > 0 ? 'local_encrypted' : undefined);
+    || (hasDraftSecretValues(form.secrets) ? 'local_encrypted' : undefined);
 
   const load = async () => {
     setLoading(true);

--- a/web/src/components/CloudConnections/CloudConnectionsPanel.tsx
+++ b/web/src/components/CloudConnections/CloudConnectionsPanel.tsx
@@ -121,7 +121,10 @@ function secretStoreBadgeClass(store?: CloudSecretStore) {
 
 function secretStoreMessage(store?: CloudSecretStore) {
   const value = store?.trim();
-  if (!value || value === 'local_encrypted') {
+  if (!value) {
+    return 'No secrets are stored for this connection yet. Add only scoped, revocable credentials when an auth method requires them.';
+  }
+  if (value === 'local_encrypted') {
     return 'Secrets are encrypted and stored locally on this machine in the IaC Studio projects directory. Use scoped, revocable credentials.';
   }
   return 'Secrets are stored using this connection’s configured secret store. Use scoped, revocable credentials.';

--- a/web/src/components/CloudConnections/CloudConnectionsPanel.tsx
+++ b/web/src/components/CloudConnections/CloudConnectionsPanel.tsx
@@ -119,6 +119,14 @@ function secretStoreBadgeClass(store?: CloudSecretStore) {
   return 'border-primary/40 bg-primary/10 text-primary';
 }
 
+function secretStoreMessage(store?: CloudSecretStore) {
+  const value = store?.trim();
+  if (!value || value === 'local_encrypted') {
+    return 'Secrets are encrypted and stored locally on this machine in the IaC Studio projects directory. Use scoped, revocable credentials.';
+  }
+  return 'Secrets are stored using this connection’s configured secret store. Use scoped, revocable credentials.';
+}
+
 function SecretStoreBadge({ store }: { store?: CloudSecretStore }) {
   const label = secretStoreLabel(store);
   return (
@@ -289,11 +297,13 @@ export function CloudConnectionsPanel({
       )}
 
       <section className="grid gap-2">
-        <div className="flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-100">
+        <div className="flex flex-col gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-100 sm:flex-row sm:items-start">
           <span className="min-w-0 flex-1">
-            Secrets are encrypted and stored locally on this machine in the IaC Studio projects directory. Use scoped, revocable credentials.
+            {secretStoreMessage(formSecretStore)}
           </span>
-          <SecretStoreBadge store={formSecretStore} />
+          <div className="self-start">
+            <SecretStoreBadge store={formSecretStore} />
+          </div>
         </div>
 
         <label className="grid gap-1 text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary
- add Cloud Connections secret store labels for local encrypted, OS keychain, Vault, AWS Secrets Manager, AWS SSM Parameter Store, Azure Key Vault, and GCP Secret Manager
- show secret storage badges on saved connection cards and the form warning
- keep unknown future stores forward-compatible by humanizing their identifiers
- fall back to local encrypted for legacy saved connections that have secret fields but no explicit secret_store

## Tests
- npm test -- --run src/components/CloudConnections/CloudConnectionsPanel.test.tsx
- npm test -- --run
- npm run build

Closes #98
Part of #91