### PR TITLE
Expose secure agent run API

### DIFF
--- a/internal/agentruns/store.go
+++ b/internal/agentruns/store.go
@@ -264,7 +264,7 @@ func (s *Store) ListProjectSummaries(project string) []RunSummary {
 	project = strings.TrimSpace(project)
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	summaries := make([]RunSummary, 0)
+	summaries := make([]RunSummary, 0, len(s.order))
 	for _, id := range s.order {
 		run, ok := s.runs[id]
 		if !ok || run.Project != project {

--- a/internal/agentruns/store.go
+++ b/internal/agentruns/store.go
@@ -97,6 +97,26 @@ type Run struct {
 	Approvals     []ApprovalGate  `json:"approvals"`
 }
 
+type RunSummary struct {
+	ID                   string     `json:"id"`
+	Project              string     `json:"project"`
+	ProviderID           string     `json:"provider_id,omitempty"`
+	Mode                 Mode       `json:"mode"`
+	Status               Status     `json:"status"`
+	PromptPreview        string     `json:"prompt_preview"`
+	PromptHash           string     `json:"prompt_hash"`
+	CreatedAt            time.Time  `json:"created_at"`
+	UpdatedAt            time.Time  `json:"updated_at"`
+	StartedAt            *time.Time `json:"started_at,omitempty"`
+	CompletedAt          *time.Time `json:"completed_at,omitempty"`
+	Canceled             bool       `json:"canceled"`
+	Error                string     `json:"error,omitempty"`
+	LogCount             int        `json:"log_count"`
+	PatchCount           int        `json:"patch_count"`
+	ApprovalCount        int        `json:"approval_count"`
+	PendingApprovalCount int        `json:"pending_approval_count"`
+}
+
 type LogEntry struct {
 	ID      string    `json:"id"`
 	At      time.Time `json:"at"`
@@ -238,6 +258,21 @@ func (s *Store) List() []Run {
 		}
 	}
 	return runs
+}
+
+func (s *Store) ListProjectSummaries(project string) []RunSummary {
+	project = strings.TrimSpace(project)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	summaries := make([]RunSummary, 0)
+	for _, id := range s.order {
+		run, ok := s.runs[id]
+		if !ok || run.Project != project {
+			continue
+		}
+		summaries = append(summaries, summarizeRun(run))
+	}
+	return summaries
 }
 
 func (s *Store) SetStatus(id string, status Status) (Run, error) {
@@ -391,6 +426,33 @@ func hasPendingApprovals(approvals []ApprovalGate) bool {
 		}
 	}
 	return false
+}
+
+func summarizeRun(run *Run) RunSummary {
+	summary := RunSummary{
+		ID:            run.ID,
+		Project:       run.Project,
+		ProviderID:    run.ProviderID,
+		Mode:          run.Mode,
+		Status:        run.Status,
+		PromptPreview: run.PromptPreview,
+		PromptHash:    run.PromptHash,
+		CreatedAt:     run.CreatedAt,
+		UpdatedAt:     run.UpdatedAt,
+		StartedAt:     cloneTimePtr(run.StartedAt),
+		CompletedAt:   cloneTimePtr(run.CompletedAt),
+		Canceled:      run.Canceled,
+		Error:         run.Error,
+		LogCount:      len(run.Logs),
+		PatchCount:    len(run.Patches),
+		ApprovalCount: len(run.Approvals),
+	}
+	for _, approval := range run.Approvals {
+		if approval.Status == ApprovalPending {
+			summary.PendingApprovalCount++
+		}
+	}
+	return summary
 }
 
 func sanitizeMetadata(text string) string {

--- a/internal/agentruns/store_test.go
+++ b/internal/agentruns/store_test.go
@@ -3,6 +3,7 @@ package agentruns
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -341,6 +342,85 @@ func TestStoreReturnsDefensiveCopies(t *testing.T) {
 	}
 	if got.Logs[0].Message == "mutated-list" {
 		t.Fatal("store returned mutable list snapshot")
+	}
+}
+
+func TestStoreListProjectSummariesSkipsHeavyFields(t *testing.T) {
+	clock := fixedClock()
+	store := NewStore(WithClock(clock.now))
+	prod, err := store.Create(CreateRequest{Project: "prod", Prompt: "make a plan", ProviderID: "codex"})
+	if err != nil {
+		t.Fatalf("Create prod returned error: %v", err)
+	}
+	if _, err := store.Create(CreateRequest{Project: "other", Prompt: "make another plan"}); err != nil {
+		t.Fatalf("Create other returned error: %v", err)
+	}
+	clock.tick(time.Second)
+	prod, err = store.SetStatus(prod.ID, StatusRunning)
+	if err != nil {
+		t.Fatalf("SetStatus returned error: %v", err)
+	}
+	if _, err := store.AddLog(prod.ID, LogInfo, "started with token=log-secret"); err != nil {
+		t.Fatalf("AddLog returned error: %v", err)
+	}
+	if _, err := store.AddPatch(prod.ID, ProposedPatch{
+		Path:    "main.tf",
+		Summary: "add resource",
+		Diff:    "+ token=diff-secret",
+	}); err != nil {
+		t.Fatalf("AddPatch returned error: %v", err)
+	}
+	if _, err := store.AddApproval(prod.ID, ApprovalGate{
+		Kind:    ApprovalCommand,
+		Summary: "run command with token=approval-secret",
+	}); err != nil {
+		t.Fatalf("AddApproval returned error: %v", err)
+	}
+
+	summaries := store.ListProjectSummaries("prod")
+	if len(summaries) != 1 {
+		t.Fatalf("summaries = %+v, want one prod summary", summaries)
+	}
+	summary := summaries[0]
+	if summary.ID != prod.ID || summary.Project != "prod" || summary.ProviderID != "codex" {
+		t.Fatalf("unexpected summary identity: %+v", summary)
+	}
+	if summary.Status != StatusWaitingApproval || summary.LogCount != 1 || summary.PatchCount != 1 || summary.ApprovalCount != 1 || summary.PendingApprovalCount != 1 {
+		t.Fatalf("unexpected summary state/counts: %+v", summary)
+	}
+	if summary.StartedAt == nil || *summary.StartedAt != clock.current {
+		t.Fatalf("started_at = %v, want %s", summary.StartedAt, clock.current)
+	}
+	*summary.StartedAt = time.Time{}
+	got, ok := store.Get(prod.ID)
+	if !ok {
+		t.Fatal("expected prod run to exist")
+	}
+	if got.StartedAt == nil || *got.StartedAt != clock.current {
+		t.Fatal("summary returned mutable StartedAt pointer")
+	}
+
+	payload, err := json.Marshal(summary)
+	if err != nil {
+		t.Fatalf("marshal summary: %v", err)
+	}
+	serialized := string(payload)
+	for _, field := range []string{"logs", "patches", "approvals", "created_by"} {
+		if strings.Contains(serialized, field) {
+			t.Fatalf("summary JSON leaked field %q: %s", field, serialized)
+		}
+	}
+	for _, secret := range []string{"log-secret", "diff-secret", "approval-secret"} {
+		if strings.Contains(serialized, secret) {
+			t.Fatalf("summary JSON leaked heavy-field secret %q: %s", secret, serialized)
+		}
+	}
+
+	if other := store.ListProjectSummaries("other"); len(other) != 1 || other[0].Project != "other" {
+		t.Fatalf("other summaries = %+v, want exactly one other summary", other)
+	}
+	if missing := store.ListProjectSummaries("missing"); len(missing) != 0 {
+		t.Fatalf("missing summaries = %+v, want none", missing)
 	}
 }
 

--- a/internal/api/agent_runs.go
+++ b/internal/api/agent_runs.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/iac-studio/iac-studio/internal/agentruns"
 )
