### PR TITLE
Fix Agent Hub review follow-ups

### DIFF
--- a/web/src/components/Chat/ChatPanel.test.tsx
+++ b/web/src/components/Chat/ChatPanel.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { render, screen, fireEvent, within } from '@testing-library/react';
 
@@ -56,10 +57,11 @@ describe('ChatPanel', () => {
     render(<ChatPanel {...baseProps} />);
     fireEvent.click(screen.getByRole('tab', { name: 'Codex' }));
 
-    expect(screen.getAllByText('Codex CLI').length).toBeGreaterThan(0);
-    expect(screen.getByText('OpenAI API')).toBeInTheDocument();
-    expect(screen.getByText(/official CLI session/)).toBeInTheDocument();
-    expect(screen.getByText(/Platform API account/)).toBeInTheDocument();
+    const codexPanel = screen.getByRole('tabpanel', { name: 'Codex' });
+    expect(within(codexPanel).getByText('Codex CLI')).toBeInTheDocument();
+    expect(within(codexPanel).getByText('OpenAI API')).toBeInTheDocument();
+    expect(within(codexPanel).getByText(/official CLI session/)).toBeInTheDocument();
+    expect(within(codexPanel).getByText(/Platform API account/)).toBeInTheDocument();
   });
 
   it('links provider tabs to stable tabpanels and supports roving keyboard selection', () => {
@@ -67,6 +69,8 @@ describe('ChatPanel', () => {
 
     const chatTab = screen.getByRole('tab', { name: 'Chat' });
     const codexTab = screen.getByRole('tab', { name: 'Codex' });
+    const tabList = screen.getByRole('tablist', { name: 'Agent Hub providers' });
+    expect(tabList).toHaveAttribute('aria-orientation', 'vertical');
     expect(chatTab).toHaveAttribute('id', 'agent-hub-tab-chat');
     expect(chatTab).toHaveAttribute('aria-controls', 'agent-hub-panel-chat');
     expect(codexTab).toHaveAttribute('aria-controls', 'agent-hub-panel-codex');
@@ -101,8 +105,24 @@ describe('ChatPanel', () => {
     render(<ChatPanel {...baseProps} providerLabel="Ollama" />);
     fireEvent.click(screen.getByRole('tab', { name: 'Local' }));
 
-    expect(screen.getAllByText('Ollama').length).toBeGreaterThan(0);
-    expect(screen.getByText('LM Studio / vLLM')).toBeInTheDocument();
-    expect(screen.getByText(/without cloud egress/)).toBeInTheDocument();
+    const localPanel = screen.getByRole('tabpanel', { name: 'Local' });
+    expect(within(localPanel).getByText('Ollama')).toBeInTheDocument();
+    expect(within(localPanel).getByText('LM Studio / vLLM')).toBeInTheDocument();
+    expect(within(localPanel).getByText(/without cloud egress/)).toBeInTheDocument();
+  });
+
+  it('scrolls to the newest chat message when returning to the Chat tab', () => {
+    const scrollAnchorRef = createRef<HTMLDivElement>();
+    render(<ChatPanel {...baseProps} scrollAnchorRef={scrollAnchorRef} />);
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(scrollAnchorRef.current, 'scrollIntoView', {
+      configurable: true,
+      value: scrollIntoView,
+    });
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Codex' }));
+    fireEvent.click(screen.getByRole('tab', { name: 'Chat' }));
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: 'nearest' });
   });
 });

--- a/web/src/components/Chat/ChatPanel.tsx
+++ b/web/src/components/Chat/ChatPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { CSSProperties, KeyboardEvent, RefObject } from 'react';
 
 import { S } from '../../styles';
@@ -211,6 +211,11 @@ export function ChatPanel({
     if (focus) focusSelectedTab(tab);
   };
 
+  useEffect(() => {
+    if (activeTab !== 'chat') return;
+    scrollAnchorRef?.current?.scrollIntoView?.({ block: 'nearest' });
+  }, [activeTab, scrollAnchorRef]);
+
   const handleTabKeyDown = (event: KeyboardEvent<HTMLButtonElement>, currentIndex: number) => {
     const lastIndex = AGENT_TABS.length - 1;
     const moveToIndex = (index: number) => {
@@ -245,7 +250,12 @@ export function ChatPanel({
 
       <div style={hubStyles.shell}>
         <div style={hubStyles.rail}>
-          <div style={hubStyles.tabList} role="tablist" aria-label="Agent Hub providers">
+          <div
+            style={hubStyles.tabList}
+            role="tablist"
+            aria-label="Agent Hub providers"
+            aria-orientation="vertical"
+          >
             {AGENT_TABS.map((tab, index) => (
               <button
                 key={tab.key}


### PR DESCRIPTION
## Summary
- scroll the chat anchor when users return to the Chat tab
- mark the Agent Hub provider tablist as vertical
- scope Codex and Local provider tests to the active tabpanel

## Validation
- npm test -- --run src/components/Chat/ChatPanel.test.tsx
- npm test -- --run
- npm run build
- npm run lint (warnings only in existing unrelated files)

Follow-up to post-merge Copilot review comments on #108.