### PR TITLE
Add agent run cancel action

### DIFF
--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -377,6 +377,37 @@ describe('api.agentRuns', () => {
 
     expect(fetchMock).toHaveBeenCalledWith('/api/projects/demo/agent-runs/run_000001');
   });
+
+  it('cancels one project-scoped agent run', async () => {
+    const response = {
+      id: 'run_000001',
+      project: 'demo',
+      mode: 'read_only',
+      status: 'canceled',
+      prompt_preview: 'Review this project',
+      prompt_hash: 'sha256:abc',
+      created_at: '2026-07-01T10:00:00Z',
+      updated_at: '2026-07-01T10:01:00Z',
+      completed_at: '2026-07-01T10:01:00Z',
+      canceled: true,
+      logs: [],
+      patches: [],
+      approvals: [],
+    };
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(response), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(api.cancelAgentRun('demo', 'run_000001')).resolves.toEqual(response);
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/projects/demo/agent-runs/run_000001/cancel', {
+      method: 'POST',
+    });
+  });
 });
 
 describe('api.listProjectStates', () => {

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -648,6 +648,13 @@ export const api = {
     return (await check(res)).json();
   },
 
+  async cancelAgentRun(projectName: string, id: string): Promise<AgentRun> {
+    const res = await fetch(`${BASE}/api/projects/${encodeURIComponent(projectName)}/agent-runs/${encodeURIComponent(id)}/cancel`, {
+      method: 'POST',
+    });
+    return (await check(res)).json();
+  },
+
   async listCloudConnections(): Promise<CloudConnection[]> {
     const res = await fetch(`${BASE}/api/cloud/connections`);
     return (await check(res)).json();

--- a/web/src/components/Chat/ChatPanel.test.tsx
+++ b/web/src/components/Chat/ChatPanel.test.tsx
@@ -6,11 +6,13 @@ import { ChatPanel } from './ChatPanel';
 
 const listLocalAgentProvidersMock = vi.hoisted(() => vi.fn());
 const listAgentRunsMock = vi.hoisted(() => vi.fn());
+const cancelAgentRunMock = vi.hoisted(() => vi.fn());
 
 vi.mock('../../api', () => ({
   api: {
     listLocalAgentProviders: listLocalAgentProvidersMock,
     listAgentRuns: listAgentRunsMock,
+    cancelAgentRun: cancelAgentRunMock,
   },
 }));
 
@@ -29,6 +31,8 @@ describe('ChatPanel', () => {
     listLocalAgentProvidersMock.mockReturnValue(new Promise(() => {}));
     listAgentRunsMock.mockReset();
     listAgentRunsMock.mockResolvedValue([]);
+    cancelAgentRunMock.mockReset();
+    cancelAgentRunMock.mockResolvedValue({});
     window.localStorage.clear();
   });
 
@@ -367,5 +371,64 @@ describe('ChatPanel', () => {
     expect(within(runsPanel).getByText('read only')).toBeInTheDocument();
     expect(within(runsPanel).getByText('2 logs')).toBeInTheDocument();
     expect(within(runsPanel).getByText('1 pending')).toBeInTheDocument();
+  });
+
+  it('cancels non-terminal runs and refreshes the Runs tab', async () => {
+    listAgentRunsMock
+      .mockResolvedValueOnce([{
+        id: 'run_000001',
+        project: 'demo',
+        provider_id: 'codex',
+        mode: 'propose_only',
+        status: 'running',
+        prompt_preview: 'Prepare a safe deployment plan',
+        prompt_hash: 'sha256:abc',
+        created_at: '2026-07-01T10:00:00Z',
+        updated_at: '2026-07-01T10:00:00Z',
+        canceled: false,
+        log_count: 2,
+        patch_count: 0,
+        approval_count: 0,
+        pending_approval_count: 0,
+      }])
+      .mockResolvedValueOnce([{
+        id: 'run_000001',
+        project: 'demo',
+        provider_id: 'codex',
+        mode: 'propose_only',
+        status: 'canceled',
+        prompt_preview: 'Prepare a safe deployment plan',
+        prompt_hash: 'sha256:abc',
+        created_at: '2026-07-01T10:00:00Z',
+        updated_at: '2026-07-01T10:01:00Z',
+        completed_at: '2026-07-01T10:01:00Z',
+        canceled: true,
+        log_count: 2,
+        patch_count: 0,
+        approval_count: 0,
+        pending_approval_count: 0,
+      }]);
+    cancelAgentRunMock.mockResolvedValueOnce({
+      id: 'run_000001',
+      project: 'demo',
+      status: 'canceled',
+    });
+
+    render(<ChatPanel {...baseProps} projectName="demo" />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Runs' }));
+    const runsPanel = screen.getByRole('tabpanel', { name: 'Runs' });
+
+    await waitFor(() => {
+      expect(within(runsPanel).getByRole('button', { name: 'Cancel run_000001' })).toBeInTheDocument();
+    });
+
+    fireEvent.click(within(runsPanel).getByRole('button', { name: 'Cancel run_000001' }));
+
+    await waitFor(() => {
+      expect(cancelAgentRunMock).toHaveBeenCalledWith('demo', 'run_000001');
+      expect(listAgentRunsMock).toHaveBeenCalledTimes(2);
+      expect(within(runsPanel).getByText('canceled')).toBeInTheDocument();
+    });
+    expect(within(runsPanel).queryByRole('button', { name: 'Cancel run_000001' })).not.toBeInTheDocument();
   });
 });

--- a/web/src/components/Chat/ChatPanel.test.tsx
+++ b/web/src/components/Chat/ChatPanel.test.tsx
@@ -431,4 +431,62 @@ describe('ChatPanel', () => {
     });
     expect(within(runsPanel).queryByRole('button', { name: 'Cancel run_000001' })).not.toBeInTheDocument();
   });
