### PR TITLE
Detect local model endpoints

### DIFF
--- a/internal/agentproviders/discovery.go
+++ b/internal/agentproviders/discovery.go
@@ -304,7 +304,9 @@ func DefaultLocalProviders() []LocalProviderDefinition {
 			Entrypoint: "OpenAI-compatible local endpoint",
 			Endpoints: []EndpointCandidate{
 				{Entrypoint: "http://127.0.0.1:1234/v1", ProbeURL: "http://127.0.0.1:1234/v1/models"},
+				{Entrypoint: "http://[::1]:1234/v1", ProbeURL: "http://[::1]:1234/v1/models"},
 				{Entrypoint: "http://127.0.0.1:8000/v1", ProbeURL: "http://127.0.0.1:8000/v1/models"},
+				{Entrypoint: "http://[::1]:8000/v1", ProbeURL: "http://[::1]:8000/v1/models"},
 			},
 			Capabilities: []string{
 				"chat",

--- a/internal/agentproviders/discovery.go
+++ b/internal/agentproviders/discovery.go
@@ -1,6 +1,16 @@
 package agentproviders
 
-import "os/exec"
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os/exec"
+	"time"
+)
+
+const localEndpointProbeTimeout = 350 * time.Millisecond
 
 const (
 	StateAvailable          = "available"
@@ -11,6 +21,12 @@ const (
 )
 
 type LookupFunc func(file string) (string, error)
+type EndpointProbeFunc func(probeURL string) bool
+
+type EndpointCandidate struct {
+	Entrypoint string
+	ProbeURL   string
+}
 
 type LocalProviderDefinition struct {
 	ID             string
@@ -23,6 +39,7 @@ type LocalProviderDefinition struct {
 	CredentialMode string
 	AuthHint       string
 	InstallHint    string
+	Endpoints      []EndpointCandidate
 }
 
 type LocalProviderStatus struct {
@@ -43,6 +60,7 @@ type LocalProviderStatus struct {
 
 type Discoverer struct {
 	lookup LookupFunc
+	probe  EndpointProbeFunc
 }
 
 type Option func(*Discoverer)
@@ -55,8 +73,16 @@ func WithLookupFunc(lookup LookupFunc) Option {
 	}
 }
 
+func WithEndpointProbeFunc(probe EndpointProbeFunc) Option {
+	return func(d *Discoverer) {
+		if probe != nil {
+			d.probe = probe
+		}
+	}
+}
+
 func NewDiscoverer(opts ...Option) Discoverer {
-	d := Discoverer{lookup: exec.LookPath}
+	d := Discoverer{lookup: exec.LookPath, probe: defaultEndpointProbe}
 	for _, opt := range opts {
 		opt(&d)
 	}
@@ -107,7 +133,56 @@ func (d Discoverer) status(definition LocalProviderDefinition) LocalProviderStat
 			break
 		}
 	}
+	if !status.Installed {
+		for _, endpoint := range definition.Endpoints {
+			if !d.probe(endpoint.ProbeURL) {
+				continue
+			}
+			status.Installed = true
+			status.State = StateAvailable
+			status.Entrypoint = endpoint.Entrypoint
+			status.InstallHint = ""
+			break
+		}
+	}
 	return status
+}
+
+func defaultEndpointProbe(probeURL string) bool {
+	parsed, err := url.Parse(probeURL)
+	if err != nil || parsed.Scheme != "http" || !isLoopbackHost(parsed.Hostname()) {
+		return false
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), localEndpointProbeTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, parsed.String(), nil)
+	if err != nil {
+		return false
+	}
+	req.Header.Set("Accept", "application/json")
+
+	client := &http.Client{
+		Timeout: localEndpointProbeTimeout,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+	return resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices
+}
+
+func isLoopbackHost(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 func cloneStringSlice(values []string) []string {
@@ -194,6 +269,25 @@ func DefaultLocalProviders() []LocalProviderDefinition {
 			CredentialMode: CredentialNone,
 			AuthHint:       "Uses local models and does not require cloud credentials.",
 			InstallHint:    "Install Ollama to enable local model workflows.",
+		},
+		{
+			ID:         "openai-compatible-local",
+			Name:       "LM Studio / vLLM",
+			Category:   "local_model",
+			Entrypoint: "OpenAI-compatible local endpoint",
+			Endpoints: []EndpointCandidate{
+				{Entrypoint: "http://127.0.0.1:1234/v1", ProbeURL: "http://127.0.0.1:1234/v1/models"},
+				{Entrypoint: "http://127.0.0.1:8000/v1", ProbeURL: "http://127.0.0.1:8000/v1/models"},
+			},
+			Capabilities: []string{
+				"chat",
+				"iac_assistance",
+				"local_model",
+				"openai_compatible",
+			},
+			CredentialMode: CredentialNone,
+			AuthHint:       "Uses a local OpenAI-compatible endpoint; IaC Studio probes /v1/models only and does not send prompts or credentials.",
+			InstallHint:    "Start LM Studio, vLLM, or another local OpenAI-compatible server.",
 		},
 	}
 }

--- a/internal/agentproviders/discovery.go
+++ b/internal/agentproviders/discovery.go
@@ -150,7 +150,13 @@ func (d Discoverer) status(definition LocalProviderDefinition) LocalProviderStat
 
 func defaultEndpointProbe(probeURL string) bool {
 	parsed, err := url.Parse(probeURL)
-	if err != nil || parsed.Scheme != "http" || !isLoopbackHost(parsed.Hostname()) {
+	if err != nil ||
+		parsed.Scheme != "http" ||
+		parsed.User != nil ||
+		parsed.Path != "/v1/models" ||
+		parsed.RawQuery != "" ||
+		parsed.Fragment != "" ||
+		!isLoopbackHost(parsed.Hostname()) {
 		return false
 	}
 
@@ -166,6 +172,10 @@ func defaultEndpointProbe(probeURL string) bool {
 		Timeout: localEndpointProbeTimeout,
 		CheckRedirect: func(*http.Request, []*http.Request) error {
 			return http.ErrUseLastResponse
+		},
+		Jar: nil,
+		Transport: &http.Transport{
+			Proxy: nil,
 		},
 	}
 	resp, err := client.Do(req)

--- a/internal/agentproviders/discovery.go
+++ b/internal/agentproviders/discovery.go
@@ -150,18 +150,18 @@ func (d Discoverer) status(definition LocalProviderDefinition) LocalProviderStat
 
 func defaultEndpointProbe(probeURL string) bool {
 	parsed, err := url.Parse(probeURL)
+	ctx, cancel := context.WithTimeout(context.Background(), localEndpointProbeTimeout)
+	defer cancel()
 	if err != nil ||
 		parsed.Scheme != "http" ||
 		parsed.User != nil ||
 		parsed.Path != "/v1/models" ||
 		parsed.RawQuery != "" ||
 		parsed.Fragment != "" ||
-		!isLoopbackHost(parsed.Hostname()) {
+		!isLoopbackHost(ctx, parsed.Hostname()) {
 		return false
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), localEndpointProbeTimeout)
-	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, parsed.String(), nil)
 	if err != nil {
 		return false
@@ -191,21 +191,21 @@ func defaultEndpointProbe(probeURL string) bool {
 	return resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices
 }
 
-func isLoopbackHost(host string) bool {
-	return isLoopbackHostWithLookup(host, net.LookupIP)
+func isLoopbackHost(ctx context.Context, host string) bool {
+	return isLoopbackHostWithLookup(ctx, host, net.DefaultResolver.LookupIPAddr)
 }
 
-func isLoopbackHostWithLookup(host string, lookup func(string) ([]net.IP, error)) bool {
+func isLoopbackHostWithLookup(ctx context.Context, host string, lookup func(context.Context, string) ([]net.IPAddr, error)) bool {
 	ip := net.ParseIP(host)
 	if ip != nil {
 		return ip.IsLoopback()
 	}
-	ips, err := lookup(host)
+	ips, err := lookup(ctx, host)
 	if err != nil {
 		return false
 	}
 	for _, resolved := range ips {
-		if !resolved.IsLoopback() {
+		if !resolved.IP.IsLoopback() {
 			return false
 		}
 	}

--- a/internal/agentproviders/discovery.go
+++ b/internal/agentproviders/discovery.go
@@ -175,8 +175,9 @@ func defaultEndpointProbe(probeURL string) bool {
 		},
 		Jar: nil,
 		Transport: &http.Transport{
-			DisableKeepAlives: true,
-			Proxy:             nil,
+			DisableCompression: true,
+			DisableKeepAlives:  true,
+			Proxy:              nil,
 		},
 	}
 	resp, err := client.Do(req)

--- a/internal/agentproviders/discovery.go
+++ b/internal/agentproviders/discovery.go
@@ -175,7 +175,8 @@ func defaultEndpointProbe(probeURL string) bool {
 		},
 		Jar: nil,
 		Transport: &http.Transport{
-			Proxy: nil,
+			DisableKeepAlives: true,
+			Proxy:             nil,
 		},
 	}
 	resp, err := client.Do(req)
@@ -190,11 +191,24 @@ func defaultEndpointProbe(probeURL string) bool {
 }
 
 func isLoopbackHost(host string) bool {
-	if host == "localhost" {
-		return true
-	}
+	return isLoopbackHostWithLookup(host, net.LookupIP)
+}
+
+func isLoopbackHostWithLookup(host string, lookup func(string) ([]net.IP, error)) bool {
 	ip := net.ParseIP(host)
-	return ip != nil && ip.IsLoopback()
+	if ip != nil {
+		return ip.IsLoopback()
+	}
+	ips, err := lookup(host)
+	if err != nil {
+		return false
+	}
+	for _, resolved := range ips {
+		if !resolved.IsLoopback() {
+			return false
+		}
+	}
+	return len(ips) > 0
 }
 
 func cloneStringSlice(values []string) []string {

--- a/internal/agentproviders/discovery.go
+++ b/internal/agentproviders/discovery.go
@@ -182,7 +182,9 @@ func defaultEndpointProbe(probeURL string) bool {
 	if err != nil {
 		return false
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
 	return resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices
 }

--- a/internal/agentproviders/discovery_test.go
+++ b/internal/agentproviders/discovery_test.go
@@ -1,6 +1,7 @@
 package agentproviders
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -157,25 +158,45 @@ func TestDefaultEndpointProbeRejectsCredentialAndModelSpecificURLs(t *testing.T)
 }
 
 func TestIsLoopbackHostResolvesLocalhost(t *testing.T) {
-	if !isLoopbackHost("127.0.0.1") {
+	ctx, cancel := context.WithTimeout(context.Background(), localEndpointProbeTimeout)
+	defer cancel()
+	if !isLoopbackHost(ctx, "127.0.0.1") {
 		t.Fatal("127.0.0.1 should be loopback")
 	}
-	if !isLoopbackHost("::1") {
+	if !isLoopbackHost(ctx, "::1") {
 		t.Fatal("::1 should be loopback")
 	}
-	if isLoopbackHost("192.0.2.1") {
+	if isLoopbackHost(ctx, "192.0.2.1") {
 		t.Fatal("192.0.2.1 should not be treated as loopback")
 	}
-	if !isLoopbackHost("localhost") {
-		t.Fatal("localhost should resolve only to loopback addresses on this host")
-	}
-	fakeLookup := func(host string) ([]net.IP, error) {
+	loopbackLookup := func(ctx context.Context, host string) ([]net.IPAddr, error) {
+		if ctx == nil {
+			return nil, errors.New("missing context")
+		}
+		if _, ok := ctx.Deadline(); !ok {
+			return nil, errors.New("missing context deadline")
+		}
 		if host != "localhost" {
 			return nil, errors.New("unexpected host")
 		}
-		return []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("192.0.2.1")}, nil
+		return []net.IPAddr{{IP: net.ParseIP("127.0.0.1")}, {IP: net.ParseIP("::1")}}, nil
 	}
-	if isLoopbackHostWithLookup("localhost", fakeLookup) {
+	if !isLoopbackHostWithLookup(ctx, "localhost", loopbackLookup) {
+		t.Fatal("localhost should be accepted when all resolved addresses are loopback")
+	}
+	mixedLookup := func(ctx context.Context, host string) ([]net.IPAddr, error) {
+		if ctx == nil {
+			return nil, errors.New("missing context")
+		}
+		if _, ok := ctx.Deadline(); !ok {
+			return nil, errors.New("missing context deadline")
+		}
+		if host != "localhost" {
+			return nil, errors.New("unexpected host")
+		}
+		return []net.IPAddr{{IP: net.ParseIP("127.0.0.1")}, {IP: net.ParseIP("192.0.2.1")}}, nil
+	}
+	if isLoopbackHostWithLookup(ctx, "localhost", mixedLookup) {
 		t.Fatal("localhost should be rejected when any resolved address is not loopback")
 	}
 }

--- a/internal/agentproviders/discovery_test.go
+++ b/internal/agentproviders/discovery_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -147,6 +148,30 @@ func TestDefaultEndpointProbeRejectsCredentialAndModelSpecificURLs(t *testing.T)
 		if defaultEndpointProbe(probeURL) {
 			t.Fatalf("probe should reject URL %q", probeURL)
 		}
+	}
+}
+
+func TestIsLoopbackHostResolvesLocalhost(t *testing.T) {
+	if !isLoopbackHost("127.0.0.1") {
+		t.Fatal("127.0.0.1 should be loopback")
+	}
+	if !isLoopbackHost("::1") {
+		t.Fatal("::1 should be loopback")
+	}
+	if isLoopbackHost("192.0.2.1") {
+		t.Fatal("192.0.2.1 should not be treated as loopback")
+	}
+	if !isLoopbackHost("localhost") {
+		t.Fatal("localhost should resolve only to loopback addresses on this host")
+	}
+	fakeLookup := func(host string) ([]net.IP, error) {
+		if host != "localhost" {
+			return nil, errors.New("unexpected host")
+		}
+		return []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("192.0.2.1")}, nil
+	}
+	if isLoopbackHostWithLookup("localhost", fakeLookup) {
+		t.Fatal("localhost should be rejected when any resolved address is not loopback")
 	}
 }
 

--- a/internal/agentproviders/discovery_test.go
+++ b/internal/agentproviders/discovery_test.go
@@ -3,10 +3,12 @@ package agentproviders
 import (
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
 )
 
@@ -94,11 +96,25 @@ func TestDiscoverLocalDetectsOpenAICompatibleEndpoint(t *testing.T) {
 
 func TestDefaultEndpointProbeOnlyAllowsLoopbackModelLists(t *testing.T) {
 	var sawAuthorization bool
+	var sawCookie bool
+	var bodySize int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("probe method = %s, want GET", r.Method)
+		}
 		if r.URL.Path != "/v1/models" {
 			t.Fatalf("probe path = %s, want /v1/models", r.URL.Path)
 		}
+		if r.URL.RawQuery != "" {
+			t.Fatalf("probe query = %q, want empty", r.URL.RawQuery)
+		}
 		sawAuthorization = r.Header.Get("Authorization") != ""
+		sawCookie = r.Header.Get("Cookie") != ""
+		payload, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read probe body: %v", err)
+		}
+		bodySize = len(payload)
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"data":[]}`))
 	}))
@@ -110,8 +126,49 @@ func TestDefaultEndpointProbeOnlyAllowsLoopbackModelLists(t *testing.T) {
 	if sawAuthorization {
 		t.Fatal("probe should not send authorization headers")
 	}
+	if sawCookie {
+		t.Fatal("probe should not send cookies")
+	}
+	if bodySize != 0 {
+		t.Fatalf("probe should not send a request body, got %d bytes", bodySize)
+	}
 	if defaultEndpointProbe("https://example.com/v1/models") {
 		t.Fatal("non-loopback endpoint should not be probed")
+	}
+}
+
+func TestDefaultEndpointProbeRejectsCredentialAndModelSpecificURLs(t *testing.T) {
+	for _, probeURL := range []string{
+		"http://" + "user:pass@" + "127.0.0.1:1234/v1/models",
+		"http://127.0.0.1:1234/v1/models?model=secret",
+		"http://127.0.0.1:1234/v1/models#fragment",
+		"http://127.0.0.1:1234/v1/chat/completions",
+	} {
+		if defaultEndpointProbe(probeURL) {
+			t.Fatalf("probe should reject URL %q", probeURL)
+		}
+	}
+}
+
+func TestDefaultEndpointProbeDoesNotFollowRedirects(t *testing.T) {
+	var redirectTargetHits atomic.Int32
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		redirectTargetHits.Add(1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	t.Cleanup(target.Close)
+
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/v1/models", http.StatusFound)
+	}))
+	t.Cleanup(redirector.Close)
+
+	if defaultEndpointProbe(redirector.URL + "/v1/models") {
+		t.Fatal("redirect responses should not be treated as available")
+	}
+	if redirectTargetHits.Load() != 0 {
+		t.Fatalf("probe followed redirect %d times", redirectTargetHits.Load())
 	}
 }
 

--- a/internal/agentproviders/discovery_test.go
+++ b/internal/agentproviders/discovery_test.go
@@ -98,6 +98,7 @@ func TestDiscoverLocalDetectsOpenAICompatibleEndpoint(t *testing.T) {
 func TestDefaultEndpointProbeOnlyAllowsLoopbackModelLists(t *testing.T) {
 	var sawAuthorization bool
 	var sawCookie bool
+	var sawAcceptEncoding bool
 	var bodySize int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
@@ -111,6 +112,7 @@ func TestDefaultEndpointProbeOnlyAllowsLoopbackModelLists(t *testing.T) {
 		}
 		sawAuthorization = r.Header.Get("Authorization") != ""
 		sawCookie = r.Header.Get("Cookie") != ""
+		sawAcceptEncoding = r.Header.Get("Accept-Encoding") != ""
 		payload, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatalf("read probe body: %v", err)
@@ -129,6 +131,9 @@ func TestDefaultEndpointProbeOnlyAllowsLoopbackModelLists(t *testing.T) {
 	}
 	if sawCookie {
 		t.Fatal("probe should not send cookies")
+	}
+	if sawAcceptEncoding {
+		t.Fatal("probe should not request compressed responses")
 	}
 	if bodySize != 0 {
 		t.Fatalf("probe should not send a request body, got %d bytes", bodySize)

--- a/internal/agentproviders/discovery_test.go
+++ b/internal/agentproviders/discovery_test.go
@@ -26,6 +26,26 @@ func TestDefaultLocalProviderOrder(t *testing.T) {
 	}
 }
 
+func TestDefaultOpenAICompatibleLocalEndpointCandidates(t *testing.T) {
+	definitions := DefaultLocalProviders()
+	var endpoints []EndpointCandidate
+	for _, definition := range definitions {
+		if definition.ID == "openai-compatible-local" {
+			endpoints = definition.Endpoints
+			break
+		}
+	}
+	want := []EndpointCandidate{
+		{Entrypoint: "http://127.0.0.1:1234/v1", ProbeURL: "http://127.0.0.1:1234/v1/models"},
+		{Entrypoint: "http://[::1]:1234/v1", ProbeURL: "http://[::1]:1234/v1/models"},
+		{Entrypoint: "http://127.0.0.1:8000/v1", ProbeURL: "http://127.0.0.1:8000/v1/models"},
+		{Entrypoint: "http://[::1]:8000/v1", ProbeURL: "http://[::1]:8000/v1/models"},
+	}
+	if !reflect.DeepEqual(endpoints, want) {
+		t.Fatalf("openai-compatible-local endpoints = %#v, want %#v", endpoints, want)
+	}
+}
+
 func TestDiscoverLocalUsesLookupWithoutLeakingPaths(t *testing.T) {
 	installed := map[string]string{
 		"codex":      "/private/bin/codex",

--- a/internal/agentproviders/discovery_test.go
+++ b/internal/agentproviders/discovery_test.go
@@ -3,6 +3,8 @@ package agentproviders
 import (
 	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"strings"
 	"testing"
@@ -14,7 +16,7 @@ func TestDefaultLocalProviderOrder(t *testing.T) {
 	for _, definition := range definitions {
 		got = append(got, definition.ID)
 	}
-	want := []string{"codex", "claude", "gemini", "copilot", "ollama"}
+	want := []string{"codex", "claude", "gemini", "copilot", "ollama", "openai-compatible-local"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("provider order = %#v, want %#v", got, want)
 	}
@@ -32,7 +34,7 @@ func TestDiscoverLocalUsesLookupWithoutLeakingPaths(t *testing.T) {
 			return "", errors.New("not found")
 		}
 		return path, nil
-	}))
+	}), WithEndpointProbeFunc(func(string) bool { return false }))
 
 	statuses := discoverer.DiscoverLocal()
 	byID := map[string]LocalProviderStatus{}
@@ -62,10 +64,61 @@ func TestDiscoverLocalUsesLookupWithoutLeakingPaths(t *testing.T) {
 	}
 }
 
+func TestDiscoverLocalDetectsOpenAICompatibleEndpoint(t *testing.T) {
+	discoverer := NewDiscoverer(
+		WithLookupFunc(func(string) (string, error) {
+			return "", errors.New("not found")
+		}),
+		WithEndpointProbeFunc(func(probeURL string) bool {
+			return probeURL == "http://127.0.0.1:1234/v1/models"
+		}),
+	)
+
+	statuses := discoverer.DiscoverLocal()
+	byID := map[string]LocalProviderStatus{}
+	for _, status := range statuses {
+		byID[status.ID] = status
+	}
+
+	status := byID["openai-compatible-local"]
+	if !status.Installed || status.State != StateAvailable || status.Category != "local_model" || status.CredentialMode != CredentialNone {
+		t.Fatalf("unexpected OpenAI-compatible status: %+v", status)
+	}
+	if status.Command != "" || status.Entrypoint != "http://127.0.0.1:1234/v1" || status.InstallHint != "" {
+		t.Fatalf("unexpected OpenAI-compatible endpoint fields: %+v", status)
+	}
+	if !hasCapability(status, "openai_compatible") || !hasCapability(status, "local_model") {
+		t.Fatalf("missing OpenAI-compatible capabilities: %+v", status.Capabilities)
+	}
+}
+
+func TestDefaultEndpointProbeOnlyAllowsLoopbackModelLists(t *testing.T) {
+	var sawAuthorization bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/models" {
+			t.Fatalf("probe path = %s, want /v1/models", r.URL.Path)
+		}
+		sawAuthorization = r.Header.Get("Authorization") != ""
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	if !defaultEndpointProbe(server.URL + "/v1/models") {
+		t.Fatal("expected loopback model-list probe to pass")
+	}
+	if sawAuthorization {
+		t.Fatal("probe should not send authorization headers")
+	}
+	if defaultEndpointProbe("https://example.com/v1/models") {
+		t.Fatal("non-loopback endpoint should not be probed")
+	}
+}
+
 func TestStatusNormalizesListFieldsForJSONConsumers(t *testing.T) {
 	discoverer := NewDiscoverer(WithLookupFunc(func(string) (string, error) {
 		return "", errors.New("not found")
-	}))
+	}), WithEndpointProbeFunc(func(string) bool { return false }))
 
 	status := discoverer.status(LocalProviderDefinition{
 		ID:         "custom",

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1084,8 +1084,9 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 	})
 
 	// List local assistant providers detected on this machine. The built-in
-	// discovery is PATH-only: it does not execute provider CLIs, read auth
-	// files, call localhost services, or return absolute executable paths.
+	// discovery does not execute provider CLIs, read auth files, or return
+	// absolute executable paths; local endpoint checks only call loopback
+	// /v1/models probes with short timeouts and no credentials.
 	mux.HandleFunc("GET /api/agent-hub/providers/local", func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"providers": opts.localAgentProviders(),

--- a/web/src/components/Chat/ChatPanel.test.tsx
+++ b/web/src/components/Chat/ChatPanel.test.tsx
@@ -271,6 +271,37 @@ describe('ChatPanel', () => {
     expect(within(localPanel).getByText(/without cloud egress/)).toBeInTheDocument();
   });
 
+  it('shows detected OpenAI-compatible local endpoint details', async () => {
+    listLocalAgentProvidersMock.mockResolvedValueOnce([{
+      id: 'openai-compatible-local',
+      name: 'LM Studio / vLLM',
+      category: 'local_model',
+      state: 'available',
+      installed: true,
+      entrypoint: 'http://127.0.0.1:1234/v1',
+      candidates: [],
+      version: 'unknown',
+      capabilities: ['chat', 'openai_compatible', 'local_model'],
+      credential_mode: 'none',
+      auth_hint: 'Uses a local OpenAI-compatible endpoint.',
+    }]);
+
+    render(<ChatPanel {...baseProps} />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Local' }));
+    const localPanel = screen.getByRole('tabpanel', { name: 'Local' });
+
+    await waitFor(() => {
+      expect(within(localPanel).getByText('Detected: http://127.0.0.1:1234/v1')).toBeInTheDocument();
+    });
+
+    fireEvent.click(within(localPanel).getByRole('button', { name: /LM Studio \/ vLLM/ }));
+    const details = within(localPanel).getByRole('region', { name: 'LM Studio / vLLM details' });
+    expect(within(details).getByText('No credentials')).toBeInTheDocument();
+    expect(within(details).getByText('http://127.0.0.1:1234/v1')).toBeInTheDocument();
+    expect(within(details).getByText('openai compatible')).toBeInTheDocument();
+    expect(within(details).getByRole('button', { name: 'Configure API' })).toBeDisabled();
+  });
+
   it('shows Gemini and Copilot as first-class assistant lanes', () => {
     render(<ChatPanel {...baseProps} />);
 

--- a/web/src/components/Chat/ChatPanel.tsx
+++ b/web/src/components/Chat/ChatPanel.tsx
@@ -115,7 +115,7 @@ const PROVIDER_GROUPS: Record<ProviderTab, {
     summary: 'Keep offline and private model workflows first-class for demos, sensitive reviews, and no-token-cost usage.',
     providers: [
       { name: 'Ollama', lane: 'Local model', state: 'available', note: 'Current default local model path.', localProviderId: 'ollama' },
-      { name: 'LM Studio / vLLM', lane: 'OpenAI-compatible', state: 'planned', note: 'Use local endpoints without cloud egress.' },
+      { name: 'LM Studio / vLLM', lane: 'OpenAI-compatible', state: 'planned', note: 'Use local endpoints without cloud egress.', localProviderId: 'openai-compatible-local' },
       { name: 'llama.cpp', lane: 'Offline', state: 'planned', note: 'Small local reviews and explain-only workflows.' },
     ],
   },


### PR DESCRIPTION
Summary:
- Add local OpenAI-compatible endpoint discovery for LM Studio / vLLM style /v1/models servers.
- Restrict endpoint probes to loopback HTTP with short timeouts, no redirects, no credentials, and bounded response reads.
- Wire the existing LM Studio / vLLM Agent Hub card to the detected provider status.

Validation:
- GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/agentproviders ./internal/api
- GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/...
- npm test -- --run src/components/Chat/ChatPanel.test.tsx
- npm test -- --run src/api.test.ts
- npm run build

Refs #104