### PR TITLE
Add agent run cancel endpoint

### DIFF
--- a/internal/api/agent_runs.go
+++ b/internal/api/agent_runs.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"os"
 
@@ -65,6 +66,34 @@ func registerAgentRunRoutes(mux *http.ServeMux, projectsDir string, store *agent
 		run, ok := store.Get(r.PathValue("id"))
 		if !ok || run.Project != name {
 			http.Error(w, "agent run not found", http.StatusNotFound)
+			return
+		}
+		setAgentRunJSONHeader(w)
+		_ = json.NewEncoder(w).Encode(run)
+	})
+
+	mux.HandleFunc("POST /api/projects/{name}/agent-runs/{id}/cancel", func(w http.ResponseWriter, r *http.Request) {
+		name := r.PathValue("name")
+		if !requireExistingAgentRunProject(w, projectsDir, name) {
+			return
+		}
+		id := r.PathValue("id")
+		run, ok := store.Get(id)
+		if !ok || run.Project != name {
+			http.Error(w, "agent run not found", http.StatusNotFound)
+			return
+		}
+		run, err := store.Cancel(id)
+		if err != nil {
+			if errors.Is(err, agentruns.ErrTerminated) {
+				http.Error(w, err.Error(), http.StatusConflict)
+				return
+			}
+			if errors.Is(err, agentruns.ErrNotFound) {
+				http.Error(w, "agent run not found", http.StatusNotFound)
+				return
+			}
+			http.Error(w, "cancel agent run: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
 		setAgentRunJSONHeader(w)

--- a/internal/api/agent_runs_test.go
+++ b/internal/api/agent_runs_test.go
@@ -237,6 +237,103 @@ func TestAgentRunRoutesDoNotExposeRunsAcrossProjects(t *testing.T) {
 	}
 }
 
+func TestAgentRunRoutesCancelRun(t *testing.T) {
+	root := scaffoldAgentRunProject(t)
+	store := agentruns.NewStore()
+	router := agentRunMux(root, store)
+
+	run, err := store.Create(agentruns.CreateRequest{
+		Project: "demo",
+		Prompt:  "review this project",
+		Mode:    agentruns.ModeProposeOnly,
+	})
+	if err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/projects/demo/agent-runs/"+run.ID+"/cancel", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("cancel status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	requireJSONResponse(t, rec)
+	var canceled agentruns.Run
+	if err := json.Unmarshal(rec.Body.Bytes(), &canceled); err != nil {
+		t.Fatalf("decode canceled run: %v", err)
+	}
+	if canceled.ID != run.ID || canceled.Project != "demo" || canceled.Status != agentruns.StatusCanceled || !canceled.Canceled || canceled.CompletedAt == nil {
+		t.Fatalf("unexpected canceled run: %+v", canceled)
+	}
+
+	got, ok := store.Get(run.ID)
+	if !ok {
+		t.Fatal("expected canceled run to remain in store")
+	}
+	if got.Status != agentruns.StatusCanceled || !got.Canceled {
+		t.Fatalf("store did not persist canceled state: %+v", got)
+	}
+}
+
+func TestAgentRunRoutesDoNotCancelRunsAcrossProjects(t *testing.T) {
+	root := scaffoldAgentRunProject(t)
+	store := agentruns.NewStore()
+	router := agentRunMux(root, store)
+
+	run, err := store.Create(agentruns.CreateRequest{
+		Project: "demo",
+		Prompt:  "review this project",
+	})
+	if err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/projects/other/agent-runs/"+run.ID+"/cancel", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("cross-project cancel status = %d, want %d, body = %s", rec.Code, http.StatusNotFound, rec.Body.String())
+	}
+	got, ok := store.Get(run.ID)
+	if !ok {
+		t.Fatal("expected original run to remain in store")
+	}
+	if got.Status != agentruns.StatusQueued || got.Canceled {
+		t.Fatalf("cross-project cancel mutated run: %+v", got)
+	}
+}
+
+func TestAgentRunRoutesReturnConflictWhenCancelingTerminalRun(t *testing.T) {
+	root := scaffoldAgentRunProject(t)
+	store := agentruns.NewStore()
+	router := agentRunMux(root, store)
+
+	run, err := store.Create(agentruns.CreateRequest{
+		Project: "demo",
+		Prompt:  "review this project",
+	})
+	if err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	if _, err := store.SetStatus(run.ID, agentruns.StatusCompleted); err != nil {
+		t.Fatalf("complete run: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/projects/demo/agent-runs/"+run.ID+"/cancel", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("terminal cancel status = %d, want %d, body = %s", rec.Code, http.StatusConflict, rec.Body.String())
+	}
+	got, ok := store.Get(run.ID)
+	if !ok {
+		t.Fatal("expected completed run to remain in store")
+	}
+	if got.Status != agentruns.StatusCompleted || got.Canceled {
+		t.Fatalf("terminal cancel mutated run: %+v", got)
+	}
+}
+
 func rawString(t *testing.T, raw map[string]json.RawMessage, field string) string {
 	t.Helper()
 	value, ok := raw[field]


### PR DESCRIPTION
## Summary
- add a project-scoped POST /api/projects/{name}/agent-runs/{id}/cancel route
- verify the run belongs to the requested project before mutating it
- return 409 when a terminal run cannot be canceled
- add API tests for successful cancel, cross-project protection, and terminal-state conflict

## Scope
This is a small issue #105 slice for cancellability. It does not execute agents, route MCP tools, read secrets, approve gates, write files, or call cloud/IaC tooling.

Refs #105

## Validation
- GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/api ./internal/agentruns
- GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/...