### PR TITLE
Expose pending agent approval gates

### DIFF
--- a/internal/agentruns/store.go
+++ b/internal/agentruns/store.go
@@ -98,23 +98,24 @@ type Run struct {
 }
 
 type RunSummary struct {
-	ID                   string     `json:"id"`
-	Project              string     `json:"project"`
-	ProviderID           string     `json:"provider_id,omitempty"`
-	Mode                 Mode       `json:"mode"`
-	Status               Status     `json:"status"`
-	PromptPreview        string     `json:"prompt_preview"`
-	PromptHash           string     `json:"prompt_hash"`
-	CreatedAt            time.Time  `json:"created_at"`
-	UpdatedAt            time.Time  `json:"updated_at"`
-	StartedAt            *time.Time `json:"started_at,omitempty"`
-	CompletedAt          *time.Time `json:"completed_at,omitempty"`
-	Canceled             bool       `json:"canceled"`
-	Error                string     `json:"error,omitempty"`
-	LogCount             int        `json:"log_count"`
-	PatchCount           int        `json:"patch_count"`
-	ApprovalCount        int        `json:"approval_count"`
-	PendingApprovalCount int        `json:"pending_approval_count"`
+	ID                   string                `json:"id"`
+	Project              string                `json:"project"`
+	ProviderID           string                `json:"provider_id,omitempty"`
+	Mode                 Mode                  `json:"mode"`
+	Status               Status                `json:"status"`
+	PromptPreview        string                `json:"prompt_preview"`
+	PromptHash           string                `json:"prompt_hash"`
+	CreatedAt            time.Time             `json:"created_at"`
+	UpdatedAt            time.Time             `json:"updated_at"`
+	StartedAt            *time.Time            `json:"started_at,omitempty"`
+	CompletedAt          *time.Time            `json:"completed_at,omitempty"`
+	Canceled             bool                  `json:"canceled"`
+	Error                string                `json:"error,omitempty"`
+	LogCount             int                   `json:"log_count"`
+	PatchCount           int                   `json:"patch_count"`
+	ApprovalCount        int                   `json:"approval_count"`
+	PendingApprovalCount int                   `json:"pending_approval_count"`
+	PendingGates         []PendingApprovalGate `json:"pending_gates,omitempty"`
 }
 
 type LogEntry struct {
@@ -140,6 +141,13 @@ type ApprovalGate struct {
 	CreatedAt time.Time      `json:"created_at"`
 	DecidedAt *time.Time     `json:"decided_at,omitempty"`
 	DecidedBy string         `json:"decided_by,omitempty"`
+}
+
+type PendingApprovalGate struct {
+	ID        string       `json:"id"`
+	Kind      ApprovalKind `json:"kind"`
+	Summary   string       `json:"summary"`
+	CreatedAt time.Time    `json:"created_at"`
 }
 
 type Store struct {
@@ -450,6 +458,12 @@ func summarizeRun(run *Run) RunSummary {
 	for _, approval := range run.Approvals {
 		if approval.Status == ApprovalPending {
 			summary.PendingApprovalCount++
+			summary.PendingGates = append(summary.PendingGates, PendingApprovalGate{
+				ID:        approval.ID,
+				Kind:      approval.Kind,
+				Summary:   approval.Summary,
+				CreatedAt: approval.CreatedAt,
+			})
 		}
 	}
 	return summary

--- a/internal/agentruns/store_test.go
+++ b/internal/agentruns/store_test.go
@@ -370,10 +370,11 @@ func TestStoreListProjectSummariesSkipsHeavyFields(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("AddPatch returned error: %v", err)
 	}
-	if _, err := store.AddApproval(prod.ID, ApprovalGate{
+	prod, err = store.AddApproval(prod.ID, ApprovalGate{
 		Kind:    ApprovalCommand,
 		Summary: "run command with token=approval-secret",
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("AddApproval returned error: %v", err)
 	}
 
@@ -387,6 +388,19 @@ func TestStoreListProjectSummariesSkipsHeavyFields(t *testing.T) {
 	}
 	if summary.Status != StatusWaitingApproval || summary.LogCount != 1 || summary.PatchCount != 1 || summary.ApprovalCount != 1 || summary.PendingApprovalCount != 1 {
 		t.Fatalf("unexpected summary state/counts: %+v", summary)
+	}
+	if len(summary.PendingGates) != 1 {
+		t.Fatalf("pending gates = %+v, want one pending gate", summary.PendingGates)
+	}
+	pendingGate := summary.PendingGates[0]
+	if pendingGate.ID != prod.Approvals[0].ID || pendingGate.Kind != ApprovalCommand {
+		t.Fatalf("unexpected pending gate identity: %+v", pendingGate)
+	}
+	if !strings.Contains(pendingGate.Summary, "[REDACTED]") || strings.Contains(pendingGate.Summary, "approval-secret") {
+		t.Fatalf("pending gate summary was not redacted: %q", pendingGate.Summary)
+	}
+	if pendingGate.CreatedAt != prod.Approvals[0].CreatedAt {
+		t.Fatalf("pending gate created_at = %s, want %s", pendingGate.CreatedAt, prod.Approvals[0].CreatedAt)
 	}
 	if summary.StartedAt == nil || *summary.StartedAt != clock.current {
 		t.Fatalf("started_at = %v, want %s", summary.StartedAt, clock.current)

--- a/internal/api/agent_runs_test.go
+++ b/internal/api/agent_runs_test.go
@@ -147,6 +147,23 @@ func TestAgentRunRoutesCreateListAndGetSanitizedRun(t *testing.T) {
 	if got := rawInt(t, summary, "pending_approval_count"); got != 1 {
 		t.Fatalf("pending_approval_count = %d, want 1", got)
 	}
+	var pendingGates []struct {
+		ID      string                 `json:"id"`
+		Kind    agentruns.ApprovalKind `json:"kind"`
+		Summary string                 `json:"summary"`
+	}
+	if err := json.Unmarshal(summary["pending_gates"], &pendingGates); err != nil {
+		t.Fatalf("decode pending_gates: %v", err)
+	}
+	if len(pendingGates) != 1 {
+		t.Fatalf("pending_gates = %+v, want one pending gate", pendingGates)
+	}
+	if pendingGates[0].ID == "" || pendingGates[0].Kind != agentruns.ApprovalCommand {
+		t.Fatalf("unexpected pending gate identity: %+v", pendingGates[0])
+	}
+	if !strings.Contains(pendingGates[0].Summary, "[REDACTED]") || strings.Contains(pendingGates[0].Summary, "approval-secret") {
+		t.Fatalf("pending gate summary was not redacted: %q", pendingGates[0].Summary)
+	}
 	for _, secret := range []string{"log-secret", "diff-secret", "approval-secret"} {
 		if strings.Contains(listRec.Body.String(), secret) {
 			t.Fatalf("list response leaked heavy-field secret %q: %s", secret, listRec.Body.String())

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -282,7 +282,13 @@ describe('api.agentRuns', () => {
         log_count: 0,
         patch_count: 0,
         approval_count: 0,
-        pending_approval_count: 0,
+        pending_approval_count: 1,
+        pending_gates: [{
+          id: 'approval_000001',
+          kind: 'command',
+          summary: 'Run terraform plan',
+          created_at: '2026-07-01T10:00:00Z',
+        }],
       }],
     };
     const fetchMock = vi.fn().mockResolvedValue(

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -270,6 +270,14 @@ export type AgentRunStatus =
   | 'failed'
   | 'canceled';
 
+export type AgentRunApprovalKind =
+  | 'file_write'
+  | 'command'
+  | 'iac_action'
+  | 'cloud_write'
+  | 'secret_read'
+  | 'mcp_network';
+
 export interface AgentRunSummary {
   id: string;
   project: string;
@@ -288,6 +296,14 @@ export interface AgentRunSummary {
   patch_count: number;
   approval_count: number;
   pending_approval_count: number;
+  pending_gates?: AgentRunPendingGate[];
+}
+
+export interface AgentRunPendingGate {
+  id: string;
+  kind: AgentRunApprovalKind;
+  summary: string;
+  created_at: string;
 }
 
 export interface AgentRunLogEntry {
@@ -307,7 +323,7 @@ export interface AgentRunPatch {
 
 export interface AgentRunApproval {
   id: string;
-  kind: 'file_write' | 'command' | 'iac_action' | 'cloud_write' | 'secret_read' | 'mcp_network';
+  kind: AgentRunApprovalKind;
   status: 'pending' | 'approved' | 'rejected';
   summary: string;
   created_at: string;


### PR DESCRIPTION
## Summary
- add lightweight pending approval gate handles to agent run summaries
- keep list responses free of logs, patches, full approval records, and raw secret text
- update frontend API types for the new pending_gates summary field

## Validation
- GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/agentruns ./internal/api
- npm test -- --run src/api.test.ts
- npm run build

Refs #105