+
+  it('refreshes run summaries when cancel finds the run already terminal', async () => {
+    const conflictError = new Error('agent run is already in a terminal state');
+    Object.assign(conflictError, { status: 409 });
+    listAgentRunsMock
+      .mockResolvedValueOnce([{
+        id: 'run_000001',
+        project: 'demo',
+        provider_id: 'codex',
+        mode: 'propose_only',
+        status: 'running',
+        prompt_preview: 'Prepare a safe deployment plan',
+        prompt_hash: 'sha256:abc',
+        created_at: '2026-07-01T10:00:00Z',
+        updated_at: '2026-07-01T10:00:00Z',
+        canceled: false,
+        log_count: 2,
+        patch_count: 0,
+        approval_count: 0,
+        pending_approval_count: 0,
+      }])
+      .mockResolvedValueOnce([{
+        id: 'run_000001',
+        project: 'demo',
+        provider_id: 'codex',
+        mode: 'propose_only',
+        status: 'completed',
+        prompt_preview: 'Prepare a safe deployment plan',
+        prompt_hash: 'sha256:abc',
+        created_at: '2026-07-01T10:00:00Z',
+        updated_at: '2026-07-01T10:01:00Z',
+        completed_at: '2026-07-01T10:01:00Z',
+        canceled: false,
+        log_count: 2,
+        patch_count: 0,
+        approval_count: 0,
+        pending_approval_count: 0,
+      }]);
+    cancelAgentRunMock.mockRejectedValueOnce(conflictError);
+
+    render(<ChatPanel {...baseProps} projectName="demo" />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Runs' }));
+    const runsPanel = screen.getByRole('tabpanel', { name: 'Runs' });
+
+    await waitFor(() => {
+      expect(within(runsPanel).getByRole('button', { name: 'Cancel run_000001' })).toBeInTheDocument();
+    });
+
+    fireEvent.click(within(runsPanel).getByRole('button', { name: 'Cancel run_000001' }));
+
+    await waitFor(() => {
+      expect(cancelAgentRunMock).toHaveBeenCalledWith('demo', 'run_000001');
+      expect(listAgentRunsMock).toHaveBeenCalledTimes(2);
+      expect(within(runsPanel).getByText('completed')).toBeInTheDocument();
+    });
+    expect(within(runsPanel).queryByRole('button', { name: 'Cancel run_000001' })).not.toBeInTheDocument();
+    expect(within(runsPanel).queryByText('Could not load agent runs.')).not.toBeInTheDocument();
+  });
 });

