### PR TITLE
Add Agent Hub panel shell

### DIFF
--- a/web/src/components/Chat/ChatPanel.test.tsx
+++ b/web/src/components/Chat/ChatPanel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 
 import { ChatPanel } from './ChatPanel';
 
@@ -60,6 +60,41 @@ describe('ChatPanel', () => {
     expect(screen.getByText('OpenAI API')).toBeInTheDocument();
     expect(screen.getByText(/official CLI session/)).toBeInTheDocument();
     expect(screen.getByText(/Platform API account/)).toBeInTheDocument();
+  });
+
+  it('links provider tabs to stable tabpanels and supports roving keyboard selection', () => {
+    render(<ChatPanel {...baseProps} />);
+
+    const chatTab = screen.getByRole('tab', { name: 'Chat' });
+    const codexTab = screen.getByRole('tab', { name: 'Codex' });
+    expect(chatTab).toHaveAttribute('id', 'agent-hub-tab-chat');
+    expect(chatTab).toHaveAttribute('aria-controls', 'agent-hub-panel-chat');
+    expect(codexTab).toHaveAttribute('aria-controls', 'agent-hub-panel-codex');
+    expect(chatTab).toHaveAttribute('tabindex', '0');
+    expect(codexTab).toHaveAttribute('tabindex', '-1');
+    expect(document.getElementById('agent-hub-panel-codex')).toHaveAttribute('role', 'tabpanel');
+    expect(screen.getByRole('tabpanel', { name: 'Chat' })).toHaveAttribute('id', 'agent-hub-panel-chat');
+
+    fireEvent.keyDown(chatTab, { key: 'ArrowDown' });
+
+    expect(codexTab).toHaveAttribute('aria-selected', 'true');
+    expect(codexTab).toHaveAttribute('tabindex', '0');
+    expect(screen.getByRole('tabpanel', { name: 'Codex' })).toHaveAttribute('id', 'agent-hub-panel-codex');
+  });
+
+  it('exposes task mode selection to assistive technology', () => {
+    render(<ChatPanel {...baseProps} />);
+
+    const taskModes = screen.getByRole('group', { name: 'Agent task modes' });
+    const reviewProject = within(taskModes).getByRole('button', { name: 'Review project' });
+    const generateIac = within(taskModes).getByRole('button', { name: 'Generate IaC' });
+    expect(reviewProject).toHaveAttribute('aria-pressed', 'true');
+    expect(generateIac).toHaveAttribute('aria-pressed', 'false');
+
+    fireEvent.click(generateIac);
+
+    expect(reviewProject).toHaveAttribute('aria-pressed', 'false');
+    expect(generateIac).toHaveAttribute('aria-pressed', 'true');
   });
 
   it('keeps local model support visible as a first-class lane', () => {

--- a/web/src/components/Chat/ChatPanel.test.tsx
+++ b/web/src/components/Chat/ChatPanel.test.tsx
@@ -15,6 +15,11 @@ describe('ChatPanel', () => {
 
   it('renders the empty-state hint when no messages are present', () => {
     render(<ChatPanel {...baseProps} />);
+    expect(screen.getByText('Agent Hub')).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Codex' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Claude Code' })).toBeInTheDocument();
+    expect(screen.getByText('Read-only default')).toBeInTheDocument();
+    expect(screen.getByText('No secret prompts')).toBeInTheDocument();
     expect(screen.getByText(/Ask me to create infrastructure/)).toBeInTheDocument();
   });
 
@@ -45,5 +50,24 @@ describe('ChatPanel', () => {
     expect(input).toBeDisabled();
     expect(screen.getByLabelText('Send message')).toBeDisabled();
     expect(screen.getByText('✦ Thinking...')).toBeInTheDocument();
+  });
+
+  it('shows the Codex provider lane without requiring API keys by default', () => {
+    render(<ChatPanel {...baseProps} />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Codex' }));
+
+    expect(screen.getAllByText('Codex CLI').length).toBeGreaterThan(0);
+    expect(screen.getByText('OpenAI API')).toBeInTheDocument();
+    expect(screen.getByText(/official CLI session/)).toBeInTheDocument();
+    expect(screen.getByText(/Platform API account/)).toBeInTheDocument();
+  });
+
+  it('keeps local model support visible as a first-class lane', () => {
+    render(<ChatPanel {...baseProps} providerLabel="Ollama" />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Local' }));
+
+    expect(screen.getAllByText('Ollama').length).toBeGreaterThan(0);
+    expect(screen.getByText('LM Studio / vLLM')).toBeInTheDocument();
+    expect(screen.getByText(/without cloud egress/)).toBeInTheDocument();
   });
 });

--- a/web/src/components/Chat/ChatPanel.tsx
+++ b/web/src/components/Chat/ChatPanel.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import type { CSSProperties, RefObject } from 'react';
+import type { CSSProperties, KeyboardEvent, RefObject } from 'react';
 
 import { S } from '../../styles';
 
@@ -112,14 +112,19 @@ const stateBackgrounds: Record<ProviderState, string> = {
   guarded: 'rgba(138, 167, 255, 0.16)',
 };
 
+const tabId = (tab: AgentHubTab) => `agent-hub-tab-${tab}`;
+const panelId = (tab: AgentHubTab) => `agent-hub-panel-${tab}`;
+
 const hubStyles: Record<string, CSSProperties> = {
   shell: { flex: 1, display: 'flex', minWidth: 0, minHeight: 0 },
   rail: { width: 176, borderRight: '1px solid var(--border-soft)', background: 'rgba(23, 29, 27, 0.76)', display: 'flex', flexDirection: 'column', flexShrink: 0, overflowY: 'auto' },
   tabList: { display: 'flex', flexDirection: 'column', padding: 8, gap: 4 },
   tabButton: { width: '100%', border: 0, borderRadius: 6, background: 'transparent', color: 'var(--text-muted)', cursor: 'pointer', fontSize: 11, fontWeight: 700, fontFamily: 'DM Sans', textAlign: 'left', padding: '7px 8px', textTransform: 'uppercase', letterSpacing: 0.4 },
   taskList: { borderTop: '1px solid var(--border-soft)', padding: '8px 8px 10px', display: 'flex', flexDirection: 'column', gap: 5, minHeight: 0 },
-  taskButton: { border: '1px solid var(--border-soft)', borderRadius: 6, background: 'var(--bg-elev-2)', color: 'var(--text-muted)', cursor: 'pointer', fontSize: 11, fontFamily: 'DM Sans', padding: '6px 7px', textAlign: 'left', whiteSpace: 'normal' },
+  taskButton: { borderWidth: 1, borderStyle: 'solid', borderColor: 'var(--border-soft)', borderRadius: 6, background: 'var(--bg-elev-2)', color: 'var(--text-muted)', cursor: 'pointer', fontSize: 11, fontFamily: 'DM Sans', padding: '6px 7px', textAlign: 'left', whiteSpace: 'normal' },
   content: { flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0, minHeight: 0 },
+  tabPanel: { flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0, minHeight: 0 },
+  hiddenTabPanel: { display: 'none' },
   posture: { display: 'flex', alignItems: 'center', gap: 6, padding: '7px 12px', borderBottom: '1px solid var(--border-soft)', color: 'var(--text-muted)', fontSize: 11, fontFamily: 'JetBrains Mono', flexWrap: 'wrap' },
   badge: { padding: '2px 7px', borderRadius: 999, background: 'var(--bg-elev-3)', color: 'var(--text-muted)', fontSize: 10, fontFamily: 'JetBrains Mono', whiteSpace: 'nowrap' },
   providerPanel: { flex: 1, minHeight: 0, overflowY: 'auto', padding: '10px 12px', display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(190px, 1fr))', gap: 8 },
@@ -176,6 +181,7 @@ export function ChatPanel({
 }: ChatPanelProps) {
   const [activeTab, setActiveTab] = useState<AgentHubTab>('chat');
   const [activeTask, setActiveTask] = useState(TASK_MODES[0]);
+
   const activeProviderLabel = useMemo(() => {
     if (activeTab === 'codex') return 'Codex CLI';
     if (activeTab === 'claude') return 'Claude Code';
@@ -184,6 +190,44 @@ export function ChatPanel({
     if (activeTab === 'runs') return 'Run history';
     return providerLabel;
   }, [activeTab, providerLabel]);
+
+  const panelStyle = (tab: AgentHubTab) => (
+    activeTab === tab ? hubStyles.tabPanel : hubStyles.hiddenTabPanel
+  );
+
+  const focusSelectedTab = (tab: AgentHubTab) => {
+    if (typeof document === 'undefined') return;
+    window.setTimeout(() => document.getElementById(tabId(tab))?.focus(), 0);
+  };
+
+  const selectTab = (tab: AgentHubTab, focus = false) => {
+    setActiveTab(tab);
+    if (focus) focusSelectedTab(tab);
+  };
+
+  const handleTabKeyDown = (event: KeyboardEvent<HTMLButtonElement>, currentIndex: number) => {
+    const lastIndex = AGENT_TABS.length - 1;
+    const moveToIndex = (index: number) => {
+      event.preventDefault();
+      selectTab(AGENT_TABS[index].key, true);
+    };
+
+    if (event.key === 'ArrowDown' || event.key === 'ArrowRight') {
+      moveToIndex(currentIndex === lastIndex ? 0 : currentIndex + 1);
+      return;
+    }
+    if (event.key === 'ArrowUp' || event.key === 'ArrowLeft') {
+      moveToIndex(currentIndex === 0 ? lastIndex : currentIndex - 1);
+      return;
+    }
+    if (event.key === 'Home') {
+      moveToIndex(0);
+      return;
+    }
+    if (event.key === 'End') {
+      moveToIndex(lastIndex);
+    }
+  };
 
   return (
     <div style={S.chat}>
@@ -196,29 +240,34 @@ export function ChatPanel({
       <div style={hubStyles.shell}>
         <div style={hubStyles.rail}>
           <div style={hubStyles.tabList} role="tablist" aria-label="Agent Hub providers">
-            {AGENT_TABS.map(tab => (
+            {AGENT_TABS.map((tab, index) => (
               <button
                 key={tab.key}
+                id={tabId(tab.key)}
                 type="button"
                 role="tab"
                 aria-selected={activeTab === tab.key}
+                aria-controls={panelId(tab.key)}
+                tabIndex={activeTab === tab.key ? 0 : -1}
                 style={{
                   ...hubStyles.tabButton,
                   ...(activeTab === tab.key
                     ? { background: 'var(--accent-action-soft)', color: 'var(--accent-action)' }
                     : {}),
                 }}
-                onClick={() => setActiveTab(tab.key)}
+                onClick={() => selectTab(tab.key)}
+                onKeyDown={(event) => handleTabKeyDown(event, index)}
               >
                 {tab.label}
               </button>
             ))}
           </div>
-          <div style={hubStyles.taskList} aria-label="Agent task modes">
+          <div style={hubStyles.taskList} role="group" aria-label="Agent task modes">
             {TASK_MODES.map(task => (
               <button
                 key={task}
                 type="button"
+                aria-pressed={activeTask === task}
                 style={{
                   ...hubStyles.taskButton,
                   ...(activeTask === task
@@ -242,7 +291,13 @@ export function ChatPanel({
             <span style={hubStyles.badge}>No secret prompts</span>
           </div>
 
-          {activeTab === 'chat' && (
+          <div
+            role="tabpanel"
+            id={panelId('chat')}
+            aria-labelledby={tabId('chat')}
+            hidden={activeTab !== 'chat'}
+            style={panelStyle('chat')}
+          >
             <div style={S.chatMsgs}>
               {messages.length === 0 && (
                 <div style={{ padding: '8px 0', color: '#888', fontSize: 13 }}>
@@ -274,13 +329,28 @@ export function ChatPanel({
               )}
               <div ref={scrollAnchorRef} />
             </div>
-          )}
+          </div>
 
-          {activeTab !== 'chat' && activeTab !== 'runs' && (
-            <ProviderGroup tab={activeTab} />
-          )}
+          {(['codex', 'claude', 'local', 'mcp'] as const).map(tab => (
+            <div
+              key={tab}
+              role="tabpanel"
+              id={panelId(tab)}
+              aria-labelledby={tabId(tab)}
+              hidden={activeTab !== tab}
+              style={panelStyle(tab)}
+            >
+              <ProviderGroup tab={tab} />
+            </div>
+          ))}
 
-          {activeTab === 'runs' && (
+          <div
+            role="tabpanel"
+            id={panelId('runs')}
+            aria-labelledby={tabId('runs')}
+            hidden={activeTab !== 'runs'}
+            style={panelStyle('runs')}
+          >
             <div style={hubStyles.runsEmpty}>
               <strong style={{ color: 'var(--text-main)' }}>No agent runs yet.</strong>
               <div style={{ marginTop: 6 }}>
@@ -290,7 +360,7 @@ export function ChatPanel({
                 This shell is UI-only; execution and approval gates land in the secure run lifecycle slice.
               </div>
             </div>
-          )}
+          </div>
         </div>
       </div>
 

--- a/web/src/components/Chat/ChatPanel.tsx
+++ b/web/src/components/Chat/ChatPanel.tsx
@@ -145,10 +145,16 @@ function providerStatus(state: ProviderState) {
   );
 }
 
-function ProviderGroup({ tab }: { tab: Exclude<AgentHubTab, 'chat' | 'runs'> }) {
+function ProviderGroup({ tab, active }: { tab: Exclude<AgentHubTab, 'chat' | 'runs'>; active: boolean }) {
   const group = PROVIDER_GROUPS[tab];
   return (
-    <div style={hubStyles.providerPanel}>
+    <div
+      role="tabpanel"
+      id={panelId(tab)}
+      aria-labelledby={tabId(tab)}
+      hidden={!active}
+      style={active ? hubStyles.providerPanel : hubStyles.hiddenTabPanel}
+    >
       <div style={hubStyles.providerIntro}>
         <strong style={{ color: 'var(--text-main)' }}>{group.title}</strong>
         <span> - {group.summary}</span>
@@ -332,16 +338,7 @@ export function ChatPanel({
           </div>
 
           {(['codex', 'claude', 'local', 'mcp'] as const).map(tab => (
-            <div
-              key={tab}
-              role="tabpanel"
-              id={panelId(tab)}
-              aria-labelledby={tabId(tab)}
-              hidden={activeTab !== tab}
-              style={panelStyle(tab)}
-            >
-              <ProviderGroup tab={tab} />
-            </div>
+            <ProviderGroup key={tab} tab={tab} active={activeTab === tab} />
           ))}
 
           <div

--- a/web/src/components/Chat/ChatPanel.tsx
+++ b/web/src/components/Chat/ChatPanel.tsx
@@ -1,4 +1,5 @@
-import type { RefObject } from 'react';
+import { useMemo, useState } from 'react';
+import type { CSSProperties, RefObject } from 'react';
 
 import { S } from '../../styles';
 
@@ -27,10 +28,142 @@ export interface ChatPanelProps {
   providerLabel?: string;
 }
 
-// Self-contained chat panel: AI message stream + input bar. No state
-// lives here — the parent owns messages and handles provider calls so
-// the component stays dumb and easy to swap (e.g. a different model
-// backend, a streaming-over-WebSocket variant).
+type AgentHubTab = 'chat' | 'codex' | 'claude' | 'local' | 'mcp' | 'runs';
+type ProviderState = 'available' | 'setup' | 'planned' | 'guarded';
+
+const AGENT_TABS: { key: AgentHubTab; label: string }[] = [
+  { key: 'chat', label: 'Chat' },
+  { key: 'codex', label: 'Codex' },
+  { key: 'claude', label: 'Claude Code' },
+  { key: 'local', label: 'Local' },
+  { key: 'mcp', label: 'MCP' },
+  { key: 'runs', label: 'Runs' },
+];
+
+const TASK_MODES = [
+  'Review project',
+  'Generate IaC',
+  'Explain plan',
+  'Fix policy',
+  'Prepare deploy',
+];
+
+const PROVIDER_GROUPS: Record<Exclude<AgentHubTab, 'chat' | 'runs'>, {
+  title: string;
+  summary: string;
+  providers: { name: string; lane: string; state: ProviderState; note: string }[];
+}> = {
+  codex: {
+    title: 'Codex',
+    summary: 'Use local Codex login first, then API or enterprise routing when teams need central controls.',
+    providers: [
+      { name: 'Codex CLI', lane: 'Local agent', state: 'planned', note: 'Use the official CLI session the user already owns.' },
+      { name: 'OpenAI API', lane: 'API', state: 'setup', note: 'Usage is billed through the Platform API account.' },
+      { name: 'Managed Codex token', lane: 'Enterprise', state: 'guarded', note: 'For workspace policy, audit, and non-interactive runs.' },
+    ],
+  },
+  claude: {
+    title: 'Claude Code',
+    summary: 'Prefer Claude Code CLI for subscription-backed local work, with API and enterprise paths as explicit choices.',
+    providers: [
+      { name: 'Claude Code CLI', lane: 'Local agent', state: 'planned', note: 'Runs through the official local Claude Code login.' },
+      { name: 'Anthropic API', lane: 'API', state: 'setup', note: 'Separate API billing for automation and hosted use.' },
+      { name: 'Claude Team or Enterprise', lane: 'Enterprise', state: 'guarded', note: 'For managed access, policy, and audit controls.' },
+    ],
+  },
+  local: {
+    title: 'Local models',
+    summary: 'Keep offline and private model workflows first-class for demos, sensitive reviews, and no-token-cost usage.',
+    providers: [
+      { name: 'Ollama', lane: 'Local model', state: 'available', note: 'Current default local model path.' },
+      { name: 'LM Studio / vLLM', lane: 'OpenAI-compatible', state: 'planned', note: 'Use local endpoints without cloud egress.' },
+      { name: 'llama.cpp', lane: 'Offline', state: 'planned', note: 'Small local reviews and explain-only workflows.' },
+    ],
+  },
+  mcp: {
+    title: 'MCP tools',
+    summary: 'Route AWS, Terraform, GitHub, and future tools through approvals instead of raw unrestricted agent access.',
+    providers: [
+      { name: 'AWS MCP', lane: 'Cloud tools', state: 'guarded', note: 'Read-only by default with explicit write approval.' },
+      { name: 'Terraform MCP', lane: 'IaC tools', state: 'guarded', note: 'Plan and state context behind MCP Airlock.' },
+      { name: 'GitHub MCP', lane: 'Collaboration', state: 'planned', note: 'Issue, PR, and review workflows with audit trails.' },
+    ],
+  },
+};
+
+const stateLabels: Record<ProviderState, string> = {
+  available: 'Available',
+  setup: 'Setup',
+  planned: 'Next',
+  guarded: 'Guarded',
+};
+
+const stateColors: Record<ProviderState, string> = {
+  available: 'var(--accent-action)',
+  setup: 'var(--accent-warn)',
+  planned: 'var(--text-muted)',
+  guarded: '#8aa7ff',
+};
+
+const stateBackgrounds: Record<ProviderState, string> = {
+  available: 'rgba(84, 184, 169, 0.16)',
+  setup: 'rgba(217, 177, 92, 0.16)',
+  planned: 'rgba(147, 163, 154, 0.14)',
+  guarded: 'rgba(138, 167, 255, 0.16)',
+};
+
+const hubStyles: Record<string, CSSProperties> = {
+  shell: { flex: 1, display: 'flex', minWidth: 0, minHeight: 0 },
+  rail: { width: 176, borderRight: '1px solid var(--border-soft)', background: 'rgba(23, 29, 27, 0.76)', display: 'flex', flexDirection: 'column', flexShrink: 0, overflowY: 'auto' },
+  tabList: { display: 'flex', flexDirection: 'column', padding: 8, gap: 4 },
+  tabButton: { width: '100%', border: 0, borderRadius: 6, background: 'transparent', color: 'var(--text-muted)', cursor: 'pointer', fontSize: 11, fontWeight: 700, fontFamily: 'DM Sans', textAlign: 'left', padding: '7px 8px', textTransform: 'uppercase', letterSpacing: 0.4 },
+  taskList: { borderTop: '1px solid var(--border-soft)', padding: '8px 8px 10px', display: 'flex', flexDirection: 'column', gap: 5, minHeight: 0 },
+  taskButton: { border: '1px solid var(--border-soft)', borderRadius: 6, background: 'var(--bg-elev-2)', color: 'var(--text-muted)', cursor: 'pointer', fontSize: 11, fontFamily: 'DM Sans', padding: '6px 7px', textAlign: 'left', whiteSpace: 'normal' },
+  content: { flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0, minHeight: 0 },
+  posture: { display: 'flex', alignItems: 'center', gap: 6, padding: '7px 12px', borderBottom: '1px solid var(--border-soft)', color: 'var(--text-muted)', fontSize: 11, fontFamily: 'JetBrains Mono', flexWrap: 'wrap' },
+  badge: { padding: '2px 7px', borderRadius: 999, background: 'var(--bg-elev-3)', color: 'var(--text-muted)', fontSize: 10, fontFamily: 'JetBrains Mono', whiteSpace: 'nowrap' },
+  providerPanel: { flex: 1, minHeight: 0, overflowY: 'auto', padding: '10px 12px', display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(190px, 1fr))', gap: 8 },
+  providerIntro: { gridColumn: '1 / -1', color: 'var(--text-muted)', fontSize: 12, lineHeight: 1.45, marginBottom: 2 },
+  providerCard: { border: '1px solid var(--border-main)', borderRadius: 8, background: 'var(--bg-elev-2)', padding: 10, minWidth: 0 },
+  providerHead: { display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 },
+  providerName: { color: 'var(--text-main)', fontWeight: 700, fontSize: 12, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
+  providerLane: { color: 'var(--text-muted)', fontFamily: 'JetBrains Mono', fontSize: 10, textTransform: 'uppercase', letterSpacing: 0.5, marginBottom: 5 },
+  providerNote: { color: '#77847d', fontSize: 11, lineHeight: 1.4 },
+  runsEmpty: { flex: 1, minHeight: 0, padding: 16, color: 'var(--text-muted)', fontSize: 12, lineHeight: 1.55 },
+};
+
+function providerStatus(state: ProviderState) {
+  return (
+    <span style={{ ...hubStyles.badge, color: stateColors[state], background: stateBackgrounds[state] }}>
+      {stateLabels[state]}
+    </span>
+  );
+}
+
+function ProviderGroup({ tab }: { tab: Exclude<AgentHubTab, 'chat' | 'runs'> }) {
+  const group = PROVIDER_GROUPS[tab];
+  return (
+    <div style={hubStyles.providerPanel}>
+      <div style={hubStyles.providerIntro}>
+        <strong style={{ color: 'var(--text-main)' }}>{group.title}</strong>
+        <span> - {group.summary}</span>
+      </div>
+      {group.providers.map(provider => (
+        <div key={provider.name} style={hubStyles.providerCard}>
+          <div style={hubStyles.providerHead}>
+            <span style={{ ...hubStyles.providerName, flex: 1 }}>{provider.name}</span>
+            {providerStatus(provider.state)}
+          </div>
+          <div style={hubStyles.providerLane}>{provider.lane}</div>
+          <div style={hubStyles.providerNote}>{provider.note}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// Self-contained Agent Hub panel: AI message stream + provider/task shell.
+// The parent still owns messages and provider calls, so this stays UI-only.
 export function ChatPanel({
   messages,
   input,
@@ -41,44 +174,126 @@ export function ChatPanel({
   scrollAnchorRef,
   providerLabel = 'Ollama',
 }: ChatPanelProps) {
+  const [activeTab, setActiveTab] = useState<AgentHubTab>('chat');
+  const [activeTask, setActiveTask] = useState(TASK_MODES[0]);
+  const activeProviderLabel = useMemo(() => {
+    if (activeTab === 'codex') return 'Codex CLI';
+    if (activeTab === 'claude') return 'Claude Code';
+    if (activeTab === 'local') return providerLabel;
+    if (activeTab === 'mcp') return 'MCP Airlock';
+    if (activeTab === 'runs') return 'Run history';
+    return providerLabel;
+  }, [activeTab, providerLabel]);
+
   return (
     <div style={S.chat}>
       <div style={S.chatHead}>
         <span style={{ fontSize: 14, color: 'var(--accent-action)' }}>✦</span>
-        <span>AI Assistant</span>
-        <span style={S.chatBadge}>{providerLabel}</span>
+        <span>Agent Hub</span>
+        <span style={S.chatBadge}>{activeProviderLabel}</span>
       </div>
-      <div style={S.chatMsgs}>
-        {messages.length === 0 && (
-          <div style={{ padding: '8px 0', color: '#888', fontSize: 13 }}>
-            <p style={{ margin: 0 }}>Ask me to create infrastructure:</p>
-            <p style={{ margin: '4px 0 0', color: '#555', fontSize: 12 }}>
-              "Add a VPC" · "Create an RDS database" · "I need an S3 bucket"
-            </p>
+
+      <div style={hubStyles.shell}>
+        <div style={hubStyles.rail}>
+          <div style={hubStyles.tabList} role="tablist" aria-label="Agent Hub providers">
+            {AGENT_TABS.map(tab => (
+              <button
+                key={tab.key}
+                type="button"
+                role="tab"
+                aria-selected={activeTab === tab.key}
+                style={{
+                  ...hubStyles.tabButton,
+                  ...(activeTab === tab.key
+                    ? { background: 'var(--accent-action-soft)', color: 'var(--accent-action)' }
+                    : {}),
+                }}
+                onClick={() => setActiveTab(tab.key)}
+              >
+                {tab.label}
+              </button>
+            ))}
           </div>
-        )}
-        {messages.map((m, i) => (
-          <div
-            key={m.id ?? i}
-            style={{
-              padding: '6px 0',
-              fontSize: 13,
-              display: 'flex',
-              gap: 8,
-              color: m.role === 'ai' ? '#999' : '#ccc',
-            }}
-          >
-            {m.role === 'ai' && (
-              <span style={{ color: toolColor, fontWeight: 700, flexShrink: 0 }}>✦</span>
-            )}
-            <span>{m.text}</span>
+          <div style={hubStyles.taskList} aria-label="Agent task modes">
+            {TASK_MODES.map(task => (
+              <button
+                key={task}
+                type="button"
+                style={{
+                  ...hubStyles.taskButton,
+                  ...(activeTask === task
+                    ? { borderColor: toolColor, color: 'var(--text-main)', background: `${toolColor}1f` }
+                    : {}),
+                }}
+                onClick={() => setActiveTask(task)}
+              >
+                {task}
+              </button>
+            ))}
           </div>
-        ))}
-        {loading && (
-          <div style={{ padding: '6px 0', fontSize: 13, color: '#666' }}>✦ Thinking...</div>
-        )}
-        <div ref={scrollAnchorRef} />
+        </div>
+
+        <div style={hubStyles.content}>
+          <div style={hubStyles.posture}>
+            <span>{activeTask}</span>
+            <span style={hubStyles.badge}>Read-only default</span>
+            <span style={hubStyles.badge}>Diff before writes</span>
+            <span style={hubStyles.badge}>Approve deploy</span>
+            <span style={hubStyles.badge}>No secret prompts</span>
+          </div>
+
+          {activeTab === 'chat' && (
+            <div style={S.chatMsgs}>
+              {messages.length === 0 && (
+                <div style={{ padding: '8px 0', color: '#888', fontSize: 13 }}>
+                  <p style={{ margin: 0 }}>Ask me to create infrastructure:</p>
+                  <p style={{ margin: '4px 0 0', color: '#555', fontSize: 12 }}>
+                    "Add a VPC" · "Create an RDS database" · "I need an S3 bucket"
+                  </p>
+                </div>
+              )}
+              {messages.map((m, i) => (
+                <div
+                  key={m.id ?? i}
+                  style={{
+                    padding: '6px 0',
+                    fontSize: 13,
+                    display: 'flex',
+                    gap: 8,
+                    color: m.role === 'ai' ? '#999' : '#ccc',
+                  }}
+                >
+                  {m.role === 'ai' && (
+                    <span style={{ color: toolColor, fontWeight: 700, flexShrink: 0 }}>✦</span>
+                  )}
+                  <span>{m.text}</span>
+                </div>
+              ))}
+              {loading && (
+                <div style={{ padding: '6px 0', fontSize: 13, color: '#666' }}>✦ Thinking...</div>
+              )}
+              <div ref={scrollAnchorRef} />
+            </div>
+          )}
+
+          {activeTab !== 'chat' && activeTab !== 'runs' && (
+            <ProviderGroup tab={activeTab} />
+          )}
+
+          {activeTab === 'runs' && (
+            <div style={hubStyles.runsEmpty}>
+              <strong style={{ color: 'var(--text-main)' }}>No agent runs yet.</strong>
+              <div style={{ marginTop: 6 }}>
+                Future runs will show provider, task mode, approvals, proposed patches, and deployment actions in one audit trail.
+              </div>
+              <div style={{ marginTop: 10, color: '#77847d' }}>
+                This shell is UI-only; execution and approval gates land in the secure run lifecycle slice.
+              </div>
+            </div>
+          )}
+        </div>
       </div>
+
       <div style={S.chatInputRow}>
         <input
           style={S.chatInput}


### PR DESCRIPTION
## Summary
- turns the bottom AI Assistant area into an Agent Hub shell with Chat, Codex, Claude Code, Local, MCP, and Runs tabs
- adds task modes for review, generation, plan explanation, policy fixes, and deploy preparation
- keeps the existing chat input/message behavior intact while making local CLI, API, enterprise, MCP, and local model lanes visible
- documents the default safety posture in the UI: read-only by default, diff before writes, approve deploy, and no secret prompts

## Validation
- npm test -- --run src/components/Chat/ChatPanel.test.tsx
- npm test -- --run
- npm run build
- npm run lint (passes with existing warnings)

Closes #103