@@ -12,7 +13,26 @@ type agentRunCreateRequest struct {
 	Prompt     string         `json:"prompt"`
 	ProviderID string         `json:"provider_id,omitempty"`
 	Mode       agentruns.Mode `json:"mode,omitempty"`
-	CreatedBy  string         `json:"created_by,omitempty"`
+}
+
+type agentRunSummary struct {
+	ID                   string           `json:"id"`
+	Project              string           `json:"project"`
+	ProviderID           string           `json:"provider_id,omitempty"`
+	Mode                 agentruns.Mode   `json:"mode"`
+	Status               agentruns.Status `json:"status"`
+	PromptPreview        string           `json:"prompt_preview"`
+	PromptHash           string           `json:"prompt_hash"`
+	CreatedAt            time.Time        `json:"created_at"`
+	UpdatedAt            time.Time        `json:"updated_at"`
+	StartedAt            *time.Time       `json:"started_at,omitempty"`
+	CompletedAt          *time.Time       `json:"completed_at,omitempty"`
+	Canceled             bool             `json:"canceled"`
+	Error                string           `json:"error,omitempty"`
+	LogCount             int              `json:"log_count"`
+	PatchCount           int              `json:"patch_count"`
+	ApprovalCount        int              `json:"approval_count"`
+	PendingApprovalCount int              `json:"pending_approval_count"`
 }
 
 func registerAgentRunRoutes(mux *http.ServeMux, projectsDir string, store *agentruns.Store) {
@@ -21,10 +41,10 @@ func registerAgentRunRoutes(mux *http.ServeMux, projectsDir string, store *agent
 		if !requireExistingAgentRunProject(w, projectsDir, name) {
 			return
 		}
-		runs := []agentruns.Run{}
+		runs := []agentRunSummary{}
 		for _, run := range store.List() {
 			if run.Project == name {
-				runs = append(runs, run)
+				runs = append(runs, summarizeAgentRun(run))
 			}
 		}
 		_ = json.NewEncoder(w).Encode(map[string]any{
@@ -52,7 +72,6 @@ func registerAgentRunRoutes(mux *http.ServeMux, projectsDir string, store *agent
 			Prompt:     req.Prompt,
 			ProviderID: req.ProviderID,
 			Mode:       req.Mode,
-			CreatedBy:  req.CreatedBy,
 		})
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
@@ -75,6 +94,33 @@ func registerAgentRunRoutes(mux *http.ServeMux, projectsDir string, store *agent
 		}
 		_ = json.NewEncoder(w).Encode(run)
 	})
+}
+
+func summarizeAgentRun(run agentruns.Run) agentRunSummary {
+	summary := agentRunSummary{
+		ID:            run.ID,
+		Project:       run.Project,
+		ProviderID:    run.ProviderID,
+		Mode:          run.Mode,
+		Status:        run.Status,
+		PromptPreview: run.PromptPreview,
+		PromptHash:    run.PromptHash,
+		CreatedAt:     run.CreatedAt,
+		UpdatedAt:     run.UpdatedAt,
+		StartedAt:     run.StartedAt,
+		CompletedAt:   run.CompletedAt,
+		Canceled:      run.Canceled,
+		Error:         run.Error,
+		LogCount:      len(run.Logs),
+		PatchCount:    len(run.Patches),
+		ApprovalCount: len(run.Approvals),
+	}
+	for _, approval := range run.Approvals {
+		if approval.Status == agentruns.ApprovalPending {
+			summary.PendingApprovalCount++
+		}
+	}
+	return summary
 }
 
 func requireExistingAgentRunProject(w http.ResponseWriter, projectsDir, name string) bool {

--- a/internal/api/agent_runs.go
+++ b/internal/api/agent_runs.go
@@ -1,0 +1,64 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/iac-studio/iac-studio/internal/agentruns"
+)
+
+type agentRunCreateRequest struct {
+	Prompt     string         `json:"prompt"`
+	ProviderID string         `json:"provider_id,omitempty"`
+	Mode       agentruns.Mode `json:"mode,omitempty"`
+	CreatedBy  string         `json:"created_by,omitempty"`
+}
+
+func registerAgentRunRoutes(mux *http.ServeMux, projectsDir string, store *agentruns.Store) {
+	mux.HandleFunc("GET /api/agent-runs", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"runs": store.List(),
+		})
+	})
+
+	mux.HandleFunc("POST /api/projects/{name}/agent-runs", func(w http.ResponseWriter, r *http.Request) {
+		limitBody(w, r)
+		if !requireJSONContentType(w, r) {
+			return
+		}
+		name := r.PathValue("name")
+		if _, err := safeProjectPath(projectsDir, name); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		var req agentRunCreateRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		run, err := store.Create(agentruns.CreateRequest{
+			Project:    name,
+			Prompt:     req.Prompt,
+			ProviderID: req.ProviderID,
+			Mode:       req.Mode,
+			CreatedBy:  req.CreatedBy,
+		})
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(run)
+	})
+
+	mux.HandleFunc("GET /api/agent-runs/{id}", func(w http.ResponseWriter, r *http.Request) {
+		run, ok := store.Get(r.PathValue("id"))
+		if !ok {
+			http.Error(w, "agent run not found", http.StatusNotFound)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(run)
+	})
+}

