### PR TITLE
Add agent provider action placeholders

### DIFF
--- a/web/src/components/Chat/ChatPanel.test.tsx
+++ b/web/src/components/Chat/ChatPanel.test.tsx
@@ -126,6 +126,11 @@ describe('ChatPanel', () => {
     expect(within(details).getByText('Provider managed')).toBeInTheDocument();
     expect(within(details).getByText('Entrypoint')).toBeInTheDocument();
     expect(within(details).getAllByText('Not applicable')).toHaveLength(2);
+    expect(within(details).getByRole('button', { name: 'Configure API' })).toBeDisabled();
+
+    fireEvent.click(within(codexPanel).getByRole('button', { name: /Managed Codex token/ }));
+    const enterpriseDetails = within(codexPanel).getByRole('region', { name: 'Managed Codex token details' });
+    expect(within(enterpriseDetails).getByRole('button', { name: 'Use enterprise policy' })).toBeDisabled();
   });
 
   it('includes detected local provider details in the selected provider panel', async () => {
@@ -158,6 +163,7 @@ describe('ChatPanel', () => {
     const selectedCapabilities = within(details).getByLabelText('Codex CLI selected capabilities');
     expect(within(selectedCapabilities).getByText('chat')).toBeInTheDocument();
     expect(within(selectedCapabilities).getByText('local cli')).toBeInTheDocument();
+    expect(within(details).getByRole('button', { name: 'Use local CLI' })).toBeDisabled();
   });
 
   it('links provider tabs to stable tabpanels and supports roving keyboard selection', () => {

--- a/web/src/components/Chat/ChatPanel.tsx
+++ b/web/src/components/Chat/ChatPanel.tsx
@@ -260,7 +260,7 @@ function localStatusDetails(localProviderId?: string, status?: LocalAgentProvide
 }
 
 function providerActionLabel(provider: ProviderDefinition) {
-  if (provider.localProviderId || provider.lane === 'Local model' || provider.lane === 'Offline') {
+  if (provider.localProviderId || provider.lane === 'Local agent' || provider.lane === 'Local model' || provider.lane === 'Offline') {
     return 'Use local CLI';
   }
   if (provider.lane === 'API' || provider.lane === 'OpenAI-compatible') {
@@ -318,7 +318,7 @@ function ProviderDetails({
           ))}
         </div>
       )}
-      <div style={hubStyles.providerActions} aria-label={`${provider.name} actions`}>
+      <div role="group" style={hubStyles.providerActions} aria-label={`${provider.name} actions`}>
         <button
           type="button"
           disabled

--- a/web/src/components/Chat/ChatPanel.tsx
+++ b/web/src/components/Chat/ChatPanel.tsx
@@ -203,6 +203,9 @@ const hubStyles: Record<string, CSSProperties> = {
   providerDetailsGrid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(130px, 1fr))', gap: 8, marginTop: 8 },
   providerDetailLabel: { color: 'var(--text-muted)', fontFamily: 'JetBrains Mono', fontSize: 10, textTransform: 'uppercase', letterSpacing: 0.5 },
   providerDetailValue: { color: 'var(--text-main)', fontSize: 12, marginTop: 2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
+  providerActions: { display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', marginTop: 10 },
+  providerActionButton: { borderWidth: 1, borderStyle: 'solid', borderColor: 'var(--border-soft)', borderRadius: 6, background: 'var(--bg-elev-3)', color: 'var(--text-muted)', cursor: 'not-allowed', fontSize: 11, fontFamily: 'DM Sans', fontWeight: 700, padding: '6px 9px', opacity: 0.72 },
+  providerActionHint: { color: '#77847d', fontSize: 11 },
   runsEmpty: { flex: 1, minHeight: 0, padding: 16, color: 'var(--text-muted)', fontSize: 12, lineHeight: 1.55 },
 };
 
@@ -256,6 +259,16 @@ function localStatusDetails(localProviderId?: string, status?: LocalAgentProvide
   };
 }
 
+function providerActionLabel(provider: ProviderDefinition) {
+  if (provider.localProviderId || provider.lane === 'Local model' || provider.lane === 'Offline') {
+    return 'Use local CLI';
+  }
+  if (provider.lane === 'API' || provider.lane === 'OpenAI-compatible') {
+    return 'Configure API';
+  }
+  return 'Use enterprise policy';
+}
+
 function ProviderDetails({
   provider,
   displayState,
@@ -305,6 +318,16 @@ function ProviderDetails({
           ))}
         </div>
       )}
+      <div style={hubStyles.providerActions} aria-label={`${provider.name} actions`}>
+        <button
+          type="button"
+          disabled
+          style={hubStyles.providerActionButton}
+        >
+          {providerActionLabel(provider)}
+        </button>
+        <span style={hubStyles.providerActionHint}>Preview only</span>
+      </div>
     </div>
   );
 }

--- a/web/src/components/Chat/ChatPanel.tsx
+++ b/web/src/components/Chat/ChatPanel.tsx
@@ -42,6 +42,7 @@ type ProviderLane =
   | 'Local model'
   | 'Offline'
   | 'OpenAI-compatible';
+type ProviderActionLabel = 'Configure API' | 'Use enterprise policy' | 'Use local CLI';
 type ProviderDefinition = { name: string; lane: ProviderLane; state: ProviderState; note: string; localProviderId?: string };
 
 const AGENT_TABS: { key: AgentHubTab; label: string }[] = [
@@ -148,6 +149,18 @@ const stateBackgrounds: Record<ProviderState, string> = {
   setup: 'rgba(217, 177, 92, 0.16)',
   planned: 'rgba(147, 163, 154, 0.14)',
   guarded: 'rgba(138, 167, 255, 0.16)',
+};
+
+const providerActionByLane: Record<ProviderLane, ProviderActionLabel> = {
+  API: 'Configure API',
+  'Cloud tools': 'Use enterprise policy',
+  Collaboration: 'Use enterprise policy',
+  Enterprise: 'Use enterprise policy',
+  'IaC tools': 'Use enterprise policy',
+  'Local agent': 'Use local CLI',
+  'Local model': 'Use local CLI',
+  Offline: 'Use local CLI',
+  'OpenAI-compatible': 'Configure API',
 };
 
 const tabId = (tab: AgentHubTab) => `agent-hub-tab-${tab}`;
@@ -270,13 +283,7 @@ function localStatusDetails(localProviderId?: string, status?: LocalAgentProvide
 }
 
 function providerActionLabel(provider: ProviderDefinition) {
-  if (provider.localProviderId || provider.lane === 'Local agent' || provider.lane === 'Local model' || provider.lane === 'Offline') {
-    return 'Use local CLI';
-  }
-  if (provider.lane === 'API' || provider.lane === 'OpenAI-compatible') {
-    return 'Configure API';
-  }
-  return 'Use enterprise policy';
+  return providerActionByLane[provider.lane];
 }
 
 function ProviderDetails({

--- a/web/src/components/Chat/ChatPanel.tsx
+++ b/web/src/components/Chat/ChatPanel.tsx
@@ -32,7 +32,17 @@ export interface ChatPanelProps {
 type AgentHubTab = 'chat' | 'codex' | 'claude' | 'gemini' | 'copilot' | 'local' | 'mcp' | 'runs';
 type ProviderState = 'available' | 'setup' | 'planned' | 'guarded';
 type ProviderTab = Exclude<AgentHubTab, 'chat' | 'runs'>;
-type ProviderDefinition = { name: string; lane: string; state: ProviderState; note: string; localProviderId?: string };
+type ProviderLane =
+  | 'API'
+  | 'Cloud tools'
+  | 'Collaboration'
+  | 'Enterprise'
+  | 'IaC tools'
+  | 'Local agent'
+  | 'Local model'
+  | 'Offline'
+  | 'OpenAI-compatible';
+type ProviderDefinition = { name: string; lane: ProviderLane; state: ProviderState; note: string; localProviderId?: string };
 
 const AGENT_TABS: { key: AgentHubTab; label: string }[] = [
   { key: 'chat', label: 'Chat' },


### PR DESCRIPTION
Summary:
- Add disabled/read-only action placeholders to Agent Hub provider details.
- Map local/model providers to Use local CLI, API/OpenAI-compatible providers to Configure API, and governed/provider-managed lanes to Use enterprise policy.
- Keep this slice UI-only: no provider execution, credential prompts, backend writes, or new dependencies.

Validation:
- npm test -- --run src/components/Chat/ChatPanel.test.tsx
- npm test -- --run src/api.test.ts
- npm run build

Refs #104