### PR TITLE
Persist agent provider selection

### DIFF
--- a/web/src/components/Chat/ChatPanel.test.tsx
+++ b/web/src/components/Chat/ChatPanel.test.tsx
@@ -25,6 +25,7 @@ describe('ChatPanel', () => {
   beforeEach(() => {
     listLocalAgentProvidersMock.mockReset();
     listLocalAgentProvidersMock.mockReturnValue(new Promise(() => {}));
+    window.localStorage.clear();
   });
 
   it('renders the empty-state hint when no messages are present', () => {
@@ -142,6 +143,22 @@ describe('ChatPanel', () => {
 
     expect(reviewProject).toHaveAttribute('aria-pressed', 'false');
     expect(generateIac).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('persists the selected provider tab and task mode locally', () => {
+    const firstRender = render(<ChatPanel {...baseProps} />);
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Gemini' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Generate IaC' }));
+
+    expect(window.localStorage.getItem('iac-studio.agentHub.activeTab')).toBe('gemini');
+    expect(window.localStorage.getItem('iac-studio.agentHub.activeTask')).toBe('Generate IaC');
+
+    firstRender.unmount();
+    render(<ChatPanel {...baseProps} />);
+
+    expect(screen.getByRole('tab', { name: 'Gemini' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('button', { name: 'Generate IaC' })).toHaveAttribute('aria-pressed', 'true');
   });
 
   it('keeps local model support visible as a first-class lane', () => {

--- a/web/src/components/Chat/ChatPanel.test.tsx
+++ b/web/src/components/Chat/ChatPanel.test.tsx
@@ -161,6 +161,48 @@ describe('ChatPanel', () => {
     expect(screen.getByRole('button', { name: 'Generate IaC' })).toHaveAttribute('aria-pressed', 'true');
   });
 
+  it('falls back to defaults when persisted provider selection is invalid', () => {
+    window.localStorage.setItem('iac-studio.agentHub.activeTab', 'missing-provider');
+    window.localStorage.setItem('iac-studio.agentHub.activeTask', 'Unsupported task');
+
+    render(<ChatPanel {...baseProps} />);
+
+    expect(screen.getByRole('tab', { name: 'Chat' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('button', { name: 'Review project' })).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('keeps the UI usable when localStorage reads are blocked', () => {
+    const getItemSpy = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('localStorage read blocked');
+    });
+
+    try {
+      render(<ChatPanel {...baseProps} />);
+
+      expect(screen.getByRole('tab', { name: 'Chat' })).toHaveAttribute('aria-selected', 'true');
+      expect(screen.getByRole('button', { name: 'Review project' })).toHaveAttribute('aria-pressed', 'true');
+    } finally {
+      getItemSpy.mockRestore();
+    }
+  });
+
+  it('keeps provider and task selection usable when localStorage writes are blocked', () => {
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('localStorage write blocked');
+    });
+
+    try {
+      render(<ChatPanel {...baseProps} />);
+
+      expect(() => fireEvent.click(screen.getByRole('tab', { name: 'Gemini' }))).not.toThrow();
+      expect(() => fireEvent.click(screen.getByRole('button', { name: 'Generate IaC' }))).not.toThrow();
+      expect(screen.getByRole('tab', { name: 'Gemini' })).toHaveAttribute('aria-selected', 'true');
+      expect(screen.getByRole('button', { name: 'Generate IaC' })).toHaveAttribute('aria-pressed', 'true');
+    } finally {
+      setItemSpy.mockRestore();
+    }
+  });
+
   it('keeps local model support visible as a first-class lane', () => {
     render(<ChatPanel {...baseProps} providerLabel="Ollama" />);
     fireEvent.click(screen.getByRole('tab', { name: 'Local' }));

--- a/web/src/components/Chat/ChatPanel.tsx
+++ b/web/src/components/Chat/ChatPanel.tsx
@@ -49,7 +49,12 @@ const TASK_MODES = [
   'Explain plan',
   'Fix policy',
   'Prepare deploy',
-];
+] as const;
+
+const AGENT_HUB_STORAGE_KEYS = {
+  activeTab: 'iac-studio.agentHub.activeTab',
+  activeTask: 'iac-studio.agentHub.activeTask',
+};
 
 const PROVIDER_GROUPS: Record<Exclude<AgentHubTab, 'chat' | 'runs'>, {
   title: string;
@@ -135,6 +140,41 @@ const stateBackgrounds: Record<ProviderState, string> = {
 
 const tabId = (tab: AgentHubTab) => `agent-hub-tab-${tab}`;
 const panelId = (tab: AgentHubTab) => `agent-hub-panel-${tab}`;
+const isAgentHubTab = (value: string | null): value is AgentHubTab => (
+  AGENT_TABS.some(tab => tab.key === value)
+);
+const isTaskMode = (value: string | null): value is typeof TASK_MODES[number] => (
+  TASK_MODES.some(task => task === value)
+);
+
+function readStoredAgentHubTab(): AgentHubTab {
+  if (typeof window === 'undefined') return 'chat';
+  try {
+    const storedTab = window.localStorage.getItem(AGENT_HUB_STORAGE_KEYS.activeTab);
+    return isAgentHubTab(storedTab) ? storedTab : 'chat';
+  } catch {
+    return 'chat';
+  }
+}
+
+function readStoredTaskMode(): typeof TASK_MODES[number] {
+  if (typeof window === 'undefined') return TASK_MODES[0];
+  try {
+    const storedTask = window.localStorage.getItem(AGENT_HUB_STORAGE_KEYS.activeTask);
+    return isTaskMode(storedTask) ? storedTask : TASK_MODES[0];
+  } catch {
+    return TASK_MODES[0];
+  }
+}
+
+function writeStoredAgentHubValue(key: string, value: string) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(key, value);
+  } catch {
+    // Browser privacy settings can disable localStorage; the UI should remain usable.
+  }
+}
 
 const hubStyles: Record<string, CSSProperties> = {
   shell: { flex: 1, display: 'flex', minWidth: 0, minHeight: 0 },
@@ -255,8 +295,8 @@ export function ChatPanel({
   scrollAnchorRef,
   providerLabel = 'Ollama',
 }: ChatPanelProps) {
-  const [activeTab, setActiveTab] = useState<AgentHubTab>('chat');
-  const [activeTask, setActiveTask] = useState(TASK_MODES[0]);
+  const [activeTab, setActiveTab] = useState<AgentHubTab>(() => readStoredAgentHubTab());
+  const [activeTask, setActiveTask] = useState<typeof TASK_MODES[number]>(() => readStoredTaskMode());
   const [localProviders, setLocalProviders] = useState<Record<string, LocalAgentProviderStatus>>({});
 
   useEffect(() => {
@@ -296,7 +336,13 @@ export function ChatPanel({
 
   const selectTab = (tab: AgentHubTab, focus = false) => {
     setActiveTab(tab);
+    writeStoredAgentHubValue(AGENT_HUB_STORAGE_KEYS.activeTab, tab);
     if (focus) focusSelectedTab(tab);
+  };
+
+  const selectTask = (task: typeof TASK_MODES[number]) => {
+    setActiveTask(task);
+    writeStoredAgentHubValue(AGENT_HUB_STORAGE_KEYS.activeTask, task);
   };
 
   useEffect(() => {
@@ -378,7 +424,7 @@ export function ChatPanel({
                     ? { borderColor: toolColor, color: 'var(--text-main)', background: `${toolColor}1f` }
                     : {}),
                 }}
-                onClick={() => setActiveTask(task)}
+                onClick={() => selectTask(task)}
               >
                 {task}
               </button>


### PR DESCRIPTION
Summary:
- Persist the selected Agent Hub tab and task mode in localStorage.
- Validate stored values and ignore localStorage failures so the UI still works in locked-down browsers.
- Add focused ChatPanel coverage for restore-on-rerender behavior.

Validation:
- npm test -- --run src/components/Chat/ChatPanel.test.tsx
- npm test -- --run src/api.test.ts
- npm run build

Refs #104