--- a/internal/api/agent_runs.go
+++ b/internal/api/agent_runs.go
@@ -20,6 +20,7 @@ func registerAgentRunRoutes(mux *http.ServeMux, projectsDir string, store *agent
 		if !requireExistingAgentRunProject(w, projectsDir, name) {
 			return
 		}
+		setAgentRunJSONHeader(w)
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"runs": store.ListProjectSummaries(name),
 		})
@@ -51,6 +52,7 @@ func registerAgentRunRoutes(mux *http.ServeMux, projectsDir string, store *agent
 			return
 		}
 
+		setAgentRunJSONHeader(w)
 		w.WriteHeader(http.StatusCreated)
 		_ = json.NewEncoder(w).Encode(run)
 	})
@@ -65,8 +67,13 @@ func registerAgentRunRoutes(mux *http.ServeMux, projectsDir string, store *agent
 			http.Error(w, "agent run not found", http.StatusNotFound)
 			return
 		}
+		setAgentRunJSONHeader(w)
 		_ = json.NewEncoder(w).Encode(run)
 	})
+}
+
+func setAgentRunJSONHeader(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
 }
 
 func requireExistingAgentRunProject(w http.ResponseWriter, projectsDir, name string) bool {

--- a/internal/api/agent_runs.go
+++ b/internal/api/agent_runs.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"net/http"
+	"os"
 
 	"github.com/iac-studio/iac-studio/internal/agentruns"
 )
