### PR TITLE
Add local agent provider discovery

### DIFF
--- a/internal/agentproviders/discovery.go
+++ b/internal/agentproviders/discovery.go
@@ -1,0 +1,144 @@
+package agentproviders
+
+import "os/exec"
+
+const (
+	StateAvailable          = "available"
+	StateNotInstalled       = "not_installed"
+	CredentialExternalLogin = "external_login"
+)
+
+type LookupFunc func(file string) (string, error)
+
+type LocalProviderDefinition struct {
+	ID          string
+	Name        string
+	Category    string
+	Entrypoint  string
+	Candidates  []string
+	AuthHint    string
+	InstallHint string
+}
+
+type LocalProviderStatus struct {
+	ID             string   `json:"id"`
+	Name           string   `json:"name"`
+	Category       string   `json:"category"`
+	State          string   `json:"state"`
+	Installed      bool     `json:"installed"`
+	Command        string   `json:"command,omitempty"`
+	Entrypoint     string   `json:"entrypoint"`
+	Candidates     []string `json:"candidates"`
+	CredentialMode string   `json:"credential_mode"`
+	AuthHint       string   `json:"auth_hint"`
+	InstallHint    string   `json:"install_hint,omitempty"`
+}
+
+type Discoverer struct {
+	lookup LookupFunc
+}
+
+type Option func(*Discoverer)
+
+func WithLookupFunc(lookup LookupFunc) Option {
+	return func(d *Discoverer) {
+		if lookup != nil {
+			d.lookup = lookup
+		}
+	}
+}
+
+func NewDiscoverer(opts ...Option) Discoverer {
+	d := Discoverer{lookup: exec.LookPath}
+	for _, opt := range opts {
+		opt(&d)
+	}
+	return d
+}
+
+func DiscoverLocal() []LocalProviderStatus {
+	return NewDiscoverer().DiscoverLocal()
+}
+
+func (d Discoverer) DiscoverLocal() []LocalProviderStatus {
+	definitions := DefaultLocalProviders()
+	statuses := make([]LocalProviderStatus, 0, len(definitions))
+	for _, definition := range definitions {
+		statuses = append(statuses, d.status(definition))
+	}
+	return statuses
+}
+
+func (d Discoverer) status(definition LocalProviderDefinition) LocalProviderStatus {
+	status := LocalProviderStatus{
+		ID:             definition.ID,
+		Name:           definition.Name,
+		Category:       definition.Category,
+		State:          StateNotInstalled,
+		Entrypoint:     definition.Entrypoint,
+		Candidates:     append([]string(nil), definition.Candidates...),
+		CredentialMode: CredentialExternalLogin,
+		AuthHint:       definition.AuthHint,
+		InstallHint:    definition.InstallHint,
+	}
+	for _, command := range definition.Candidates {
+		if _, err := d.lookup(command); err == nil {
+			status.Installed = true
+			status.State = StateAvailable
+			status.Command = command
+			status.InstallHint = ""
+			break
+		}
+	}
+	return status
+}
+
+func DefaultLocalProviders() []LocalProviderDefinition {
+	return []LocalProviderDefinition{
+		{
+			ID:          "codex",
+			Name:        "Codex CLI",
+			Category:    "local_agent",
+			Entrypoint:  "codex",
+			Candidates:  []string{"codex"},
+			AuthHint:    "Use the official local Codex sign-in; IaC Studio does not collect ChatGPT credentials.",
+			InstallHint: "Install the Codex CLI and sign in locally.",
+		},
+		{
+			ID:          "claude",
+			Name:        "Claude Code CLI",
+			Category:    "local_agent",
+			Entrypoint:  "claude",
+			Candidates:  []string{"claude"},
+			AuthHint:    "Use the official local Claude Code sign-in; IaC Studio does not collect Claude credentials.",
+			InstallHint: "Install Claude Code and sign in locally.",
+		},
+		{
+			ID:          "gemini",
+			Name:        "Gemini CLI",
+			Category:    "local_agent",
+			Entrypoint:  "gemini",
+			Candidates:  []string{"gemini"},
+			AuthHint:    "Use the local Gemini session when present; hosted API keys stay on the separate API path.",
+			InstallHint: "Install the Gemini CLI and sign in locally.",
+		},
+		{
+			ID:          "copilot",
+			Name:        "GitHub Copilot CLI",
+			Category:    "local_agent",
+			Entrypoint:  "gh copilot",
+			Candidates:  []string{"gh"},
+			AuthHint:    "Use the local GitHub CLI auth session and Copilot entitlement.",
+			InstallHint: "Install GitHub CLI with Copilot access and sign in locally.",
+		},
+		{
+			ID:          "ollama",
+			Name:        "Ollama",
+			Category:    "local_model",
+			Entrypoint:  "ollama",
+			Candidates:  []string{"ollama"},
+			AuthHint:    "Uses local models and does not require cloud credentials.",
+			InstallHint: "Install Ollama to enable local model workflows.",
+		},
+	}
+}

