### PR TITLE
Add secure agent run store

### DIFF
--- a/internal/agentruns/store.go
+++ b/internal/agentruns/store.go
@@ -373,6 +373,9 @@ func (s *Store) DecideApproval(id, approvalID string, decision ApprovalStatus, d
 				}
 				if run.Status == StatusWaitingApproval && !hasPendingApprovals(run.Approvals) {
 					run.Status = StatusRunning
+					if run.StartedAt == nil {
+						run.StartedAt = timePtr(now)
+					}
 				}
 				return nil
 			}

--- a/internal/agentruns/store.go
+++ b/internal/agentruns/store.go
@@ -315,6 +315,8 @@ func (s *Store) AddApproval(id string, gate ApprovalGate) (Run, error) {
 		gate.Status = ApprovalPending
 		gate.Summary = truncate(redactText(gate.Summary), maxLogMessageLen)
 		gate.CreatedAt = now
+		gate.DecidedAt = nil
+		gate.DecidedBy = ""
 		run.Approvals = append(run.Approvals, gate)
 		run.Status = StatusWaitingApproval
 		return nil
@@ -336,7 +338,7 @@ func (s *Store) DecideApproval(id, approvalID string, decision ApprovalStatus, d
 				}
 				run.Approvals[i].Status = decision
 				run.Approvals[i].DecidedAt = timePtr(now)
-				run.Approvals[i].DecidedBy = decidedBy
+				run.Approvals[i].DecidedBy = truncate(redactText(decidedBy), maxLogMessageLen)
 				return nil
 			}
 		}