@@ -15,9 +16,19 @@ type agentRunCreateRequest struct {
 }
 
 func registerAgentRunRoutes(mux *http.ServeMux, projectsDir string, store *agentruns.Store) {
-	mux.HandleFunc("GET /api/agent-runs", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("GET /api/projects/{name}/agent-runs", func(w http.ResponseWriter, r *http.Request) {
+		name := r.PathValue("name")
+		if !requireExistingAgentRunProject(w, projectsDir, name) {
+			return
+		}
+		runs := []agentruns.Run{}
+		for _, run := range store.List() {
+			if run.Project == name {
+				runs = append(runs, run)
+			}
+		}
 		_ = json.NewEncoder(w).Encode(map[string]any{
-			"runs": store.List(),
+			"runs": runs,
 		})
 	})
 
@@ -27,8 +38,7 @@ func registerAgentRunRoutes(mux *http.ServeMux, projectsDir string, store *agent
 			return
 		}
 		name := r.PathValue("name")
-		if _, err := safeProjectPath(projectsDir, name); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
+		if !requireExistingAgentRunProject(w, projectsDir, name) {
 			return
 		}
 
@@ -53,12 +63,38 @@ func registerAgentRunRoutes(mux *http.ServeMux, projectsDir string, store *agent
 		_ = json.NewEncoder(w).Encode(run)
 	})
 
-	mux.HandleFunc("GET /api/agent-runs/{id}", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("GET /api/projects/{name}/agent-runs/{id}", func(w http.ResponseWriter, r *http.Request) {
+		name := r.PathValue("name")
+		if !requireExistingAgentRunProject(w, projectsDir, name) {
+			return
+		}
 		run, ok := store.Get(r.PathValue("id"))
-		if !ok {
+		if !ok || run.Project != name {
 			http.Error(w, "agent run not found", http.StatusNotFound)
 			return
 		}
 		_ = json.NewEncoder(w).Encode(run)
 	})
+}
+
+func requireExistingAgentRunProject(w http.ResponseWriter, projectsDir, name string) bool {
+	projectPath, err := safeProjectPath(projectsDir, name)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return false
+	}
+	info, err := os.Stat(projectPath)
+	if os.IsNotExist(err) {
+		http.Error(w, "project not found", http.StatusNotFound)
+		return false
+	}
+	if err != nil {
+		http.Error(w, "stat project: "+err.Error(), http.StatusInternalServerError)
+		return false
+	}
+	if !info.IsDir() {
+		http.Error(w, "project not found", http.StatusNotFound)
+		return false
+	}
+	return true
 }

--- a/internal/api/agent_runs.go
+++ b/internal/api/agent_runs.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"os"
-	"time"
 
 	"github.com/iac-studio/iac-studio/internal/agentruns"
 )
@@ -15,40 +14,14 @@ type agentRunCreateRequest struct {
 	Mode       agentruns.Mode `json:"mode,omitempty"`
 }
 
-type agentRunSummary struct {
-	ID                   string           `json:"id"`
-	Project              string           `json:"project"`
-	ProviderID           string           `json:"provider_id,omitempty"`
-	Mode                 agentruns.Mode   `json:"mode"`
-	Status               agentruns.Status `json:"status"`
-	PromptPreview        string           `json:"prompt_preview"`
-	PromptHash           string           `json:"prompt_hash"`
-	CreatedAt            time.Time        `json:"created_at"`
-	UpdatedAt            time.Time        `json:"updated_at"`
-	StartedAt            *time.Time       `json:"started_at,omitempty"`
-	CompletedAt          *time.Time       `json:"completed_at,omitempty"`
-	Canceled             bool             `json:"canceled"`
-	Error                string           `json:"error,omitempty"`
-	LogCount             int              `json:"log_count"`
-	PatchCount           int              `json:"patch_count"`
-	ApprovalCount        int              `json:"approval_count"`
-	PendingApprovalCount int              `json:"pending_approval_count"`
-}
-
 func registerAgentRunRoutes(mux *http.ServeMux, projectsDir string, store *agentruns.Store) {
 	mux.HandleFunc("GET /api/projects/{name}/agent-runs", func(w http.ResponseWriter, r *http.Request) {
 		name := r.PathValue("name")
 		if !requireExistingAgentRunProject(w, projectsDir, name) {
 			return
 		}
-		runs := []agentRunSummary{}
-		for _, run := range store.List() {
-			if run.Project == name {
-				runs = append(runs, summarizeAgentRun(run))
-			}
-		}
 		_ = json.NewEncoder(w).Encode(map[string]any{
-			"runs": runs,
+			"runs": store.ListProjectSummaries(name),
 		})
 	})
 
@@ -94,33 +67,6 @@ func registerAgentRunRoutes(mux *http.ServeMux, projectsDir string, store *agent
 		}
 		_ = json.NewEncoder(w).Encode(run)
 	})
