### PR TITLE
Add agent approval actions to Runs tab

### DIFF
--- a/web/src/components/Chat/ChatPanel.test.tsx
+++ b/web/src/components/Chat/ChatPanel.test.tsx
@@ -455,6 +455,60 @@ describe('ChatPanel', () => {
     expect(within(runsPanel).queryByText('Apply Terraform changes')).not.toBeInTheDocument();
   });
 
+  it('disables all gate action buttons while an approval decision is in-flight', async () => {
+    let resolveDecision!: (value: unknown) => void;
+    decideAgentRunApprovalMock.mockReturnValueOnce(
+      new Promise(resolve => { resolveDecision = resolve; }),
+    );
+    listAgentRunsMock.mockResolvedValueOnce([{
+      id: 'run_000001',
+      project: 'demo',
+      provider_id: 'codex',
+      mode: 'approved_execute',
+      status: 'waiting_approval',
+      prompt_preview: 'Waiting for approval',
+      prompt_hash: 'sha256:abc',
+      created_at: '2026-07-01T10:00:00Z',
+      updated_at: '2026-07-01T10:00:00Z',
+      canceled: false,
+      log_count: 0,
+      patch_count: 0,
+      approval_count: 1,
+      pending_approval_count: 2,
+      pending_gates: [
+        { id: 'approval_000001', kind: 'command', summary: 'First gate', created_at: '2026-07-01T10:00:00Z' },
+        { id: 'approval_000002', kind: 'iac_action', summary: 'Second gate', created_at: '2026-07-01T10:00:01Z' },
+      ],
+    }]);
+
+    render(<ChatPanel {...baseProps} projectName="demo" />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Runs' }));
+    const runsPanel = screen.getByRole('tabpanel', { name: 'Runs' });
+
+    await waitFor(() => {
+      expect(within(runsPanel).getByRole('button', { name: 'Approve approval_000001 for run_000001' })).toBeInTheDocument();
+    });
+
+    fireEvent.click(within(runsPanel).getByRole('button', { name: 'Approve approval_000001 for run_000001' }));
+
+    // While the decision is in-flight all four gate buttons must be disabled
+    expect(within(runsPanel).getByRole('button', { name: 'Approve approval_000001 for run_000001' })).toBeDisabled();
+    expect(within(runsPanel).getByRole('button', { name: 'Reject approval_000001 for run_000001' })).toBeDisabled();
+    expect(within(runsPanel).getByRole('button', { name: 'Approve approval_000002 for run_000001' })).toBeDisabled();
+    expect(within(runsPanel).getByRole('button', { name: 'Reject approval_000002 for run_000001' })).toBeDisabled();
+
+    // The deciding gate's buttons carry aria-busy; the other gate's do not
+    expect(within(runsPanel).getByRole('button', { name: 'Approve approval_000001 for run_000001' })).toHaveAttribute('aria-busy', 'true');
+    expect(within(runsPanel).getByRole('button', { name: 'Reject approval_000001 for run_000001' })).toHaveAttribute('aria-busy', 'true');
+    expect(within(runsPanel).getByRole('button', { name: 'Approve approval_000002 for run_000001' })).toHaveAttribute('aria-busy', 'false');
+    expect(within(runsPanel).getByRole('button', { name: 'Reject approval_000002 for run_000001' })).toHaveAttribute('aria-busy', 'false');
+
+    // Resolve the in-flight request so the component can settle
+    listAgentRunsMock.mockResolvedValueOnce([]);
+    act(() => resolveDecision({}));
+    await waitFor(() => expect(decideAgentRunApprovalMock).toHaveBeenCalledTimes(1));
+  });
+
   it('cancels non-terminal runs and refreshes the Runs tab', async () => {
     listAgentRunsMock
       .mockResolvedValueOnce([{

--- a/web/src/components/Chat/ChatPanel.test.tsx
+++ b/web/src/components/Chat/ChatPanel.test.tsx
@@ -7,12 +7,14 @@ import { ChatPanel } from './ChatPanel';
 const listLocalAgentProvidersMock = vi.hoisted(() => vi.fn());
 const listAgentRunsMock = vi.hoisted(() => vi.fn());
 const cancelAgentRunMock = vi.hoisted(() => vi.fn());
+const decideAgentRunApprovalMock = vi.hoisted(() => vi.fn());
 
 vi.mock('../../api', () => ({
   api: {
     listLocalAgentProviders: listLocalAgentProvidersMock,
     listAgentRuns: listAgentRunsMock,
     cancelAgentRun: cancelAgentRunMock,
+    decideAgentRunApproval: decideAgentRunApprovalMock,
   },
 }));
 
@@ -33,6 +35,8 @@ describe('ChatPanel', () => {
     listAgentRunsMock.mockResolvedValue([]);
     cancelAgentRunMock.mockReset();
     cancelAgentRunMock.mockResolvedValue({});
+    decideAgentRunApprovalMock.mockReset();
+    decideAgentRunApprovalMock.mockResolvedValue({});
     window.localStorage.clear();
   });
 
@@ -357,6 +361,12 @@ describe('ChatPanel', () => {
       patch_count: 1,
       approval_count: 1,
       pending_approval_count: 1,
+      pending_gates: [{
+        id: 'approval_000001',
+        kind: 'command',
+        summary: 'Run terraform plan after reviewing the patch',
+        created_at: '2026-07-01T10:00:00Z',
+      }],
     }]);
 
     render(<ChatPanel {...baseProps} projectName="demo" />);
@@ -371,6 +381,78 @@ describe('ChatPanel', () => {
     expect(within(runsPanel).getByText('read only')).toBeInTheDocument();
     expect(within(runsPanel).getByText('2 logs')).toBeInTheDocument();
     expect(within(runsPanel).getByText('1 pending')).toBeInTheDocument();
+    expect(within(runsPanel).getByText('Run terraform plan after reviewing the patch')).toBeInTheDocument();
+    expect(within(runsPanel).getByRole('button', { name: 'Approve approval_000001 for run_000001' })).toBeInTheDocument();
+    expect(within(runsPanel).getByRole('button', { name: 'Reject approval_000001 for run_000001' })).toBeInTheDocument();
+  });
+
+  it.each([
+    { action: 'Approve', decision: 'approved', finalStatus: 'running' },
+    { action: 'Reject', decision: 'rejected', finalStatus: 'failed' },
+  ] as const)('decides pending approval gates with $action and refreshes the Runs tab', async ({ action, decision, finalStatus }) => {
+    listAgentRunsMock
+      .mockResolvedValueOnce([{
+        id: 'run_000001',
+        project: 'demo',
+        provider_id: 'codex',
+        mode: 'approved_execute',
+        status: 'waiting_approval',
+        prompt_preview: 'Apply a reviewed Terraform plan',
+        prompt_hash: 'sha256:abc',
+        created_at: '2026-07-01T10:00:00Z',
+        updated_at: '2026-07-01T10:00:00Z',
+        canceled: false,
+        log_count: 2,
+        patch_count: 1,
+        approval_count: 1,
+        pending_approval_count: 1,
+        pending_gates: [{
+          id: 'approval_000001',
+          kind: 'iac_action',
+          summary: 'Apply Terraform changes',
+          created_at: '2026-07-01T10:00:00Z',
+        }],
+      }])
+      .mockResolvedValueOnce([{
+        id: 'run_000001',
+        project: 'demo',
+        provider_id: 'codex',
+        mode: 'approved_execute',
+        status: finalStatus,
+        prompt_preview: 'Apply a reviewed Terraform plan',
+        prompt_hash: 'sha256:abc',
+        created_at: '2026-07-01T10:00:00Z',
+        updated_at: '2026-07-01T10:01:00Z',
+        canceled: false,
+        log_count: 3,
+        patch_count: 1,
+        approval_count: 1,
+        pending_approval_count: 0,
+      }]);
+    decideAgentRunApprovalMock.mockResolvedValueOnce({
+      id: 'run_000001',
+      project: 'demo',
+      status: finalStatus,
+    });
+
+    render(<ChatPanel {...baseProps} projectName="demo" />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Runs' }));
+    const runsPanel = screen.getByRole('tabpanel', { name: 'Runs' });
+
+    await waitFor(() => {
+      expect(within(runsPanel).getByRole('button', { name: `${action} approval_000001 for run_000001` })).toBeInTheDocument();
+    });
+
+    fireEvent.click(within(runsPanel).getByRole('button', { name: `${action} approval_000001 for run_000001` }));
+
+    await waitFor(() => {
+      expect(decideAgentRunApprovalMock).toHaveBeenCalledWith('demo', 'run_000001', 'approval_000001', decision);
+      expect(listAgentRunsMock).toHaveBeenCalledTimes(2);
+      expect(within(runsPanel).getByText(finalStatus)).toBeInTheDocument();
+    });
+    expect(within(runsPanel).queryByRole('button', { name: 'Approve approval_000001 for run_000001' })).not.toBeInTheDocument();
+    expect(within(runsPanel).queryByRole('button', { name: 'Reject approval_000001 for run_000001' })).not.toBeInTheDocument();
+    expect(within(runsPanel).queryByText('Apply Terraform changes')).not.toBeInTheDocument();
   });
 
   it('cancels non-terminal runs and refreshes the Runs tab', async () => {

--- a/web/src/components/Chat/ChatPanel.tsx
+++ b/web/src/components/Chat/ChatPanel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { CSSProperties, KeyboardEvent, RefObject } from 'react';
 
-import { api, type AgentRunSummary, type LocalAgentProviderStatus } from '../../api';
+import { api, type AgentRunApprovalDecision, type AgentRunSummary, type LocalAgentProviderStatus } from '../../api';
 import { S } from '../../styles';
 
 export interface ChatMessage {
@@ -240,6 +240,12 @@ const hubStyles: Record<string, CSSProperties> = {
   runMeta: { display: 'flex', gap: 5, flexWrap: 'wrap', marginTop: 8 },
   runActions: { display: 'flex', justifyContent: 'flex-end', marginTop: 8 },
   runCancelButton: { borderWidth: 1, borderStyle: 'solid', borderColor: 'var(--border-soft)', borderRadius: 6, background: 'var(--bg-elev-3)', color: 'var(--text-muted)', cursor: 'pointer', fontSize: 11, fontFamily: 'DM Sans', fontWeight: 700, padding: '5px 8px' },
+  pendingGateList: { borderTop: '1px solid var(--border-soft)', marginTop: 9, paddingTop: 8, display: 'flex', flexDirection: 'column', gap: 7 },
+  pendingGateRow: { display: 'grid', gridTemplateColumns: 'minmax(0, 1fr) auto', gap: 8, alignItems: 'center' },
+  pendingGateSummary: { color: 'var(--text-muted)', fontSize: 11, lineHeight: 1.35, overflowWrap: 'anywhere' },
+  pendingGateActions: { display: 'flex', gap: 5, flexWrap: 'wrap', justifyContent: 'flex-end' },
+  approveButton: { borderWidth: 1, borderStyle: 'solid', borderColor: 'rgba(84, 184, 169, 0.45)', borderRadius: 6, background: 'rgba(84, 184, 169, 0.16)', color: 'var(--accent-action)', cursor: 'pointer', fontSize: 11, fontFamily: 'DM Sans', fontWeight: 700, padding: '5px 8px' },
+  rejectButton: { borderWidth: 1, borderStyle: 'solid', borderColor: 'rgba(232, 111, 111, 0.42)', borderRadius: 6, background: 'rgba(232, 111, 111, 0.14)', color: 'var(--accent-danger)', cursor: 'pointer', fontSize: 11, fontFamily: 'DM Sans', fontWeight: 700, padding: '5px 8px' },
 };
 
 function providerStatus(state: ProviderState) {
@@ -473,15 +479,22 @@ function RunSummaryCard({
   run,
   canceling,
   cancelDisabled,
+  decidingGateKey,
+  decisionDisabled,
   onCancel,
+  onDecideApproval,
 }: {
   run: AgentRunSummary;
   canceling: boolean;
   cancelDisabled: boolean;
+  decidingGateKey: string | null;
+  decisionDisabled: boolean;
   onCancel: (id: string) => void;
+  onDecideApproval: (runId: string, gateId: string, decision: AgentRunApprovalDecision) => void;
 }) {
   const canCancel = !isTerminalAgentRun(run.status);
   const disabled = canceling || cancelDisabled;
+  const pendingGates = run.pending_gates ?? [];
   return (
     <div style={hubStyles.runCard}>
       <div style={hubStyles.runCardHead}>
@@ -501,6 +514,52 @@ function RunSummaryCard({
           <span style={{ ...hubStyles.badge, color: '#8aa7ff' }}>{run.pending_approval_count} pending</span>
         )}
       </div>
+      {pendingGates.length > 0 && (
+        <div style={hubStyles.pendingGateList} aria-label={`${run.id} pending approval gates`}>
+          {pendingGates.map(gate => {
+            const gateKey = `${run.id}:${gate.id}`;
+            const deciding = decidingGateKey === gateKey;
+            const gateDisabled = decisionDisabled || deciding;
+            return (
+              <div key={gate.id} style={hubStyles.pendingGateRow}>
+                <div>
+                  <div style={hubStyles.pendingGateSummary}>{gate.summary}</div>
+                  <div style={hubStyles.runMeta}>
+                    <span style={hubStyles.badge}>{gate.kind.replaceAll('_', ' ')}</span>
+                    <span style={hubStyles.badge}>{gate.id}</span>
+                  </div>
+                </div>
+                <div style={hubStyles.pendingGateActions}>
+                  <button
+                    type="button"
+                    style={{
+                      ...hubStyles.approveButton,
+                      ...(gateDisabled ? { cursor: deciding ? 'wait' : 'not-allowed', opacity: 0.7 } : {}),
+                    }}
+                    disabled={gateDisabled}
+                    aria-label={`Approve ${gate.id} for ${run.id}`}
+                    onClick={() => onDecideApproval(run.id, gate.id, 'approved')}
+                  >
+                    Approve
+                  </button>
+                  <button
+                    type="button"
+                    style={{
+                      ...hubStyles.rejectButton,
+                      ...(gateDisabled ? { cursor: deciding ? 'wait' : 'not-allowed', opacity: 0.7 } : {}),
+                    }}
+                    disabled={gateDisabled}
+                    aria-label={`Reject ${gate.id} for ${run.id}`}
+                    onClick={() => onDecideApproval(run.id, gate.id, 'rejected')}
+                  >
+                    Reject
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
       {canCancel && (
         <div style={hubStyles.runActions}>
           <button
@@ -527,14 +586,18 @@ function RunsPanel({
   loading,
   error,
   cancelingRunId,
+  decidingGateKey,
   onCancelRun,
+  onDecideApproval,
 }: {
   projectName?: string;
   runs: AgentRunSummary[];
   loading: boolean;
   error: string | null;
   cancelingRunId: string | null;
+  decidingGateKey: string | null;
   onCancelRun: (id: string) => void;
+  onDecideApproval: (runId: string, gateId: string, decision: AgentRunApprovalDecision) => void;
 }) {
   if (!projectName) {
     return (
@@ -575,8 +638,11 @@ function RunsPanel({
           key={run.id}
           run={run}
           canceling={cancelingRunId === run.id}
-          cancelDisabled={cancelingRunId !== null}
+          cancelDisabled={cancelingRunId !== null || decidingGateKey !== null}
+          decidingGateKey={decidingGateKey}
+          decisionDisabled={cancelingRunId !== null || decidingGateKey !== null}
           onCancel={onCancelRun}
+          onDecideApproval={onDecideApproval}
         />
       ))}
     </div>
@@ -604,6 +670,7 @@ export function ChatPanel({
   const [agentRunsLoading, setAgentRunsLoading] = useState(false);
   const [agentRunsError, setAgentRunsError] = useState<string | null>(null);
   const [cancelingRunId, setCancelingRunId] = useState<string | null>(null);
+  const [decidingGateKey, setDecidingGateKey] = useState<string | null>(null);
   const latestProjectNameRef = useRef(projectName);
   latestProjectNameRef.current = projectName;
 
@@ -687,6 +754,7 @@ export function ChatPanel({
 
   useEffect(() => {
     setCancelingRunId(null);
+    setDecidingGateKey(null);
   }, [projectName]);
 
   const refreshAgentRunsForProject = (requestProjectName: string) => {
@@ -704,7 +772,7 @@ export function ChatPanel({
 
   const cancelAgentRun = (id: string) => {
     const requestProjectName = projectName;
-    if (!requestProjectName || cancelingRunId) return;
+    if (!requestProjectName || cancelingRunId || decidingGateKey) return;
     setCancelingRunId(id);
     setAgentRunsError(null);
     api.cancelAgentRun(requestProjectName, id)
@@ -721,6 +789,30 @@ export function ChatPanel({
       .finally(() => {
         if (latestProjectNameRef.current === requestProjectName) {
           setCancelingRunId(null);
+        }
+      });
+  };
+
+  const decideApprovalGate = (runId: string, gateId: string, decision: AgentRunApprovalDecision) => {
+    const requestProjectName = projectName;
+    if (!requestProjectName || cancelingRunId || decidingGateKey) return;
+    const gateKey = `${runId}:${gateId}`;
+    setDecidingGateKey(gateKey);
+    setAgentRunsError(null);
+    api.decideAgentRunApproval(requestProjectName, runId, gateId, decision)
+      .then(() => refreshAgentRunsForProject(requestProjectName))
+      .catch((err: unknown) => {
+        if (isConflictError(err)) {
+          return refreshAgentRunsForProject(requestProjectName);
+        }
+        if (latestProjectNameRef.current === requestProjectName) {
+          setAgentRunsError(err instanceof Error ? err.message : 'agent run approval decision failed');
+        }
+        return undefined;
+      })
+      .finally(() => {
+        if (latestProjectNameRef.current === requestProjectName) {
+          setDecidingGateKey(null);
         }
       });
   };
@@ -880,7 +972,9 @@ export function ChatPanel({
               loading={agentRunsLoading}
               error={agentRunsError}
               cancelingRunId={cancelingRunId}
+              decidingGateKey={decidingGateKey}
               onCancelRun={cancelAgentRun}
+              onDecideApproval={decideApprovalGate}
             />
           </div>
         </div>

--- a/web/src/components/Chat/ChatPanel.tsx
+++ b/web/src/components/Chat/ChatPanel.tsx
@@ -515,7 +515,7 @@ function RunSummaryCard({
         )}
       </div>
       {pendingGates.length > 0 && (
-        <div style={hubStyles.pendingGateList} aria-label={`${run.id} pending approval gates`}>
+        <div role="group" style={hubStyles.pendingGateList} aria-label={`${run.id} pending approval gates`}>
           {pendingGates.map(gate => {
             const gateKey = `${run.id}:${gate.id}`;
             const deciding = decidingGateKey === gateKey;
@@ -537,6 +537,7 @@ function RunSummaryCard({
                       ...(gateDisabled ? { cursor: deciding ? 'wait' : 'not-allowed', opacity: 0.7 } : {}),
                     }}
                     disabled={gateDisabled}
+                    aria-busy={deciding}
                     aria-label={`Approve ${gate.id} for ${run.id}`}
                     onClick={() => onDecideApproval(run.id, gate.id, 'approved')}
                   >
@@ -549,6 +550,7 @@ function RunSummaryCard({
                       ...(gateDisabled ? { cursor: deciding ? 'wait' : 'not-allowed', opacity: 0.7 } : {}),
                     }}
                     disabled={gateDisabled}
+                    aria-busy={deciding}
                     aria-label={`Reject ${gate.id} for ${run.id}`}
                     onClick={() => onDecideApproval(run.id, gate.id, 'rejected')}
                   >

--- a/web/src/components/Chat/ChatPanel.tsx
+++ b/web/src/components/Chat/ChatPanel.tsx
@@ -490,7 +490,7 @@ function RunSummaryCard({
   decidingGateKey: string | null;
   decisionDisabled: boolean;
   onCancel: (id: string) => void;
-  onDecideApproval: (runId: string, gateId: string, decision: AgentRunApprovalDecision) => void;
+  onDecideApproval: (runId: string, approvalId: string, decision: AgentRunApprovalDecision) => void;
 }) {
   const canCancel = !isTerminalAgentRun(run.status);
   const disabled = canceling || cancelDisabled;
@@ -599,7 +599,7 @@ function RunsPanel({
   cancelingRunId: string | null;
   decidingGateKey: string | null;
   onCancelRun: (id: string) => void;
-  onDecideApproval: (runId: string, gateId: string, decision: AgentRunApprovalDecision) => void;
+  onDecideApproval: (runId: string, approvalId: string, decision: AgentRunApprovalDecision) => void;
 }) {
   if (!projectName) {
     return (
@@ -795,13 +795,13 @@ export function ChatPanel({
       });
   };
 
-  const decideApprovalGate = (runId: string, gateId: string, decision: AgentRunApprovalDecision) => {
+  const decideApprovalGate = (runId: string, approvalId: string, decision: AgentRunApprovalDecision) => {
     const requestProjectName = projectName;
     if (!requestProjectName || cancelingRunId || decidingGateKey) return;
-    const gateKey = `${runId}:${gateId}`;
+    const gateKey = `${runId}:${approvalId}`;
     setDecidingGateKey(gateKey);
     setAgentRunsError(null);
-    api.decideAgentRunApproval(requestProjectName, runId, gateId, decision)
+    api.decideAgentRunApproval(requestProjectName, runId, approvalId, decision)
       .then(() => refreshAgentRunsForProject(requestProjectName))
       .catch((err: unknown) => {
         if (isConflictError(err)) {


### PR DESCRIPTION
## Summary
- show pending approval gates in Agent Hub run summary cards
- add Approve and Reject actions backed by the existing approval decision API
- refresh run summaries after decisions and serialize concurrent cancel/approval actions

## Validation
- npm test -- --run src/components/Chat/ChatPanel.test.tsx
- npm run build

Refs #105