--- a/web/src/components/Chat/ChatPanel.test.tsx
+++ b/web/src/components/Chat/ChatPanel.test.tsx
@@ -1,6 +1,6 @@
 import { createRef } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { act, render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 
 import { ChatPanel } from './ChatPanel';
 
@@ -488,5 +488,113 @@ describe('ChatPanel', () => {
     });
     expect(within(runsPanel).queryByRole('button', { name: 'Cancel run_000001' })).not.toBeInTheDocument();
     expect(within(runsPanel).queryByText('Could not load agent runs.')).not.toBeInTheDocument();
+  });
+
+  it('reports refresh failures separately after a successful cancel', async () => {
+    listAgentRunsMock
+      .mockResolvedValueOnce([{
+        id: 'run_000001',
+        project: 'demo',
+        provider_id: 'codex',
+        mode: 'propose_only',
+        status: 'running',
+        prompt_preview: 'Prepare a safe deployment plan',
+        prompt_hash: 'sha256:abc',
+        created_at: '2026-07-01T10:00:00Z',
+        updated_at: '2026-07-01T10:00:00Z',
+        canceled: false,
+        log_count: 2,
+        patch_count: 0,
+        approval_count: 0,
+        pending_approval_count: 0,
+      }])
+      .mockRejectedValueOnce(new Error('network unavailable'));
+    cancelAgentRunMock.mockResolvedValueOnce({
+      id: 'run_000001',
+      project: 'demo',
+      status: 'canceled',
+    });
+
+    render(<ChatPanel {...baseProps} projectName="demo" />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Runs' }));
+    const runsPanel = screen.getByRole('tabpanel', { name: 'Runs' });
+
+    await waitFor(() => {
+      expect(within(runsPanel).getByRole('button', { name: 'Cancel run_000001' })).toBeInTheDocument();
+    });
+
+    fireEvent.click(within(runsPanel).getByRole('button', { name: 'Cancel run_000001' }));
+
+    await waitFor(() => {
+      expect(cancelAgentRunMock).toHaveBeenCalledWith('demo', 'run_000001');
+      expect(listAgentRunsMock).toHaveBeenCalledTimes(2);
+      expect(within(runsPanel).getByText('agent run refresh failed: network unavailable')).toBeInTheDocument();
+    });
+    expect(within(runsPanel).queryByText('agent run cancel failed')).not.toBeInTheDocument();
+  });
+
+  it('does not overwrite run summaries after switching projects during cancel', async () => {
+    let resolveCancel: (_value: { id: string; project: string; status: string }) => void = () => {};
+    const cancelPromise = new Promise(resolve => {
+      resolveCancel = resolve;
+    });
+    listAgentRunsMock
+      .mockResolvedValueOnce([{
+        id: 'run_000001',
+        project: 'demo',
+        provider_id: 'codex',
+        mode: 'propose_only',
+        status: 'running',
+        prompt_preview: 'Prepare a safe deployment plan',
+        prompt_hash: 'sha256:abc',
+        created_at: '2026-07-01T10:00:00Z',
+        updated_at: '2026-07-01T10:00:00Z',
+        canceled: false,
+        log_count: 2,
+        patch_count: 0,
+        approval_count: 0,
+        pending_approval_count: 0,
+      }])
+      .mockResolvedValueOnce([{
+        id: 'run_000002',
+        project: 'other',
+        provider_id: 'codex',
+        mode: 'read_only',
+        status: 'queued',
+        prompt_preview: 'Other project queued run',
+        prompt_hash: 'sha256:def',
+        created_at: '2026-07-01T10:02:00Z',
+        updated_at: '2026-07-01T10:02:00Z',
+        canceled: false,
+        log_count: 1,
+        patch_count: 0,
+        approval_count: 0,
+        pending_approval_count: 0,
+      }]);
+    cancelAgentRunMock.mockReturnValueOnce(cancelPromise);
+
+    const { rerender } = render(<ChatPanel {...baseProps} projectName="demo" />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Runs' }));
+    const runsPanel = screen.getByRole('tabpanel', { name: 'Runs' });
+
+    await waitFor(() => {
+      expect(within(runsPanel).getByRole('button', { name: 'Cancel run_000001' })).toBeInTheDocument();
+    });
+
+    fireEvent.click(within(runsPanel).getByRole('button', { name: 'Cancel run_000001' }));
+    rerender(<ChatPanel {...baseProps} projectName="other" />);
+
+    await waitFor(() => {
+      expect(listAgentRunsMock).toHaveBeenCalledWith('other');
+      expect(within(runsPanel).getByText('Other project queued run')).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      resolveCancel({ id: 'run_000001', project: 'demo', status: 'canceled' });
+    });
+
+    expect(listAgentRunsMock).toHaveBeenCalledTimes(2);
+    expect(within(runsPanel).getByText('Other project queued run')).toBeInTheDocument();
+    expect(within(runsPanel).queryByText('Prepare a safe deployment plan')).not.toBeInTheDocument();
   });
 });