-}
-
-func summarizeAgentRun(run agentruns.Run) agentRunSummary {
-	summary := agentRunSummary{
-		ID:            run.ID,
-		Project:       run.Project,
-		ProviderID:    run.ProviderID,
-		Mode:          run.Mode,
-		Status:        run.Status,
-		PromptPreview: run.PromptPreview,
-		PromptHash:    run.PromptHash,
-		CreatedAt:     run.CreatedAt,
-		UpdatedAt:     run.UpdatedAt,
-		StartedAt:     run.StartedAt,
-		CompletedAt:   run.CompletedAt,
-		Canceled:      run.Canceled,
-		Error:         run.Error,
-		LogCount:      len(run.Logs),
-		PatchCount:    len(run.Patches),
-		ApprovalCount: len(run.Approvals),
-	}
-	for _, approval := range run.Approvals {
-		if approval.Status == agentruns.ApprovalPending {
-			summary.PendingApprovalCount++
-		}
-	}
-	return summary
 }
 
 func requireExistingAgentRunProject(w http.ResponseWriter, projectsDir, name string) bool {

--- a/internal/api/agent_runs_test.go
+++ b/internal/api/agent_runs_test.go
@@ -54,12 +54,18 @@ func TestAgentRunRoutesCreateListAndGetSanitizedRun(t *testing.T) {
 	if _, ok := raw["prompt"]; ok {
 		t.Fatal("create response leaked raw prompt field")
 	}
+	if _, ok := raw["created_by"]; ok {
+		t.Fatal("create response accepted client-supplied created_by field")
+	}
 	var created agentruns.Run
 	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
 		t.Fatalf("decode created run: %v", err)
 	}
 	if created.ID == "" || created.Project != "demo" || created.Mode != agentruns.ModeReadOnly || created.Status != agentruns.StatusQueued {
 		t.Fatalf("unexpected created run: %+v", created)
+	}
+	if created.CreatedBy != "" {
+		t.Fatalf("created_by = %q, want empty until identity is server-derived", created.CreatedBy)
 	}
 	if created.PromptHash == "" {
 		t.Fatal("prompt hash is empty")
@@ -85,6 +91,23 @@ func TestAgentRunRoutesCreateListAndGetSanitizedRun(t *testing.T) {
 		t.Fatalf("fetched run mismatch: got %+v want %+v", fetched, created)
 	}
 
+	if _, err := store.AddLog(created.ID, agentruns.LogInfo, "started with token=log-secret"); err != nil {
+		t.Fatalf("add log: %v", err)
+	}
+	if _, err := store.AddPatch(created.ID, agentruns.ProposedPatch{
+		Path:    "main.tf",
+		Summary: "add resource",
+		Diff:    "+ token=diff-secret",
+	}); err != nil {
+		t.Fatalf("add patch: %v", err)
+	}
+	if _, err := store.AddApproval(created.ID, agentruns.ApprovalGate{
+		Kind:    agentruns.ApprovalCommand,
+		Summary: "run command with token=approval-secret",
+	}); err != nil {
+		t.Fatalf("add approval: %v", err)
+	}
+
 	listReq := httptest.NewRequest(http.MethodGet, "/api/projects/demo/agent-runs", nil)
 	listRec := httptest.NewRecorder()
 	router.ServeHTTP(listRec, listReq)
@@ -92,13 +115,39 @@ func TestAgentRunRoutesCreateListAndGetSanitizedRun(t *testing.T) {
 		t.Fatalf("list status = %d, body = %s", listRec.Code, listRec.Body.String())
 	}
 	var listed struct {
-		Runs []agentruns.Run `json:"runs"`
+		Runs []map[string]json.RawMessage `json:"runs"`
 	}
 	if err := json.Unmarshal(listRec.Body.Bytes(), &listed); err != nil {
 		t.Fatalf("decode listed runs: %v", err)
 	}
-	if len(listed.Runs) != 1 || listed.Runs[0].ID != created.ID {
+	if len(listed.Runs) != 1 {
 		t.Fatalf("listed runs = %+v, want created run %s", listed.Runs, created.ID)
+	}
+	summary := listed.Runs[0]
+	if got := rawString(t, summary, "id"); got != created.ID {
+		t.Fatalf("listed run id = %q, want %q", got, created.ID)
+	}
+	for _, field := range []string{"logs", "patches", "approvals", "created_by"} {
+		if _, ok := summary[field]; ok {
+			t.Fatalf("list summary leaked field %q: %s", field, listRec.Body.String())
+		}
+	}
+	if got := rawInt(t, summary, "log_count"); got != 1 {
+		t.Fatalf("log_count = %d, want 1", got)
+	}
+	if got := rawInt(t, summary, "patch_count"); got != 1 {
+		t.Fatalf("patch_count = %d, want 1", got)
+	}
+	if got := rawInt(t, summary, "approval_count"); got != 1 {
+		t.Fatalf("approval_count = %d, want 1", got)
+	}
+	if got := rawInt(t, summary, "pending_approval_count"); got != 1 {
+		t.Fatalf("pending_approval_count = %d, want 1", got)
+	}
+	for _, secret := range []string{"log-secret", "diff-secret", "approval-secret"} {
+		if strings.Contains(listRec.Body.String(), secret) {
+			t.Fatalf("list response leaked heavy-field secret %q: %s", secret, listRec.Body.String())
+		}
 	}
 }
 
@@ -175,7 +224,7 @@ func TestAgentRunRoutesDoNotExposeRunsAcrossProjects(t *testing.T) {
 		t.Fatalf("cross-project list status = %d, body = %s", listRec.Code, listRec.Body.String())
 	}
 	var listed struct {
-		Runs []agentruns.Run `json:"runs"`
+		Runs []agentRunSummary `json:"runs"`
 	}
 	if err := json.Unmarshal(listRec.Body.Bytes(), &listed); err != nil {
 		t.Fatalf("decode listed runs: %v", err)
@@ -183,4 +232,30 @@ func TestAgentRunRoutesDoNotExposeRunsAcrossProjects(t *testing.T) {
 	if len(listed.Runs) != 0 {
 		t.Fatalf("cross-project list leaked runs: %+v", listed.Runs)
 	}
+}
+
+func rawString(t *testing.T, raw map[string]json.RawMessage, field string) string {
+	t.Helper()
+	value, ok := raw[field]
+	if !ok {
+		t.Fatalf("missing field %q in %#v", field, raw)
+	}
+	var decoded string
+	if err := json.Unmarshal(value, &decoded); err != nil {
+		t.Fatalf("decode field %q as string: %v", field, err)
+	}
+	return decoded
+}
+
+func rawInt(t *testing.T, raw map[string]json.RawMessage, field string) int {
+	t.Helper()
+	value, ok := raw[field]
+	if !ok {
+		t.Fatalf("missing field %q in %#v", field, raw)
+	}
+	var decoded int
+	if err := json.Unmarshal(value, &decoded); err != nil {
+		t.Fatalf("decode field %q as int: %v", field, err)
+	}
+	return decoded
 }

--- a/internal/api/agent_runs_test.go
+++ b/internal/api/agent_runs_test.go
@@ -1,0 +1,146 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/iac-studio/iac-studio/internal/agentruns"
+)
+
+func agentRunMux(projectsDir string, store *agentruns.Store) *http.ServeMux {
+	mux := http.NewServeMux()
+	registerAgentRunRoutes(mux, projectsDir, store)
+	return mux
+}
+
+func scaffoldAgentRunProject(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "demo"), 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	return root
+}
+
+func TestAgentRunRoutesCreateListAndGetSanitizedRun(t *testing.T) {
+	root := scaffoldAgentRunProject(t)
+	store := agentruns.NewStore(agentruns.WithPromptHashKey([]byte("stable-test-key")))
+	router := agentRunMux(root, store)
+
+	body := `{
+		"prompt": "create a VPC with token=super-secret",
+		"provider_id": "codex token=provider-secret",
+		"created_by": "alice password=hunter2"
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/api/projects/demo/agent-runs", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	raw := map[string]json.RawMessage{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode raw response: %v", err)
+	}
+	if _, ok := raw["prompt"]; ok {
+		t.Fatal("create response leaked raw prompt field")
+	}
+	var created agentruns.Run
+	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode created run: %v", err)
+	}
+	if created.ID == "" || created.Project != "demo" || created.Mode != agentruns.ModeReadOnly || created.Status != agentruns.StatusQueued {
+		t.Fatalf("unexpected created run: %+v", created)
+	}
+	if created.PromptHash == "" {
+		t.Fatal("prompt hash is empty")
+	}
+	serialized := rec.Body.String()
+	for _, secret := range []string{"super-secret", "provider-secret", "hunter2"} {
+		if strings.Contains(serialized, secret) {
+			t.Fatalf("response leaked secret %q: %s", secret, serialized)
+		}
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/api/agent-runs/"+created.ID, nil)
+	getRec := httptest.NewRecorder()
+	router.ServeHTTP(getRec, getReq)
+	if getRec.Code != http.StatusOK {
+		t.Fatalf("get status = %d, body = %s", getRec.Code, getRec.Body.String())
+	}
+	var fetched agentruns.Run
+	if err := json.Unmarshal(getRec.Body.Bytes(), &fetched); err != nil {
+		t.Fatalf("decode fetched run: %v", err)
+	}
+	if fetched.ID != created.ID || fetched.PromptHash != created.PromptHash {
+		t.Fatalf("fetched run mismatch: got %+v want %+v", fetched, created)
+	}
+
+	listReq := httptest.NewRequest(http.MethodGet, "/api/agent-runs", nil)
+	listRec := httptest.NewRecorder()
+	router.ServeHTTP(listRec, listReq)
+	if listRec.Code != http.StatusOK {
+		t.Fatalf("list status = %d, body = %s", listRec.Code, listRec.Body.String())
+	}
+	var listed struct {
+		Runs []agentruns.Run `json:"runs"`
+	}
+	if err := json.Unmarshal(listRec.Body.Bytes(), &listed); err != nil {
+		t.Fatalf("decode listed runs: %v", err)
+	}
+	if len(listed.Runs) != 1 || listed.Runs[0].ID != created.ID {
+		t.Fatalf("listed runs = %+v, want created run %s", listed.Runs, created.ID)
+	}
+}
+
+func TestAgentRunRoutesRejectBadRequests(t *testing.T) {
+	root := scaffoldAgentRunProject(t)
+	router := agentRunMux(root, agentruns.NewStore())
+
+	cases := []struct {
+		name   string
+		path   string
+		body   string
+		status int
+	}{
+		{"missing content type", "/api/projects/demo/agent-runs", `{"prompt":"x"}`, http.StatusUnsupportedMediaType},
+		{"malformed JSON", "/api/projects/demo/agent-runs", "{not-json", http.StatusBadRequest},
+		{"missing prompt", "/api/projects/demo/agent-runs", `{}`, http.StatusBadRequest},
+		{"invalid mode", "/api/projects/demo/agent-runs", `{"prompt":"x","mode":"write_everything"}`, http.StatusBadRequest},
+		{"project traversal", "/api/projects/%2e%2e%2fetc/agent-runs", `{"prompt":"x"}`, http.StatusBadRequest},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, tc.path, strings.NewReader(tc.body))
+			if tc.name != "missing content type" {
+				req.Header.Set("Content-Type", "application/json")
+			}
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+			if rec.Code != tc.status {
+				t.Fatalf("status = %d, want %d, body = %s", rec.Code, tc.status, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestAgentRunRoutesReturn404ForMissingRun(t *testing.T) {
+	root := scaffoldAgentRunProject(t)
+	router := agentRunMux(root, agentruns.NewStore())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/agent-runs/missing", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d, body = %s", rec.Code, http.StatusNotFound, rec.Body.String())
+	}
+}

--- a/internal/api/agent_runs_test.go
+++ b/internal/api/agent_runs_test.go
@@ -224,7 +224,7 @@ func TestAgentRunRoutesDoNotExposeRunsAcrossProjects(t *testing.T) {
 		t.Fatalf("cross-project list status = %d, body = %s", listRec.Code, listRec.Body.String())
 	}
 	var listed struct {
-		Runs []agentRunSummary `json:"runs"`
+		Runs []agentruns.RunSummary `json:"runs"`
 	}
 	if err := json.Unmarshal(listRec.Body.Bytes(), &listed); err != nil {
 		t.Fatalf("decode listed runs: %v", err)

--- a/internal/api/agent_runs_test.go
+++ b/internal/api/agent_runs_test.go
@@ -21,8 +21,10 @@ func agentRunMux(projectsDir string, store *agentruns.Store) *http.ServeMux {
 func scaffoldAgentRunProject(t *testing.T) string {
 	t.Helper()
 	root := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(root, "demo"), 0o755); err != nil {
-		t.Fatalf("mkdir project: %v", err)
+	for _, name := range []string{"demo", "other"} {
+		if err := os.MkdirAll(filepath.Join(root, name), 0o755); err != nil {
+			t.Fatalf("mkdir project %s: %v", name, err)
+		}
 	}
 	return root
 }
@@ -69,7 +71,7 @@ func TestAgentRunRoutesCreateListAndGetSanitizedRun(t *testing.T) {
 		}
 	}
 
-	getReq := httptest.NewRequest(http.MethodGet, "/api/agent-runs/"+created.ID, nil)
+	getReq := httptest.NewRequest(http.MethodGet, "/api/projects/demo/agent-runs/"+created.ID, nil)
 	getRec := httptest.NewRecorder()
 	router.ServeHTTP(getRec, getReq)
 	if getRec.Code != http.StatusOK {
@@ -83,7 +85,7 @@ func TestAgentRunRoutesCreateListAndGetSanitizedRun(t *testing.T) {
 		t.Fatalf("fetched run mismatch: got %+v want %+v", fetched, created)
 	}
 
-	listReq := httptest.NewRequest(http.MethodGet, "/api/agent-runs", nil)
+	listReq := httptest.NewRequest(http.MethodGet, "/api/projects/demo/agent-runs", nil)
 	listRec := httptest.NewRecorder()
 	router.ServeHTTP(listRec, listReq)
 	if listRec.Code != http.StatusOK {
@@ -115,6 +117,7 @@ func TestAgentRunRoutesRejectBadRequests(t *testing.T) {
 		{"missing prompt", "/api/projects/demo/agent-runs", `{}`, http.StatusBadRequest},
 		{"invalid mode", "/api/projects/demo/agent-runs", `{"prompt":"x","mode":"write_everything"}`, http.StatusBadRequest},
 		{"project traversal", "/api/projects/%2e%2e%2fetc/agent-runs", `{"prompt":"x"}`, http.StatusBadRequest},
+		{"missing project", "/api/projects/missing/agent-runs", `{"prompt":"x"}`, http.StatusNotFound},
 	}
 
 	for _, tc := range cases {
@@ -136,11 +139,48 @@ func TestAgentRunRoutesReturn404ForMissingRun(t *testing.T) {
 	root := scaffoldAgentRunProject(t)
 	router := agentRunMux(root, agentruns.NewStore())
 
-	req := httptest.NewRequest(http.MethodGet, "/api/agent-runs/missing", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/projects/demo/agent-runs/missing", nil)
 	rec := httptest.NewRecorder()
 	router.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, want %d, body = %s", rec.Code, http.StatusNotFound, rec.Body.String())
+	}
+}
+
+func TestAgentRunRoutesDoNotExposeRunsAcrossProjects(t *testing.T) {
+	root := scaffoldAgentRunProject(t)
+	store := agentruns.NewStore()
+	router := agentRunMux(root, store)
+
+	run, err := store.Create(agentruns.CreateRequest{
+		Project: "demo",
+		Prompt:  "create a VPC",
+	})
+	if err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/api/projects/other/agent-runs/"+run.ID, nil)
+	getRec := httptest.NewRecorder()
+	router.ServeHTTP(getRec, getReq)
+	if getRec.Code != http.StatusNotFound {
+		t.Fatalf("cross-project get status = %d, want %d, body = %s", getRec.Code, http.StatusNotFound, getRec.Body.String())
+	}
+
+	listReq := httptest.NewRequest(http.MethodGet, "/api/projects/other/agent-runs", nil)
+	listRec := httptest.NewRecorder()
+	router.ServeHTTP(listRec, listReq)
+	if listRec.Code != http.StatusOK {
+		t.Fatalf("cross-project list status = %d, body = %s", listRec.Code, listRec.Body.String())
+	}
+	var listed struct {
+		Runs []agentruns.Run `json:"runs"`
+	}
+	if err := json.Unmarshal(listRec.Body.Bytes(), &listed); err != nil {
+		t.Fatalf("decode listed runs: %v", err)
+	}
+	if len(listed.Runs) != 0 {
+		t.Fatalf("cross-project list leaked runs: %+v", listed.Runs)
 	}
 }

--- a/internal/api/agent_runs_test.go
+++ b/internal/api/agent_runs_test.go
@@ -47,6 +47,7 @@ func TestAgentRunRoutesCreateListAndGetSanitizedRun(t *testing.T) {
 	if rec.Code != http.StatusCreated {
 		t.Fatalf("create status = %d, body = %s", rec.Code, rec.Body.String())
 	}
+	requireJSONResponse(t, rec)
 	raw := map[string]json.RawMessage{}
 	if err := json.Unmarshal(rec.Body.Bytes(), &raw); err != nil {
 		t.Fatalf("decode raw response: %v", err)
@@ -83,6 +84,7 @@ func TestAgentRunRoutesCreateListAndGetSanitizedRun(t *testing.T) {
 	if getRec.Code != http.StatusOK {
 		t.Fatalf("get status = %d, body = %s", getRec.Code, getRec.Body.String())
 	}
+	requireJSONResponse(t, getRec)
 	var fetched agentruns.Run
 	if err := json.Unmarshal(getRec.Body.Bytes(), &fetched); err != nil {
 		t.Fatalf("decode fetched run: %v", err)
@@ -114,6 +116,7 @@ func TestAgentRunRoutesCreateListAndGetSanitizedRun(t *testing.T) {
 	if listRec.Code != http.StatusOK {
 		t.Fatalf("list status = %d, body = %s", listRec.Code, listRec.Body.String())
 	}
+	requireJSONResponse(t, listRec)
 	var listed struct {
 		Runs []map[string]json.RawMessage `json:"runs"`
 	}
@@ -258,4 +261,11 @@ func rawInt(t *testing.T, raw map[string]json.RawMessage, field string) int {
 		t.Fatalf("decode field %q as int: %v", field, err)
 	}
 	return decoded
+}
+
+func requireJSONResponse(t *testing.T, rec *httptest.ResponseRecorder) {
+	t.Helper()
+	if got := rec.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("Content-Type = %q, want application/json", got)
+	}
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/iac-studio/iac-studio/internal/agentproviders"
+	"github.com/iac-studio/iac-studio/internal/agentruns"
 	"github.com/iac-studio/iac-studio/internal/ai"
 	"github.com/iac-studio/iac-studio/internal/ai/providers"
 	"github.com/iac-studio/iac-studio/internal/catalog"
@@ -1036,6 +1037,7 @@ func requireOptionalJSONContentType(w http.ResponseWriter, r *http.Request) bool
 // explicit ownership outside the router.
 type RouterOptions struct {
 	MCPAirlock          *mcpairlock.Manager
+	AgentRuns           *agentruns.Store
 	AppVersion          string
 	LocalAgentProviders func() []agentproviders.LocalProviderStatus
 }
@@ -1066,6 +1068,10 @@ func NewRouter(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runn
 func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client, run *runner.SafeRunner, projectsDir string, opts RouterOptions) *http.ServeMux {
 	mux := http.NewServeMux()
 	appVersion := opts.appVersion()
+	agentRuns := opts.AgentRuns
+	if agentRuns == nil {
+		agentRuns = agentruns.NewStore()
+	}
 	if fw != nil {
 		fw.OnChange(func(file, _ string) {
 			invalidatePlanForChangedFile(projectsDir, file)
@@ -1092,6 +1098,7 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 			"providers": opts.localAgentProviders(),
 		})
 	})
+	registerAgentRunRoutes(mux, projectsDir, agentRuns)
 
 	// Resource catalog — returns all resources for a tool, optionally filtered by provider
 	mux.HandleFunc("GET /api/catalog", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- add create/list/get API routes for secure agent run records
- wire an injectable agent run store through router options
- cover sanitized responses, bad requests, invalid projects, and missing runs

## Scope
This is intentionally API-only for issue #105. It does not execute agents, call providers, route MCP tools, touch cloud credentials, or write files.

## Validation
- GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/api
- GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/...

Refs #105