### PR TITLE
Add Cloud Connections secret store registry

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1577,7 +1577,7 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 		var connectionSummary cloudconnections.PublicConnection
 		if req.ConnectionID != "" {
 			scopedConnection = true
-			connection, connErr := cloudConnections.Get(req.ConnectionID)
+			connection, connErr := cloudConnections.GetForUse(req.ConnectionID)
 			if connErr != nil {
 				if errors.Is(connErr, os.ErrNotExist) {
 					http.Error(w, "connection not found", 404)

--- a/internal/cloudconnections/connections.go
+++ b/internal/cloudconnections/connections.go
@@ -208,20 +208,7 @@ func (m *Manager) List() ([]PublicConnection, error) {
 }
 
 func (m *Manager) Get(id string) (*Connection, error) {
-	connections, err := m.loadForUse()
-	if err != nil {
-		return nil, err
-	}
-	for _, connection := range connections {
-		if connection.ID == id {
-			connectionCopy := connection
-			connectionCopy.Metadata = cloneMap(connection.Metadata)
-			connectionCopy.Secrets = cloneMap(connection.Secrets)
-			connectionCopy.SecretRefs = cloneMap(connection.SecretRefs)
-			return &connectionCopy, nil
-		}
-	}
-	return nil, os.ErrNotExist
+	return m.loadOneForUse(id)
 }
 
 func (m *Manager) Save(input Connection) (PublicConnection, error) {
@@ -255,6 +242,7 @@ func (m *Manager) Save(input Connection) (PublicConnection, error) {
 	input.UpdatedAt = now
 	input.Metadata = publicMetadata(input.AuthMethod, input.Metadata)
 	input.Secrets = secretMetadata(input.AuthMethod, input.Secrets)
+	input.SecretRefs = secretRefsMetadata(input.AuthMethod, input.SecretRefs)
 	applySecretReferenceDefaults(&input)
 
 	replaced := false
@@ -352,31 +340,43 @@ func (m *Manager) load() ([]Connection, error) {
 	return connections, nil
 }
 
-func (m *Manager) loadForUse() ([]Connection, error) {
+func (m *Manager) loadOneForUse(id string) (*Connection, error) {
 	m.mu.RLock()
-	connections, needsMigration, err := m.loadUnlockedWithMigrationFlag(true)
+	connections, index, needsMigration, err := m.loadOneUnlockedWithMigrationFlag(id, true)
 	m.mu.RUnlock()
 	if err != nil {
 		return nil, err
 	}
+	if index < 0 {
+		return nil, os.ErrNotExist
+	}
 	if !needsMigration {
-		return connections, nil
+		return cloneConnection(connections[index]), nil
 	}
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	connections, needsMigration, err = m.loadUnlockedWithMigrationFlag(true)
+	connections, index, needsMigration, err = m.loadOneUnlockedWithMigrationFlag(id, true)
 	if err != nil {
 		return nil, err
 	}
+	if index < 0 {
+		return nil, os.ErrNotExist
+	}
 	if !needsMigration {
-		return connections, nil
+		return cloneConnection(connections[index]), nil
 	}
 	if err := m.saveUnlocked(connections); err != nil {
 		return nil, err
 	}
-	connections, _, err = m.loadUnlockedWithMigrationFlag(true)
-	return connections, err
+	connections, index, _, err = m.loadOneUnlockedWithMigrationFlag(id, true)
+	if err != nil {
+		return nil, err
+	}
+	if index < 0 {
+		return nil, os.ErrNotExist
+	}
+	return cloneConnection(connections[index]), nil
 }
 
 func (m *Manager) loadUnlocked() ([]Connection, error) {
@@ -397,6 +397,27 @@ func (m *Manager) loadUnlockedWithMigrationFlag(resolveSecretRefs bool) ([]Conne
 		needsMigration = true
 	}
 	return connections, needsMigration, nil
+}
+
+func (m *Manager) loadOneUnlockedWithMigrationFlag(id string, resolveSecretRefs bool) ([]Connection, int, bool, error) {
+	connections, err := m.readConnectionsUnlocked()
+	if err != nil {
+		return nil, -1, false, err
+	}
+	for index := range connections {
+		if connections[index].ID != id {
+			continue
+		}
+		needsMigration, err := m.loadConnectionSecrets(connections[index:index+1], resolveSecretRefs)
+		if err != nil {
+			return nil, -1, false, err
+		}
+		if applySecretReferenceDefaults(&connections[index]) {
+			needsMigration = true
+		}
+		return connections, index, needsMigration, nil
+	}
+	return connections, -1, false, nil
 }
 
 func (m *Manager) readConnectionsUnlocked() ([]Connection, error) {
@@ -457,7 +478,7 @@ func (m *Manager) storeConnectionSecrets(connections []Connection) ([]Connection
 			return nil, err
 		}
 		next.Secrets = stored.Values
-		next.SecretRefs = stored.Refs
+		next.SecretRefs = secretRefsMetadata(next.AuthMethod, mergeSecretRefs(next.SecretRefs, stored.Refs))
 		if len(next.Secrets) > 0 || len(next.SecretRefs) > 0 {
 			next.SecretStore = store.Kind()
 		}
@@ -830,6 +851,14 @@ func publicConnection(connection Connection) PublicConnection {
 	}
 }
 
+func cloneConnection(connection Connection) *Connection {
+	connectionCopy := connection
+	connectionCopy.Metadata = cloneMap(connection.Metadata)
+	connectionCopy.Secrets = cloneMap(connection.Secrets)
+	connectionCopy.SecretRefs = cloneMap(connection.SecretRefs)
+	return &connectionCopy
+}
+
 func applySecretReferenceDefaultsToAll(connections []Connection) bool {
 	changed := false
 	for index := range connections {
@@ -845,10 +874,10 @@ func preserveExistingExternalSecretRefs(input *Connection, existing Connection) 
 	if secretStore == "" || secretStore == SecretStoreLocalEncrypted {
 		return
 	}
-	if input.SecretStore != "" || len(input.SecretRefs) != 0 || len(input.Secrets) != 0 {
+	if input.SecretStore != "" && input.SecretStore != secretStore {
 		return
 	}
-	secretRefs := trimMap(existing.SecretRefs)
+	secretRefs := secretRefsMetadata(input.AuthMethod, mergeSecretRefs(existing.SecretRefs, input.SecretRefs))
 	if len(secretRefs) == 0 {
 		return
 	}
@@ -936,6 +965,19 @@ func secretMetadata(authMethod string, secrets map[string]string) map[string]str
 	return out
 }
 
+func secretRefsMetadata(authMethod string, refs map[string]string) map[string]string {
+	out := map[string]string{}
+	for _, key := range secretFieldsByMethod[authMethod] {
+		if value := strings.TrimSpace(refs[key]); value != "" {
+			out[key] = value
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
 func presentSecretFields(authMethod string, secrets, secretRefs map[string]string) []string {
 	out := []string{}
 	for _, key := range secretFieldsByMethod[authMethod] {
@@ -950,6 +992,22 @@ func mergeSecrets(existing, submitted map[string]string) map[string]string {
 	out := cloneMap(existing)
 	for key, value := range submitted {
 		if value = strings.TrimSpace(value); value != "" && !isMasked(value) {
+			if out == nil {
+				out = map[string]string{}
+			}
+			out[key] = value
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func mergeSecretRefs(existing, submitted map[string]string) map[string]string {
+	out := cloneMap(existing)
+	for key, value := range submitted {
+		if value = strings.TrimSpace(value); value != "" {
 			if out == nil {
 				out = map[string]string{}
 			}

--- a/internal/cloudconnections/connections.go
+++ b/internal/cloudconnections/connections.go
@@ -109,10 +109,11 @@ type Check struct {
 }
 
 type Manager struct {
-	path         string
-	keyPath      string
-	secretStores map[string]SecretStore
-	mu           sync.RWMutex
+	path           string
+	keyPath        string
+	secretStores   map[string]SecretStore
+	secretStoresMu sync.RWMutex
+	mu             sync.RWMutex
 }
 
 func NewManager(projectsDir string, opts ...Option) *Manager {
@@ -278,7 +279,7 @@ func (m *Manager) Delete(id string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	connections, err := m.loadUnlocked()
+	connections, err := m.readConnectionsUnlocked()
 	if err != nil {
 		return err
 	}
@@ -287,6 +288,9 @@ func (m *Manager) Delete(id string) error {
 	for _, connection := range connections {
 		if connection.ID == id {
 			found = true
+			if err := m.deleteConnectionSecrets(connection); err != nil {
+				return err
+			}
 			continue
 		}
 		next = append(next, connection)
@@ -381,16 +385,9 @@ func (m *Manager) loadUnlocked() ([]Connection, error) {
 }
 
 func (m *Manager) loadUnlockedWithMigrationFlag(resolveSecretRefs bool) ([]Connection, bool, error) {
-	data, err := os.ReadFile(m.path)
+	connections, err := m.readConnectionsUnlocked()
 	if err != nil {
-		if os.IsNotExist(err) {
-			return []Connection{}, false, nil
-		}
-		return nil, false, fmt.Errorf("read cloud connections: %w", err)
-	}
-	var connections []Connection
-	if err := json.Unmarshal(data, &connections); err != nil {
-		return nil, false, fmt.Errorf("parse cloud connections: %w", err)
+		return nil, false, err
 	}
 	needsMigration, err := m.loadConnectionSecrets(connections, resolveSecretRefs)
 	if err != nil {
@@ -400,6 +397,21 @@ func (m *Manager) loadUnlockedWithMigrationFlag(resolveSecretRefs bool) ([]Conne
 		needsMigration = true
 	}
 	return connections, needsMigration, nil
+}
+
+func (m *Manager) readConnectionsUnlocked() ([]Connection, error) {
+	data, err := os.ReadFile(m.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []Connection{}, nil
+		}
+		return nil, fmt.Errorf("read cloud connections: %w", err)
+	}
+	var connections []Connection
+	if err := json.Unmarshal(data, &connections); err != nil {
+		return nil, fmt.Errorf("parse cloud connections: %w", err)
+	}
+	return connections, nil
 }
 
 func (m *Manager) saveUnlocked(connections []Connection) error {
@@ -483,6 +495,24 @@ func (m *Manager) loadConnectionSecrets(connections []Connection, resolveSecretR
 		}
 	}
 	return needsMigration, nil
+}
+
+func (m *Manager) deleteConnectionSecrets(connection Connection) error {
+	connection.SecretStore = strings.TrimSpace(connection.SecretStore)
+	store, ok := m.secretStoreFor(connection.SecretStore)
+	if !ok {
+		if hasNonEmptySecrets(connection.Secrets) {
+			return fmt.Errorf("connection %s uses unsupported secret store %q with local secret values", connectionLabel(connection), connection.SecretStore)
+		}
+		return nil
+	}
+	if len(connection.Secrets) == 0 && len(connection.SecretRefs) == 0 {
+		return nil
+	}
+	return store.Delete(context.Background(), secretScope(connection), StoredSecrets{
+		Values: cloneMap(connection.Secrets),
+		Refs:   cloneMap(connection.SecretRefs),
+	})
 }
 
 func secretScope(connection Connection) SecretScope {

--- a/internal/cloudconnections/connections.go
+++ b/internal/cloudconnections/connections.go
@@ -361,16 +361,18 @@ func (m *Manager) loadForUse() ([]Connection, error) {
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	migrationConnections, needsMigration, err := m.loadUnlockedWithMigrationFlag(false)
+	connections, needsMigration, err = m.loadUnlockedWithMigrationFlag(true)
 	if err != nil {
 		return nil, err
 	}
-	if needsMigration {
-		if err := m.saveUnlocked(migrationConnections); err != nil {
-			return nil, err
-		}
+	if !needsMigration {
+		return connections, nil
 	}
-	return connections, nil
+	if err := m.saveUnlocked(connections); err != nil {
+		return nil, err
+	}
+	connections, _, err = m.loadUnlockedWithMigrationFlag(true)
+	return connections, err
 }
 
 func (m *Manager) loadUnlocked() ([]Connection, error) {

--- a/internal/cloudconnections/connections.go
+++ b/internal/cloudconnections/connections.go
@@ -207,8 +207,18 @@ func (m *Manager) List() ([]PublicConnection, error) {
 	return out, nil
 }
 
+// Get returns a saved connection without resolving external secret refs. This
+// is safe for metadata/existence checks because registered stores are not
+// contacted just to resolve refs; persisted local values can still be loaded
+// when a record needs migration.
 func (m *Manager) Get(id string) (*Connection, error) {
-	return m.loadOneForUse(id)
+	return m.loadOne(id, false)
+}
+
+// GetForUse returns a saved connection with registered external secret refs
+// resolved for command execution, readiness checks, and MCP runner workflows.
+func (m *Manager) GetForUse(id string) (*Connection, error) {
+	return m.loadOne(id, true)
 }
 
 func (m *Manager) Save(input Connection) (PublicConnection, error) {
@@ -290,7 +300,7 @@ func (m *Manager) Delete(id string) error {
 }
 
 func (m *Manager) Test(id string) (TestResult, error) {
-	connection, err := m.Get(id)
+	connection, err := m.GetForUse(id)
 	if err != nil {
 		return TestResult{}, err
 	}
@@ -340,9 +350,9 @@ func (m *Manager) load() ([]Connection, error) {
 	return connections, nil
 }
 
-func (m *Manager) loadOneForUse(id string) (*Connection, error) {
+func (m *Manager) loadOne(id string, resolveSecretRefs bool) (*Connection, error) {
 	m.mu.RLock()
-	connections, index, needsMigration, err := m.loadOneUnlockedWithMigrationFlag(id, true)
+	connections, index, needsMigration, err := m.loadOneUnlockedWithMigrationFlag(id, resolveSecretRefs)
 	m.mu.RUnlock()
 	if err != nil {
 		return nil, err
@@ -356,7 +366,7 @@ func (m *Manager) loadOneForUse(id string) (*Connection, error) {
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	connections, index, needsMigration, err = m.loadOneUnlockedWithMigrationFlag(id, true)
+	connections, index, needsMigration, err = m.loadOneUnlockedWithMigrationFlag(id, resolveSecretRefs)
 	if err != nil {
 		return nil, err
 	}
@@ -366,10 +376,10 @@ func (m *Manager) loadOneForUse(id string) (*Connection, error) {
 	if !needsMigration {
 		return cloneConnection(connections[index]), nil
 	}
-	if err := m.saveUnlocked(connections); err != nil {
+	if err := m.saveOneUnlocked(connections, index); err != nil {
 		return nil, err
 	}
-	connections, index, _, err = m.loadOneUnlockedWithMigrationFlag(id, true)
+	connections, index, _, err = m.loadOneUnlockedWithMigrationFlag(id, resolveSecretRefs)
 	if err != nil {
 		return nil, err
 	}
@@ -443,6 +453,26 @@ func (m *Manager) saveUnlocked(connections []Connection) error {
 	if err != nil {
 		return err
 	}
+	return m.writeConnectionsUnlocked(persisted)
+}
+
+func (m *Manager) saveOneUnlocked(connections []Connection, index int) error {
+	if index < 0 || index >= len(connections) {
+		return os.ErrNotExist
+	}
+	if err := os.MkdirAll(filepath.Dir(m.path), 0o755); err != nil {
+		return fmt.Errorf("create cloud connections directory: %w", err)
+	}
+	persistedOne, err := m.storeConnectionSecrets([]Connection{connections[index]})
+	if err != nil {
+		return err
+	}
+	persisted := slices.Clone(connections)
+	persisted[index] = persistedOne[0]
+	return m.writeConnectionsUnlocked(persisted)
+}
+
+func (m *Manager) writeConnectionsUnlocked(persisted []Connection) error {
 	data, err := json.MarshalIndent(persisted, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal cloud connections: %w", err)
@@ -511,7 +541,7 @@ func (m *Manager) loadConnectionSecrets(connections []Connection, resolveSecretR
 			return false, err
 		}
 		connections[index].Secrets = loaded.Values
-		if loaded.NeedsMigration {
+		if loaded.NeedsMigration && hasNonEmptySecrets(loaded.Values) {
 			needsMigration = true
 		}
 	}
@@ -524,6 +554,9 @@ func (m *Manager) deleteConnectionSecrets(connection Connection) error {
 	if !ok {
 		if hasNonEmptySecrets(connection.Secrets) {
 			return fmt.Errorf("connection %s uses unsupported secret store %q with local secret values", connectionLabel(connection), connection.SecretStore)
+		}
+		if hasNonEmptySecrets(connection.SecretRefs) {
+			return fmt.Errorf("connection %s uses unsupported secret store %q with external secret refs; register the store before deleting", connectionLabel(connection), connection.SecretStore)
 		}
 		return nil
 	}
@@ -1023,6 +1056,15 @@ func mergeSecretRefs(existing, submitted map[string]string) map[string]string {
 func hasNonEmptySecrets(secrets map[string]string) bool {
 	for _, value := range secrets {
 		if strings.TrimSpace(value) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func hasNonEmptyUnmaskedSecrets(secrets map[string]string) bool {
+	for _, value := range secrets {
+		if value = strings.TrimSpace(value); value != "" && !isMasked(value) {
 			return true
 		}
 	}

--- a/internal/cloudconnections/connections.go
+++ b/internal/cloudconnections/connections.go
@@ -109,16 +109,25 @@ type Check struct {
 }
 
 type Manager struct {
-	path    string
-	keyPath string
-	mu      sync.RWMutex
+	path         string
+	keyPath      string
+	secretStores map[string]SecretStore
+	mu           sync.RWMutex
 }
 
-func NewManager(projectsDir string) *Manager {
-	return &Manager{
-		path:    filepath.Join(projectsDir, connectionsFileName),
-		keyPath: filepath.Join(projectsDir, connectionsKeyFileName),
+func NewManager(projectsDir string, opts ...Option) *Manager {
+	manager := &Manager{
+		path:         filepath.Join(projectsDir, connectionsFileName),
+		keyPath:      filepath.Join(projectsDir, connectionsKeyFileName),
+		secretStores: map[string]SecretStore{},
 	}
+	manager.registerSecretStore(newLocalEncryptedSecretStore(manager.encryptionKeyForEncrypt, manager.encryptionKeyForDecrypt))
+	for _, opt := range opts {
+		if opt != nil {
+			opt(manager)
+		}
+	}
+	return manager
 }
 
 func SupportedAuthMethods(provider string) []string {
@@ -198,7 +207,7 @@ func (m *Manager) List() ([]PublicConnection, error) {
 }
 
 func (m *Manager) Get(id string) (*Connection, error) {
-	connections, err := m.load()
+	connections, err := m.loadForUse()
 	if err != nil {
 		return nil, err
 	}
@@ -215,7 +224,7 @@ func (m *Manager) Get(id string) (*Connection, error) {
 }
 
 func (m *Manager) Save(input Connection) (PublicConnection, error) {
-	if err := normalizeAndValidate(&input); err != nil {
+	if err := m.normalizeAndValidate(&input); err != nil {
 		return PublicConnection{}, err
 	}
 
@@ -315,7 +324,7 @@ func (m *Manager) Test(id string) (TestResult, error) {
 
 func (m *Manager) load() ([]Connection, error) {
 	m.mu.RLock()
-	connections, needsMigration, err := m.loadUnlockedWithMigrationFlag()
+	connections, needsMigration, err := m.loadUnlockedWithMigrationFlag(false)
 	m.mu.RUnlock()
 	if err != nil {
 		return nil, err
@@ -326,7 +335,7 @@ func (m *Manager) load() ([]Connection, error) {
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	connections, needsMigration, err = m.loadUnlockedWithMigrationFlag()
+	connections, needsMigration, err = m.loadUnlockedWithMigrationFlag(false)
 	if err != nil {
 		return nil, err
 	}
@@ -339,12 +348,37 @@ func (m *Manager) load() ([]Connection, error) {
 	return connections, nil
 }
 
+func (m *Manager) loadForUse() ([]Connection, error) {
+	m.mu.RLock()
+	connections, needsMigration, err := m.loadUnlockedWithMigrationFlag(true)
+	m.mu.RUnlock()
+	if err != nil {
+		return nil, err
+	}
+	if !needsMigration {
+		return connections, nil
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	migrationConnections, needsMigration, err := m.loadUnlockedWithMigrationFlag(false)
+	if err != nil {
+		return nil, err
+	}
+	if needsMigration {
+		if err := m.saveUnlocked(migrationConnections); err != nil {
+			return nil, err
+		}
+	}
+	return connections, nil
+}
+
 func (m *Manager) loadUnlocked() ([]Connection, error) {
-	connections, _, err := m.loadUnlockedWithMigrationFlag()
+	connections, _, err := m.loadUnlockedWithMigrationFlag(false)
 	return connections, err
 }
 
-func (m *Manager) loadUnlockedWithMigrationFlag() ([]Connection, bool, error) {
+func (m *Manager) loadUnlockedWithMigrationFlag(resolveSecretRefs bool) ([]Connection, bool, error) {
 	data, err := os.ReadFile(m.path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -356,7 +390,7 @@ func (m *Manager) loadUnlockedWithMigrationFlag() ([]Connection, bool, error) {
 	if err := json.Unmarshal(data, &connections); err != nil {
 		return nil, false, fmt.Errorf("parse cloud connections: %w", err)
 	}
-	needsMigration, err := m.loadConnectionSecrets(connections)
+	needsMigration, err := m.loadConnectionSecrets(connections, resolveSecretRefs)
 	if err != nil {
 		return nil, false, err
 	}
@@ -386,14 +420,14 @@ func (m *Manager) saveUnlocked(connections []Connection) error {
 
 func (m *Manager) storeConnectionSecrets(connections []Connection) ([]Connection, error) {
 	out := make([]Connection, 0, len(connections))
-	store := m.localSecretStore()
 	for _, connection := range connections {
 		next := connection
 		next.Metadata = cloneMap(connection.Metadata)
 		next.Secrets = cloneMap(connection.Secrets)
 		next.SecretRefs = cloneMap(connection.SecretRefs)
 		next.SecretStore = strings.TrimSpace(next.SecretStore)
-		if next.SecretStore != "" && next.SecretStore != store.Kind() {
+		store, ok := m.secretStoreFor(next.SecretStore)
+		if !ok {
 			if hasNonEmptySecrets(next.Secrets) {
 				return nil, fmt.Errorf("connection %s uses unsupported secret store %q with local secret values", connectionLabel(next), next.SecretStore)
 			}
@@ -410,7 +444,7 @@ func (m *Manager) storeConnectionSecrets(connections []Connection) ([]Connection
 		}
 		next.Secrets = stored.Values
 		next.SecretRefs = stored.Refs
-		if len(next.Secrets) > 0 {
+		if len(next.Secrets) > 0 || len(next.SecretRefs) > 0 {
 			next.SecretStore = store.Kind()
 		}
 		out = append(out, next)
@@ -418,18 +452,20 @@ func (m *Manager) storeConnectionSecrets(connections []Connection) ([]Connection
 	return out, nil
 }
 
-func (m *Manager) loadConnectionSecrets(connections []Connection) (bool, error) {
+func (m *Manager) loadConnectionSecrets(connections []Connection, resolveSecretRefs bool) (bool, error) {
 	needsMigration := false
-	store := m.localSecretStore()
 	for index := range connections {
 		connections[index].SecretStore = strings.TrimSpace(connections[index].SecretStore)
-		if connections[index].SecretStore != "" && connections[index].SecretStore != store.Kind() {
+		store, ok := m.secretStoreFor(connections[index].SecretStore)
+		if !ok {
 			if hasNonEmptySecrets(connections[index].Secrets) {
 				return false, fmt.Errorf("connection %s uses unsupported secret store %q with local secret values", connectionLabel(connections[index]), connections[index].SecretStore)
 			}
 			continue
 		}
-		if len(connections[index].Secrets) == 0 {
+		hasStoredValues := len(connections[index].Secrets) > 0
+		hasResolvableRefs := resolveSecretRefs && store.Kind() != SecretStoreLocalEncrypted && len(connections[index].SecretRefs) > 0
+		if !hasStoredValues && !hasResolvableRefs {
 			continue
 		}
 		loaded, err := store.Load(context.Background(), secretScope(connections[index]), StoredSecrets{
@@ -445,10 +481,6 @@ func (m *Manager) loadConnectionSecrets(connections []Connection) (bool, error) 
 		}
 	}
 	return needsMigration, nil
-}
-
-func (m *Manager) localSecretStore() SecretStore {
-	return newLocalEncryptedSecretStore(m.encryptionKeyForEncrypt, m.encryptionKeyForDecrypt)
 }
 
 func secretScope(connection Connection) SecretScope {
@@ -723,7 +755,7 @@ func syncDirBestEffort(dir string) {
 	_ = handle.Sync()
 }
 
-func normalizeAndValidate(connection *Connection) error {
+func normalizeConnectionFields(connection *Connection) error {
 	connection.ID = strings.TrimSpace(connection.ID)
 	connection.Name = strings.TrimSpace(connection.Name)
 	connection.Provider = strings.TrimSpace(connection.Provider)
@@ -744,9 +776,6 @@ func normalizeAndValidate(connection *Connection) error {
 	connection.Metadata = trimMap(connection.Metadata)
 	connection.Secrets = trimMap(connection.Secrets)
 	connection.SecretRefs = trimMap(connection.SecretRefs)
-	if connection.SecretStore != "" && connection.SecretStore != SecretStoreLocalEncrypted {
-		return fmt.Errorf("unsupported secret store %q", connection.SecretStore)
-	}
 	return nil
 }
 

--- a/internal/cloudconnections/connections_test.go
+++ b/internal/cloudconnections/connections_test.go
@@ -1,6 +1,7 @@
 package cloudconnections
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"slices"
@@ -9,6 +10,53 @@ import (
 	"testing"
 	"time"
 )
+
+type fakeSecretStore struct {
+	kind   string
+	values map[string]string
+	saves  []StoredSecrets
+	loads  []StoredSecrets
+}
+
+func (s *fakeSecretStore) Kind() string {
+	return s.kind
+}
+
+func (s *fakeSecretStore) Save(_ context.Context, scope SecretScope, secrets map[string]string) (StoredSecrets, error) {
+	refs := map[string]string{}
+	for key, value := range secrets {
+		if strings.TrimSpace(value) == "" {
+			continue
+		}
+		ref := s.kind + "://connections/" + scope.ConnectionID + "/" + key
+		refs[key] = ref
+		if s.values == nil {
+			s.values = map[string]string{}
+		}
+		s.values[ref] = value
+	}
+	stored := StoredSecrets{Refs: refs}
+	s.saves = append(s.saves, stored)
+	return stored, nil
+}
+
+func (s *fakeSecretStore) Load(_ context.Context, _ SecretScope, stored StoredSecrets) (LoadedSecrets, error) {
+	s.loads = append(s.loads, stored)
+	values := map[string]string{}
+	for key, ref := range stored.Refs {
+		if value := s.values[ref]; strings.TrimSpace(value) != "" {
+			values[key] = value
+		}
+	}
+	if len(values) == 0 {
+		return LoadedSecrets{}, nil
+	}
+	return LoadedSecrets{Values: values}, nil
+}
+
+func (s *fakeSecretStore) Delete(context.Context, SecretScope, StoredSecrets) error {
+	return nil
+}
 
 func TestManagerRedactsStaticSecrets(t *testing.T) {
 	manager := NewManager(t.TempDir())
@@ -76,6 +124,112 @@ func TestManagerRedactsStaticSecrets(t *testing.T) {
 	}
 	if got := stored.SecretRefs["secret_access_key"]; got != "local://connections/"+created.ID+"/secret_access_key" {
 		t.Fatalf("stored secret ref should point at local encrypted store, got %q", got)
+	}
+}
+
+func TestManagerRegistersLocalEncryptedStoreByDefault(t *testing.T) {
+	manager := NewManager(t.TempDir())
+
+	stores := manager.SupportedSecretStores()
+	if len(stores) != 1 || stores[0] != SecretStoreLocalEncrypted {
+		t.Fatalf("default manager should only register local encrypted store, got %#v", stores)
+	}
+}
+
+func TestManagerSavesSecretsWithRegisteredStore(t *testing.T) {
+	store := &fakeSecretStore{kind: "vault"}
+	manager := NewManager(t.TempDir(), WithSecretStore(store))
+
+	created, err := manager.Save(Connection{
+		Name:        "external",
+		Provider:    ProviderAWS,
+		AuthMethod:  "aws_static",
+		Metadata:    map[string]string{"access_key_id": "AKIAEXAMPLE"},
+		Secrets:     map[string]string{"secret_access_key": "super-secret"},
+		SecretStore: "vault",
+	})
+	if err != nil {
+		t.Fatalf("Save with registered secret store: %v", err)
+	}
+	if got := created.SecretStore; got != "vault" {
+		t.Fatalf("public connection should report registered secret store, got %q", got)
+	}
+	if !slices.Contains(created.SecretFields, "secret_access_key") {
+		t.Fatalf("public connection should expose referenced secret field: %#v", created.SecretFields)
+	}
+	if len(store.saves) != 1 {
+		t.Fatalf("registered store should save secrets once, got %d calls", len(store.saves))
+	}
+
+	data, err := os.ReadFile(manager.path)
+	if err != nil {
+		t.Fatalf("read persisted external record: %v", err)
+	}
+	if contains(string(data), "super-secret") || contains(string(data), "local://connections/") {
+		t.Fatalf("registered external store should persist refs without local plaintext or local refs: %s", string(data))
+	}
+	if !contains(string(data), `"secret_store": "vault"`) || !contains(string(data), `vault://connections/`) {
+		t.Fatalf("registered external store should persist external refs: %s", string(data))
+	}
+
+	stored, err := manager.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get registered store connection: %v", err)
+	}
+	if got := stored.Secrets["secret_access_key"]; got != "super-secret" {
+		t.Fatalf("registered store should resolve secret for runner use, got %q", got)
+	}
+	if len(store.loads) == 0 {
+		t.Fatal("registered store should load referenced secrets")
+	}
+}
+
+func TestManagerLoadsSecretRefsWithRegisteredStore(t *testing.T) {
+	dir := t.TempDir()
+	ref := "vault://connections/conn_external/secret_access_key"
+	store := &fakeSecretStore{
+		kind:   "vault",
+		values: map[string]string{ref: "super-secret"},
+	}
+	manager := NewManager(dir, WithSecretStore(store))
+	record := `[{
+		"id":"conn_external",
+		"name":"external",
+		"provider":"aws",
+		"auth_method":"aws_static",
+		"metadata":{"access_key_id":"AKIAEXAMPLE"},
+		"secret_store":"vault",
+		"secret_refs":{"secret_access_key":"` + ref + `"},
+		"created_at":"2026-06-18T00:00:00Z",
+		"updated_at":"2026-06-18T00:00:00Z"
+	}]`
+	if err := os.WriteFile(manager.path, []byte(record), 0o600); err != nil {
+		t.Fatalf("write registered store record: %v", err)
+	}
+
+	listed, err := manager.List()
+	if err != nil {
+		t.Fatalf("List registered store record: %v", err)
+	}
+	if len(listed) != 1 || !slices.Contains(listed[0].SecretFields, "secret_access_key") {
+		t.Fatalf("List should expose referenced secret field without resolving the value: %#v", listed)
+	}
+	if len(store.loads) != 0 {
+		t.Fatalf("List should not resolve external secret refs, got %d loads", len(store.loads))
+	}
+
+	stored, err := manager.Get("conn_external")
+	if err != nil {
+		t.Fatalf("Get registered store record: %v", err)
+	}
+	if got := stored.Secrets["secret_access_key"]; got != "super-secret" {
+		t.Fatalf("registered store should resolve secret refs, got %q", got)
+	}
+	if len(store.loads) != 1 {
+		t.Fatalf("registered store should load refs once, got %d calls", len(store.loads))
+	}
+	if got := store.loads[0].Refs["secret_access_key"]; got != ref {
+		t.Fatalf("registered store should receive persisted ref, got %q", got)
 	}
 }
 

--- a/internal/cloudconnections/connections_test.go
+++ b/internal/cloudconnections/connections_test.go
@@ -43,15 +43,19 @@ func (s *fakeSecretStore) Save(_ context.Context, scope SecretScope, secrets map
 func (s *fakeSecretStore) Load(_ context.Context, _ SecretScope, stored StoredSecrets) (LoadedSecrets, error) {
 	s.loads = append(s.loads, stored)
 	values := map[string]string{}
+	needsMigration := false
 	for key, ref := range stored.Refs {
+		if strings.Contains(ref, "://legacy/") {
+			needsMigration = true
+		}
 		if value := s.values[ref]; strings.TrimSpace(value) != "" {
 			values[key] = value
 		}
 	}
 	if len(values) == 0 {
-		return LoadedSecrets{}, nil
+		return LoadedSecrets{NeedsMigration: needsMigration}, nil
 	}
-	return LoadedSecrets{Values: values}, nil
+	return LoadedSecrets{Values: values, NeedsMigration: needsMigration}, nil
 }
 
 func (s *fakeSecretStore) Delete(context.Context, SecretScope, StoredSecrets) error {
@@ -230,6 +234,56 @@ func TestManagerLoadsSecretRefsWithRegisteredStore(t *testing.T) {
 	}
 	if got := store.loads[0].Refs["secret_access_key"]; got != ref {
 		t.Fatalf("registered store should receive persisted ref, got %q", got)
+	}
+}
+
+func TestManagerMigratesRegisteredStoreRefsForUse(t *testing.T) {
+	dir := t.TempDir()
+	oldRef := "vault://legacy/conn_external/secret_access_key"
+	newRef := "vault://connections/conn_external/secret_access_key"
+	store := &fakeSecretStore{
+		kind:   "vault",
+		values: map[string]string{oldRef: "super-secret"},
+	}
+	manager := NewManager(dir, WithSecretStore(store))
+	record := `[{
+		"id":"conn_external",
+		"name":"external",
+		"provider":"aws",
+		"auth_method":"aws_static",
+		"metadata":{"access_key_id":"AKIAEXAMPLE"},
+		"secret_store":"vault",
+		"secret_refs":{"secret_access_key":"` + oldRef + `"},
+		"created_at":"2026-06-18T00:00:00Z",
+		"updated_at":"2026-06-18T00:00:00Z"
+	}]`
+	if err := os.WriteFile(manager.path, []byte(record), 0o600); err != nil {
+		t.Fatalf("write registered store record: %v", err)
+	}
+
+	stored, err := manager.Get("conn_external")
+	if err != nil {
+		t.Fatalf("Get registered store record: %v", err)
+	}
+	if got := stored.Secrets["secret_access_key"]; got != "super-secret" {
+		t.Fatalf("registered store should resolve migrated secret refs, got %q", got)
+	}
+	if got := stored.SecretRefs["secret_access_key"]; got != newRef {
+		t.Fatalf("registered store should return migrated ref, got %q", got)
+	}
+	if len(store.saves) != 1 {
+		t.Fatalf("registered store should save migrated refs once, got %d saves", len(store.saves))
+	}
+
+	data, err := os.ReadFile(manager.path)
+	if err != nil {
+		t.Fatalf("read migrated registered store record: %v", err)
+	}
+	if contains(string(data), "super-secret") {
+		t.Fatalf("registered store migration should not persist plaintext: %s", string(data))
+	}
+	if contains(string(data), oldRef) || !contains(string(data), newRef) {
+		t.Fatalf("registered store migration should replace old ref with new ref: %s", string(data))
 	}
 }
 

--- a/internal/cloudconnections/connections_test.go
+++ b/internal/cloudconnections/connections_test.go
@@ -12,10 +12,11 @@ import (
 )
 
 type fakeSecretStore struct {
-	kind   string
-	values map[string]string
-	saves  []StoredSecrets
-	loads  []StoredSecrets
+	kind    string
+	values  map[string]string
+	saves   []StoredSecrets
+	loads   []StoredSecrets
+	deletes []StoredSecrets
 }
 
 func (s *fakeSecretStore) Kind() string {
@@ -58,7 +59,11 @@ func (s *fakeSecretStore) Load(_ context.Context, _ SecretScope, stored StoredSe
 	return LoadedSecrets{Values: values, NeedsMigration: needsMigration}, nil
 }
 
-func (s *fakeSecretStore) Delete(context.Context, SecretScope, StoredSecrets) error {
+func (s *fakeSecretStore) Delete(_ context.Context, _ SecretScope, stored StoredSecrets) error {
+	s.deletes = append(s.deletes, stored)
+	for _, ref := range stored.Refs {
+		delete(s.values, ref)
+	}
 	return nil
 }
 
@@ -284,6 +289,48 @@ func TestManagerMigratesRegisteredStoreRefsForUse(t *testing.T) {
 	}
 	if contains(string(data), oldRef) || !contains(string(data), newRef) {
 		t.Fatalf("registered store migration should replace old ref with new ref: %s", string(data))
+	}
+}
+
+func TestManagerDeletesRegisteredStoreSecrets(t *testing.T) {
+	store := &fakeSecretStore{kind: "vault"}
+	manager := NewManager(t.TempDir(), WithSecretStore(store))
+
+	created, err := manager.Save(Connection{
+		Name:        "external",
+		Provider:    ProviderAWS,
+		AuthMethod:  "aws_static",
+		Metadata:    map[string]string{"access_key_id": "AKIAEXAMPLE"},
+		Secrets:     map[string]string{"secret_access_key": "super-secret"},
+		SecretStore: "vault",
+	})
+	if err != nil {
+		t.Fatalf("Save with registered secret store: %v", err)
+	}
+	ref := "vault://connections/" + created.ID + "/secret_access_key"
+	if _, ok := store.values[ref]; !ok {
+		t.Fatalf("registered store should retain saved test secret at %q", ref)
+	}
+
+	if err := manager.Delete(created.ID); err != nil {
+		t.Fatalf("Delete registered store connection: %v", err)
+	}
+	if len(store.deletes) != 1 {
+		t.Fatalf("registered store should delete persisted secret refs once, got %d calls", len(store.deletes))
+	}
+	if got := store.deletes[0].Refs["secret_access_key"]; got != ref {
+		t.Fatalf("registered store should delete persisted ref, got %q", got)
+	}
+	if _, ok := store.values[ref]; ok {
+		t.Fatalf("registered store should remove secret value for %q", ref)
+	}
+
+	listed, err := manager.List()
+	if err != nil {
+		t.Fatalf("List after registered store delete: %v", err)
+	}
+	if len(listed) != 0 {
+		t.Fatalf("deleted connection should be removed from persisted records: %#v", listed)
 	}
 }
 

--- a/internal/cloudconnections/connections_test.go
+++ b/internal/cloudconnections/connections_test.go
@@ -242,6 +242,129 @@ func TestManagerLoadsSecretRefsWithRegisteredStore(t *testing.T) {
 	}
 }
 
+func TestManagerGetResolvesOnlyRequestedRegisteredStore(t *testing.T) {
+	dir := t.TempDir()
+	firstRef := "vault://connections/conn_first/secret_access_key"
+	secondRef := "vault://connections/conn_second/secret_access_key"
+	store := &fakeSecretStore{
+		kind: "vault",
+		values: map[string]string{
+			firstRef:  "first-secret",
+			secondRef: "second-secret",
+		},
+	}
+	manager := NewManager(dir, WithSecretStore(store))
+	record := `[{
+		"id":"conn_first",
+		"name":"first",
+		"provider":"aws",
+		"auth_method":"aws_static",
+		"metadata":{"access_key_id":"AKIAFIRST"},
+		"secret_store":"vault",
+		"secret_refs":{"secret_access_key":"` + firstRef + `"},
+		"created_at":"2026-06-18T00:00:00Z",
+		"updated_at":"2026-06-18T00:00:00Z"
+	},{
+		"id":"conn_second",
+		"name":"second",
+		"provider":"aws",
+		"auth_method":"aws_static",
+		"metadata":{"access_key_id":"AKIASECOND"},
+		"secret_store":"vault",
+		"secret_refs":{"secret_access_key":"` + secondRef + `"},
+		"created_at":"2026-06-18T00:00:00Z",
+		"updated_at":"2026-06-18T00:00:00Z"
+	}]`
+	if err := os.WriteFile(manager.path, []byte(record), 0o600); err != nil {
+		t.Fatalf("write registered store records: %v", err)
+	}
+
+	stored, err := manager.Get("conn_second")
+	if err != nil {
+		t.Fatalf("Get requested registered store record: %v", err)
+	}
+	if got := stored.Secrets["secret_access_key"]; got != "second-secret" {
+		t.Fatalf("registered store should resolve requested secret only, got %q", got)
+	}
+	if len(store.loads) != 1 {
+		t.Fatalf("Get should resolve only one registered store record, got %d loads", len(store.loads))
+	}
+	if got := store.loads[0].Refs["secret_access_key"]; got != secondRef {
+		t.Fatalf("registered store should receive requested ref, got %q", got)
+	}
+}
+
+func TestManagerPreservesRegisteredStoreRefsOnPartialSecretUpdate(t *testing.T) {
+	store := &fakeSecretStore{kind: "vault"}
+	manager := NewManager(t.TempDir(), WithSecretStore(store))
+
+	created, err := manager.Save(Connection{
+		Name:        "external",
+		Provider:    ProviderAWS,
+		AuthMethod:  "aws_static",
+		Metadata:    map[string]string{"access_key_id": "AKIAEXAMPLE"},
+		Secrets:     map[string]string{"secret_access_key": "old-secret", "session_token": "session-token"},
+		SecretStore: "vault",
+	})
+	if err != nil {
+		t.Fatalf("Save initial registered store connection: %v", err)
+	}
+	secretRef := "vault://connections/" + created.ID + "/secret_access_key"
+	sessionRef := "vault://connections/" + created.ID + "/session_token"
+
+	updated, err := manager.Save(Connection{
+		ID:         created.ID,
+		Name:       "external",
+		Provider:   ProviderAWS,
+		AuthMethod: "aws_static",
+		Metadata:   map[string]string{"access_key_id": "AKIAEXAMPLE"},
+		Secrets:    map[string]string{"secret_access_key": "rotated-secret"},
+	})
+	if err != nil {
+		t.Fatalf("Save partial registered store secret update: %v", err)
+	}
+	if got := updated.SecretStore; got != "vault" {
+		t.Fatalf("partial update should preserve registered store, got %q", got)
+	}
+	if !slices.Contains(updated.SecretFields, "secret_access_key") || !slices.Contains(updated.SecretFields, "session_token") {
+		t.Fatalf("partial update should preserve all referenced secret fields: %#v", updated.SecretFields)
+	}
+	if len(store.saves) != 2 {
+		t.Fatalf("registered store should save initial and rotated secrets, got %d saves", len(store.saves))
+	}
+	if _, ok := store.saves[1].Refs["session_token"]; ok {
+		t.Fatalf("partial update should only write submitted secret values, got refs %#v", store.saves[1].Refs)
+	}
+
+	stored, err := manager.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get partial registered store secret update: %v", err)
+	}
+	if got := stored.Secrets["secret_access_key"]; got != "rotated-secret" {
+		t.Fatalf("registered store should resolve rotated secret, got %q", got)
+	}
+	if got := stored.Secrets["session_token"]; got != "session-token" {
+		t.Fatalf("registered store should preserve existing session token ref, got %q", got)
+	}
+	if got := stored.SecretRefs["secret_access_key"]; got != secretRef {
+		t.Fatalf("registered store should preserve rotated secret ref, got %q", got)
+	}
+	if got := stored.SecretRefs["session_token"]; got != sessionRef {
+		t.Fatalf("registered store should preserve untouched secret ref, got %q", got)
+	}
+
+	data, err := os.ReadFile(manager.path)
+	if err != nil {
+		t.Fatalf("read persisted partial update: %v", err)
+	}
+	if contains(string(data), "rotated-secret") || contains(string(data), "session-token") {
+		t.Fatalf("registered store partial update should not persist plaintext: %s", string(data))
+	}
+	if !contains(string(data), secretRef) || !contains(string(data), sessionRef) {
+		t.Fatalf("registered store partial update should preserve both refs: %s", string(data))
+	}
+}
+
 func TestManagerMigratesRegisteredStoreRefsForUse(t *testing.T) {
 	dir := t.TempDir()
 	oldRef := "vault://legacy/conn_external/secret_access_key"

--- a/internal/cloudconnections/connections_test.go
+++ b/internal/cloudconnections/connections_test.go
@@ -2,6 +2,7 @@ package cloudconnections
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"slices"
@@ -124,7 +125,7 @@ func TestManagerRedactsStaticSecrets(t *testing.T) {
 		t.Fatalf("expected persisted local secret refs: %s", string(data))
 	}
 
-	stored, err := manager.Get(created.ID)
+	stored, err := manager.GetForUse(created.ID)
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
@@ -181,7 +182,7 @@ func TestManagerSavesSecretsWithRegisteredStore(t *testing.T) {
 		t.Fatalf("registered external store should persist external refs: %s", string(data))
 	}
 
-	stored, err := manager.Get(created.ID)
+	stored, err := manager.GetForUse(created.ID)
 	if err != nil {
 		t.Fatalf("Get registered store connection: %v", err)
 	}
@@ -227,7 +228,7 @@ func TestManagerLoadsSecretRefsWithRegisteredStore(t *testing.T) {
 		t.Fatalf("List should not resolve external secret refs, got %d loads", len(store.loads))
 	}
 
-	stored, err := manager.Get("conn_external")
+	stored, err := manager.GetForUse("conn_external")
 	if err != nil {
 		t.Fatalf("Get registered store record: %v", err)
 	}
@@ -239,6 +240,44 @@ func TestManagerLoadsSecretRefsWithRegisteredStore(t *testing.T) {
 	}
 	if got := store.loads[0].Refs["secret_access_key"]; got != ref {
 		t.Fatalf("registered store should receive persisted ref, got %q", got)
+	}
+}
+
+func TestManagerGetDoesNotResolveRegisteredSecretRefs(t *testing.T) {
+	dir := t.TempDir()
+	ref := "vault://connections/conn_external/secret_access_key"
+	store := &fakeSecretStore{
+		kind:   "vault",
+		values: map[string]string{ref: "super-secret"},
+	}
+	manager := NewManager(dir, WithSecretStore(store))
+	record := `[{
+		"id":"conn_external",
+		"name":"external",
+		"provider":"aws",
+		"auth_method":"aws_static",
+		"metadata":{"access_key_id":"AKIAEXAMPLE"},
+		"secret_store":"vault",
+		"secret_refs":{"secret_access_key":"` + ref + `"},
+		"created_at":"2026-06-18T00:00:00Z",
+		"updated_at":"2026-06-18T00:00:00Z"
+	}]`
+	if err := os.WriteFile(manager.path, []byte(record), 0o600); err != nil {
+		t.Fatalf("write registered store record: %v", err)
+	}
+
+	stored, err := manager.Get("conn_external")
+	if err != nil {
+		t.Fatalf("Get registered store metadata: %v", err)
+	}
+	if got := stored.SecretRefs["secret_access_key"]; got != ref {
+		t.Fatalf("Get should preserve refs without resolving them, got %q", got)
+	}
+	if len(stored.Secrets) != 0 {
+		t.Fatalf("Get should not resolve external secret values: %#v", stored.Secrets)
+	}
+	if len(store.loads) != 0 {
+		t.Fatalf("Get should not contact external store, got %d loads", len(store.loads))
 	}
 }
 
@@ -279,7 +318,7 @@ func TestManagerGetResolvesOnlyRequestedRegisteredStore(t *testing.T) {
 		t.Fatalf("write registered store records: %v", err)
 	}
 
-	stored, err := manager.Get("conn_second")
+	stored, err := manager.GetForUse("conn_second")
 	if err != nil {
 		t.Fatalf("Get requested registered store record: %v", err)
 	}
@@ -336,7 +375,7 @@ func TestManagerPreservesRegisteredStoreRefsOnPartialSecretUpdate(t *testing.T) 
 		t.Fatalf("partial update should only write submitted secret values, got refs %#v", store.saves[1].Refs)
 	}
 
-	stored, err := manager.Get(created.ID)
+	stored, err := manager.GetForUse(created.ID)
 	if err != nil {
 		t.Fatalf("Get partial registered store secret update: %v", err)
 	}
@@ -389,7 +428,7 @@ func TestManagerMigratesRegisteredStoreRefsForUse(t *testing.T) {
 		t.Fatalf("write registered store record: %v", err)
 	}
 
-	stored, err := manager.Get("conn_external")
+	stored, err := manager.GetForUse("conn_external")
 	if err != nil {
 		t.Fatalf("Get registered store record: %v", err)
 	}
@@ -412,6 +451,111 @@ func TestManagerMigratesRegisteredStoreRefsForUse(t *testing.T) {
 	}
 	if contains(string(data), oldRef) || !contains(string(data), newRef) {
 		t.Fatalf("registered store migration should replace old ref with new ref: %s", string(data))
+	}
+}
+
+func TestManagerSkipsRegisteredStoreMigrationWithoutResolvedValues(t *testing.T) {
+	dir := t.TempDir()
+	oldRef := "vault://legacy/conn_external/secret_access_key"
+	store := &fakeSecretStore{kind: "vault", values: map[string]string{}}
+	manager := NewManager(dir, WithSecretStore(store))
+	record := `[{
+		"id":"conn_external",
+		"name":"external",
+		"provider":"aws",
+		"auth_method":"aws_static",
+		"metadata":{"access_key_id":"AKIAEXAMPLE"},
+		"secret_store":"vault",
+		"secret_refs":{"secret_access_key":"` + oldRef + `"},
+		"created_at":"2026-06-18T00:00:00Z",
+		"updated_at":"2026-06-18T00:00:00Z"
+	}]`
+	if err := os.WriteFile(manager.path, []byte(record), 0o600); err != nil {
+		t.Fatalf("write registered store record: %v", err)
+	}
+
+	stored, err := manager.GetForUse("conn_external")
+	if err != nil {
+		t.Fatalf("GetForUse registered store record: %v", err)
+	}
+	if len(stored.Secrets) != 0 {
+		t.Fatalf("missing external secret should not produce resolved values: %#v", stored.Secrets)
+	}
+	if len(store.saves) != 0 {
+		t.Fatalf("missing external secret should not trigger migration save, got %d saves", len(store.saves))
+	}
+	data, err := os.ReadFile(manager.path)
+	if err != nil {
+		t.Fatalf("read registered store record: %v", err)
+	}
+	if !contains(string(data), oldRef) {
+		t.Fatalf("unresolved legacy ref should remain unchanged: %s", string(data))
+	}
+}
+
+func TestManagerSingleConnectionMigrationDoesNotRewriteOtherSecrets(t *testing.T) {
+	manager := NewManager(t.TempDir())
+
+	first, err := manager.Save(Connection{
+		Name:       "first",
+		Provider:   ProviderAWS,
+		AuthMethod: "aws_static",
+		Metadata:   map[string]string{"access_key_id": "AKIAFIRST"},
+		Secrets:    map[string]string{"secret_access_key": "legacy-first"},
+	})
+	if err != nil {
+		t.Fatalf("Save first connection: %v", err)
+	}
+	second, err := manager.Save(Connection{
+		Name:       "second",
+		Provider:   ProviderAWS,
+		AuthMethod: "aws_static",
+		Metadata:   map[string]string{"access_key_id": "AKIASECOND"},
+		Secrets:    map[string]string{"secret_access_key": "second-secret"},
+	})
+	if err != nil {
+		t.Fatalf("Save second connection: %v", err)
+	}
+
+	data, err := os.ReadFile(manager.path)
+	if err != nil {
+		t.Fatalf("read persisted records: %v", err)
+	}
+	var records []Connection
+	if err := json.Unmarshal(data, &records); err != nil {
+		t.Fatalf("parse persisted records: %v", err)
+	}
+	for index := range records {
+		if records[index].ID == first.ID {
+			records[index].Secrets = map[string]string{"secret_access_key": "legacy-first"}
+			records[index].SecretRefs = nil
+			records[index].SecretStore = ""
+		}
+	}
+	rewritten, err := json.MarshalIndent(records, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal legacy records: %v", err)
+	}
+	if err := os.WriteFile(manager.path, rewritten, 0o600); err != nil {
+		t.Fatalf("write legacy records: %v", err)
+	}
+
+	migrated, err := manager.GetForUse(first.ID)
+	if err != nil {
+		t.Fatalf("GetForUse first connection: %v", err)
+	}
+	if got := migrated.Secrets["secret_access_key"]; got != "legacy-first" {
+		t.Fatalf("first secret should resolve before migration, got %q", got)
+	}
+	storedSecond, err := manager.GetForUse(second.ID)
+	if err != nil {
+		t.Fatalf("GetForUse second connection: %v", err)
+	}
+	if got := storedSecond.Secrets["secret_access_key"]; got != "second-secret" {
+		t.Fatalf("second secret should not be re-encrypted during first migration, got %q", got)
+	}
+	if isEncryptedSecret(storedSecond.Secrets["secret_access_key"]) {
+		t.Fatalf("second secret was returned as an encrypted envelope after unrelated migration")
 	}
 }
 
@@ -457,6 +601,41 @@ func TestManagerDeletesRegisteredStoreSecrets(t *testing.T) {
 	}
 }
 
+func TestManagerDeleteRejectsUnsupportedStoreSecretRefs(t *testing.T) {
+	dir := t.TempDir()
+	manager := NewManager(dir)
+	ref := "vault://connections/conn_external/secret_access_key"
+	record := `[{
+		"id":"conn_external",
+		"name":"external",
+		"provider":"aws",
+		"auth_method":"aws_static",
+		"metadata":{"access_key_id":"AKIAEXAMPLE"},
+		"secret_store":"vault",
+		"secret_refs":{"secret_access_key":"` + ref + `"},
+		"created_at":"2026-06-18T00:00:00Z",
+		"updated_at":"2026-06-18T00:00:00Z"
+	}]`
+	if err := os.WriteFile(manager.path, []byte(record), 0o600); err != nil {
+		t.Fatalf("write unsupported store record: %v", err)
+	}
+
+	err := manager.Delete("conn_external")
+	if err == nil {
+		t.Fatal("Delete should fail closed for unsupported external secret refs")
+	}
+	if !strings.Contains(err.Error(), `secret store "vault"`) || !strings.Contains(err.Error(), "register the store before deleting") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	listed, listErr := manager.List()
+	if listErr != nil {
+		t.Fatalf("List after failed delete: %v", listErr)
+	}
+	if len(listed) != 1 {
+		t.Fatalf("failed delete should keep connection metadata, got %#v", listed)
+	}
+}
+
 func TestManagerRejectsUnsupportedSecretStore(t *testing.T) {
 	manager := NewManager(t.TempDir())
 
@@ -473,6 +652,51 @@ func TestManagerRejectsUnsupportedSecretStore(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "unsupported secret store") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestManagerAllowsUnsupportedSecretStoreWithRefsOnly(t *testing.T) {
+	manager := NewManager(t.TempDir())
+	ref := "vault://connections/conn_external/secret_access_key"
+
+	created, err := manager.Save(Connection{
+		ID:          "conn_external",
+		Name:        "external",
+		Provider:    ProviderAWS,
+		AuthMethod:  "aws_static",
+		Metadata:    map[string]string{"access_key_id": "AKIAEXAMPLE"},
+		SecretStore: "vault",
+		SecretRefs:  map[string]string{"secret_access_key": ref},
+	})
+	if err != nil {
+		t.Fatalf("Save unsupported store refs-only connection: %v", err)
+	}
+	if got := created.SecretStore; got != "vault" {
+		t.Fatalf("refs-only unsupported store should be preserved, got %q", got)
+	}
+	if !slices.Contains(created.SecretFields, "secret_access_key") {
+		t.Fatalf("public connection should expose referenced secret field: %#v", created.SecretFields)
+	}
+
+	updated, err := manager.Save(Connection{
+		ID:         "conn_external",
+		Name:       "external-renamed",
+		Provider:   ProviderAWS,
+		AuthMethod: "aws_static",
+		Metadata:   map[string]string{"access_key_id": "AKIARENAMED"},
+	})
+	if err != nil {
+		t.Fatalf("Save metadata update for unsupported refs-only connection: %v", err)
+	}
+	if got := updated.SecretStore; got != "vault" {
+		t.Fatalf("metadata update should preserve unsupported refs-only store, got %q", got)
+	}
+	stored, err := manager.Get("conn_external")
+	if err != nil {
+		t.Fatalf("Get unsupported refs-only connection: %v", err)
+	}
+	if got := stored.SecretRefs["secret_access_key"]; got != ref {
+		t.Fatalf("metadata update should preserve unsupported ref, got %q", got)
 	}
 }
 

--- a/internal/cloudconnections/secret_store_registry.go
+++ b/internal/cloudconnections/secret_store_registry.go
@@ -1,0 +1,77 @@
+package cloudconnections
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Option customizes a Cloud Connections manager.
+type Option func(*Manager)
+
+// WithSecretStore registers a secret store backend. Later registrations for the
+// same kind replace earlier ones, which keeps tests and future backend wiring
+// straightforward while preserving fail-closed lookup behavior.
+func WithSecretStore(store SecretStore) Option {
+	return func(m *Manager) {
+		m.registerSecretStore(store)
+	}
+}
+
+// SupportedSecretStores returns the registered backend kinds for diagnostics
+// and future UI/API discovery.
+func (m *Manager) SupportedSecretStores() []string {
+	kinds := make([]string, 0, len(m.secretStores))
+	for kind := range m.secretStores {
+		kinds = append(kinds, kind)
+	}
+	sort.Strings(kinds)
+	return kinds
+}
+
+func (m *Manager) normalizeAndValidate(connection *Connection) error {
+	if err := normalizeConnectionFields(connection); err != nil {
+		return err
+	}
+	if connection.SecretStore != "" && !m.supportsSecretStore(connection.SecretStore) {
+		return unsupportedSecretStoreError(connection.SecretStore)
+	}
+	return nil
+}
+
+func (m *Manager) registerSecretStore(store SecretStore) {
+	if store == nil {
+		return
+	}
+	kind := strings.TrimSpace(store.Kind())
+	if kind == "" {
+		return
+	}
+	m.secretStores[kind] = store
+}
+
+func (m *Manager) supportsSecretStore(kind string) bool {
+	_, ok := m.secretStoreFor(kind)
+	return ok
+}
+
+func (m *Manager) secretStoreFor(kind string) (SecretStore, bool) {
+	kind = strings.TrimSpace(kind)
+	if kind == "" {
+		kind = SecretStoreLocalEncrypted
+	}
+	store, ok := m.secretStores[kind]
+	return store, ok
+}
+
+func unsupportedSecretStoreError(kind string) error {
+	return errUnsupportedSecretStore{kind: kind}
+}
+
+type errUnsupportedSecretStore struct {
+	kind string
+}
+
+func (e errUnsupportedSecretStore) Error() string {
+	return "unsupported secret store " + strconv.Quote(e.kind)
+}

--- a/internal/cloudconnections/secret_store_registry.go
+++ b/internal/cloudconnections/secret_store_registry.go
@@ -9,9 +9,9 @@ import (
 // Option customizes a Cloud Connections manager.
 type Option func(*Manager)
 
-// WithSecretStore registers a secret store backend. Later registrations for the
-// same kind replace earlier ones, which keeps tests and future backend wiring
-// straightforward while preserving fail-closed lookup behavior.
+// WithSecretStore registers a secret store backend. It is intended for
+// NewManager construction-time wiring; registry access is synchronized so later
+// test or adapter wiring cannot race with lookups.
 func WithSecretStore(store SecretStore) Option {
 	return func(m *Manager) {
 		m.registerSecretStore(store)
@@ -21,6 +21,9 @@ func WithSecretStore(store SecretStore) Option {
 // SupportedSecretStores returns the registered backend kinds for diagnostics
 // and future UI/API discovery.
 func (m *Manager) SupportedSecretStores() []string {
+	m.secretStoresMu.RLock()
+	defer m.secretStoresMu.RUnlock()
+
 	kinds := make([]string, 0, len(m.secretStores))
 	for kind := range m.secretStores {
 		kinds = append(kinds, kind)
@@ -47,6 +50,8 @@ func (m *Manager) registerSecretStore(store SecretStore) {
 	if kind == "" {
 		return
 	}
+	m.secretStoresMu.Lock()
+	defer m.secretStoresMu.Unlock()
 	m.secretStores[kind] = store
 }
 
@@ -60,6 +65,8 @@ func (m *Manager) secretStoreFor(kind string) (SecretStore, bool) {
 	if kind == "" {
 		kind = SecretStoreLocalEncrypted
 	}
+	m.secretStoresMu.RLock()
+	defer m.secretStoresMu.RUnlock()
 	store, ok := m.secretStores[kind]
 	return store, ok
 }

--- a/internal/cloudconnections/secret_store_registry.go
+++ b/internal/cloudconnections/secret_store_registry.go
@@ -36,7 +36,7 @@ func (m *Manager) normalizeAndValidate(connection *Connection) error {
 	if err := normalizeConnectionFields(connection); err != nil {
 		return err
 	}
-	if connection.SecretStore != "" && !m.supportsSecretStore(connection.SecretStore) {
+	if connection.SecretStore != "" && !m.supportsSecretStore(connection.SecretStore) && hasNonEmptyUnmaskedSecrets(connection.Secrets) {
 		return unsupportedSecretStoreError(connection.SecretStore)
 	}
 	return nil

--- a/internal/mcp/service.go
+++ b/internal/mcp/service.go
@@ -135,7 +135,7 @@ func (s *Server) handleInspectConnectionScope(_ context.Context, raw json.RawMes
 	if err := requireNonEmpty("connection_id", args.ConnectionID); err != nil {
 		return errResponse("inspect_connection_scope", err, AuditDecision{Tool: "inspect_connection_scope", ConnectionID: args.ConnectionID})
 	}
-	connection, err := s.cloudConnections.Get(args.ConnectionID)
+	connection, err := s.cloudConnections.GetForUse(args.ConnectionID)
 	if err != nil {
 		return errResponse("inspect_connection_scope", err, AuditDecision{Tool: "inspect_connection_scope", ConnectionID: args.ConnectionID})
 	}
@@ -819,7 +819,7 @@ func (s *Server) commandEnvironment(connectionID string) (map[string]string, any
 	if strings.TrimSpace(connectionID) == "" {
 		return nil, nil, nil
 	}
-	connection, err := s.cloudConnections.Get(connectionID)
+	connection, err := s.cloudConnections.GetForUse(connectionID)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Summary:
- add a Cloud Connections secret store registry with `WithSecretStore` extension points
- keep `local_encrypted` registered by default while allowing future external adapters
- route save/load validation through the registry without resolving external refs on public list paths
- split `Get` (metadata/existence, no external ref resolution) from `GetForUse` (runner/test/MCP flows with ref resolution); update all API and MCP call sites accordingly
- resolve registered external refs only for `GetForUse`/runner-use flows and preserve fail-closed behavior for unsupported stores with local values
- preserve existing external `SecretRefs` across partial secret updates; merge `store.Save` returned refs over existing map instead of replacing it
- scope single-connection migration writes to only the migrated record, preventing unrelated `local_encrypted` secrets from being re-encrypted
- only flag secret-store migration when `Load` returns resolved values, preventing repeated no-op writes for missing external refs
- allow unsupported external `secret_store` + `secret_refs` records to be preserved and edited when no local secret values are submitted
- make `Delete` fail closed for unsupported external `secret_refs` so connection metadata is not removed while external secrets are orphaned
- synchronize the registry map with a dedicated `sync.RWMutex` to prevent data races

Tests:
- `GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/cloudconnections ./internal/api ./internal/mcp`
- `GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/...`

Closes #100
Part of #91