### PR TITLE
Add local agent provider API client

### DIFF
--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -214,6 +214,42 @@ describe('api.mcpAirlock', () => {
   });
 });
 
+describe('api.listLocalAgentProviders', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('fetches local agent provider statuses from Agent Hub', async () => {
+    const response = {
+      providers: [{
+        id: 'ollama',
+        name: 'Ollama',
+        category: 'local_model',
+        state: 'available',
+        installed: true,
+        command: 'ollama',
+        entrypoint: 'ollama',
+        candidates: ['ollama'],
+        version: 'unknown',
+        capabilities: ['chat', 'local_model', 'offline_runtime'],
+        credential_mode: 'none',
+        auth_hint: 'Uses local models and does not require cloud credentials.',
+      }],
+    };
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(response), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(api.listLocalAgentProviders()).resolves.toEqual(response.providers);
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/agent-hub/providers/local');
+  });
+});
+
 describe('api.listProjectStates', () => {
   afterEach(() => {
     vi.unstubAllGlobals();

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -248,6 +248,17 @@ describe('api.listLocalAgentProviders', () => {
 
     expect(fetchMock).toHaveBeenCalledWith('/api/agent-hub/providers/local');
   });
+
+  it('coerces null local agent provider responses to an empty array', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response('null', {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    ));
+
+    await expect(api.listLocalAgentProviders()).resolves.toEqual([]);
+  });
 });
 
 describe('api.listProjectStates', () => {

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -550,8 +550,10 @@ export const api = {
 
   async listLocalAgentProviders(): Promise<LocalAgentProviderStatus[]> {
     const res = await fetch(`${BASE}/api/agent-hub/providers/local`);
-    const body = (await (await check(res)).json()) as LocalAgentProvidersResponse;
-    return Array.isArray(body.providers) ? body.providers : [];
+    const body = (await (await check(res)).json()) as unknown;
+    if (!body || typeof body !== 'object') return [];
+    const providers = (body as Partial<LocalAgentProvidersResponse>).providers;
+    return Array.isArray(providers) ? providers : [];
   },
 
   async listCloudConnections(): Promise<CloudConnection[]> {

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -226,6 +226,41 @@ export interface MCPAirlockToolInventory {
   checks: MCPAirlockCheck[];
 }
 
+export type LocalAgentProviderState =
+  | 'available'
+  | 'not_installed'
+  | (string & Record<never, never>);
+
+export type LocalAgentProviderCategory =
+  | 'local_agent'
+  | 'local_model'
+  | (string & Record<never, never>);
+
+export type LocalAgentProviderCredentialMode =
+  | 'external_login'
+  | 'none'
+  | (string & Record<never, never>);
+
+export interface LocalAgentProviderStatus {
+  id: string;
+  name: string;
+  category: LocalAgentProviderCategory;
+  state: LocalAgentProviderState;
+  installed: boolean;
+  command?: string;
+  entrypoint: string;
+  candidates: string[];
+  version: string;
+  capabilities: string[];
+  credential_mode: LocalAgentProviderCredentialMode;
+  auth_hint: string;
+  install_hint?: string;
+}
+
+export interface LocalAgentProvidersResponse {
+  providers: LocalAgentProviderStatus[];
+}
+
 export type PlanRiskLevel = 'safe' | 'risky' | 'destructive' | 'unknown';
 
 export interface PlanFieldChange {
@@ -511,6 +546,12 @@ export const api = {
       body: JSON.stringify({ tool_name: toolName, project, allowed }),
     });
     return (await check(res)).json();
+  },
+
+  async listLocalAgentProviders(): Promise<LocalAgentProviderStatus[]> {
+    const res = await fetch(`${BASE}/api/agent-hub/providers/local`);
+    const body = (await (await check(res)).json()) as LocalAgentProvidersResponse;
+    return Array.isArray(body.providers) ? body.providers : [];
   },
 
   async listCloudConnections(): Promise<CloudConnection[]> {


### PR DESCRIPTION
## Summary
- add frontend types for local Agent Hub provider discovery responses
- add api.listLocalAgentProviders() for GET /api/agent-hub/providers/local
- cover the new client method in web/src/api.test.ts

## Scope
Small frontend API-client slice for #104. No UI rendering, provider selection, login, or execution logic in this PR.

## Validation
- npm test -- --run src/api.test.ts
- npm run build