--- a/internal/agentproviders/discovery.go
+++ b/internal/agentproviders/discovery.go
@@ -7,6 +7,7 @@ const (
 	StateNotInstalled       = "not_installed"
 	CredentialExternalLogin = "external_login"
 	CredentialNone          = "none"
+	VersionUnknown          = "unknown"
 )
 
 type LookupFunc func(file string) (string, error)
@@ -17,6 +18,8 @@ type LocalProviderDefinition struct {
 	Category       string
 	Entrypoint     string
 	Candidates     []string
+	Version        string
+	Capabilities   []string
 	CredentialMode string
 	AuthHint       string
 	InstallHint    string
@@ -31,6 +34,8 @@ type LocalProviderStatus struct {
 	Command        string   `json:"command,omitempty"`
 	Entrypoint     string   `json:"entrypoint"`
 	Candidates     []string `json:"candidates"`
+	Version        string   `json:"version"`
+	Capabilities   []string `json:"capabilities"`
 	CredentialMode string   `json:"credential_mode"`
 	AuthHint       string   `json:"auth_hint"`
 	InstallHint    string   `json:"install_hint,omitempty"`
@@ -76,6 +81,10 @@ func (d Discoverer) status(definition LocalProviderDefinition) LocalProviderStat
 	if credentialMode == "" {
 		credentialMode = CredentialExternalLogin
 	}
+	version := definition.Version
+	if version == "" {
+		version = VersionUnknown
+	}
 	status := LocalProviderStatus{
 		ID:             definition.ID,
 		Name:           definition.Name,
@@ -83,6 +92,8 @@ func (d Discoverer) status(definition LocalProviderDefinition) LocalProviderStat
 		State:          StateNotInstalled,
 		Entrypoint:     definition.Entrypoint,
 		Candidates:     append([]string(nil), definition.Candidates...),
+		Version:        version,
+		Capabilities:   append([]string(nil), definition.Capabilities...),
 		CredentialMode: credentialMode,
 		AuthHint:       definition.AuthHint,
 		InstallHint:    definition.InstallHint,
@@ -102,47 +113,77 @@ func (d Discoverer) status(definition LocalProviderDefinition) LocalProviderStat
 func DefaultLocalProviders() []LocalProviderDefinition {
 	return []LocalProviderDefinition{
 		{
-			ID:          "codex",
-			Name:        "Codex CLI",
-			Category:    "local_agent",
-			Entrypoint:  "codex",
-			Candidates:  []string{"codex"},
+			ID:         "codex",
+			Name:       "Codex CLI",
+			Category:   "local_agent",
+			Entrypoint: "codex",
+			Candidates: []string{"codex"},
+			Capabilities: []string{
+				"chat",
+				"code_editing",
+				"iac_assistance",
+				"local_cli",
+			},
 			AuthHint:    "Use the official local Codex sign-in; IaC Studio does not collect ChatGPT credentials.",
 			InstallHint: "Install the Codex CLI and sign in locally.",
 		},
 		{
-			ID:          "claude",
-			Name:        "Claude Code CLI",
-			Category:    "local_agent",
-			Entrypoint:  "claude",
-			Candidates:  []string{"claude"},
+			ID:         "claude",
+			Name:       "Claude Code CLI",
+			Category:   "local_agent",
+			Entrypoint: "claude",
+			Candidates: []string{"claude"},
+			Capabilities: []string{
+				"chat",
+				"code_editing",
+				"iac_assistance",
+				"local_cli",
+			},
 			AuthHint:    "Use the official local Claude Code sign-in; IaC Studio does not collect Claude credentials.",
 			InstallHint: "Install Claude Code and sign in locally.",
 		},
 		{
-			ID:          "gemini",
-			Name:        "Gemini CLI",
-			Category:    "local_agent",
-			Entrypoint:  "gemini",
-			Candidates:  []string{"gemini"},
+			ID:         "gemini",
+			Name:       "Gemini CLI",
+			Category:   "local_agent",
+			Entrypoint: "gemini",
+			Candidates: []string{"gemini"},
+			Capabilities: []string{
+				"chat",
+				"code_editing",
+				"iac_assistance",
+				"local_cli",
+			},
 			AuthHint:    "Use the local Gemini session when present; hosted API keys stay on the separate API path.",
 			InstallHint: "Install the Gemini CLI and sign in locally.",
 		},
 		{
-			ID:          "copilot",
-			Name:        "GitHub Copilot CLI",
-			Category:    "local_agent",
-			Entrypoint:  "gh copilot",
-			Candidates:  []string{"gh-copilot"},
+			ID:         "copilot",
+			Name:       "GitHub Copilot CLI",
+			Category:   "local_agent",
+			Entrypoint: "gh-copilot",
+			Candidates: []string{"gh-copilot"},
+			Capabilities: []string{
+				"chat",
+				"code_assistance",
+				"iac_assistance",
+				"local_cli",
+			},
 			AuthHint:    "Use the local GitHub CLI auth session and Copilot entitlement.",
 			InstallHint: "Install the GitHub CLI Copilot extension and sign in locally.",
 		},
 		{
-			ID:             "ollama",
-			Name:           "Ollama",
-			Category:       "local_model",
-			Entrypoint:     "ollama",
-			Candidates:     []string{"ollama"},
+			ID:         "ollama",
+			Name:       "Ollama",
+			Category:   "local_model",
+			Entrypoint: "ollama",
+			Candidates: []string{"ollama"},
+			Capabilities: []string{
+				"chat",
+				"iac_assistance",
+				"local_model",
+				"offline_runtime",
+			},
 			CredentialMode: CredentialNone,
 			AuthHint:       "Uses local models and does not require cloud credentials.",
 			InstallHint:    "Install Ollama to enable local model workflows.",

--- a/internal/agentproviders/discovery.go
+++ b/internal/agentproviders/discovery.go
@@ -127,9 +127,9 @@ func DefaultLocalProviders() []LocalProviderDefinition {
 			Name:        "GitHub Copilot CLI",
 			Category:    "local_agent",
 			Entrypoint:  "gh copilot",
-			Candidates:  []string{"gh"},
+			Candidates:  []string{"gh-copilot"},
 			AuthHint:    "Use the local GitHub CLI auth session and Copilot entitlement.",
-			InstallHint: "Install GitHub CLI with Copilot access and sign in locally.",
+			InstallHint: "Install the GitHub CLI Copilot extension and sign in locally.",
 		},
 		{
 			ID:          "ollama",

--- a/internal/agentproviders/discovery.go
+++ b/internal/agentproviders/discovery.go
@@ -6,18 +6,20 @@ const (
 	StateAvailable          = "available"
 	StateNotInstalled       = "not_installed"
 	CredentialExternalLogin = "external_login"
+	CredentialNone          = "none"
 )
 
 type LookupFunc func(file string) (string, error)
 
 type LocalProviderDefinition struct {
-	ID          string
-	Name        string
-	Category    string
-	Entrypoint  string
-	Candidates  []string
-	AuthHint    string
-	InstallHint string
+	ID             string
+	Name           string
+	Category       string
+	Entrypoint     string
+	Candidates     []string
+	CredentialMode string
+	AuthHint       string
+	InstallHint    string
 }
 
 type LocalProviderStatus struct {
@@ -70,6 +72,10 @@ func (d Discoverer) DiscoverLocal() []LocalProviderStatus {
 }
 
 func (d Discoverer) status(definition LocalProviderDefinition) LocalProviderStatus {
+	credMode := definition.CredentialMode
+	if credMode == "" {
+		credMode = CredentialExternalLogin
+	}
 	status := LocalProviderStatus{
 		ID:             definition.ID,
 		Name:           definition.Name,
@@ -77,7 +83,7 @@ func (d Discoverer) status(definition LocalProviderDefinition) LocalProviderStat
 		State:          StateNotInstalled,
 		Entrypoint:     definition.Entrypoint,
 		Candidates:     append([]string(nil), definition.Candidates...),
-		CredentialMode: CredentialExternalLogin,
+		CredentialMode: credMode,
 		AuthHint:       definition.AuthHint,
 		InstallHint:    definition.InstallHint,
 	}
@@ -132,13 +138,14 @@ func DefaultLocalProviders() []LocalProviderDefinition {
 			InstallHint: "Install the GitHub CLI Copilot extension and sign in locally.",
 		},
 		{
-			ID:          "ollama",
-			Name:        "Ollama",
-			Category:    "local_model",
-			Entrypoint:  "ollama",
-			Candidates:  []string{"ollama"},
-			AuthHint:    "Uses local models and does not require cloud credentials.",
-			InstallHint: "Install Ollama to enable local model workflows.",
+			ID:             "ollama",
+			Name:           "Ollama",
+			Category:       "local_model",
+			Entrypoint:     "ollama",
+			Candidates:     []string{"ollama"},
+			CredentialMode: CredentialNone,
+			AuthHint:       "Uses local models and does not require cloud credentials.",
+			InstallHint:    "Install Ollama to enable local model workflows.",
 		},
 	}
 }

--- a/internal/agentproviders/discovery.go
+++ b/internal/agentproviders/discovery.go
@@ -91,9 +91,9 @@ func (d Discoverer) status(definition LocalProviderDefinition) LocalProviderStat
 		Category:       definition.Category,
 		State:          StateNotInstalled,
 		Entrypoint:     definition.Entrypoint,
-		Candidates:     append([]string(nil), definition.Candidates...),
+		Candidates:     cloneStringSlice(definition.Candidates),
 		Version:        version,
-		Capabilities:   append([]string(nil), definition.Capabilities...),
+		Capabilities:   cloneStringSlice(definition.Capabilities),
 		CredentialMode: credentialMode,
 		AuthHint:       definition.AuthHint,
 		InstallHint:    definition.InstallHint,
@@ -108,6 +108,13 @@ func (d Discoverer) status(definition LocalProviderDefinition) LocalProviderStat
 		}
 	}
 	return status
+}
+
+func cloneStringSlice(values []string) []string {
+	if len(values) == 0 {
+		return []string{}
+	}
+	return append([]string(nil), values...)
 }
 
 func DefaultLocalProviders() []LocalProviderDefinition {

--- a/internal/agentproviders/discovery.go
+++ b/internal/agentproviders/discovery.go
@@ -6,18 +6,20 @@ const (
 	StateAvailable          = "available"
 	StateNotInstalled       = "not_installed"
 	CredentialExternalLogin = "external_login"
+	CredentialNone          = "none"
 )
 
 type LookupFunc func(file string) (string, error)
 
 type LocalProviderDefinition struct {
-	ID          string
-	Name        string
-	Category    string
-	Entrypoint  string
-	Candidates  []string
-	AuthHint    string
-	InstallHint string
+	ID             string
+	Name           string
+	Category       string
+	Entrypoint     string
+	Candidates     []string
+	CredentialMode string
+	AuthHint       string
+	InstallHint    string
 }
 
 type LocalProviderStatus struct {
@@ -70,6 +72,10 @@ func (d Discoverer) DiscoverLocal() []LocalProviderStatus {
 }
 
 func (d Discoverer) status(definition LocalProviderDefinition) LocalProviderStatus {
+	credentialMode := definition.CredentialMode
+	if credentialMode == "" {
+		credentialMode = CredentialExternalLogin
+	}
 	status := LocalProviderStatus{
 		ID:             definition.ID,
 		Name:           definition.Name,
@@ -77,7 +83,7 @@ func (d Discoverer) status(definition LocalProviderDefinition) LocalProviderStat
 		State:          StateNotInstalled,
 		Entrypoint:     definition.Entrypoint,
 		Candidates:     append([]string(nil), definition.Candidates...),
-		CredentialMode: CredentialExternalLogin,
+		CredentialMode: credentialMode,
 		AuthHint:       definition.AuthHint,
 		InstallHint:    definition.InstallHint,
 	}
@@ -132,13 +138,14 @@ func DefaultLocalProviders() []LocalProviderDefinition {
 			InstallHint: "Install the GitHub CLI Copilot extension and sign in locally.",
 		},
 		{
-			ID:          "ollama",
-			Name:        "Ollama",
-			Category:    "local_model",
-			Entrypoint:  "ollama",
-			Candidates:  []string{"ollama"},
-			AuthHint:    "Uses local models and does not require cloud credentials.",
-			InstallHint: "Install Ollama to enable local model workflows.",
+			ID:             "ollama",
+			Name:           "Ollama",
+			Category:       "local_model",
+			Entrypoint:     "ollama",
+			Candidates:     []string{"ollama"},
+			CredentialMode: CredentialNone,
+			AuthHint:       "Uses local models and does not require cloud credentials.",
+			InstallHint:    "Install Ollama to enable local model workflows.",
 		},
 	}
 }

--- a/internal/agentproviders/discovery_test.go
+++ b/internal/agentproviders/discovery_test.go
@@ -49,7 +49,7 @@ func TestDiscoverLocalUsesLookupWithoutLeakingPaths(t *testing.T) {
 	if status := byID["copilot"]; !status.Installed || status.Command != "gh-copilot" || status.Entrypoint != "gh copilot" {
 		t.Fatalf("unexpected copilot status: %+v", status)
 	}
-	if status := byID["ollama"]; !status.Installed || status.Category != "local_model" {
+	if status := byID["ollama"]; !status.Installed || status.Category != "local_model" || status.CredentialMode != CredentialNone {
 		t.Fatalf("unexpected ollama status: %+v", status)
 	}
 

--- a/internal/agentproviders/discovery_test.go
+++ b/internal/agentproviders/discovery_test.go
@@ -22,9 +22,9 @@ func TestDefaultLocalProviderOrder(t *testing.T) {
 
 func TestDiscoverLocalUsesLookupWithoutLeakingPaths(t *testing.T) {
 	installed := map[string]string{
-		"codex":  "/private/bin/codex",
-		"gh":     "/private/bin/gh",
-		"ollama": "/private/bin/ollama",
+		"codex":      "/private/bin/codex",
+		"gh-copilot": "/private/bin/gh-copilot",
+		"ollama":     "/private/bin/ollama",
 	}
 	discoverer := NewDiscoverer(WithLookupFunc(func(file string) (string, error) {
 		path, ok := installed[file]
@@ -46,7 +46,7 @@ func TestDiscoverLocalUsesLookupWithoutLeakingPaths(t *testing.T) {
 	if status := byID["claude"]; status.Installed || status.State != StateNotInstalled || status.Command != "" {
 		t.Fatalf("unexpected claude status: %+v", status)
 	}
-	if status := byID["copilot"]; !status.Installed || status.Command != "gh" || status.Entrypoint != "gh copilot" {
+	if status := byID["copilot"]; !status.Installed || status.Command != "gh-copilot" || status.Entrypoint != "gh copilot" {
 		t.Fatalf("unexpected copilot status: %+v", status)
 	}
 	if status := byID["ollama"]; !status.Installed || status.Category != "local_model" {
@@ -57,7 +57,7 @@ func TestDiscoverLocalUsesLookupWithoutLeakingPaths(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal statuses: %v", err)
 	}
-	if got := string(data); containsAny(got, []string{"/private/bin/codex", "/private/bin/gh", "/private/bin/ollama"}) {
+	if got := string(data); containsAny(got, []string{"/private/bin/codex", "/private/bin/gh-copilot", "/private/bin/ollama"}) {
 		t.Fatalf("status JSON leaked executable path: %s", got)
 	}
 }

--- a/internal/agentproviders/discovery_test.go
+++ b/internal/agentproviders/discovery_test.go
@@ -40,7 +40,7 @@ func TestDiscoverLocalUsesLookupWithoutLeakingPaths(t *testing.T) {
 		byID[status.ID] = status
 	}
 
-	if status := byID["codex"]; !status.Installed || status.Command != "codex" || status.Entrypoint != "codex" {
+	if status := byID["codex"]; !status.Installed || status.Command != "codex" || status.Entrypoint != "codex" || status.CredentialMode != CredentialExternalLogin {
 		t.Fatalf("unexpected codex status: %+v", status)
 	}
 	if status := byID["claude"]; status.Installed || status.State != StateNotInstalled || status.Command != "" {
@@ -49,7 +49,7 @@ func TestDiscoverLocalUsesLookupWithoutLeakingPaths(t *testing.T) {
 	if status := byID["copilot"]; !status.Installed || status.Command != "gh-copilot" || status.Entrypoint != "gh copilot" {
 		t.Fatalf("unexpected copilot status: %+v", status)
 	}
-	if status := byID["ollama"]; !status.Installed || status.Category != "local_model" {
+	if status := byID["ollama"]; !status.Installed || status.Category != "local_model" || status.CredentialMode != CredentialNone {
 		t.Fatalf("unexpected ollama status: %+v", status)
 	}
 

--- a/internal/agentproviders/discovery_test.go
+++ b/internal/agentproviders/discovery_test.go
@@ -1,0 +1,72 @@
+package agentproviders
+
+import (
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestDefaultLocalProviderOrder(t *testing.T) {
+	definitions := DefaultLocalProviders()
+	got := make([]string, 0, len(definitions))
+	for _, definition := range definitions {
+		got = append(got, definition.ID)
+	}
+	want := []string{"codex", "claude", "gemini", "copilot", "ollama"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("provider order = %#v, want %#v", got, want)
+	}
+}
+
+func TestDiscoverLocalUsesLookupWithoutLeakingPaths(t *testing.T) {
+	installed := map[string]string{
+		"codex":  "/private/bin/codex",
+		"gh":     "/private/bin/gh",
+		"ollama": "/private/bin/ollama",
+	}
+	discoverer := NewDiscoverer(WithLookupFunc(func(file string) (string, error) {
+		path, ok := installed[file]
+		if !ok {
+			return "", errors.New("not found")
+		}
+		return path, nil
+	}))
+
+	statuses := discoverer.DiscoverLocal()
+	byID := map[string]LocalProviderStatus{}
+	for _, status := range statuses {
+		byID[status.ID] = status
+	}
+
+	if status := byID["codex"]; !status.Installed || status.Command != "codex" || status.Entrypoint != "codex" {
+		t.Fatalf("unexpected codex status: %+v", status)
+	}
+	if status := byID["claude"]; status.Installed || status.State != StateNotInstalled || status.Command != "" {
+		t.Fatalf("unexpected claude status: %+v", status)
+	}
+	if status := byID["copilot"]; !status.Installed || status.Command != "gh" || status.Entrypoint != "gh copilot" {
+		t.Fatalf("unexpected copilot status: %+v", status)
+	}
+	if status := byID["ollama"]; !status.Installed || status.Category != "local_model" {
+		t.Fatalf("unexpected ollama status: %+v", status)
+	}
+
+	data, err := json.Marshal(statuses)
+	if err != nil {
+		t.Fatalf("marshal statuses: %v", err)
+	}
+	if got := string(data); containsAny(got, []string{"/private/bin/codex", "/private/bin/gh", "/private/bin/ollama"}) {
+		t.Fatalf("status JSON leaked executable path: %s", got)
+	}
+}
+
+func containsAny(s string, needles []string) bool {
+	for _, needle := range needles {
+		if len(needle) > 0 && strings.Contains(s, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/agentproviders/discovery_test.go
+++ b/internal/agentproviders/discovery_test.go
@@ -62,6 +62,34 @@ func TestDiscoverLocalUsesLookupWithoutLeakingPaths(t *testing.T) {
 	}
 }
 
+func TestStatusNormalizesListFieldsForJSONConsumers(t *testing.T) {
+	discoverer := NewDiscoverer(WithLookupFunc(func(string) (string, error) {
+		return "", errors.New("not found")
+	}))
+
+	status := discoverer.status(LocalProviderDefinition{
+		ID:         "custom",
+		Name:       "Custom Provider",
+		Category:   "local_agent",
+		Entrypoint: "custom",
+	})
+
+	if status.Candidates == nil {
+		t.Fatalf("candidates should be an empty slice, got nil")
+	}
+	if status.Capabilities == nil {
+		t.Fatalf("capabilities should be an empty slice, got nil")
+	}
+	data, err := json.Marshal(status)
+	if err != nil {
+		t.Fatalf("marshal status: %v", err)
+	}
+	got := string(data)
+	if !strings.Contains(got, `"candidates":[]`) || !strings.Contains(got, `"capabilities":[]`) {
+		t.Fatalf("status JSON should expose empty arrays, got %s", got)
+	}
+}
+
 func containsAny(s string, needles []string) bool {
 	for _, needle := range needles {
 		if len(needle) > 0 && strings.Contains(s, needle) {

--- a/internal/agentproviders/discovery_test.go
+++ b/internal/agentproviders/discovery_test.go
@@ -40,16 +40,16 @@ func TestDiscoverLocalUsesLookupWithoutLeakingPaths(t *testing.T) {
 		byID[status.ID] = status
 	}
 
-	if status := byID["codex"]; !status.Installed || status.Command != "codex" || status.Entrypoint != "codex" || status.CredentialMode != CredentialExternalLogin {
+	if status := byID["codex"]; !status.Installed || status.Command != "codex" || status.Entrypoint != "codex" || status.CredentialMode != CredentialExternalLogin || status.Version != VersionUnknown || !hasCapability(status, "local_cli") {
 		t.Fatalf("unexpected codex status: %+v", status)
 	}
 	if status := byID["claude"]; status.Installed || status.State != StateNotInstalled || status.Command != "" {
 		t.Fatalf("unexpected claude status: %+v", status)
 	}
-	if status := byID["copilot"]; !status.Installed || status.Command != "gh-copilot" || status.Entrypoint != "gh copilot" {
+	if status := byID["copilot"]; !status.Installed || status.Command != "gh-copilot" || status.Entrypoint != "gh-copilot" {
 		t.Fatalf("unexpected copilot status: %+v", status)
 	}
-	if status := byID["ollama"]; !status.Installed || status.Category != "local_model" || status.CredentialMode != CredentialNone {
+	if status := byID["ollama"]; !status.Installed || status.Category != "local_model" || status.CredentialMode != CredentialNone || !hasCapability(status, "offline_runtime") {
 		t.Fatalf("unexpected ollama status: %+v", status)
 	}
 
@@ -65,6 +65,15 @@ func TestDiscoverLocalUsesLookupWithoutLeakingPaths(t *testing.T) {
 func containsAny(s string, needles []string) bool {
 	for _, needle := range needles {
 		if len(needle) > 0 && strings.Contains(s, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasCapability(status LocalProviderStatus, want string) bool {
+	for _, capability := range status.Capabilities {
+		if capability == want {
 			return true
 		}
 	}

--- a/internal/api/agent_providers_test.go
+++ b/internal/api/agent_providers_test.go
@@ -36,6 +36,8 @@ func TestAgentHubLocalProvidersRouteUsesConfiguredDiscovery(t *testing.T) {
 				Command:        "gemini",
 				Entrypoint:     "gemini",
 				Candidates:     []string{"gemini"},
+				Version:        agentproviders.VersionUnknown,
+				Capabilities:   []string{"chat", "local_cli"},
 				CredentialMode: agentproviders.CredentialExternalLogin,
 				AuthHint:       "Use the local Gemini session.",
 			}}
@@ -59,7 +61,7 @@ func TestAgentHubLocalProvidersRouteUsesConfiguredDiscovery(t *testing.T) {
 		t.Fatalf("providers = %+v", body.Providers)
 	}
 	got := body.Providers[0]
-	if got.ID != "gemini" || !got.Installed || got.Command != "gemini" || got.CredentialMode != agentproviders.CredentialExternalLogin {
+	if got.ID != "gemini" || !got.Installed || got.Command != "gemini" || got.Version != agentproviders.VersionUnknown || len(got.Capabilities) != 2 || got.CredentialMode != agentproviders.CredentialExternalLogin {
 		t.Fatalf("unexpected provider payload: %+v", got)
 	}
 }

--- a/internal/api/agent_providers_test.go
+++ b/internal/api/agent_providers_test.go
@@ -1,0 +1,65 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/iac-studio/iac-studio/internal/agentproviders"
+	"github.com/iac-studio/iac-studio/internal/ai"
+	"github.com/iac-studio/iac-studio/internal/runner"
+	"github.com/iac-studio/iac-studio/internal/watcher"
+)
+
+func TestAgentHubLocalProvidersRouteUsesConfiguredDiscovery(t *testing.T) {
+	root := t.TempDir()
+	hub := NewHub()
+	go hub.Run()
+	t.Cleanup(hub.Close)
+	fw := watcher.New(hub)
+	t.Cleanup(fw.Close)
+
+	router := NewRouterWithOptions(
+		hub,
+		fw,
+		ai.NewClient("http://127.0.0.1:1", "ignored"),
+		runner.NewSafeRunner(runner.DefaultSafetyConfig()),
+		root,
+		RouterOptions{LocalAgentProviders: func() []agentproviders.LocalProviderStatus {
+			return []agentproviders.LocalProviderStatus{{
+				ID:             "gemini",
+				Name:           "Gemini CLI",
+				Category:       "local_agent",
+				State:          agentproviders.StateAvailable,
+				Installed:      true,
+				Command:        "gemini",
+				Entrypoint:     "gemini",
+				Candidates:     []string{"gemini"},
+				CredentialMode: agentproviders.CredentialExternalLogin,
+				AuthHint:       "Use the local Gemini session.",
+			}}
+		}},
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/agent-hub/providers/local", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	var body struct {
+		Providers []agentproviders.LocalProviderStatus `json:"providers"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(body.Providers) != 1 {
+		t.Fatalf("providers = %+v", body.Providers)
+	}
+	got := body.Providers[0]
+	if got.ID != "gemini" || !got.Installed || got.Command != "gemini" || got.CredentialMode != agentproviders.CredentialExternalLogin {
+		t.Fatalf("unexpected provider payload: %+v", got)
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1083,9 +1083,9 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 		_ = json.NewEncoder(w).Encode(tools)
 	})
 
-	// List local assistant providers detected on this machine. Discovery is
-	// PATH-only: it does not execute provider CLIs, read auth files, call
-	// localhost services, or return absolute executable paths.
+	// List local assistant providers detected on this machine. The built-in
+	// discovery is PATH-only: it does not execute provider CLIs, read auth
+	// files, call localhost services, or return absolute executable paths.
 	mux.HandleFunc("GET /api/agent-hub/providers/local", func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"providers": opts.localAgentProviders(),

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/iac-studio/iac-studio/internal/agentproviders"
 	"github.com/iac-studio/iac-studio/internal/ai"
 	"github.com/iac-studio/iac-studio/internal/ai/providers"
 	"github.com/iac-studio/iac-studio/internal/catalog"
@@ -1034,8 +1035,9 @@ func requireOptionalJSONContentType(w http.ResponseWriter, r *http.Request) bool
 // RouterOptions allows callers to provide services and configuration that need
 // explicit ownership outside the router.
 type RouterOptions struct {
-	MCPAirlock *mcpairlock.Manager
-	AppVersion string
+	MCPAirlock          *mcpairlock.Manager
+	AppVersion          string
+	LocalAgentProviders func() []agentproviders.LocalProviderStatus
 }
 
 const defaultAppVersion = "0.1.0"
@@ -1046,6 +1048,13 @@ func (opts RouterOptions) appVersion() string {
 		return defaultAppVersion
 	}
 	return version
+}
+
+func (opts RouterOptions) localAgentProviders() []agentproviders.LocalProviderStatus {
+	if opts.LocalAgentProviders != nil {
+		return opts.LocalAgentProviders()
+	}
+	return agentproviders.DiscoverLocal()
 }
 
 // NewRouter creates the HTTP router with all endpoints.
@@ -1072,6 +1081,15 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 	mux.HandleFunc("GET /api/tools", func(w http.ResponseWriter, r *http.Request) {
 		tools := run.DetectTools()
 		_ = json.NewEncoder(w).Encode(tools)
+	})
+
+	// List local assistant providers detected on this machine. Discovery is
+	// PATH-only: it does not execute provider CLIs, read auth files, call
+	// localhost services, or return absolute executable paths.
+	mux.HandleFunc("GET /api/agent-hub/providers/local", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"providers": opts.localAgentProviders(),
+		})
 	})
 
 	// Resource catalog — returns all resources for a tool, optionally filtered by provider


### PR DESCRIPTION
## Summary
- add backend discovery for local assistant providers: Codex, Claude Code, Gemini, GitHub Copilot, and Ollama
- expose GET /api/agent-hub/providers/local
- keep the built-in discovery PATH-only: no CLI execution, no auth-file reads, no localhost probes, no absolute executable paths in responses
- use `gh-copilot` (Copilot-specific extension binary) instead of generic `gh` for GitHub Copilot detection
- add per-provider `credential_mode` field; introduce `CredentialNone` for providers that require no cloud credentials (Ollama)
- include PATH-only `version` and `capabilities` fields in local provider status (`version: unknown` for this slice)
- normalize `candidates` and `capabilities` JSON fields to emit `[]` instead of `null`

## Scope
Backend-only slice for #104. Frontend wiring and per-provider execution/auth flows will land in separate small PRs.

## Validation
- GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/agentproviders ./internal/api
- GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/...