### PR TITLE
Add agent approval decision endpoint

### DIFF
--- a/internal/agentruns/store.go
+++ b/internal/agentruns/store.go
@@ -393,7 +393,7 @@ func (s *Store) DecideApproval(id, approvalID string, decision ApprovalStatus, d
 		for i := range run.Approvals {
 			if run.Approvals[i].ID == approvalID {
 				if run.Approvals[i].Status != ApprovalPending {
-					return fmt.Errorf("%w: %q", ErrApprovalDecided, approvalID)
+					return ErrApprovalDecided
 				}
 				run.Approvals[i].Status = decision
 				run.Approvals[i].DecidedAt = timePtr(now)

--- a/internal/agentruns/store.go
+++ b/internal/agentruns/store.go
@@ -393,7 +393,7 @@ func (s *Store) DecideApproval(id, approvalID string, decision ApprovalStatus, d
 		for i := range run.Approvals {
 			if run.Approvals[i].ID == approvalID {
 				if run.Approvals[i].Status != ApprovalPending {
-					return fmt.Errorf("approval gate %q is already decided", approvalID)
+					return fmt.Errorf("%w: %s", ErrApprovalDecided, approvalID)
 				}
 				run.Approvals[i].Status = decision
 				run.Approvals[i].DecidedAt = timePtr(now)
@@ -510,6 +510,7 @@ var (
 	ErrNotFound         = errors.New("agent run not found")
 	ErrTerminated       = errors.New("agent run is already in a terminal state")
 	ErrApprovalNotFound = errors.New("approval gate not found")
+	ErrApprovalDecided  = errors.New("approval gate is already decided")
 	ErrUnsafePatchPath  = errors.New("patch path must be a relative path within the project")
 )
 

--- a/internal/agentruns/store.go
+++ b/internal/agentruns/store.go
@@ -393,7 +393,7 @@ func (s *Store) DecideApproval(id, approvalID string, decision ApprovalStatus, d
 		for i := range run.Approvals {
 			if run.Approvals[i].ID == approvalID {
 				if run.Approvals[i].Status != ApprovalPending {
-					return fmt.Errorf("%w: %s", ErrApprovalDecided, approvalID)
+					return fmt.Errorf("%w: %q", ErrApprovalDecided, approvalID)
 				}
 				run.Approvals[i].Status = decision
 				run.Approvals[i].DecidedAt = timePtr(now)

--- a/internal/api/agent_runs.go
+++ b/internal/api/agent_runs.go
@@ -122,6 +122,11 @@ func registerAgentRunRoutes(mux *http.ServeMux, projectsDir string, store *agent
 
 		var req agentRunApprovalDecisionRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			var maxBytes *http.MaxBytesError
+			if errors.As(err, &maxBytes) {
+				http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+				return
+			}
 			http.Error(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
 			return
 		}

--- a/internal/api/agent_runs.go
+++ b/internal/api/agent_runs.go
@@ -132,7 +132,11 @@ func registerAgentRunRoutes(mux *http.ServeMux, projectsDir string, store *agent
 
 		run, err := store.DecideApproval(id, r.PathValue("approval_id"), req.Decision, "")
 		if err != nil {
-			if errors.Is(err, agentruns.ErrApprovalNotFound) || errors.Is(err, agentruns.ErrNotFound) {
+			if errors.Is(err, agentruns.ErrNotFound) {
+				http.Error(w, "agent run not found", http.StatusNotFound)
+				return
+			}
+			if errors.Is(err, agentruns.ErrApprovalNotFound) {
 				http.Error(w, "approval gate not found", http.StatusNotFound)
 				return
 			}

--- a/internal/api/agent_runs.go
+++ b/internal/api/agent_runs.go
@@ -15,6 +15,10 @@ type agentRunCreateRequest struct {
 	Mode       agentruns.Mode `json:"mode,omitempty"`
 }
 
+type agentRunApprovalDecisionRequest struct {
+	Decision agentruns.ApprovalStatus `json:"decision"`
+}
+
 func registerAgentRunRoutes(mux *http.ServeMux, projectsDir string, store *agentruns.Store) {
 	mux.HandleFunc("GET /api/projects/{name}/agent-runs", func(w http.ResponseWriter, r *http.Request) {
 		name := r.PathValue("name")
@@ -94,6 +98,49 @@ func registerAgentRunRoutes(mux *http.ServeMux, projectsDir string, store *agent
 				return
 			}
 			http.Error(w, "cancel agent run: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		setAgentRunJSONHeader(w)
+		_ = json.NewEncoder(w).Encode(run)
+	})
+
+	mux.HandleFunc("POST /api/projects/{name}/agent-runs/{id}/approvals/{approval_id}/decision", func(w http.ResponseWriter, r *http.Request) {
+		limitBody(w, r)
+		if !requireJSONContentType(w, r) {
+			return
+		}
+		name := r.PathValue("name")
+		if !requireExistingAgentRunProject(w, projectsDir, name) {
+			return
+		}
+		id := r.PathValue("id")
+		run, ok := store.Get(id)
+		if !ok || run.Project != name {
+			http.Error(w, "agent run not found", http.StatusNotFound)
+			return
+		}
+
+		var req agentRunApprovalDecisionRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		if req.Decision != agentruns.ApprovalApproved && req.Decision != agentruns.ApprovalRejected {
+			http.Error(w, "invalid approval decision: "+string(req.Decision), http.StatusBadRequest)
+			return
+		}
+
+		run, err := store.DecideApproval(id, r.PathValue("approval_id"), req.Decision, "")
+		if err != nil {
+			if errors.Is(err, agentruns.ErrApprovalNotFound) || errors.Is(err, agentruns.ErrNotFound) {
+				http.Error(w, "approval gate not found", http.StatusNotFound)
+				return
+			}
+			if errors.Is(err, agentruns.ErrTerminated) || errors.Is(err, agentruns.ErrApprovalDecided) {
+				http.Error(w, err.Error(), http.StatusConflict)
+				return
+			}
+			http.Error(w, "decide approval: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
 		setAgentRunJSONHeader(w)

--- a/internal/api/agent_runs.go
+++ b/internal/api/agent_runs.go
@@ -125,6 +125,10 @@ func registerAgentRunRoutes(mux *http.ServeMux, projectsDir string, store *agent
 			http.Error(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
 			return
 		}
+		if req.Decision == "" {
+			http.Error(w, "approval decision is required", http.StatusBadRequest)
+			return
+		}
 		if req.Decision != agentruns.ApprovalApproved && req.Decision != agentruns.ApprovalRejected {
 			http.Error(w, "invalid approval decision: "+string(req.Decision), http.StatusBadRequest)
 			return

--- a/internal/api/agent_runs_test.go
+++ b/internal/api/agent_runs_test.go
@@ -399,6 +399,14 @@ func TestAgentRunRoutesRejectBadApprovalDecisions(t *testing.T) {
 			wantBody:   "approval decision is required",
 		},
 		{
+			name:       "oversized body",
+			path:       "/api/projects/demo/agent-runs/" + run.ID + "/approvals/" + approvalID + "/decision",
+			body:       strings.Repeat(" ", maxRequestBody+1),
+			contentTyp: "application/json",
+			status:     http.StatusRequestEntityTooLarge,
+			wantBody:   "request body too large",
+		},
+		{
 			name:       "missing run",
 			path:       "/api/projects/demo/agent-runs/run_999999/approvals/" + approvalID + "/decision",
 			body:       `{"decision":"approved"}`,

--- a/internal/api/agent_runs_test.go
+++ b/internal/api/agent_runs_test.go
@@ -334,6 +334,152 @@ func TestAgentRunRoutesReturnConflictWhenCancelingTerminalRun(t *testing.T) {
 	}
 }
 
+func TestAgentRunRoutesDecideApproval(t *testing.T) {
+	_, router, run, approvalID := agentRunApprovalFixture(t, "run plan with token=approval-secret")
+
+	rec := postApprovalDecision(router, "demo", run.ID, approvalID, `{"decision":"approved","decided_by":"mallory token=spoofed"}`, "application/json")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("approval decision status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	requireJSONResponse(t, rec)
+	var decided agentruns.Run
+	if err := json.Unmarshal(rec.Body.Bytes(), &decided); err != nil {
+		t.Fatalf("decode decided run: %v", err)
+	}
+	if decided.Status != agentruns.StatusRunning {
+		t.Fatalf("run status = %q, want %q", decided.Status, agentruns.StatusRunning)
+	}
+	if len(decided.Approvals) != 1 || decided.Approvals[0].Status != agentruns.ApprovalApproved {
+		t.Fatalf("approval not approved: %+v", decided.Approvals)
+	}
+	if decided.Approvals[0].DecidedAt == nil {
+		t.Fatalf("decided_at was not set: %+v", decided.Approvals[0])
+	}
+	if decided.Approvals[0].DecidedBy != "" {
+		t.Fatalf("route accepted client-supplied decided_by: %+v", decided.Approvals[0])
+	}
+	for _, secret := range []string{"approval-secret", "spoofed"} {
+		if strings.Contains(rec.Body.String(), secret) {
+			t.Fatalf("approval decision response leaked secret %q: %s", secret, rec.Body.String())
+		}
+	}
+}
+
+func TestAgentRunRoutesRejectBadApprovalDecisions(t *testing.T) {
+	_, router, run, approvalID := agentRunApprovalFixture(t, "run plan")
+
+	cases := []struct {
+		name       string
+		path       string
+		body       string
+		contentTyp string
+		status     int
+	}{
+		{
+			name:       "missing content type",
+			path:       "/api/projects/demo/agent-runs/" + run.ID + "/approvals/" + approvalID + "/decision",
+			body:       `{"decision":"approved"}`,
+			contentTyp: "",
+			status:     http.StatusUnsupportedMediaType,
+		},
+		{
+			name:       "invalid decision",
+			path:       "/api/projects/demo/agent-runs/" + run.ID + "/approvals/" + approvalID + "/decision",
+			body:       `{"decision":"maybe"}`,
+			contentTyp: "application/json",
+			status:     http.StatusBadRequest,
+		},
+		{
+			name:       "missing approval",
+			path:       "/api/projects/demo/agent-runs/" + run.ID + "/approvals/approval_999999/decision",
+			body:       `{"decision":"approved"}`,
+			contentTyp: "application/json",
+			status:     http.StatusNotFound,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, tc.path, strings.NewReader(tc.body))
+			if tc.contentTyp != "" {
+				req.Header.Set("Content-Type", tc.contentTyp)
+			}
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+			if rec.Code != tc.status {
+				t.Fatalf("status = %d, want %d, body = %s", rec.Code, tc.status, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestAgentRunRoutesDoNotDecideApprovalsAcrossProjects(t *testing.T) {
+	store, router, run, approvalID := agentRunApprovalFixture(t, "run plan")
+
+	rec := postApprovalDecision(router, "other", run.ID, approvalID, `{"decision":"approved"}`, "application/json")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("cross-project approval status = %d, want %d, body = %s", rec.Code, http.StatusNotFound, rec.Body.String())
+	}
+	got, ok := store.Get(run.ID)
+	if !ok {
+		t.Fatal("expected original run to remain in store")
+	}
+	if got.Approvals[0].Status != agentruns.ApprovalPending {
+		t.Fatalf("cross-project approval mutated run: %+v", got)
+	}
+}
+
+func TestAgentRunRoutesReturnConflictWhenDecidingUnavailableApproval(t *testing.T) {
+	_, router, run, approvalID := agentRunApprovalFixture(t, "run plan")
+
+	rec := postApprovalDecision(router, "demo", run.ID, approvalID, `{"decision":"approved"}`, "application/json")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("approve approval status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+
+	rec = postApprovalDecision(router, "demo", run.ID, approvalID, `{"decision":"approved"}`, "application/json")
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("decide terminal approval status = %d, want %d, body = %s", rec.Code, http.StatusConflict, rec.Body.String())
+	}
+}
+
+func agentRunApprovalFixture(t *testing.T, summary string) (*agentruns.Store, *http.ServeMux, agentruns.Run, string) {
+	t.Helper()
+	root := scaffoldAgentRunProject(t)
+	store := agentruns.NewStore()
+	router := agentRunMux(root, store)
+	run, err := store.Create(agentruns.CreateRequest{
+		Project: "demo",
+		Prompt:  "review this project",
+		Mode:    agentruns.ModeProposeOnly,
+	})
+	if err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	run, err = store.AddApproval(run.ID, agentruns.ApprovalGate{
+		Kind:    agentruns.ApprovalCommand,
+		Summary: summary,
+	})
+	if err != nil {
+		t.Fatalf("add approval: %v", err)
+	}
+	return store, router, run, run.Approvals[0].ID
+}
+
+func postApprovalDecision(router *http.ServeMux, project, runID, approvalID, body, contentType string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/projects/"+project+"/agent-runs/"+runID+"/approvals/"+approvalID+"/decision",
+		strings.NewReader(body),
+	)
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	return rec
+}
+
 func rawString(t *testing.T, raw map[string]json.RawMessage, field string) string {
 	t.Helper()
 	value, ok := raw[field]

--- a/internal/api/agent_runs_test.go
+++ b/internal/api/agent_runs_test.go
@@ -459,7 +459,7 @@ func TestAgentRunRoutesDoNotDecideApprovalsAcrossProjects(t *testing.T) {
 }
 
 func TestAgentRunRoutesReturnConflictWhenDecidingUnavailableApproval(t *testing.T) {
-	_, router, run, approvalID := agentRunApprovalFixture(t, "run plan")
+	store, router, run, approvalID := agentRunApprovalFixture(t, "run plan")
 
 	rec := postApprovalDecision(router, "demo", run.ID, approvalID, `{"decision":"approved"}`, "application/json")
 	if rec.Code != http.StatusOK {
@@ -468,7 +468,18 @@ func TestAgentRunRoutesReturnConflictWhenDecidingUnavailableApproval(t *testing.
 
 	rec = postApprovalDecision(router, "demo", run.ID, approvalID, `{"decision":"approved"}`, "application/json")
 	if rec.Code != http.StatusConflict {
+		t.Fatalf("decide already-decided approval status = %d, want %d, body = %s", rec.Code, http.StatusConflict, rec.Body.String())
+	}
+
+	if _, err := store.SetStatus(run.ID, agentruns.StatusCompleted); err != nil {
+		t.Fatalf("complete run: %v", err)
+	}
+	rec = postApprovalDecision(router, "demo", run.ID, approvalID, `{"decision":"approved"}`, "application/json")
+	if rec.Code != http.StatusConflict {
 		t.Fatalf("decide terminal approval status = %d, want %d, body = %s", rec.Code, http.StatusConflict, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), agentruns.ErrTerminated.Error()) {
+		t.Fatalf("terminal approval body = %q, want it to contain %q", rec.Body.String(), agentruns.ErrTerminated.Error())
 	}
 }
 

--- a/internal/api/agent_runs_test.go
+++ b/internal/api/agent_runs_test.go
@@ -374,6 +374,7 @@ func TestAgentRunRoutesRejectBadApprovalDecisions(t *testing.T) {
 		body       string
 		contentTyp string
 		status     int
+		wantBody   string
 	}{
 		{
 			name:       "missing content type",
@@ -390,11 +391,20 @@ func TestAgentRunRoutesRejectBadApprovalDecisions(t *testing.T) {
 			status:     http.StatusBadRequest,
 		},
 		{
+			name:       "missing run",
+			path:       "/api/projects/demo/agent-runs/run_999999/approvals/" + approvalID + "/decision",
+			body:       `{"decision":"approved"}`,
+			contentTyp: "application/json",
+			status:     http.StatusNotFound,
+			wantBody:   "agent run not found",
+		},
+		{
 			name:       "missing approval",
 			path:       "/api/projects/demo/agent-runs/" + run.ID + "/approvals/approval_999999/decision",
 			body:       `{"decision":"approved"}`,
 			contentTyp: "application/json",
 			status:     http.StatusNotFound,
+			wantBody:   "approval gate not found",
 		},
 	}
 
@@ -408,6 +418,9 @@ func TestAgentRunRoutesRejectBadApprovalDecisions(t *testing.T) {
 			router.ServeHTTP(rec, req)
 			if rec.Code != tc.status {
 				t.Fatalf("status = %d, want %d, body = %s", rec.Code, tc.status, rec.Body.String())
+			}
+			if tc.wantBody != "" && !strings.Contains(rec.Body.String(), tc.wantBody) {
+				t.Fatalf("body = %q, want it to contain %q", rec.Body.String(), tc.wantBody)
 			}
 		})
 	}

--- a/internal/api/agent_runs_test.go
+++ b/internal/api/agent_runs_test.go
@@ -391,6 +391,14 @@ func TestAgentRunRoutesRejectBadApprovalDecisions(t *testing.T) {
 			status:     http.StatusBadRequest,
 		},
 		{
+			name:       "missing decision",
+			path:       "/api/projects/demo/agent-runs/" + run.ID + "/approvals/" + approvalID + "/decision",
+			body:       `{}`,
+			contentTyp: "application/json",
+			status:     http.StatusBadRequest,
+			wantBody:   "approval decision is required",
+		},
+		{
 			name:       "missing run",
 			path:       "/api/projects/demo/agent-runs/run_999999/approvals/" + approvalID + "/decision",
 			body:       `{"decision":"approved"}`,

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -408,6 +408,50 @@ describe('api.agentRuns', () => {
       method: 'POST',
     });
   });
+
+  it('decides one project-scoped agent run approval', async () => {
+    const response = {
+      id: 'run_000001',
+      project: 'demo',
+      mode: 'propose_only',
+      status: 'running',
+      prompt_preview: 'Review this project',
+      prompt_hash: 'sha256:abc',
+      created_at: '2026-07-01T10:00:00Z',
+      updated_at: '2026-07-01T10:01:00Z',
+      canceled: false,
+      logs: [],
+      patches: [],
+      approvals: [{
+        id: 'approval_000001',
+        kind: 'command',
+        status: 'approved',
+        summary: 'Run terraform plan',
+        created_at: '2026-07-01T10:00:00Z',
+        decided_at: '2026-07-01T10:01:00Z',
+      }],
+    };
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(response), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(api.decideAgentRunApproval(
+      'demo',
+      'run_000001',
+      'approval_000001',
+      'approved',
+    )).resolves.toEqual(response);
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/projects/demo/agent-runs/run_000001/approvals/approval_000001/decision', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ decision: 'approved' }),
+    });
+  });
 });
 
 describe('api.listProjectStates', () => {

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -321,6 +321,8 @@ export interface AgentRun extends AgentRunSummary {
   approvals: AgentRunApproval[];
 }
 
+export type AgentRunApprovalDecision = 'approved' | 'rejected';
+
 export interface AgentRunCreateInput {
   prompt: string;
   provider_id?: string;
@@ -652,6 +654,23 @@ export const api = {
     const res = await fetch(`${BASE}/api/projects/${encodeURIComponent(projectName)}/agent-runs/${encodeURIComponent(id)}/cancel`, {
       method: 'POST',
     });
+    return (await check(res)).json();
+  },
+
+  async decideAgentRunApproval(
+    projectName: string,
+    id: string,
+    approvalId: string,
+    decision: AgentRunApprovalDecision,
+  ): Promise<AgentRun> {
+    const res = await fetch(
+      `${BASE}/api/projects/${encodeURIComponent(projectName)}/agent-runs/${encodeURIComponent(id)}/approvals/${encodeURIComponent(approvalId)}/decision`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ decision }),
+      },
+    );
     return (await check(res)).json();
   },
 


### PR DESCRIPTION
## Summary
- add a project-scoped approval decision endpoint for agent runs
- add a typed frontend API client method for approval decisions
- classify missing, terminal, already-decided, and invalid approval decisions with explicit HTTP statuses

Refs #105

## Validation
- GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/agentruns ./internal/api
- GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/...
- npm --prefix web test -- --run src/api.test.ts
- npm --prefix web test -- --run
- npm --prefix web run build