--- a/web/src/components/Chat/ChatPanel.tsx
+++ b/web/src/components/Chat/ChatPanel.tsx
@@ -238,6 +238,8 @@ const hubStyles: Record<string, CSSProperties> = {
   runTitle: { flex: 1, minWidth: 0, color: 'var(--text-main)', fontWeight: 700, fontSize: 12, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
   runPreview: { color: 'var(--text-muted)', fontSize: 12, lineHeight: 1.45, marginTop: 7, overflowWrap: 'anywhere' },
   runMeta: { display: 'flex', gap: 5, flexWrap: 'wrap', marginTop: 8 },
+  runActions: { display: 'flex', justifyContent: 'flex-end', marginTop: 8 },
+  runCancelButton: { borderWidth: 1, borderStyle: 'solid', borderColor: 'var(--border-soft)', borderRadius: 6, background: 'var(--bg-elev-3)', color: 'var(--text-muted)', cursor: 'pointer', fontSize: 11, fontFamily: 'DM Sans', fontWeight: 700, padding: '5px 8px' },
 };
 
 function providerStatus(state: ProviderState) {
@@ -449,7 +451,23 @@ function runModeLabel(mode: AgentRunSummary['mode']) {
   return mode.replaceAll('_', ' ');
 }
 
-function RunSummaryCard({ run }: { run: AgentRunSummary }) {
+function isTerminalAgentRun(status: AgentRunSummary['status']) {
+  return status === 'completed' || status === 'failed' || status === 'canceled';
+}
+
+function RunSummaryCard({
+  run,
+  canceling,
+  cancelDisabled,
+  onCancel,
+}: {
+  run: AgentRunSummary;
+  canceling: boolean;
+  cancelDisabled: boolean;
+  onCancel: (id: string) => void;
+}) {
+  const canCancel = !isTerminalAgentRun(run.status);
+  const disabled = canceling || cancelDisabled;
   return (
     <div style={hubStyles.runCard}>
       <div style={hubStyles.runCardHead}>
@@ -469,6 +487,22 @@ function RunSummaryCard({ run }: { run: AgentRunSummary }) {
           <span style={{ ...hubStyles.badge, color: '#8aa7ff' }}>{run.pending_approval_count} pending</span>
         )}
       </div>
+      {canCancel && (
+        <div style={hubStyles.runActions}>
+          <button
+            type="button"
+            style={{
+              ...hubStyles.runCancelButton,
+              ...(disabled ? { cursor: canceling ? 'wait' : 'not-allowed', opacity: 0.7 } : {}),
+            }}
+            disabled={disabled}
+            aria-label={`Cancel ${run.id}`}
+            onClick={() => onCancel(run.id)}
+          >
+            {canceling ? 'Canceling...' : 'Cancel run'}
+          </button>
+        </div>
+      )}
     </div>
   );
 }
@@ -478,11 +512,15 @@ function RunsPanel({
   runs,
   loading,
   error,
+  cancelingRunId,
+  onCancelRun,
 }: {
   projectName?: string;
   runs: AgentRunSummary[];
   loading: boolean;
   error: string | null;
+  cancelingRunId: string | null;
+  onCancelRun: (id: string) => void;
 }) {
   if (!projectName) {
     return (
@@ -518,7 +556,15 @@ function RunsPanel({
   }
   return (
     <div style={hubStyles.runsPanel} aria-label={`${projectName} agent runs`}>
-      {runs.map(run => <RunSummaryCard key={run.id} run={run} />)}
+      {runs.map(run => (
+        <RunSummaryCard
+          key={run.id}
+          run={run}
+          canceling={cancelingRunId === run.id}
+          cancelDisabled={cancelingRunId !== null}
+          onCancel={onCancelRun}
+        />
+      ))}
     </div>
   );
 }
@@ -543,6 +589,7 @@ export function ChatPanel({
   const [agentRuns, setAgentRuns] = useState<AgentRunSummary[]>([]);
   const [agentRunsLoading, setAgentRunsLoading] = useState(false);
   const [agentRunsError, setAgentRunsError] = useState<string | null>(null);
+  const [cancelingRunId, setCancelingRunId] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -621,6 +668,19 @@ export function ChatPanel({
       cancelled = true;
     };
   }, [activeTab, projectName]);
+
+  const cancelAgentRun = (id: string) => {
+    if (!projectName || cancelingRunId) return;
+    setCancelingRunId(id);
+    setAgentRunsError(null);
+    api.cancelAgentRun(projectName, id)
+      .then(() => api.listAgentRuns(projectName))
+      .then(runs => setAgentRuns(runs))
+      .catch((err: unknown) => {
+        setAgentRunsError(err instanceof Error ? err.message : 'agent run cancel failed');
+      })
+      .finally(() => setCancelingRunId(null));
+  };
 
   const handleTabKeyDown = (event: KeyboardEvent<HTMLButtonElement>, currentIndex: number) => {
     const lastIndex = AGENT_TABS.length - 1;
@@ -776,6 +836,8 @@ export function ChatPanel({
               runs={agentRuns}
               loading={agentRunsLoading}
               error={agentRunsError}
+              cancelingRunId={cancelingRunId}
+              onCancelRun={cancelAgentRun}
             />
           </div>
         </div>

--- a/web/src/components/Chat/ChatPanel.tsx
+++ b/web/src/components/Chat/ChatPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { CSSProperties, KeyboardEvent, RefObject } from 'react';
 
 import { api, type AgentRunSummary, type LocalAgentProviderStatus } from '../../api';
@@ -464,6 +464,11 @@ function isConflictError(err: unknown) {
   );
 }
 
+function agentRunRefreshErrorMessage(err: unknown) {
+  if (err instanceof Error && err.message) return `agent run refresh failed: ${err.message}`;
+  return 'agent run refresh failed';
+}
+
 function RunSummaryCard({
   run,
   canceling,
@@ -599,6 +604,8 @@ export function ChatPanel({
   const [agentRunsLoading, setAgentRunsLoading] = useState(false);
   const [agentRunsError, setAgentRunsError] = useState<string | null>(null);
   const [cancelingRunId, setCancelingRunId] = useState<string | null>(null);
+  const latestProjectNameRef = useRef(projectName);
+  latestProjectNameRef.current = projectName;
 
   useEffect(() => {
     let cancelled = false;
@@ -678,24 +685,44 @@ export function ChatPanel({
     };
   }, [activeTab, projectName]);
 
+  useEffect(() => {
+    setCancelingRunId(null);
+  }, [projectName]);
+
+  const refreshAgentRunsForProject = (requestProjectName: string) => {
+    if (latestProjectNameRef.current !== requestProjectName) return Promise.resolve();
+    return api.listAgentRuns(requestProjectName)
+      .then(runs => {
+        if (latestProjectNameRef.current !== requestProjectName) return;
+        setAgentRuns(runs);
+      })
+      .catch((err: unknown) => {
+        if (latestProjectNameRef.current !== requestProjectName) return;
+        setAgentRunsError(agentRunRefreshErrorMessage(err));
+      });
+  };
+
   const cancelAgentRun = (id: string) => {
-    if (!projectName || cancelingRunId) return;
+    const requestProjectName = projectName;
+    if (!requestProjectName || cancelingRunId) return;
     setCancelingRunId(id);
     setAgentRunsError(null);
-    api.cancelAgentRun(projectName, id)
-      .then(() => api.listAgentRuns(projectName))
-      .then(runs => setAgentRuns(runs))
+    api.cancelAgentRun(requestProjectName, id)
+      .then(() => refreshAgentRunsForProject(requestProjectName))
       .catch((err: unknown) => {
         if (isConflictError(err)) {
-          return api.listAgentRuns(projectName)
-            .then(runs => setAgentRuns(runs))
-            .catch((refreshErr: unknown) => {
-              setAgentRunsError(refreshErr instanceof Error ? refreshErr.message : 'agent run refresh failed');
-            });
+          return refreshAgentRunsForProject(requestProjectName);
         }
-        setAgentRunsError(err instanceof Error ? err.message : 'agent run cancel failed');
+        if (latestProjectNameRef.current === requestProjectName) {
+          setAgentRunsError(err instanceof Error ? err.message : 'agent run cancel failed');
+        }
+        return undefined;
       })
-      .finally(() => setCancelingRunId(null));
+      .finally(() => {
+        if (latestProjectNameRef.current === requestProjectName) {
+          setCancelingRunId(null);
+        }
+      });
   };
 
   const handleTabKeyDown = (event: KeyboardEvent<HTMLButtonElement>, currentIndex: number) => {

--- a/web/src/components/Chat/ChatPanel.tsx
+++ b/web/src/components/Chat/ChatPanel.tsx
@@ -455,6 +455,15 @@ function isTerminalAgentRun(status: AgentRunSummary['status']) {
   return status === 'completed' || status === 'failed' || status === 'canceled';
 }
 
+function isConflictError(err: unknown) {
+  return (
+    typeof err === 'object'
+    && err !== null
+    && 'status' in err
+    && (err as { status?: unknown }).status === 409
+  );
+}
+
 function RunSummaryCard({
   run,
   canceling,
@@ -677,6 +686,13 @@ export function ChatPanel({
       .then(() => api.listAgentRuns(projectName))
       .then(runs => setAgentRuns(runs))
       .catch((err: unknown) => {
+        if (isConflictError(err)) {
+          return api.listAgentRuns(projectName)
+            .then(runs => setAgentRuns(runs))
+            .catch((refreshErr: unknown) => {
+              setAgentRunsError(refreshErr instanceof Error ? refreshErr.message : 'agent run refresh failed');
+            });
+        }
         setAgentRunsError(err instanceof Error ? err.message : 'agent run cancel failed');
       })
       .finally(() => setCancelingRunId(null));


### PR DESCRIPTION
## Summary
- add a typed frontend cancelAgentRun API client method
- show Cancel buttons for non-terminal Agent Hub run summaries
- refresh project-scoped run summaries after cancel completes
- add API and ChatPanel tests for the cancel path

## Scope
This is a small issue #105 frontend slice for cancellability. It only calls the project-scoped cancel endpoint added in #122. It does not execute agents, approve gates, route MCP tools, read secrets, write files, or call cloud/IaC tooling.

Refs #105

## Validation
- npm --prefix web test -- --run src/api.test.ts src/components/Chat/ChatPanel.test.tsx
- npm --prefix web test -- --run
- npm --prefix web run build