### PR TITLE
Add Gemini and Copilot Agent Hub lanes

### DIFF
--- a/web/src/components/Chat/ChatPanel.test.tsx
+++ b/web/src/components/Chat/ChatPanel.test.tsx
@@ -19,6 +19,8 @@ describe('ChatPanel', () => {
     expect(screen.getByText('Agent Hub')).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: 'Codex' })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: 'Claude Code' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Gemini' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Copilot' })).toBeInTheDocument();
     expect(screen.getByText('Read-only default')).toBeInTheDocument();
     expect(screen.getByText('No secret prompts')).toBeInTheDocument();
     expect(screen.getByText(/Ask me to create infrastructure/)).toBeInTheDocument();
@@ -109,6 +111,22 @@ describe('ChatPanel', () => {
     expect(within(localPanel).getByText('Ollama')).toBeInTheDocument();
     expect(within(localPanel).getByText('LM Studio / vLLM')).toBeInTheDocument();
     expect(within(localPanel).getByText(/without cloud egress/)).toBeInTheDocument();
+  });
+
+  it('shows Gemini and Copilot as first-class assistant lanes', () => {
+    render(<ChatPanel {...baseProps} />);
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Gemini' }));
+    const geminiPanel = screen.getByRole('tabpanel', { name: 'Gemini' });
+    expect(within(geminiPanel).getByText('Gemini CLI')).toBeInTheDocument();
+    expect(within(geminiPanel).getByText('Gemini API')).toBeInTheDocument();
+    expect(within(geminiPanel).getByText(/local Gemini session/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Copilot' }));
+    const copilotPanel = screen.getByRole('tabpanel', { name: 'Copilot' });
+    expect(within(copilotPanel).getByText('GitHub Copilot CLI')).toBeInTheDocument();
+    expect(within(copilotPanel).getByText('Copilot coding agent')).toBeInTheDocument();
+    expect(within(copilotPanel).getByText(/GitHub auth session/)).toBeInTheDocument();
   });
 
   it('scrolls to the newest chat message when returning to the Chat tab', () => {

--- a/web/src/components/Chat/ChatPanel.tsx
+++ b/web/src/components/Chat/ChatPanel.tsx
@@ -28,13 +28,15 @@ export interface ChatPanelProps {
   providerLabel?: string;
 }
 
-type AgentHubTab = 'chat' | 'codex' | 'claude' | 'local' | 'mcp' | 'runs';
+type AgentHubTab = 'chat' | 'codex' | 'claude' | 'gemini' | 'copilot' | 'local' | 'mcp' | 'runs';
 type ProviderState = 'available' | 'setup' | 'planned' | 'guarded';
 
 const AGENT_TABS: { key: AgentHubTab; label: string }[] = [
   { key: 'chat', label: 'Chat' },
   { key: 'codex', label: 'Codex' },
   { key: 'claude', label: 'Claude Code' },
+  { key: 'gemini', label: 'Gemini' },
+  { key: 'copilot', label: 'Copilot' },
   { key: 'local', label: 'Local' },
   { key: 'mcp', label: 'MCP' },
   { key: 'runs', label: 'Runs' },
@@ -69,6 +71,24 @@ const PROVIDER_GROUPS: Record<Exclude<AgentHubTab, 'chat' | 'runs'>, {
       { name: 'Claude Code CLI', lane: 'Local agent', state: 'planned', note: 'Runs through the official local Claude Code login.' },
       { name: 'Anthropic API', lane: 'API', state: 'setup', note: 'Separate API billing for automation and hosted use.' },
       { name: 'Claude Team or Enterprise', lane: 'Enterprise', state: 'guarded', note: 'For managed access, policy, and audit controls.' },
+    ],
+  },
+  gemini: {
+    title: 'Gemini',
+    summary: 'Support Gemini CLI and API paths without forcing users into a separate hosted account flow first.',
+    providers: [
+      { name: 'Gemini CLI', lane: 'Local agent', state: 'planned', note: 'Use the local Gemini session when present.' },
+      { name: 'Gemini API', lane: 'API', state: 'setup', note: 'Explicit API billing path for automation and hosted workflows.' },
+      { name: 'Google Cloud enterprise controls', lane: 'Enterprise', state: 'guarded', note: 'For governed workspace use through organization policy.' },
+    ],
+  },
+  copilot: {
+    title: 'GitHub Copilot',
+    summary: 'Expose Copilot as a first-class assistant lane for teams already signed in through GitHub.',
+    providers: [
+      { name: 'GitHub Copilot CLI', lane: 'Local agent', state: 'planned', note: 'Use the local GitHub auth session and Copilot entitlement.' },
+      { name: 'Copilot coding agent', lane: 'Collaboration', state: 'guarded', note: 'Route issue and PR work through auditable GitHub workflows.' },
+      { name: 'Copilot Business or Enterprise', lane: 'Enterprise', state: 'setup', note: 'Use organization-managed access and policy controls.' },
     ],
   },
   local: {
@@ -191,6 +211,8 @@ export function ChatPanel({
   const activeProviderLabel = useMemo(() => {
     if (activeTab === 'codex') return 'Codex CLI';
     if (activeTab === 'claude') return 'Claude Code';
+    if (activeTab === 'gemini') return 'Gemini';
+    if (activeTab === 'copilot') return 'GitHub Copilot';
     if (activeTab === 'local') return providerLabel;
     if (activeTab === 'mcp') return 'MCP Airlock';
     if (activeTab === 'runs') return 'Run history';
@@ -347,7 +369,7 @@ export function ChatPanel({
             </div>
           </div>
 
-          {(['codex', 'claude', 'local', 'mcp'] as const).map(tab => (
+          {(['codex', 'claude', 'gemini', 'copilot', 'local', 'mcp'] as const).map(tab => (
             <ProviderGroup key={tab} tab={tab} active={activeTab === tab} />
           ))}
 


### PR DESCRIPTION
## Summary
- add Gemini and GitHub Copilot tabs to the Agent Hub shell
- add Gemini local/API/enterprise lanes and Copilot local/collaboration/enterprise lanes
- cover the new lanes with focused ChatPanel tests

## Scope
This is intentionally UI catalog only. Backend provider discovery for Codex, Claude Code, Gemini, Copilot, and Ollama will land in separate small PRs under #104.

## Validation
- npm test -- --run src/components/Chat/ChatPanel.test.tsx
- npm test -- --run
- npm run build
- npm run lint (warnings only in existing unrelated files)

Refs #104.