### PR TITLE
Show agent run summaries in Agent Hub

### DIFF
--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -261,6 +261,124 @@ describe('api.listLocalAgentProviders', () => {
   });
 });
 
+describe('api.agentRuns', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('lists project-scoped agent run summaries', async () => {
+    const response = {
+      runs: [{
+        id: 'run_000001',
+        project: 'demo',
+        provider_id: 'codex',
+        mode: 'read_only',
+        status: 'queued',
+        prompt_preview: 'Review this project',
+        prompt_hash: 'sha256:abc',
+        created_at: '2026-07-01T10:00:00Z',
+        updated_at: '2026-07-01T10:00:00Z',
+        canceled: false,
+        log_count: 0,
+        patch_count: 0,
+        approval_count: 0,
+        pending_approval_count: 0,
+      }],
+    };
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(response), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(api.listAgentRuns('demo')).resolves.toEqual(response.runs);
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/projects/demo/agent-runs');
+  });
+
+  it('coerces missing agent run lists to an empty array', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    ));
+
+    await expect(api.listAgentRuns('demo')).resolves.toEqual([]);
+  });
+
+  it('creates project-scoped agent runs without client identity fields', async () => {
+    const response = {
+      id: 'run_000001',
+      project: 'demo',
+      provider_id: 'codex',
+      mode: 'read_only',
+      status: 'queued',
+      prompt_preview: 'Review this project',
+      prompt_hash: 'sha256:abc',
+      created_at: '2026-07-01T10:00:00Z',
+      updated_at: '2026-07-01T10:00:00Z',
+      canceled: false,
+      logs: [],
+      patches: [],
+      approvals: [],
+    };
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(response), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(api.createAgentRun('demo', {
+      prompt: 'Review this project',
+      provider_id: 'codex',
+      mode: 'read_only',
+    })).resolves.toEqual(response);
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/projects/demo/agent-runs', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        prompt: 'Review this project',
+        provider_id: 'codex',
+        mode: 'read_only',
+      }),
+    });
+  });
+
+  it('gets one project-scoped agent run detail record', async () => {
+    const response = {
+      id: 'run_000001',
+      project: 'demo',
+      mode: 'read_only',
+      status: 'queued',
+      prompt_preview: 'Review this project',
+      prompt_hash: 'sha256:abc',
+      created_at: '2026-07-01T10:00:00Z',
+      updated_at: '2026-07-01T10:00:00Z',
+      canceled: false,
+      logs: [],
+      patches: [],
+      approvals: [],
+    };
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(response), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(api.getAgentRun('demo', 'run_000001')).resolves.toEqual(response);
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/projects/demo/agent-runs/run_000001');
+  });
+});
+
 describe('api.listProjectStates', () => {
   afterEach(() => {
     vi.unstubAllGlobals();

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -261,6 +261,76 @@ export interface LocalAgentProvidersResponse {
   providers: LocalAgentProviderStatus[];
 }
 
+export type AgentRunMode = 'read_only' | 'propose_only' | 'approved_execute';
+export type AgentRunStatus =
+  | 'queued'
+  | 'running'
+  | 'waiting_approval'
+  | 'completed'
+  | 'failed'
+  | 'canceled';
+
+export interface AgentRunSummary {
+  id: string;
+  project: string;
+  provider_id?: string;
+  mode: AgentRunMode;
+  status: AgentRunStatus;
+  prompt_preview: string;
+  prompt_hash: string;
+  created_at: string;
+  updated_at: string;
+  started_at?: string;
+  completed_at?: string;
+  canceled: boolean;
+  error?: string;
+  log_count: number;
+  patch_count: number;
+  approval_count: number;
+  pending_approval_count: number;
+}
+
+export interface AgentRunLogEntry {
+  id: string;
+  at: string;
+  level: 'info' | 'warn' | 'error' | 'audit';
+  message: string;
+}
+
+export interface AgentRunPatch {
+  id: string;
+  path: string;
+  summary: string;
+  diff: string;
+  created_at: string;
+}
+
+export interface AgentRunApproval {
+  id: string;
+  kind: 'file_write' | 'command' | 'iac_action' | 'cloud_write' | 'secret_read' | 'mcp_network';
+  status: 'pending' | 'approved' | 'rejected';
+  summary: string;
+  created_at: string;
+  decided_at?: string;
+  decided_by?: string;
+}
+
+export interface AgentRun extends AgentRunSummary {
+  logs: AgentRunLogEntry[];
+  patches: AgentRunPatch[];
+  approvals: AgentRunApproval[];
+}
+
+export interface AgentRunCreateInput {
+  prompt: string;
+  provider_id?: string;
+  mode?: AgentRunMode;
+}
+
+export interface AgentRunsResponse {
+  runs?: AgentRunSummary[] | null;
+}
+
 export type PlanRiskLevel = 'safe' | 'risky' | 'destructive' | 'unknown';
 
 export interface PlanFieldChange {
@@ -554,6 +624,28 @@ export const api = {
     if (!body || typeof body !== 'object') return [];
     const providers = (body as Partial<LocalAgentProvidersResponse>).providers;
     return Array.isArray(providers) ? providers : [];
+  },
+
+  async listAgentRuns(projectName: string): Promise<AgentRunSummary[]> {
+    const res = await fetch(`${BASE}/api/projects/${encodeURIComponent(projectName)}/agent-runs`);
+    const body = (await (await check(res)).json()) as unknown;
+    if (!body || typeof body !== 'object') return [];
+    const runs = (body as AgentRunsResponse).runs;
+    return Array.isArray(runs) ? runs : [];
+  },
+
+  async createAgentRun(projectName: string, input: AgentRunCreateInput): Promise<AgentRun> {
+    const res = await fetch(`${BASE}/api/projects/${encodeURIComponent(projectName)}/agent-runs`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    });
+    return (await check(res)).json();
+  },
+
+  async getAgentRun(projectName: string, id: string): Promise<AgentRun> {
+    const res = await fetch(`${BASE}/api/projects/${encodeURIComponent(projectName)}/agent-runs/${encodeURIComponent(id)}`);
+    return (await check(res)).json();
   },
 
   async listCloudConnections(): Promise<CloudConnection[]> {

--- a/web/src/components/Chat/ChatPanel.test.tsx
+++ b/web/src/components/Chat/ChatPanel.test.tsx
@@ -5,10 +5,12 @@ import { render, screen, fireEvent, waitFor, within } from '@testing-library/rea
 import { ChatPanel } from './ChatPanel';
 
 const listLocalAgentProvidersMock = vi.hoisted(() => vi.fn());
+const listAgentRunsMock = vi.hoisted(() => vi.fn());
 
 vi.mock('../../api', () => ({
   api: {
     listLocalAgentProviders: listLocalAgentProvidersMock,
+    listAgentRuns: listAgentRunsMock,
   },
 }));
 
@@ -25,6 +27,8 @@ describe('ChatPanel', () => {
   beforeEach(() => {
     listLocalAgentProvidersMock.mockReset();
     listLocalAgentProvidersMock.mockReturnValue(new Promise(() => {}));
+    listAgentRunsMock.mockReset();
+    listAgentRunsMock.mockResolvedValue([]);
     window.localStorage.clear();
   });
 
@@ -331,5 +335,37 @@ describe('ChatPanel', () => {
     fireEvent.click(screen.getByRole('tab', { name: 'Chat' }));
 
     expect(scrollIntoView).toHaveBeenCalledWith({ block: 'nearest' });
+  });
+
+  it('loads project-scoped run summaries in the Runs tab', async () => {
+    listAgentRunsMock.mockResolvedValueOnce([{
+      id: 'run_000001',
+      project: 'demo',
+      provider_id: 'codex',
+      mode: 'read_only',
+      status: 'queued',
+      prompt_preview: 'Review this project for unsafe Terraform changes',
+      prompt_hash: 'sha256:abc',
+      created_at: '2026-07-01T10:00:00Z',
+      updated_at: '2026-07-01T10:00:00Z',
+      canceled: false,
+      log_count: 2,
+      patch_count: 1,
+      approval_count: 1,
+      pending_approval_count: 1,
+    }]);
+
+    render(<ChatPanel {...baseProps} projectName="demo" />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Runs' }));
+    const runsPanel = screen.getByRole('tabpanel', { name: 'Runs' });
+
+    await waitFor(() => {
+      expect(within(runsPanel).getByText('Review this project for unsafe Terraform changes')).toBeInTheDocument();
+    });
+    expect(listAgentRunsMock).toHaveBeenCalledWith('demo');
+    expect(within(runsPanel).getByText('queued')).toBeInTheDocument();
+    expect(within(runsPanel).getByText('read only')).toBeInTheDocument();
+    expect(within(runsPanel).getByText('2 logs')).toBeInTheDocument();
+    expect(within(runsPanel).getByText('1 pending')).toBeInTheDocument();
   });
 });

--- a/web/src/components/Chat/ChatPanel.tsx
+++ b/web/src/components/Chat/ChatPanel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import type { CSSProperties, KeyboardEvent, RefObject } from 'react';
 
-import { api, type LocalAgentProviderStatus } from '../../api';
+import { api, type AgentRunSummary, type LocalAgentProviderStatus } from '../../api';
 import { S } from '../../styles';
 
 export interface ChatMessage {
@@ -27,6 +27,8 @@ export interface ChatPanelProps {
   scrollAnchorRef?: RefObject<HTMLDivElement>;
   // Provider name shown in the header badge. Defaults to "Ollama".
   providerLabel?: string;
+  // Current project used to fetch agent run audit summaries.
+  projectName?: string;
 }
 
 type AgentHubTab = 'chat' | 'codex' | 'claude' | 'gemini' | 'copilot' | 'local' | 'mcp' | 'runs';
@@ -229,7 +231,13 @@ const hubStyles: Record<string, CSSProperties> = {
   providerActions: { display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', marginTop: 10 },
   providerActionButton: { borderWidth: 1, borderStyle: 'solid', borderColor: 'var(--border-soft)', borderRadius: 6, background: 'var(--bg-elev-3)', color: 'var(--text-muted)', cursor: 'not-allowed', fontSize: 11, fontFamily: 'DM Sans', fontWeight: 700, padding: '6px 9px', opacity: 0.72 },
   providerActionHint: { color: '#77847d', fontSize: 11 },
+  runsPanel: { flex: 1, minHeight: 0, overflowY: 'auto', padding: 12, display: 'flex', flexDirection: 'column', gap: 8 },
   runsEmpty: { flex: 1, minHeight: 0, padding: 16, color: 'var(--text-muted)', fontSize: 12, lineHeight: 1.55 },
+  runCard: { borderWidth: 1, borderStyle: 'solid', borderColor: 'var(--border-main)', borderRadius: 8, background: 'var(--bg-elev-2)', padding: 10, minWidth: 0 },
+  runCardHead: { display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 },
+  runTitle: { flex: 1, minWidth: 0, color: 'var(--text-main)', fontWeight: 700, fontSize: 12, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
+  runPreview: { color: 'var(--text-muted)', fontSize: 12, lineHeight: 1.45, marginTop: 7, overflowWrap: 'anywhere' },
+  runMeta: { display: 'flex', gap: 5, flexWrap: 'wrap', marginTop: 8 },
 };
 
 function providerStatus(state: ProviderState) {
@@ -430,6 +438,91 @@ function ProviderGroup({
   );
 }
 
+function runStatusColor(status: AgentRunSummary['status']) {
+  if (status === 'completed') return 'var(--accent-action)';
+  if (status === 'failed' || status === 'canceled') return 'var(--accent-danger)';
+  if (status === 'waiting_approval') return '#8aa7ff';
+  return 'var(--accent-warn)';
+}
+
+function runModeLabel(mode: AgentRunSummary['mode']) {
+  return mode.replaceAll('_', ' ');
+}
+
+function RunSummaryCard({ run }: { run: AgentRunSummary }) {
+  return (
+    <div style={hubStyles.runCard}>
+      <div style={hubStyles.runCardHead}>
+        <span style={hubStyles.runTitle}>{run.id}</span>
+        <span style={{ ...hubStyles.badge, color: runStatusColor(run.status) }}>{run.status.replaceAll('_', ' ')}</span>
+      </div>
+      <div style={hubStyles.runPreview}>
+        {run.prompt_preview || 'Prompt preview unavailable'}
+      </div>
+      <div style={hubStyles.runMeta}>
+        <span style={hubStyles.badge}>{runModeLabel(run.mode)}</span>
+        {run.provider_id && <span style={hubStyles.badge}>{run.provider_id}</span>}
+        <span style={hubStyles.badge}>{run.log_count} logs</span>
+        <span style={hubStyles.badge}>{run.patch_count} patches</span>
+        <span style={hubStyles.badge}>{run.approval_count} approvals</span>
+        {run.pending_approval_count > 0 && (
+          <span style={{ ...hubStyles.badge, color: '#8aa7ff' }}>{run.pending_approval_count} pending</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function RunsPanel({
+  projectName,
+  runs,
+  loading,
+  error,
+}: {
+  projectName?: string;
+  runs: AgentRunSummary[];
+  loading: boolean;
+  error: string | null;
+}) {
+  if (!projectName) {
+    return (
+      <div style={hubStyles.runsEmpty}>
+        <strong style={{ color: 'var(--text-main)' }}>Open a project to see agent runs.</strong>
+        <div style={{ marginTop: 6 }}>Run history is scoped to the active project.</div>
+      </div>
+    );
+  }
+  if (loading) {
+    return <div style={hubStyles.runsEmpty}>Loading agent runs...</div>;
+  }
+  if (error) {
+    return (
+      <div style={hubStyles.runsEmpty}>
+        <strong style={{ color: 'var(--text-main)' }}>Could not load agent runs.</strong>
+        <div style={{ marginTop: 6 }}>{error}</div>
+      </div>
+    );
+  }
+  if (runs.length === 0) {
+    return (
+      <div style={hubStyles.runsEmpty}>
+        <strong style={{ color: 'var(--text-main)' }}>No agent runs yet.</strong>
+        <div style={{ marginTop: 6 }}>
+          Future runs will show provider, task mode, approvals, proposed patches, and deployment actions in one audit trail.
+        </div>
+        <div style={{ marginTop: 10, color: '#77847d' }}>
+          This view is read-only; execution and approval gates remain behind the secure run lifecycle.
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div style={hubStyles.runsPanel} aria-label={`${projectName} agent runs`}>
+      {runs.map(run => <RunSummaryCard key={run.id} run={run} />)}
+    </div>
+  );
+}
+
 // Self-contained Agent Hub panel: AI message stream + provider/task shell.
 // The parent still owns messages and provider calls, so this stays UI-only.
 export function ChatPanel({
@@ -441,11 +534,15 @@ export function ChatPanel({
   toolColor,
   scrollAnchorRef,
   providerLabel = 'Ollama',
+  projectName,
 }: ChatPanelProps) {
   const [activeTab, setActiveTab] = useState<AgentHubTab>(() => readStoredAgentHubTab());
   const [activeTask, setActiveTask] = useState<typeof TASK_MODES[number]>(() => readStoredTaskMode());
   const [selectedProviders, setSelectedProviders] = useState<Partial<Record<ProviderTab, string>>>({});
   const [localProviders, setLocalProviders] = useState<Record<string, LocalAgentProviderStatus>>({});
+  const [agentRuns, setAgentRuns] = useState<AgentRunSummary[]>([]);
+  const [agentRunsLoading, setAgentRunsLoading] = useState(false);
+  const [agentRunsError, setAgentRunsError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -501,6 +598,29 @@ export function ChatPanel({
     if (activeTab !== 'chat') return;
     scrollAnchorRef?.current?.scrollIntoView?.({ block: 'nearest' });
   }, [activeTab, scrollAnchorRef]);
+
+  useEffect(() => {
+    if (activeTab !== 'runs' || !projectName) return;
+    let cancelled = false;
+    setAgentRunsLoading(true);
+    setAgentRunsError(null);
+    api.listAgentRuns(projectName)
+      .then(runs => {
+        if (cancelled) return;
+        setAgentRuns(runs);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setAgentRuns([]);
+        setAgentRunsError(err instanceof Error ? err.message : 'agent run list failed');
+      })
+      .finally(() => {
+        if (!cancelled) setAgentRunsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [activeTab, projectName]);
 
   const handleTabKeyDown = (event: KeyboardEvent<HTMLButtonElement>, currentIndex: number) => {
     const lastIndex = AGENT_TABS.length - 1;
@@ -651,15 +771,12 @@ export function ChatPanel({
             hidden={activeTab !== 'runs'}
             style={panelStyle('runs')}
           >
-            <div style={hubStyles.runsEmpty}>
-              <strong style={{ color: 'var(--text-main)' }}>No agent runs yet.</strong>
-              <div style={{ marginTop: 6 }}>
-                Future runs will show provider, task mode, approvals, proposed patches, and deployment actions in one audit trail.
-              </div>
-              <div style={{ marginTop: 10, color: '#77847d' }}>
-                This shell is UI-only; execution and approval gates land in the secure run lifecycle slice.
-              </div>
-            </div>
+            <RunsPanel
+              projectName={projectName}
+              runs={agentRuns}
+              loading={agentRunsLoading}
+              error={agentRunsError}
+            />
           </div>
         </div>
       </div>

--- a/web/src/components/Workspace/WorkspaceShell.tsx
+++ b/web/src/components/Workspace/WorkspaceShell.tsx
@@ -332,6 +332,7 @@ export function WorkspaceShell({
           loading={chatLoading}
           toolColor={toolMeta.color}
           scrollAnchorRef={chatEndRef}
+          projectName={projectName}
         />
         <TerminalPanel
           lines={terminalOutput}


### PR DESCRIPTION
## Summary
- add typed frontend API methods for project-scoped agent run create/list/get routes
- pass the active project into Agent Hub and load run summaries in the Runs tab
- render read-only run metadata: status, mode, provider, log/patch/approval counts

## Scope
This is intentionally read-only UI/client wiring for issue #105. It does not execute agents, route MCP tools, read secrets, write files, approve gates, or start cloud/IaC actions.

Refs #105

## Validation
- npm --prefix web test -- --run src/api.test.ts src/components/Chat/ChatPanel.test.tsx
- npm --prefix web test -- --run
- npm --prefix web run build