@@ -424,15 +426,16 @@ func hashText(text string) string {
 }
 
 var secretPatterns = []*regexp.Regexp{
-	regexp.MustCompile(`AKIA[0-9A-Z]{16}`),
-	regexp.MustCompile(`(?i)(secret|token|password|api[_-]?key|access[_-]?key)\s*[:=]\s*(?:"[^"]*"|'[^']*'|[^\s]+)`),
+	regexp.MustCompile(`(?:AKIA|ASIA)[0-9A-Z]{16}`),
+	regexp.MustCompile(`(?i)(secret|token|password|api[_-]?key|access[_-]?key(?:[_-]?id)?|secret[_-]?access[_-]?key|session[_-]?token)\s*[:=]\s*(?:"[^"]*"|'[^']*'|[^\s]+)`),
 }
 
 func redactText(text string) string {
 	redacted := text
 	for _, pattern := range secretPatterns {
 		redacted = pattern.ReplaceAllStringFunc(redacted, func(match string) string {
-			if strings.HasPrefix(match, "AKIA") {
+			upper := strings.ToUpper(match)
+			if strings.HasPrefix(upper, "AKIA") || strings.HasPrefix(upper, "ASIA") {
 				return "[REDACTED]"
 			}
 			if idx := strings.IndexAny(match, ":="); idx >= 0 {

--- a/internal/agentruns/store.go
+++ b/internal/agentruns/store.go
@@ -158,7 +158,8 @@ func NewStore(opts ...Option) *Store {
 }
 
 func (s *Store) Create(req CreateRequest) (Run, error) {
-	if strings.TrimSpace(req.Project) == "" {
+	project := strings.TrimSpace(req.Project)
+	if project == "" {
 		return Run{}, errors.New("project is required")
 	}
 	if strings.TrimSpace(req.Prompt) == "" {
@@ -180,7 +181,7 @@ func (s *Store) Create(req CreateRequest) (Run, error) {
 	id := fmt.Sprintf("run_%06d", s.next)
 	run := &Run{
 		ID:            id,
-		Project:       req.Project,
+		Project:       project,
 		ProviderID:    req.ProviderID,
 		Mode:          mode,
 		Status:        StatusQueued,
@@ -287,7 +288,8 @@ func (s *Store) AddLog(id string, level LogLevel, message string) (Run, error) {
 }
 
 func (s *Store) AddPatch(id string, patch ProposedPatch) (Run, error) {
-	if strings.TrimSpace(patch.Path) == "" {
+	path := strings.TrimSpace(patch.Path)
+	if path == "" {
 		return Run{}, errors.New("patch path is required")
 	}
 	return s.update(id, func(run *Run, now time.Time) error {
@@ -295,6 +297,7 @@ func (s *Store) AddPatch(id string, patch ProposedPatch) (Run, error) {
 			return ErrTerminated
 		}
 		patch.ID = fmt.Sprintf("patch_%06d", len(run.Patches)+1)
+		patch.Path = path
 		patch.Summary = truncate(redactText(patch.Summary), maxLogMessageLen)
 		patch.Diff = truncate(redactText(patch.Diff), maxPatchDiffLen)
 		patch.CreatedAt = now

--- a/internal/agentruns/store.go
+++ b/internal/agentruns/store.go
@@ -225,7 +225,10 @@ func (s *Store) SetStatus(id string, status Status) (Run, error) {
 	if !validStatus(status) {
 		return Run{}, fmt.Errorf("invalid agent run status: %s", status)
 	}
-	return s.update(id, func(run *Run, now time.Time) {
+	return s.update(id, func(run *Run, now time.Time) error {
+		if terminalStatus(run.Status) {
+			return ErrTerminated
+		}
 		run.Status = status
 		if status == StatusRunning && run.StartedAt == nil {
 			run.StartedAt = timePtr(now)
@@ -233,26 +236,35 @@ func (s *Store) SetStatus(id string, status Status) (Run, error) {
 		if terminalStatus(status) && run.CompletedAt == nil {
 			run.CompletedAt = timePtr(now)
 		}
+		return nil
 	})
 }
 
 func (s *Store) Cancel(id string) (Run, error) {
-	return s.update(id, func(run *Run, now time.Time) {
+	return s.update(id, func(run *Run, now time.Time) error {
+		if terminalStatus(run.Status) {
+			return ErrTerminated
+		}
 		run.Canceled = true
 		run.Status = StatusCanceled
 		if run.CompletedAt == nil {
 			run.CompletedAt = timePtr(now)
 		}
+		return nil
 	})
 }
 
 func (s *Store) Fail(id string, message string) (Run, error) {
-	return s.update(id, func(run *Run, now time.Time) {
+	return s.update(id, func(run *Run, now time.Time) error {
+		if terminalStatus(run.Status) {
+			return ErrTerminated
+		}
 		run.Status = StatusFailed
 		run.Error = truncate(redactText(message), maxLogMessageLen)
 		if run.CompletedAt == nil {
 			run.CompletedAt = timePtr(now)
 		}
+		return nil
 	})
 }
 
@@ -260,13 +272,14 @@ func (s *Store) AddLog(id string, level LogLevel, message string) (Run, error) {
 	if !validLogLevel(level) {
 		return Run{}, fmt.Errorf("invalid agent log level: %s", level)
 	}
-	return s.update(id, func(run *Run, now time.Time) {
+	return s.update(id, func(run *Run, now time.Time) error {
 		run.Logs = append(run.Logs, LogEntry{
 			ID:      fmt.Sprintf("log_%06d", len(run.Logs)+1),
 			At:      now,
 			Level:   level,
 			Message: truncate(redactText(message), maxLogMessageLen),
 		})
+		return nil
 	})
 }
 
@@ -274,12 +287,16 @@ func (s *Store) AddPatch(id string, patch ProposedPatch) (Run, error) {
 	if strings.TrimSpace(patch.Path) == "" {
 		return Run{}, errors.New("patch path is required")
 	}
-	return s.update(id, func(run *Run, now time.Time) {
+	return s.update(id, func(run *Run, now time.Time) error {
+		if terminalStatus(run.Status) {
+			return ErrTerminated
+		}
 		patch.ID = fmt.Sprintf("patch_%06d", len(run.Patches)+1)
 		patch.Summary = truncate(redactText(patch.Summary), maxLogMessageLen)
 		patch.Diff = truncate(redactText(patch.Diff), maxPatchDiffLen)
 		patch.CreatedAt = now
 		run.Patches = append(run.Patches, patch)
+		return nil
 	})
 }
 
@@ -287,17 +304,41 @@ func (s *Store) AddApproval(id string, gate ApprovalGate) (Run, error) {
 	if !validApprovalKind(gate.Kind) {
 		return Run{}, fmt.Errorf("invalid approval kind: %s", gate.Kind)
 	}
-	return s.update(id, func(run *Run, now time.Time) {
+	return s.update(id, func(run *Run, now time.Time) error {
+		if terminalStatus(run.Status) {
+			return ErrTerminated
+		}
 		gate.ID = fmt.Sprintf("approval_%06d", len(run.Approvals)+1)
 		gate.Status = ApprovalPending
 		gate.Summary = truncate(redactText(gate.Summary), maxLogMessageLen)
 		gate.CreatedAt = now
 		run.Approvals = append(run.Approvals, gate)
 		run.Status = StatusWaitingApproval
+		return nil
 	})
 }
 
-func (s *Store) update(id string, mutate func(*Run, time.Time)) (Run, error) {
+func (s *Store) DecideApproval(id, approvalID string, decision ApprovalStatus, decidedBy string) (Run, error) {
+	if decision != ApprovalApproved && decision != ApprovalRejected {
+		return Run{}, fmt.Errorf("invalid approval decision: %s", decision)
+	}
+	return s.update(id, func(run *Run, now time.Time) error {
+		for i := range run.Approvals {
+			if run.Approvals[i].ID == approvalID {
+				if run.Approvals[i].Status != ApprovalPending {
+					return fmt.Errorf("approval gate %q is already decided", approvalID)
+				}
+				run.Approvals[i].Status = decision
+				run.Approvals[i].DecidedAt = timePtr(now)
+				run.Approvals[i].DecidedBy = decidedBy
+				return nil
+			}
+		}
+		return ErrApprovalNotFound
+	})
+}
+
+func (s *Store) update(id string, mutate func(*Run, time.Time) error) (Run, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	run, ok := s.runs[id]
@@ -305,7 +346,9 @@ func (s *Store) update(id string, mutate func(*Run, time.Time)) (Run, error) {
 		return Run{}, ErrNotFound
 	}
 	now := s.now()
-	mutate(run, now)
+	if err := mutate(run, now); err != nil {
+		return Run{}, err
+	}
 	run.UpdatedAt = now
 	return cloneRun(*run), nil
 }
@@ -318,7 +361,11 @@ func (s *Store) evictLocked() {
 	}
 }
 
-var ErrNotFound = errors.New("agent run not found")
+var (
+	ErrNotFound        = errors.New("agent run not found")
+	ErrTerminated      = errors.New("agent run is already in a terminal state")
+	ErrApprovalNotFound = errors.New("approval gate not found")
+)
 
 func validMode(mode Mode) bool {
 	switch mode {
@@ -405,6 +452,8 @@ func cloneRun(run Run) Run {
 	run.Logs = cloneLogs(run.Logs)
 	run.Patches = clonePatches(run.Patches)
 	run.Approvals = cloneApprovals(run.Approvals)
+	run.StartedAt = cloneTimePtr(run.StartedAt)
+	run.CompletedAt = cloneTimePtr(run.CompletedAt)
 	return run
 }
 
@@ -426,7 +475,20 @@ func cloneApprovals(approvals []ApprovalGate) []ApprovalGate {
 	if approvals == nil {
 		return nil
 	}
-	return append([]ApprovalGate{}, approvals...)
+	out := make([]ApprovalGate, len(approvals))
+	for i, a := range approvals {
+		a.DecidedAt = cloneTimePtr(a.DecidedAt)
+		out[i] = a
+	}
+	return out
+}
+
+func cloneTimePtr(t *time.Time) *time.Time {
+	if t == nil {
+		return nil
+	}
+	copied := *t
+	return &copied
 }
 
 func timePtr(t time.Time) *time.Time {

--- a/internal/agentruns/store.go
+++ b/internal/agentruns/store.go
@@ -427,7 +427,7 @@ func hashText(text string) string {
 
 var secretPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`(?:AKIA|ASIA)[0-9A-Z]{16}`),
-	regexp.MustCompile(`(?i)(secret|token|password|api[_-]?key|access[_-]?key(?:[_-]?id)?|secret[_-]?access[_-]?key|session[_-]?token)\s*[:=]\s*(?:"[^"]*"|'[^']*'|[^\s]+)`),
+	regexp.MustCompile(`(?i)(secret|token|password|api[_-]?key|access[_-]?key(?:[_-]?id)?|secret[_-]?access[_-]?key|session[_-]?token)\s*(?::=|[:=])\s*(?:"[^"]*"|'[^']*'|[^\s]+)`),
 }
 
 func redactText(text string) string {
@@ -438,8 +438,8 @@ func redactText(text string) string {
 			if strings.HasPrefix(upper, "AKIA") || strings.HasPrefix(upper, "ASIA") {
 				return "[REDACTED]"
 			}
-			if idx := strings.IndexAny(match, ":="); idx >= 0 {
-				return match[:idx+1] + "[REDACTED]"
+			if replacement := redactKeyValue(match); replacement != "" {
+				return replacement
 			}
 			return "[REDACTED]"
 		})
@@ -447,14 +447,58 @@ func redactText(text string) string {
 	return redacted
 }
 
+func redactKeyValue(match string) string {
+	end := redactionPrefixEnd(match)
+	if end < 0 {
+		return ""
+	}
+	prefix := strings.TrimRight(match[:end], " \t")
+	if strings.HasSuffix(prefix, ":=") {
+		return prefix + " [REDACTED]"
+	}
+	return prefix + "[REDACTED]"
+}
+
+func redactionPrefixEnd(match string) int {
+	for i := 0; i < len(match); i++ {
+		switch match[i] {
+		case ':':
+			if i+1 < len(match) && match[i+1] == '=' {
+				return i + 2
+			}
+			return i + 1
+		case '=':
+			return i + 1
+		}
+	}
+	return -1
+}
+
 func truncate(text string, limit int) string {
 	if limit <= 0 || len(text) <= limit {
 		return text
 	}
 	if limit <= 3 {
-		return text[:limit]
+		return text[:safeUTF8PrefixLen(text, limit)]
 	}
-	return text[:limit-3] + "..."
+	return text[:safeUTF8PrefixLen(text, limit-3)] + "..."
+}
+
+func safeUTF8PrefixLen(text string, limit int) int {
+	if limit <= 0 {
+		return 0
+	}
+	if limit >= len(text) {
+		return len(text)
+	}
+	last := 0
+	for i := range text {
+		if i > limit {
+			break
+		}
+		last = i
+	}
+	return last
 }
 
 func cloneRun(run Run) Run {

--- a/internal/agentruns/store.go
+++ b/internal/agentruns/store.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"path"
 	"regexp"
 	"strings"
 	"sync"
@@ -234,6 +235,9 @@ func (s *Store) SetStatus(id string, status Status) (Run, error) {
 		if status == StatusRunning && run.StartedAt == nil {
 			run.StartedAt = timePtr(now)
 		}
+		if status == StatusCanceled {
+			run.Canceled = true
+		}
 		if terminalStatus(status) && run.CompletedAt == nil {
 			run.CompletedAt = timePtr(now)
 		}
@@ -288,16 +292,16 @@ func (s *Store) AddLog(id string, level LogLevel, message string) (Run, error) {
 }
 
 func (s *Store) AddPatch(id string, patch ProposedPatch) (Run, error) {
-	path := strings.TrimSpace(patch.Path)
-	if path == "" {
-		return Run{}, errors.New("patch path is required")
+	patchPath, err := normalizePatchPath(patch.Path)
+	if err != nil {
+		return Run{}, err
 	}
 	return s.update(id, func(run *Run, now time.Time) error {
 		if terminalStatus(run.Status) {
 			return ErrTerminated
 		}
 		patch.ID = fmt.Sprintf("patch_%06d", len(run.Patches)+1)
-		patch.Path = path
+		patch.Path = patchPath
 		patch.Summary = truncate(redactText(patch.Summary), maxLogMessageLen)
 		patch.Diff = truncate(redactText(patch.Diff), maxPatchDiffLen)
 		patch.CreatedAt = now
@@ -349,6 +353,30 @@ func (s *Store) DecideApproval(id, approvalID string, decision ApprovalStatus, d
 	})
 }
 
+func normalizePatchPath(raw string) (string, error) {
+	patchPath := strings.TrimSpace(raw)
+	if patchPath == "" {
+		return "", errors.New("patch path is required")
+	}
+	if strings.Contains(patchPath, "\\") || hasWindowsDrivePrefix(patchPath) || path.IsAbs(patchPath) {
+		return "", ErrUnsafePatchPath
+	}
+	for _, segment := range strings.Split(patchPath, "/") {
+		if segment == ".." {
+			return "", ErrUnsafePatchPath
+		}
+	}
+	cleaned := path.Clean(patchPath)
+	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return "", ErrUnsafePatchPath
+	}
+	return cleaned, nil
+}
+
+func hasWindowsDrivePrefix(p string) bool {
+	return len(p) >= 2 && p[1] == ':' && ((p[0] >= 'A' && p[0] <= 'Z') || (p[0] >= 'a' && p[0] <= 'z'))
+}
+
 func (s *Store) update(id string, mutate func(*Run, time.Time) error) (Run, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -376,6 +404,7 @@ var (
 	ErrNotFound         = errors.New("agent run not found")
 	ErrTerminated       = errors.New("agent run is already in a terminal state")
 	ErrApprovalNotFound = errors.New("approval gate not found")
+	ErrUnsafePatchPath  = errors.New("patch path must be a relative path within the project")
 )
 
 func validMode(mode Mode) bool {
@@ -456,10 +485,7 @@ func redactKeyValue(match string) string {
 		return ""
 	}
 	prefix := strings.TrimRight(match[:end], " \t")
-	if strings.HasSuffix(prefix, ":=") {
-		return prefix + " [REDACTED]"
-	}
-	return prefix + "[REDACTED]"
+	return prefix + " [REDACTED]"
 }
 
 func redactionPrefixEnd(match string) int {

--- a/internal/agentruns/store.go
+++ b/internal/agentruns/store.go
@@ -273,6 +273,9 @@ func (s *Store) AddLog(id string, level LogLevel, message string) (Run, error) {
 		return Run{}, fmt.Errorf("invalid agent log level: %s", level)
 	}
 	return s.update(id, func(run *Run, now time.Time) error {
+		if terminalStatus(run.Status) {
+			return ErrTerminated
+		}
 		run.Logs = append(run.Logs, LogEntry{
 			ID:      fmt.Sprintf("log_%06d", len(run.Logs)+1),
 			At:      now,
@@ -323,6 +326,9 @@ func (s *Store) DecideApproval(id, approvalID string, decision ApprovalStatus, d
 		return Run{}, fmt.Errorf("invalid approval decision: %s", decision)
 	}
 	return s.update(id, func(run *Run, now time.Time) error {
+		if terminalStatus(run.Status) {
+			return ErrTerminated
+		}
 		for i := range run.Approvals {
 			if run.Approvals[i].ID == approvalID {
 				if run.Approvals[i].Status != ApprovalPending {
@@ -362,8 +368,8 @@ func (s *Store) evictLocked() {
 }
 
 var (
-	ErrNotFound        = errors.New("agent run not found")
-	ErrTerminated      = errors.New("agent run is already in a terminal state")
+	ErrNotFound         = errors.New("agent run not found")
+	ErrTerminated       = errors.New("agent run is already in a terminal state")
 	ErrApprovalNotFound = errors.New("approval gate not found")
 )
 
@@ -419,7 +425,7 @@ func hashText(text string) string {
 
 var secretPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`AKIA[0-9A-Z]{16}`),
-	regexp.MustCompile(`(?i)(secret|token|password|api[_-]?key|access[_-]?key)\s*[:=]\s*["']?[^"'\s]+`),
+	regexp.MustCompile(`(?i)(secret|token|password|api[_-]?key|access[_-]?key)\s*[:=]\s*(?:"[^"]*"|'[^']*'|[^\s]+)`),
 }
 
 func redactText(text string) string {

--- a/internal/agentruns/store.go
+++ b/internal/agentruns/store.go
@@ -1,6 +1,8 @@
 package agentruns
 
 import (
+	"crypto/hmac"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -17,6 +19,7 @@ const (
 	maxPromptPreviewLen = 240
 	maxLogMessageLen    = 2000
 	maxPatchDiffLen     = 20000
+	promptHashKeyLen    = 32
 )
 
 type Status string
@@ -126,6 +129,7 @@ type Store struct {
 	next    uint64
 	runs    map[string]*Run
 	order   []string
+	hashKey []byte
 }
 
 type Option func(*Store)
@@ -146,6 +150,16 @@ func WithMaxRuns(maxRun int) Option {
 	}
 }
 
+// WithPromptHashKey overrides the per-store HMAC key used for prompt
+// fingerprints. It is primarily intended for deterministic tests.
+func WithPromptHashKey(key []byte) Option {
+	return func(s *Store) {
+		if len(key) > 0 {
+			s.hashKey = append([]byte(nil), key...)
+		}
+	}
+}
+
 func NewStore(opts ...Option) *Store {
 	s := &Store{
 		now:     func() time.Time { return time.Now().UTC() },
@@ -154,6 +168,9 @@ func NewStore(opts ...Option) *Store {
 	}
 	for _, opt := range opts {
 		opt(s)
+	}
+	if len(s.hashKey) == 0 {
+		s.hashKey = newPromptHashKey()
 	}
 	return s
 }
@@ -187,7 +204,7 @@ func (s *Store) Create(req CreateRequest) (Run, error) {
 		Mode:          mode,
 		Status:        StatusQueued,
 		PromptPreview: truncate(redactText(req.Prompt), maxPromptPreviewLen),
-		PromptHash:    hashText(req.Prompt),
+		PromptHash:    hashText(req.Prompt, s.hashKey),
 		CreatedBy:     req.CreatedBy,
 		CreatedAt:     now,
 		UpdatedAt:     now,
@@ -346,11 +363,23 @@ func (s *Store) DecideApproval(id, approvalID string, decision ApprovalStatus, d
 				run.Approvals[i].Status = decision
 				run.Approvals[i].DecidedAt = timePtr(now)
 				run.Approvals[i].DecidedBy = truncate(redactText(decidedBy), maxLogMessageLen)
+				if run.Status == StatusWaitingApproval && !hasPendingApprovals(run.Approvals) {
+					run.Status = StatusRunning
+				}
 				return nil
 			}
 		}
 		return ErrApprovalNotFound
 	})
+}
+
+func hasPendingApprovals(approvals []ApprovalGate) bool {
+	for _, approval := range approvals {
+		if approval.Status == ApprovalPending {
+			return true
+		}
+	}
+	return false
 }
 
 func normalizePatchPath(raw string) (string, error) {
@@ -452,9 +481,18 @@ func validApprovalKind(kind ApprovalKind) bool {
 	}
 }
 
-func hashText(text string) string {
-	sum := sha256.Sum256([]byte(text))
-	return hex.EncodeToString(sum[:])
+func newPromptHashKey() []byte {
+	key := make([]byte, promptHashKeyLen)
+	if _, err := rand.Read(key); err != nil {
+		panic(fmt.Sprintf("generate prompt hash key: %v", err))
+	}
+	return key
+}
+
+func hashText(text string, key []byte) string {
+	mac := hmac.New(sha256.New, key)
+	_, _ = mac.Write([]byte(text))
+	return hex.EncodeToString(mac.Sum(nil))
 }
 
 var secretPatterns = []*regexp.Regexp{

--- a/internal/agentruns/store.go
+++ b/internal/agentruns/store.go
@@ -1,0 +1,434 @@
+package agentruns
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	defaultMaxRuns      = 100
+	maxPromptPreviewLen = 240
+	maxLogMessageLen    = 2000
+	maxPatchDiffLen     = 20000
+)
+
+type Status string
+
+const (
+	StatusQueued          Status = "queued"
+	StatusRunning         Status = "running"
+	StatusWaitingApproval Status = "waiting_approval"
+	StatusCompleted       Status = "completed"
+	StatusFailed          Status = "failed"
+	StatusCanceled        Status = "canceled"
+)
+
+type Mode string
+
+const (
+	ModeReadOnly        Mode = "read_only"
+	ModeProposeOnly     Mode = "propose_only"
+	ModeApprovedExecute Mode = "approved_execute"
+)
+
+type LogLevel string
+
+const (
+	LogInfo  LogLevel = "info"
+	LogWarn  LogLevel = "warn"
+	LogError LogLevel = "error"
+	LogAudit LogLevel = "audit"
+)
+
+type ApprovalKind string
+
+const (
+	ApprovalFileWrite  ApprovalKind = "file_write"
+	ApprovalCommand    ApprovalKind = "command"
+	ApprovalIaCAction  ApprovalKind = "iac_action"
+	ApprovalCloudWrite ApprovalKind = "cloud_write"
+	ApprovalSecretRead ApprovalKind = "secret_read"
+	ApprovalMCPNetwork ApprovalKind = "mcp_network"
+)
+
+type ApprovalStatus string
+
+const (
+	ApprovalPending  ApprovalStatus = "pending"
+	ApprovalApproved ApprovalStatus = "approved"
+	ApprovalRejected ApprovalStatus = "rejected"
+)
+
+type CreateRequest struct {
+	Project    string
+	Prompt     string
+	ProviderID string
+	Mode       Mode
+	CreatedBy  string
+}
+
+type Run struct {
+	ID            string          `json:"id"`
+	Project       string          `json:"project"`
+	ProviderID    string          `json:"provider_id,omitempty"`
+	Mode          Mode            `json:"mode"`
+	Status        Status          `json:"status"`
+	PromptPreview string          `json:"prompt_preview"`
+	PromptHash    string          `json:"prompt_hash"`
+	CreatedBy     string          `json:"created_by,omitempty"`
+	CreatedAt     time.Time       `json:"created_at"`
+	UpdatedAt     time.Time       `json:"updated_at"`
+	StartedAt     *time.Time      `json:"started_at,omitempty"`
+	CompletedAt   *time.Time      `json:"completed_at,omitempty"`
+	Canceled      bool            `json:"canceled"`
+	Error         string          `json:"error,omitempty"`
+	Logs          []LogEntry      `json:"logs"`
+	Patches       []ProposedPatch `json:"patches"`
+	Approvals     []ApprovalGate  `json:"approvals"`
+}
+
+type LogEntry struct {
+	ID      string    `json:"id"`
+	At      time.Time `json:"at"`
+	Level   LogLevel  `json:"level"`
+	Message string    `json:"message"`
+}
+
+type ProposedPatch struct {
+	ID        string    `json:"id"`
+	Path      string    `json:"path"`
+	Summary   string    `json:"summary"`
+	Diff      string    `json:"diff"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+type ApprovalGate struct {
+	ID        string         `json:"id"`
+	Kind      ApprovalKind   `json:"kind"`
+	Status    ApprovalStatus `json:"status"`
+	Summary   string         `json:"summary"`
+	CreatedAt time.Time      `json:"created_at"`
+	DecidedAt *time.Time     `json:"decided_at,omitempty"`
+	DecidedBy string         `json:"decided_by,omitempty"`
+}
+
+type Store struct {
+	mu      sync.Mutex
+	now     func() time.Time
+	maxRuns int
+	next    uint64
+	runs    map[string]*Run
+	order   []string
+}
+
+type Option func(*Store)
+
+func WithClock(now func() time.Time) Option {
+	return func(s *Store) {
+		if now != nil {
+			s.now = now
+		}
+	}
+}
+
+func WithMaxRuns(maxRun int) Option {
+	return func(s *Store) {
+		if maxRun > 0 {
+			s.maxRuns = maxRun
+		}
+	}
+}
+
+func NewStore(opts ...Option) *Store {
+	s := &Store{
+		now:     func() time.Time { return time.Now().UTC() },
+		maxRuns: defaultMaxRuns,
+		runs:    make(map[string]*Run),
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+func (s *Store) Create(req CreateRequest) (Run, error) {
+	if strings.TrimSpace(req.Project) == "" {
+		return Run{}, errors.New("project is required")
+	}
+	if strings.TrimSpace(req.Prompt) == "" {
+		return Run{}, errors.New("prompt is required")
+	}
+	mode := req.Mode
+	if mode == "" {
+		mode = ModeReadOnly
+	}
+	if !validMode(mode) {
+		return Run{}, fmt.Errorf("invalid agent run mode: %s", mode)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := s.now()
+	s.next++
+	id := fmt.Sprintf("run_%06d", s.next)
+	run := &Run{
+		ID:            id,
+		Project:       req.Project,
+		ProviderID:    req.ProviderID,
+		Mode:          mode,
+		Status:        StatusQueued,
+		PromptPreview: truncate(redactText(req.Prompt), maxPromptPreviewLen),
+		PromptHash:    hashText(req.Prompt),
+		CreatedBy:     req.CreatedBy,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+		Logs:          []LogEntry{},
+		Patches:       []ProposedPatch{},
+		Approvals:     []ApprovalGate{},
+	}
+	s.runs[id] = run
+	s.order = append(s.order, id)
+	s.evictLocked()
+	return cloneRun(*run), nil
+}
+
+func (s *Store) Get(id string) (Run, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	run, ok := s.runs[id]
+	if !ok {
+		return Run{}, false
+	}
+	return cloneRun(*run), true
+}
+
+func (s *Store) List() []Run {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	runs := make([]Run, 0, len(s.order))
+	for _, id := range s.order {
+		if run, ok := s.runs[id]; ok {
+			runs = append(runs, cloneRun(*run))
+		}
+	}
+	return runs
+}
+
+func (s *Store) SetStatus(id string, status Status) (Run, error) {
+	if !validStatus(status) {
+		return Run{}, fmt.Errorf("invalid agent run status: %s", status)
+	}
+	return s.update(id, func(run *Run, now time.Time) {
+		run.Status = status
+		if status == StatusRunning && run.StartedAt == nil {
+			run.StartedAt = timePtr(now)
+		}
+		if terminalStatus(status) && run.CompletedAt == nil {
+			run.CompletedAt = timePtr(now)
+		}
+	})
+}
+
+func (s *Store) Cancel(id string) (Run, error) {
+	return s.update(id, func(run *Run, now time.Time) {
+		run.Canceled = true
+		run.Status = StatusCanceled
+		if run.CompletedAt == nil {
+			run.CompletedAt = timePtr(now)
+		}
+	})
+}
+
+func (s *Store) Fail(id string, message string) (Run, error) {
+	return s.update(id, func(run *Run, now time.Time) {
+		run.Status = StatusFailed
+		run.Error = truncate(redactText(message), maxLogMessageLen)
+		if run.CompletedAt == nil {
+			run.CompletedAt = timePtr(now)
+		}
+	})
+}
+
+func (s *Store) AddLog(id string, level LogLevel, message string) (Run, error) {
+	if !validLogLevel(level) {
+		return Run{}, fmt.Errorf("invalid agent log level: %s", level)
+	}
+	return s.update(id, func(run *Run, now time.Time) {
+		run.Logs = append(run.Logs, LogEntry{
+			ID:      fmt.Sprintf("log_%06d", len(run.Logs)+1),
+			At:      now,
+			Level:   level,
+			Message: truncate(redactText(message), maxLogMessageLen),
+		})
+	})
+}
+
+func (s *Store) AddPatch(id string, patch ProposedPatch) (Run, error) {
+	if strings.TrimSpace(patch.Path) == "" {
+		return Run{}, errors.New("patch path is required")
+	}
+	return s.update(id, func(run *Run, now time.Time) {
+		patch.ID = fmt.Sprintf("patch_%06d", len(run.Patches)+1)
+		patch.Summary = truncate(redactText(patch.Summary), maxLogMessageLen)
+		patch.Diff = truncate(redactText(patch.Diff), maxPatchDiffLen)
+		patch.CreatedAt = now
+		run.Patches = append(run.Patches, patch)
+	})
+}
+
+func (s *Store) AddApproval(id string, gate ApprovalGate) (Run, error) {
+	if !validApprovalKind(gate.Kind) {
+		return Run{}, fmt.Errorf("invalid approval kind: %s", gate.Kind)
+	}
+	return s.update(id, func(run *Run, now time.Time) {
+		gate.ID = fmt.Sprintf("approval_%06d", len(run.Approvals)+1)
+		gate.Status = ApprovalPending
+		gate.Summary = truncate(redactText(gate.Summary), maxLogMessageLen)
+		gate.CreatedAt = now
+		run.Approvals = append(run.Approvals, gate)
+		run.Status = StatusWaitingApproval
+	})
+}
+
+func (s *Store) update(id string, mutate func(*Run, time.Time)) (Run, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	run, ok := s.runs[id]
+	if !ok {
+		return Run{}, ErrNotFound
+	}
+	now := s.now()
+	mutate(run, now)
+	run.UpdatedAt = now
+	return cloneRun(*run), nil
+}
+
+func (s *Store) evictLocked() {
+	for len(s.order) > s.maxRuns {
+		oldest := s.order[0]
+		s.order = s.order[1:]
+		delete(s.runs, oldest)
+	}
+}
+
+var ErrNotFound = errors.New("agent run not found")
+
+func validMode(mode Mode) bool {
+	switch mode {
+	case ModeReadOnly, ModeProposeOnly, ModeApprovedExecute:
+		return true
+	default:
+		return false
+	}
+}
+
+func validStatus(status Status) bool {
+	switch status {
+	case StatusQueued, StatusRunning, StatusWaitingApproval, StatusCompleted, StatusFailed, StatusCanceled:
+		return true
+	default:
+		return false
+	}
+}
+
+func terminalStatus(status Status) bool {
+	switch status {
+	case StatusCompleted, StatusFailed, StatusCanceled:
+		return true
+	default:
+		return false
+	}
+}
+
+func validLogLevel(level LogLevel) bool {
+	switch level {
+	case LogInfo, LogWarn, LogError, LogAudit:
+		return true
+	default:
+		return false
+	}
+}
+
+func validApprovalKind(kind ApprovalKind) bool {
+	switch kind {
+	case ApprovalFileWrite, ApprovalCommand, ApprovalIaCAction, ApprovalCloudWrite, ApprovalSecretRead, ApprovalMCPNetwork:
+		return true
+	default:
+		return false
+	}
+}
+
+func hashText(text string) string {
+	sum := sha256.Sum256([]byte(text))
+	return hex.EncodeToString(sum[:])
+}
+
+var secretPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`AKIA[0-9A-Z]{16}`),
+	regexp.MustCompile(`(?i)(secret|token|password|api[_-]?key|access[_-]?key)\s*[:=]\s*["']?[^"'\s]+`),
+}
+
+func redactText(text string) string {
+	redacted := text
+	for _, pattern := range secretPatterns {
+		redacted = pattern.ReplaceAllStringFunc(redacted, func(match string) string {
+			if strings.HasPrefix(match, "AKIA") {
+				return "[REDACTED]"
+			}
+			if idx := strings.IndexAny(match, ":="); idx >= 0 {
+				return match[:idx+1] + "[REDACTED]"
+			}
+			return "[REDACTED]"
+		})
+	}
+	return redacted
+}
+
+func truncate(text string, limit int) string {
+	if limit <= 0 || len(text) <= limit {
+		return text
+	}
+	if limit <= 3 {
+		return text[:limit]
+	}
+	return text[:limit-3] + "..."
+}
+
+func cloneRun(run Run) Run {
+	run.Logs = cloneLogs(run.Logs)
+	run.Patches = clonePatches(run.Patches)
+	run.Approvals = cloneApprovals(run.Approvals)
+	return run
+}
+
+func cloneLogs(logs []LogEntry) []LogEntry {
+	if logs == nil {
+		return nil
+	}
+	return append([]LogEntry{}, logs...)
+}
+
+func clonePatches(patches []ProposedPatch) []ProposedPatch {
+	if patches == nil {
+		return nil
+	}
+	return append([]ProposedPatch{}, patches...)
+}
+
+func cloneApprovals(approvals []ApprovalGate) []ApprovalGate {
+	if approvals == nil {
+		return nil
+	}
+	return append([]ApprovalGate{}, approvals...)
+}
+
+func timePtr(t time.Time) *time.Time {
+	return &t
+}

--- a/internal/agentruns/store.go
+++ b/internal/agentruns/store.go
@@ -200,12 +200,12 @@ func (s *Store) Create(req CreateRequest) (Run, error) {
 	run := &Run{
 		ID:            id,
 		Project:       project,
-		ProviderID:    req.ProviderID,
+		ProviderID:    sanitizeMetadata(req.ProviderID),
 		Mode:          mode,
 		Status:        StatusQueued,
 		PromptPreview: truncate(redactText(req.Prompt), maxPromptPreviewLen),
 		PromptHash:    hashText(req.Prompt, s.hashKey),
-		CreatedBy:     req.CreatedBy,
+		CreatedBy:     sanitizeMetadata(req.CreatedBy),
 		CreatedAt:     now,
 		UpdatedAt:     now,
 		Logs:          []LogEntry{},
@@ -363,6 +363,14 @@ func (s *Store) DecideApproval(id, approvalID string, decision ApprovalStatus, d
 				run.Approvals[i].Status = decision
 				run.Approvals[i].DecidedAt = timePtr(now)
 				run.Approvals[i].DecidedBy = truncate(redactText(decidedBy), maxLogMessageLen)
+				if decision == ApprovalRejected {
+					run.Status = StatusFailed
+					run.Error = "approval gate rejected"
+					if run.CompletedAt == nil {
+						run.CompletedAt = timePtr(now)
+					}
+					return nil
+				}
 				if run.Status == StatusWaitingApproval && !hasPendingApprovals(run.Approvals) {
 					run.Status = StatusRunning
 				}
@@ -380,6 +388,10 @@ func hasPendingApprovals(approvals []ApprovalGate) bool {
 		}
 	}
 	return false
+}
+
+func sanitizeMetadata(text string) string {
+	return truncate(redactText(strings.TrimSpace(text)), maxLogMessageLen)
 }
 
 func normalizePatchPath(raw string) (string, error) {

--- a/internal/agentruns/store_test.go
+++ b/internal/agentruns/store_test.go
@@ -477,7 +477,8 @@ func TestStoreDecideApproval(t *testing.T) {
 }
 
 func TestStoreDecideApprovalWaitsForAllPendingGates(t *testing.T) {
-	store := NewStore(WithClock(fixedClock().now))
+	clock := fixedClock()
+	store := NewStore(WithClock(clock.now))
 	run, err := store.Create(CreateRequest{Project: "prod", Prompt: "x"})
 	if err != nil {
 		t.Fatalf("Create returned error: %v", err)
@@ -500,13 +501,21 @@ func TestStoreDecideApprovalWaitsForAllPendingGates(t *testing.T) {
 	if run.Status != StatusWaitingApproval {
 		t.Fatalf("run status with remaining pending gate = %q, want %q", run.Status, StatusWaitingApproval)
 	}
+	if run.StartedAt != nil {
+		t.Fatalf("started_at with remaining pending gate = %v, want nil", run.StartedAt)
+	}
 
+	clock.tick(time.Second)
+	startTime := clock.current
 	run, err = store.DecideApproval(run.ID, secondID, ApprovalApproved, "bob")
 	if err != nil {
 		t.Fatalf("DecideApproval second returned error: %v", err)
 	}
 	if run.Status != StatusRunning {
 		t.Fatalf("run status after all gates approved = %q, want %q", run.Status, StatusRunning)
+	}
+	if run.StartedAt == nil || *run.StartedAt != startTime {
+		t.Fatalf("started_at after approval-driven start = %v, want %s", run.StartedAt, startTime)
 	}
 }
 

--- a/internal/agentruns/store_test.go
+++ b/internal/agentruns/store_test.go
@@ -1,0 +1,194 @@
+package agentruns
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestStoreCreateRedactsPromptAndDefaultsReadOnly(t *testing.T) {
+	now := fixedClock()
+	store := NewStore(WithClock(now.now))
+
+	run, err := store.Create(CreateRequest{
+		Project:    "prod",
+		Prompt:     "rotate password=supersecret for AKIA1234567890ABCDEF",
+		ProviderID: "codex",
+		CreatedBy:  "alice",
+	})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+
+	if run.ID != "run_000001" {
+		t.Fatalf("run ID = %q, want run_000001", run.ID)
+	}
+	if run.Mode != ModeReadOnly {
+		t.Fatalf("mode = %q, want %q", run.Mode, ModeReadOnly)
+	}
+	if run.Status != StatusQueued {
+		t.Fatalf("status = %q, want %q", run.Status, StatusQueued)
+	}
+	if strings.Contains(run.PromptPreview, "supersecret") || strings.Contains(run.PromptPreview, "AKIA1234567890ABCDEF") {
+		t.Fatalf("prompt preview leaked secret: %q", run.PromptPreview)
+	}
+	if run.PromptHash == "" || strings.Contains(run.PromptHash, "supersecret") {
+		t.Fatalf("prompt hash was not set safely: %q", run.PromptHash)
+	}
+	if run.CreatedAt != now.current || run.UpdatedAt != now.current {
+		t.Fatalf("timestamps = %s/%s, want %s", run.CreatedAt, run.UpdatedAt, now.current)
+	}
+	if run.Logs == nil || run.Patches == nil || run.Approvals == nil {
+		t.Fatalf("list fields should be initialized: %+v", run)
+	}
+}
+
+func TestStoreLifecycleUpdates(t *testing.T) {
+	clock := fixedClock()
+	store := NewStore(WithClock(clock.now))
+	run, err := store.Create(CreateRequest{Project: "prod", Prompt: "make a plan", Mode: ModeProposeOnly})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+
+	clock.tick(time.Second)
+	run, err = store.SetStatus(run.ID, StatusRunning)
+	if err != nil {
+		t.Fatalf("SetStatus running returned error: %v", err)
+	}
+	if run.Status != StatusRunning || run.StartedAt == nil || *run.StartedAt != clock.current {
+		t.Fatalf("running state not recorded: %+v", run)
+	}
+
+	clock.tick(time.Second)
+	run, err = store.AddLog(run.ID, LogInfo, "using token=abc123")
+	if err != nil {
+		t.Fatalf("AddLog returned error: %v", err)
+	}
+	if len(run.Logs) != 1 || run.Logs[0].ID != "log_000001" {
+		t.Fatalf("unexpected logs: %+v", run.Logs)
+	}
+	if strings.Contains(run.Logs[0].Message, "abc123") {
+		t.Fatalf("log leaked token: %q", run.Logs[0].Message)
+	}
+
+	clock.tick(time.Second)
+	run, err = store.AddPatch(run.ID, ProposedPatch{
+		Path:    "main.tf",
+		Summary: "add bucket",
+		Diff:    "+ secret = \"dont-store-me\"",
+	})
+	if err != nil {
+		t.Fatalf("AddPatch returned error: %v", err)
+	}
+	if len(run.Patches) != 1 || run.Patches[0].ID != "patch_000001" {
+		t.Fatalf("unexpected patches: %+v", run.Patches)
+	}
+	if strings.Contains(run.Patches[0].Diff, "dont-store-me") {
+		t.Fatalf("patch diff leaked secret: %q", run.Patches[0].Diff)
+	}
+
+	clock.tick(time.Second)
+	run, err = store.AddApproval(run.ID, ApprovalGate{
+		Kind:    ApprovalCommand,
+		Summary: "run terraform plan",
+	})
+	if err != nil {
+		t.Fatalf("AddApproval returned error: %v", err)
+	}
+	if run.Status != StatusWaitingApproval || len(run.Approvals) != 1 || run.Approvals[0].Status != ApprovalPending {
+		t.Fatalf("approval state not recorded: %+v", run)
+	}
+
+	clock.tick(time.Second)
+	run, err = store.Cancel(run.ID)
+	if err != nil {
+		t.Fatalf("Cancel returned error: %v", err)
+	}
+	if !run.Canceled || run.Status != StatusCanceled || run.CompletedAt == nil || *run.CompletedAt != clock.current {
+		t.Fatalf("cancel state not recorded: %+v", run)
+	}
+}
+
+func TestStoreReturnsDefensiveCopies(t *testing.T) {
+	store := NewStore(WithClock(fixedClock().now))
+	run, err := store.Create(CreateRequest{Project: "prod", Prompt: "make a plan"})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	run, err = store.AddLog(run.ID, LogInfo, "first")
+	if err != nil {
+		t.Fatalf("AddLog returned error: %v", err)
+	}
+
+	run.Logs[0].Message = "mutated"
+	got, ok := store.Get(run.ID)
+	if !ok {
+		t.Fatal("expected run to exist")
+	}
+	if got.Logs[0].Message == "mutated" {
+		t.Fatal("store returned mutable log slice")
+	}
+
+	list := store.List()
+	list[0].Logs[0].Message = "mutated-list"
+	got, ok = store.Get(run.ID)
+	if !ok {
+		t.Fatal("expected run to exist")
+	}
+	if got.Logs[0].Message == "mutated-list" {
+		t.Fatal("store returned mutable list snapshot")
+	}
+}
+
+func TestStoreValidatesInputsAndEvictsOldRuns(t *testing.T) {
+	store := NewStore(WithClock(fixedClock().now), WithMaxRuns(2))
+	if _, err := store.Create(CreateRequest{Project: "", Prompt: "x"}); err == nil {
+		t.Fatal("expected missing project error")
+	}
+	if _, err := store.Create(CreateRequest{Project: "prod", Prompt: ""}); err == nil {
+		t.Fatal("expected missing prompt error")
+	}
+	if _, err := store.Create(CreateRequest{Project: "prod", Prompt: "x", Mode: "unsafe"}); err == nil {
+		t.Fatal("expected invalid mode error")
+	}
+
+	first, err := store.Create(CreateRequest{Project: "prod", Prompt: "first"})
+	if err != nil {
+		t.Fatalf("Create first returned error: %v", err)
+	}
+	if _, err := store.Create(CreateRequest{Project: "prod", Prompt: "second"}); err != nil {
+		t.Fatalf("Create second returned error: %v", err)
+	}
+	third, err := store.Create(CreateRequest{Project: "prod", Prompt: "third"})
+	if err != nil {
+		t.Fatalf("Create third returned error: %v", err)
+	}
+	if _, ok := store.Get(first.ID); ok {
+		t.Fatal("oldest run should have been evicted")
+	}
+	if runs := store.List(); len(runs) != 2 || runs[1].ID != third.ID {
+		t.Fatalf("unexpected retained runs: %+v", runs)
+	}
+
+	if _, err := store.AddLog("missing", LogInfo, "x"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("missing run error = %v, want ErrNotFound", err)
+	}
+}
+
+type testClock struct {
+	current time.Time
+}
+
+func fixedClock() *testClock {
+	return &testClock{current: time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)}
+}
+
+func (c *testClock) now() time.Time {
+	return c.current
+}
+
+func (c *testClock) tick(d time.Duration) {
+	c.current = c.current.Add(d)
+}

--- a/internal/agentruns/store_test.go
+++ b/internal/agentruns/store_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 )
 
 func TestStoreCreateRedactsPromptAndDefaultsReadOnly(t *testing.T) {
@@ -80,6 +81,47 @@ func TestStoreRedactsQuotedSecretsWithSpaces(t *testing.T) {
 	if strings.Contains(run.Patches[0].Diff, "quoted cloud secret") ||
 		strings.Contains(run.Patches[0].Diff, "quoted aws secret") {
 		t.Fatalf("patch leaked quoted secret: %q", run.Patches[0].Diff)
+	}
+}
+
+func TestStoreRedactsShortAssignmentSecrets(t *testing.T) {
+	store := NewStore(WithClock(fixedClock().now))
+	run, err := store.Create(CreateRequest{
+		Project: "prod",
+		Prompt:  `run with token := "short assignment secret"`,
+	})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	if strings.Contains(run.PromptPreview, "short assignment secret") {
+		t.Fatalf("prompt preview leaked short assignment secret: %q", run.PromptPreview)
+	}
+	if !strings.Contains(run.PromptPreview, "token := [REDACTED]") {
+		t.Fatalf("prompt preview did not preserve short assignment delimiter: %q", run.PromptPreview)
+	}
+
+	run, err = store.AddLog(run.ID, LogInfo, `password := 'operator supplied secret'`)
+	if err != nil {
+		t.Fatalf("AddLog returned error: %v", err)
+	}
+	if strings.Contains(run.Logs[0].Message, "operator supplied secret") {
+		t.Fatalf("log leaked short assignment secret: %q", run.Logs[0].Message)
+	}
+	if !strings.Contains(run.Logs[0].Message, "password := [REDACTED]") {
+		t.Fatalf("log did not preserve short assignment delimiter: %q", run.Logs[0].Message)
+	}
+}
+
+func TestTruncatePreservesUTF8(t *testing.T) {
+	got := truncate("世界🙂terraform", 8)
+	if got != "世..." {
+		t.Fatalf("truncate = %q, want %q", got, "世...")
+	}
+	if len(got) > 8 {
+		t.Fatalf("truncate length = %d, want at most 8 bytes", len(got))
+	}
+	if !utf8.ValidString(got) {
+		t.Fatalf("truncate returned invalid UTF-8: %q", got)
 	}
 }
 

--- a/internal/agentruns/store_test.go
+++ b/internal/agentruns/store_test.go
@@ -44,6 +44,39 @@ func TestStoreCreateRedactsPromptAndDefaultsReadOnly(t *testing.T) {
 	}
 }
 
+func TestStoreRedactsQuotedSecretsWithSpaces(t *testing.T) {
+	store := NewStore(WithClock(fixedClock().now))
+	run, err := store.Create(CreateRequest{
+		Project: "prod",
+		Prompt:  `rotate password="two word secret" and token='another secret phrase'`,
+	})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	if strings.Contains(run.PromptPreview, "two word secret") || strings.Contains(run.PromptPreview, "another secret phrase") {
+		t.Fatalf("prompt preview leaked quoted secret: %q", run.PromptPreview)
+	}
+
+	run, err = store.AddLog(run.ID, LogInfo, `using api_key="local model secret"`)
+	if err != nil {
+		t.Fatalf("AddLog returned error: %v", err)
+	}
+	if strings.Contains(run.Logs[0].Message, "local model secret") {
+		t.Fatalf("log leaked quoted secret: %q", run.Logs[0].Message)
+	}
+
+	run, err = store.AddPatch(run.ID, ProposedPatch{
+		Path: "main.tf",
+		Diff: `+ access_key = "quoted cloud secret"`,
+	})
+	if err != nil {
+		t.Fatalf("AddPatch returned error: %v", err)
+	}
+	if strings.Contains(run.Patches[0].Diff, "quoted cloud secret") {
+		t.Fatalf("patch leaked quoted secret: %q", run.Patches[0].Diff)
+	}
+}
+
 func TestStoreLifecycleUpdates(t *testing.T) {
 	clock := fixedClock()
 	store := NewStore(WithClock(clock.now))
@@ -186,6 +219,11 @@ func TestStoreTerminalStateGuard(t *testing.T) {
 	if _, err := store.SetStatus(run.ID, StatusRunning); err != nil {
 		t.Fatalf("SetStatus running: %v", err)
 	}
+	run, err = store.AddApproval(run.ID, ApprovalGate{Kind: ApprovalCommand, Summary: "x"})
+	if err != nil {
+		t.Fatalf("AddApproval: %v", err)
+	}
+	approvalID := run.Approvals[0].ID
 	if _, err := store.SetStatus(run.ID, StatusCompleted); err != nil {
 		t.Fatalf("SetStatus completed: %v", err)
 	}
@@ -199,11 +237,17 @@ func TestStoreTerminalStateGuard(t *testing.T) {
 	if _, err := store.Fail(run.ID, "late fail"); !errors.Is(err, ErrTerminated) {
 		t.Fatalf("Fail on completed run: got %v, want ErrTerminated", err)
 	}
+	if _, err := store.AddLog(run.ID, LogInfo, "late log"); !errors.Is(err, ErrTerminated) {
+		t.Fatalf("AddLog on completed run: got %v, want ErrTerminated", err)
+	}
 	if _, err := store.AddApproval(run.ID, ApprovalGate{Kind: ApprovalCommand, Summary: "x"}); !errors.Is(err, ErrTerminated) {
 		t.Fatalf("AddApproval on completed run: got %v, want ErrTerminated", err)
 	}
 	if _, err := store.AddPatch(run.ID, ProposedPatch{Path: "x.tf", Summary: "s", Diff: "d"}); !errors.Is(err, ErrTerminated) {
 		t.Fatalf("AddPatch on completed run: got %v, want ErrTerminated", err)
+	}
+	if _, err := store.DecideApproval(run.ID, approvalID, ApprovalApproved, "alice"); !errors.Is(err, ErrTerminated) {
+		t.Fatalf("DecideApproval on completed run: got %v, want ErrTerminated", err)
 	}
 }
 

--- a/internal/agentruns/store_test.go
+++ b/internal/agentruns/store_test.go
@@ -115,6 +115,22 @@ func TestStoreRedactsShortAssignmentSecrets(t *testing.T) {
 	}
 }
 
+func TestStoreFormatsKeyValueRedactionsConsistently(t *testing.T) {
+	cases := map[string]string{
+		`secret="plain secret"`:      "secret= [REDACTED]",
+		`token: "colon secret"`:      "token: [REDACTED]",
+		`password := "short secret"`: "password := [REDACTED]",
+	}
+	for input, want := range cases {
+		t.Run(input, func(t *testing.T) {
+			got := redactText(input)
+			if got != want {
+				t.Fatalf("redactText(%q) = %q, want %q", input, got, want)
+			}
+		})
+	}
+}
+
 func TestTruncatePreservesUTF8(t *testing.T) {
 	got := truncate("世界🙂terraform", 8)
 	if got != "世..." {
@@ -125,6 +141,24 @@ func TestTruncatePreservesUTF8(t *testing.T) {
 	}
 	if !utf8.ValidString(got) {
 		t.Fatalf("truncate returned invalid UTF-8: %q", got)
+	}
+}
+
+func TestStoreSetStatusCanceledMarksCanceled(t *testing.T) {
+	clock := fixedClock()
+	store := NewStore(WithClock(clock.now))
+	run, err := store.Create(CreateRequest{Project: "prod", Prompt: "x"})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+
+	clock.tick(time.Second)
+	run, err = store.SetStatus(run.ID, StatusCanceled)
+	if err != nil {
+		t.Fatalf("SetStatus canceled returned error: %v", err)
+	}
+	if !run.Canceled || run.Status != StatusCanceled || run.CompletedAt == nil || *run.CompletedAt != clock.current {
+		t.Fatalf("canceled status not recorded consistently: %+v", run)
 	}
 }
 
@@ -200,6 +234,41 @@ func TestStoreLifecycleUpdates(t *testing.T) {
 	}
 	if !run.Canceled || run.Status != StatusCanceled || run.CompletedAt == nil || *run.CompletedAt != clock.current {
 		t.Fatalf("cancel state not recorded: %+v", run)
+	}
+}
+
+func TestStoreRejectsUnsafePatchPaths(t *testing.T) {
+	store := NewStore(WithClock(fixedClock().now))
+	run, err := store.Create(CreateRequest{Project: "prod", Prompt: "x"})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+
+	unsafePaths := []string{
+		"/etc/passwd",
+		"../main.tf",
+		"dir/../main.tf",
+		"dir/sub/../../main.tf",
+		`C:\temp\main.tf`,
+		"C:/temp/main.tf",
+		`\\server\share\main.tf`,
+		`dir\main.tf`,
+	}
+	for _, unsafePath := range unsafePaths {
+		t.Run(unsafePath, func(t *testing.T) {
+			_, err := store.AddPatch(run.ID, ProposedPatch{Path: unsafePath, Diff: "x"})
+			if !errors.Is(err, ErrUnsafePatchPath) {
+				t.Fatalf("AddPatch error = %v, want ErrUnsafePatchPath", err)
+			}
+		})
+	}
+
+	got, err := store.AddPatch(run.ID, ProposedPatch{Path: " ./dir/main.tf ", Diff: "x"})
+	if err != nil {
+		t.Fatalf("AddPatch safe path returned error: %v", err)
+	}
+	if got.Patches[0].Path != "dir/main.tf" {
+		t.Fatalf("safe patch path = %q, want dir/main.tf", got.Patches[0].Path)
 	}
 }
 

--- a/internal/agentruns/store_test.go
+++ b/internal/agentruns/store_test.go
@@ -14,7 +14,7 @@ func TestStoreCreateRedactsPromptAndDefaultsReadOnly(t *testing.T) {
 	prompt := "rotate password=supersecret for AKIA1234567890ABCDEF"
 
 	run, err := store.Create(CreateRequest{
-		Project:    "prod",
+		Project:    " prod ",
 		Prompt:     prompt,
 		ProviderID: "codex",
 		CreatedBy:  "alice",
@@ -25,6 +25,9 @@ func TestStoreCreateRedactsPromptAndDefaultsReadOnly(t *testing.T) {
 
 	if run.ID != "run_000001" {
 		t.Fatalf("run ID = %q, want run_000001", run.ID)
+	}
+	if run.Project != "prod" {
+		t.Fatalf("project = %q, want prod", run.Project)
 	}
 	if run.Mode != ModeReadOnly {
 		t.Fatalf("mode = %q, want %q", run.Mode, ModeReadOnly)
@@ -156,7 +159,7 @@ func TestStoreLifecycleUpdates(t *testing.T) {
 
 	clock.tick(time.Second)
 	run, err = store.AddPatch(run.ID, ProposedPatch{
-		Path:    "main.tf",
+		Path:    " main.tf ",
 		Summary: "add bucket",
 		Diff:    "+ secret = \"dont-store-me\"",
 	})
@@ -165,6 +168,9 @@ func TestStoreLifecycleUpdates(t *testing.T) {
 	}
 	if len(run.Patches) != 1 || run.Patches[0].ID != "patch_000001" {
 		t.Fatalf("unexpected patches: %+v", run.Patches)
+	}
+	if run.Patches[0].Path != "main.tf" {
+		t.Fatalf("patch path = %q, want main.tf", run.Patches[0].Path)
 	}
 	if strings.Contains(run.Patches[0].Diff, "dont-store-me") {
 		t.Fatalf("patch diff leaked secret: %q", run.Patches[0].Diff)

--- a/internal/agentruns/store_test.go
+++ b/internal/agentruns/store_test.go
@@ -10,10 +10,11 @@ import (
 func TestStoreCreateRedactsPromptAndDefaultsReadOnly(t *testing.T) {
 	now := fixedClock()
 	store := NewStore(WithClock(now.now))
+	prompt := "rotate password=supersecret for AKIA1234567890ABCDEF"
 
 	run, err := store.Create(CreateRequest{
 		Project:    "prod",
-		Prompt:     "rotate password=supersecret for AKIA1234567890ABCDEF",
+		Prompt:     prompt,
 		ProviderID: "codex",
 		CreatedBy:  "alice",
 	})
@@ -33,8 +34,8 @@ func TestStoreCreateRedactsPromptAndDefaultsReadOnly(t *testing.T) {
 	if strings.Contains(run.PromptPreview, "supersecret") || strings.Contains(run.PromptPreview, "AKIA1234567890ABCDEF") {
 		t.Fatalf("prompt preview leaked secret: %q", run.PromptPreview)
 	}
-	if run.PromptHash == "" || strings.Contains(run.PromptHash, "supersecret") {
-		t.Fatalf("prompt hash was not set safely: %q", run.PromptHash)
+	if want := hashText(prompt); run.PromptHash != want {
+		t.Fatalf("prompt hash = %q, want %q", run.PromptHash, want)
 	}
 	if run.CreatedAt != now.current || run.UpdatedAt != now.current {
 		t.Fatalf("timestamps = %s/%s, want %s", run.CreatedAt, run.UpdatedAt, now.current)
@@ -48,31 +49,36 @@ func TestStoreRedactsQuotedSecretsWithSpaces(t *testing.T) {
 	store := NewStore(WithClock(fixedClock().now))
 	run, err := store.Create(CreateRequest{
 		Project: "prod",
-		Prompt:  `rotate password="two word secret" and token='another secret phrase'`,
+		Prompt:  `rotate password="two word secret" and token='another secret phrase' for ASIA1234567890ABCDEF`,
 	})
 	if err != nil {
 		t.Fatalf("Create returned error: %v", err)
 	}
-	if strings.Contains(run.PromptPreview, "two word secret") || strings.Contains(run.PromptPreview, "another secret phrase") {
+	if strings.Contains(run.PromptPreview, "two word secret") ||
+		strings.Contains(run.PromptPreview, "another secret phrase") ||
+		strings.Contains(run.PromptPreview, "ASIA1234567890ABCDEF") {
 		t.Fatalf("prompt preview leaked quoted secret: %q", run.PromptPreview)
 	}
 
-	run, err = store.AddLog(run.ID, LogInfo, `using api_key="local model secret"`)
+	run, err = store.AddLog(run.ID, LogInfo, `using api_key="local model secret" and session_token='temporary session secret'`)
 	if err != nil {
 		t.Fatalf("AddLog returned error: %v", err)
 	}
-	if strings.Contains(run.Logs[0].Message, "local model secret") {
+	if strings.Contains(run.Logs[0].Message, "local model secret") ||
+		strings.Contains(run.Logs[0].Message, "temporary session secret") {
 		t.Fatalf("log leaked quoted secret: %q", run.Logs[0].Message)
 	}
 
 	run, err = store.AddPatch(run.ID, ProposedPatch{
 		Path: "main.tf",
-		Diff: `+ access_key = "quoted cloud secret"`,
+		Diff: `+ access_key_id = "quoted cloud secret"
++ secret_access_key = "quoted aws secret"`,
 	})
 	if err != nil {
 		t.Fatalf("AddPatch returned error: %v", err)
 	}
-	if strings.Contains(run.Patches[0].Diff, "quoted cloud secret") {
+	if strings.Contains(run.Patches[0].Diff, "quoted cloud secret") ||
+		strings.Contains(run.Patches[0].Diff, "quoted aws secret") {
 		t.Fatalf("patch leaked quoted secret: %q", run.Patches[0].Diff)
 	}
 }
@@ -124,14 +130,19 @@ func TestStoreLifecycleUpdates(t *testing.T) {
 
 	clock.tick(time.Second)
 	run, err = store.AddApproval(run.ID, ApprovalGate{
-		Kind:    ApprovalCommand,
-		Summary: "run terraform plan",
+		Kind:      ApprovalCommand,
+		Summary:   "run terraform plan",
+		DecidedAt: timePtr(clock.current),
+		DecidedBy: "caller-supplied",
 	})
 	if err != nil {
 		t.Fatalf("AddApproval returned error: %v", err)
 	}
 	if run.Status != StatusWaitingApproval || len(run.Approvals) != 1 || run.Approvals[0].Status != ApprovalPending {
 		t.Fatalf("approval state not recorded: %+v", run)
+	}
+	if run.Approvals[0].DecidedAt != nil || run.Approvals[0].DecidedBy != "" {
+		t.Fatalf("pending approval should not retain decision metadata: %+v", run.Approvals[0])
 	}
 
 	clock.tick(time.Second)
@@ -273,7 +284,7 @@ func TestStoreDecideApproval(t *testing.T) {
 
 	clock.tick(time.Second)
 	decideTime := clock.current
-	run, err = store.DecideApproval(run.ID, approvalID, ApprovalApproved, "alice")
+	run, err = store.DecideApproval(run.ID, approvalID, ApprovalApproved, "alice token=abc123")
 	if err != nil {
 		t.Fatalf("DecideApproval returned error: %v", err)
 	}
@@ -281,8 +292,8 @@ func TestStoreDecideApproval(t *testing.T) {
 	if a.Status != ApprovalApproved {
 		t.Fatalf("approval status = %q, want %q", a.Status, ApprovalApproved)
 	}
-	if a.DecidedBy != "alice" {
-		t.Fatalf("decided_by = %q, want alice", a.DecidedBy)
+	if strings.Contains(a.DecidedBy, "abc123") {
+		t.Fatalf("decided_by leaked token: %q", a.DecidedBy)
 	}
 	if a.DecidedAt == nil || *a.DecidedAt != decideTime {
 		t.Fatalf("decided_at = %v, want %s", a.DecidedAt, decideTime)

--- a/internal/agentruns/store_test.go
+++ b/internal/agentruns/store_test.go
@@ -1,6 +1,8 @@
 package agentruns
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"strings"
 	"testing"
@@ -8,9 +10,11 @@ import (
 	"unicode/utf8"
 )
 
+var testPromptHashKey = []byte("01234567890123456789012345678901")
+
 func TestStoreCreateRedactsPromptAndDefaultsReadOnly(t *testing.T) {
 	now := fixedClock()
-	store := NewStore(WithClock(now.now))
+	store := NewStore(WithClock(now.now), WithPromptHashKey(testPromptHashKey))
 	prompt := "rotate password=supersecret for AKIA1234567890ABCDEF"
 
 	run, err := store.Create(CreateRequest{
@@ -38,7 +42,7 @@ func TestStoreCreateRedactsPromptAndDefaultsReadOnly(t *testing.T) {
 	if strings.Contains(run.PromptPreview, "supersecret") || strings.Contains(run.PromptPreview, "AKIA1234567890ABCDEF") {
 		t.Fatalf("prompt preview leaked secret: %q", run.PromptPreview)
 	}
-	if want := hashText(prompt); run.PromptHash != want {
+	if want := hashText(prompt, testPromptHashKey); run.PromptHash != want {
 		t.Fatalf("prompt hash = %q, want %q", run.PromptHash, want)
 	}
 	if run.CreatedAt != now.current || run.UpdatedAt != now.current {
@@ -46,6 +50,37 @@ func TestStoreCreateRedactsPromptAndDefaultsReadOnly(t *testing.T) {
 	}
 	if run.Logs == nil || run.Patches == nil || run.Approvals == nil {
 		t.Fatalf("list fields should be initialized: %+v", run)
+	}
+}
+
+func TestStorePromptHashUsesStoreKey(t *testing.T) {
+	prompt := "short secret"
+	store := NewStore(WithClock(fixedClock().now), WithPromptHashKey(testPromptHashKey))
+
+	first, err := store.Create(CreateRequest{Project: "prod", Prompt: prompt})
+	if err != nil {
+		t.Fatalf("Create first returned error: %v", err)
+	}
+	second, err := store.Create(CreateRequest{Project: "prod", Prompt: prompt})
+	if err != nil {
+		t.Fatalf("Create second returned error: %v", err)
+	}
+	if first.PromptHash != second.PromptHash {
+		t.Fatalf("same prompt in one store produced different hashes: %q/%q", first.PromptHash, second.PromptHash)
+	}
+
+	otherStore := NewStore(WithClock(fixedClock().now), WithPromptHashKey([]byte("another-test-key-for-prompt-hmac")))
+	other, err := otherStore.Create(CreateRequest{Project: "prod", Prompt: prompt})
+	if err != nil {
+		t.Fatalf("Create other returned error: %v", err)
+	}
+	if first.PromptHash == other.PromptHash {
+		t.Fatalf("different store keys produced identical prompt hash: %q", first.PromptHash)
+	}
+
+	plain := sha256.Sum256([]byte(prompt))
+	if first.PromptHash == hex.EncodeToString(plain[:]) {
+		t.Fatal("prompt hash should not be a plain SHA-256 digest")
 	}
 }
 
@@ -409,6 +444,9 @@ func TestStoreDecideApproval(t *testing.T) {
 	if a.Status != ApprovalApproved {
 		t.Fatalf("approval status = %q, want %q", a.Status, ApprovalApproved)
 	}
+	if run.Status != StatusRunning {
+		t.Fatalf("run status after final approval = %q, want %q", run.Status, StatusRunning)
+	}
 	if strings.Contains(a.DecidedBy, "abc123") {
 		t.Fatalf("decided_by leaked token: %q", a.DecidedBy)
 	}
@@ -429,6 +467,40 @@ func TestStoreDecideApproval(t *testing.T) {
 	// Invalid decision value should error before hitting the store.
 	if _, err := store.DecideApproval(run.ID, approvalID, "maybe", "alice"); err == nil {
 		t.Fatal("expected error for invalid approval decision value")
+	}
+}
+
+func TestStoreDecideApprovalWaitsForAllPendingGates(t *testing.T) {
+	store := NewStore(WithClock(fixedClock().now))
+	run, err := store.Create(CreateRequest{Project: "prod", Prompt: "x"})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	run, err = store.AddApproval(run.ID, ApprovalGate{Kind: ApprovalCommand, Summary: "first"})
+	if err != nil {
+		t.Fatalf("AddApproval first returned error: %v", err)
+	}
+	firstID := run.Approvals[0].ID
+	run, err = store.AddApproval(run.ID, ApprovalGate{Kind: ApprovalFileWrite, Summary: "second"})
+	if err != nil {
+		t.Fatalf("AddApproval second returned error: %v", err)
+	}
+	secondID := run.Approvals[1].ID
+
+	run, err = store.DecideApproval(run.ID, firstID, ApprovalApproved, "alice")
+	if err != nil {
+		t.Fatalf("DecideApproval first returned error: %v", err)
+	}
+	if run.Status != StatusWaitingApproval {
+		t.Fatalf("run status with remaining pending gate = %q, want %q", run.Status, StatusWaitingApproval)
+	}
+
+	run, err = store.DecideApproval(run.ID, secondID, ApprovalRejected, "bob")
+	if err != nil {
+		t.Fatalf("DecideApproval second returned error: %v", err)
+	}
+	if run.Status != StatusRunning {
+		t.Fatalf("run status after all gates decided = %q, want %q", run.Status, StatusRunning)
 	}
 }
 

--- a/internal/agentruns/store_test.go
+++ b/internal/agentruns/store_test.go
@@ -20,8 +20,8 @@ func TestStoreCreateRedactsPromptAndDefaultsReadOnly(t *testing.T) {
 	run, err := store.Create(CreateRequest{
 		Project:    " prod ",
 		Prompt:     prompt,
-		ProviderID: "codex",
-		CreatedBy:  "alice",
+		ProviderID: " codex token=provider-secret ",
+		CreatedBy:  " alice token=creator-secret ",
 	})
 	if err != nil {
 		t.Fatalf("Create returned error: %v", err)
@@ -32,6 +32,12 @@ func TestStoreCreateRedactsPromptAndDefaultsReadOnly(t *testing.T) {
 	}
 	if run.Project != "prod" {
 		t.Fatalf("project = %q, want prod", run.Project)
+	}
+	if run.ProviderID != "codex token= [REDACTED]" {
+		t.Fatalf("provider ID = %q, want sanitized provider metadata", run.ProviderID)
+	}
+	if run.CreatedBy != "alice token= [REDACTED]" {
+		t.Fatalf("created by = %q, want sanitized creator metadata", run.CreatedBy)
 	}
 	if run.Mode != ModeReadOnly {
 		t.Fatalf("mode = %q, want %q", run.Mode, ModeReadOnly)
@@ -495,12 +501,42 @@ func TestStoreDecideApprovalWaitsForAllPendingGates(t *testing.T) {
 		t.Fatalf("run status with remaining pending gate = %q, want %q", run.Status, StatusWaitingApproval)
 	}
 
-	run, err = store.DecideApproval(run.ID, secondID, ApprovalRejected, "bob")
+	run, err = store.DecideApproval(run.ID, secondID, ApprovalApproved, "bob")
 	if err != nil {
 		t.Fatalf("DecideApproval second returned error: %v", err)
 	}
 	if run.Status != StatusRunning {
-		t.Fatalf("run status after all gates decided = %q, want %q", run.Status, StatusRunning)
+		t.Fatalf("run status after all gates approved = %q, want %q", run.Status, StatusRunning)
+	}
+}
+
+func TestStoreDecideApprovalRejectsRun(t *testing.T) {
+	clock := fixedClock()
+	store := NewStore(WithClock(clock.now))
+	run, err := store.Create(CreateRequest{Project: "prod", Prompt: "x"})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	run, err = store.AddApproval(run.ID, ApprovalGate{Kind: ApprovalCommand, Summary: "run apply"})
+	if err != nil {
+		t.Fatalf("AddApproval returned error: %v", err)
+	}
+	approvalID := run.Approvals[0].ID
+
+	clock.tick(time.Second)
+	rejectTime := clock.current
+	run, err = store.DecideApproval(run.ID, approvalID, ApprovalRejected, "bob")
+	if err != nil {
+		t.Fatalf("DecideApproval returned error: %v", err)
+	}
+	if run.Status != StatusFailed {
+		t.Fatalf("run status after rejected approval = %q, want %q", run.Status, StatusFailed)
+	}
+	if run.Error != "approval gate rejected" {
+		t.Fatalf("run error after rejected approval = %q", run.Error)
+	}
+	if run.CompletedAt == nil || *run.CompletedAt != rejectTime {
+		t.Fatalf("completed_at = %v, want %s", run.CompletedAt, rejectTime)
 	}
 }
 

--- a/internal/agentruns/store_test.go
+++ b/internal/agentruns/store_test.go
@@ -177,6 +177,136 @@ func TestStoreValidatesInputsAndEvictsOldRuns(t *testing.T) {
 	}
 }
 
+func TestStoreTerminalStateGuard(t *testing.T) {
+	store := NewStore(WithClock(fixedClock().now))
+	run, err := store.Create(CreateRequest{Project: "prod", Prompt: "x"})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	if _, err := store.SetStatus(run.ID, StatusRunning); err != nil {
+		t.Fatalf("SetStatus running: %v", err)
+	}
+	if _, err := store.SetStatus(run.ID, StatusCompleted); err != nil {
+		t.Fatalf("SetStatus completed: %v", err)
+	}
+
+	if _, err := store.SetStatus(run.ID, StatusRunning); !errors.Is(err, ErrTerminated) {
+		t.Fatalf("SetStatus on completed run: got %v, want ErrTerminated", err)
+	}
+	if _, err := store.Cancel(run.ID); !errors.Is(err, ErrTerminated) {
+		t.Fatalf("Cancel on completed run: got %v, want ErrTerminated", err)
+	}
+	if _, err := store.Fail(run.ID, "late fail"); !errors.Is(err, ErrTerminated) {
+		t.Fatalf("Fail on completed run: got %v, want ErrTerminated", err)
+	}
+	if _, err := store.AddApproval(run.ID, ApprovalGate{Kind: ApprovalCommand, Summary: "x"}); !errors.Is(err, ErrTerminated) {
+		t.Fatalf("AddApproval on completed run: got %v, want ErrTerminated", err)
+	}
+	if _, err := store.AddPatch(run.ID, ProposedPatch{Path: "x.tf", Summary: "s", Diff: "d"}); !errors.Is(err, ErrTerminated) {
+		t.Fatalf("AddPatch on completed run: got %v, want ErrTerminated", err)
+	}
+}
+
+func TestStoreDecideApproval(t *testing.T) {
+	clock := fixedClock()
+	store := NewStore(WithClock(clock.now))
+	run, err := store.Create(CreateRequest{Project: "prod", Prompt: "x", Mode: ModeProposeOnly})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	if _, err := store.SetStatus(run.ID, StatusRunning); err != nil {
+		t.Fatalf("SetStatus running: %v", err)
+	}
+
+	run, err = store.AddApproval(run.ID, ApprovalGate{Kind: ApprovalCommand, Summary: "run plan"})
+	if err != nil {
+		t.Fatalf("AddApproval returned error: %v", err)
+	}
+	if run.Status != StatusWaitingApproval || len(run.Approvals) != 1 {
+		t.Fatalf("unexpected state after AddApproval: %+v", run)
+	}
+	approvalID := run.Approvals[0].ID
+
+	clock.tick(time.Second)
+	decideTime := clock.current
+	run, err = store.DecideApproval(run.ID, approvalID, ApprovalApproved, "alice")
+	if err != nil {
+		t.Fatalf("DecideApproval returned error: %v", err)
+	}
+	a := run.Approvals[0]
+	if a.Status != ApprovalApproved {
+		t.Fatalf("approval status = %q, want %q", a.Status, ApprovalApproved)
+	}
+	if a.DecidedBy != "alice" {
+		t.Fatalf("decided_by = %q, want alice", a.DecidedBy)
+	}
+	if a.DecidedAt == nil || *a.DecidedAt != decideTime {
+		t.Fatalf("decided_at = %v, want %s", a.DecidedAt, decideTime)
+	}
+
+	// Re-deciding an already-decided gate should error.
+	if _, err := store.DecideApproval(run.ID, approvalID, ApprovalApproved, "alice"); err == nil {
+		t.Fatal("expected error re-deciding an already-decided gate")
+	}
+
+	// Non-existent approval gate should return ErrApprovalNotFound.
+	if _, err := store.DecideApproval(run.ID, "approval_999999", ApprovalApproved, "alice"); !errors.Is(err, ErrApprovalNotFound) {
+		t.Fatalf("missing gate error = %v, want ErrApprovalNotFound", err)
+	}
+
+	// Invalid decision value should error before hitting the store.
+	if _, err := store.DecideApproval(run.ID, approvalID, "maybe", "alice"); err == nil {
+		t.Fatal("expected error for invalid approval decision value")
+	}
+}
+
+func TestStoreDefensiveTimePointers(t *testing.T) {
+	clock := fixedClock()
+	store := NewStore(WithClock(clock.now))
+	run, err := store.Create(CreateRequest{Project: "prod", Prompt: "x"})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+
+	clock.tick(time.Second)
+	startTime := clock.current
+	run, err = store.SetStatus(run.ID, StatusRunning)
+	if err != nil {
+		t.Fatalf("SetStatus running: %v", err)
+	}
+	if run.StartedAt == nil || *run.StartedAt != startTime {
+		t.Fatalf("StartedAt not recorded: %v", run.StartedAt)
+	}
+
+	// Mutate the pointer from the returned copy; the stored run must be unaffected.
+	*run.StartedAt = time.Time{}
+
+	got, ok := store.Get(run.ID)
+	if !ok {
+		t.Fatal("expected run to exist")
+	}
+	if got.StartedAt == nil || *got.StartedAt != startTime {
+		t.Fatal("time pointer aliasing: stored StartedAt was mutated via returned copy")
+	}
+
+	// Same isolation must hold for ApprovalGate.DecidedAt.
+	if _, err := store.AddApproval(run.ID, ApprovalGate{Kind: ApprovalCommand, Summary: "x"}); err != nil {
+		t.Fatalf("AddApproval: %v", err)
+	}
+	clock.tick(time.Second)
+	decideTime := clock.current
+	run, err = store.DecideApproval(run.ID, "approval_000001", ApprovalApproved, "bob")
+	if err != nil {
+		t.Fatalf("DecideApproval: %v", err)
+	}
+	*run.Approvals[0].DecidedAt = time.Time{}
+
+	got, _ = store.Get(run.ID)
+	if got.Approvals[0].DecidedAt == nil || *got.Approvals[0].DecidedAt != decideTime {
+		t.Fatal("time pointer aliasing: stored ApprovalGate.DecidedAt was mutated via returned copy")
+	}
+}
+
 type testClock struct {
 	current time.Time
 }


### PR DESCRIPTION
## Summary
- Add an internal agent run lifecycle model for issue #105
- Store redacted prompt previews plus SHA-256 prompt fingerprints instead of raw prompts
- Track statuses, logs, proposed patches, approval gates, cancel state, timestamps, and bounded in-memory retention
- Keep this slice model/store only: no execution, no HTTP routes, no MCP/tool routing

## Security notes
- Defaults new runs to read-only mode
- Redacts common token/password/API key/access key patterns from prompt previews, logs, errors, patch summaries, and patch diffs
- Returns defensive copies so callers cannot mutate stored run state

## Validation
- `GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/agentruns`
- `GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/...`

Refs #105