### PR TITLE
Queue agent runs from Runs tab

### DIFF
--- a/web/src/components/Chat/ChatPanel.test.tsx
+++ b/web/src/components/Chat/ChatPanel.test.tsx
@@ -465,6 +465,77 @@ describe('ChatPanel', () => {
     });
   });
 
+  it('keeps the run queue action available while run summaries load', async () => {
+    listAgentRunsMock.mockReturnValueOnce(new Promise(() => {}));
+
+    render(<ChatPanel {...baseProps} projectName="demo" input="Review the current plan" />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Runs' }));
+    const runsPanel = screen.getByRole('tabpanel', { name: 'Runs' });
+
+    await waitFor(() => {
+      expect(within(runsPanel).getByText('Loading agent runs...')).toBeInTheDocument();
+    });
+    expect(within(runsPanel).getByRole('button', { name: 'Queue current prompt as agent run' })).toBeEnabled();
+  });
+
+  it('keeps the run queue action available when run summaries fail to load', async () => {
+    listAgentRunsMock.mockRejectedValueOnce(new Error('backend offline'));
+
+    render(<ChatPanel {...baseProps} projectName="demo" input="Review the current plan" />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Runs' }));
+    const runsPanel = screen.getByRole('tabpanel', { name: 'Runs' });
+
+    await waitFor(() => {
+      expect(within(runsPanel).getByText('Could not load agent runs.')).toBeInTheDocument();
+    });
+    expect(within(runsPanel).getByText('backend offline')).toBeInTheDocument();
+    expect(within(runsPanel).getByRole('button', { name: 'Queue current prompt as agent run' })).toBeEnabled();
+  });
+
+  it('refreshes run summaries when queueing hits a conflict', async () => {
+    const conflictError = new Error('agent run changed before queueing');
+    Object.assign(conflictError, { status: 409 });
+    listAgentRunsMock
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{
+        id: 'run_000001',
+        project: 'demo',
+        provider_id: 'codex',
+        mode: 'read_only',
+        status: 'running',
+        prompt_preview: 'Review the current plan',
+        prompt_hash: 'sha256:abc',
+        created_at: '2026-07-01T10:00:00Z',
+        updated_at: '2026-07-01T10:00:00Z',
+        canceled: false,
+        log_count: 0,
+        patch_count: 0,
+        approval_count: 0,
+        pending_approval_count: 0,
+      }]);
+    createAgentRunMock.mockRejectedValueOnce(conflictError);
+
+    render(<ChatPanel {...baseProps} projectName="demo" input="Review the current plan" />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Runs' }));
+    const runsPanel = screen.getByRole('tabpanel', { name: 'Runs' });
+
+    await waitFor(() => {
+      expect(within(runsPanel).getByRole('button', { name: 'Queue current prompt as agent run' })).toBeEnabled();
+    });
+
+    fireEvent.click(within(runsPanel).getByRole('button', { name: 'Queue current prompt as agent run' }));
+
+    await waitFor(() => {
+      expect(createAgentRunMock).toHaveBeenCalledWith('demo', {
+        prompt: 'Review the current plan',
+        mode: 'read_only',
+      });
+      expect(listAgentRunsMock).toHaveBeenCalledTimes(2);
+      expect(within(runsPanel).getByText('running')).toBeInTheDocument();
+    });
+    expect(within(runsPanel).queryByText('agent run changed before queueing')).not.toBeInTheDocument();
+  });
+
   it('loads one run detail record with logs, patches, and approvals', async () => {
     listAgentRunsMock.mockResolvedValueOnce([{
       id: 'run_000001',

--- a/web/src/components/Chat/ChatPanel.test.tsx
+++ b/web/src/components/Chat/ChatPanel.test.tsx
@@ -7,6 +7,7 @@ import { ChatPanel } from './ChatPanel';
 
 const listLocalAgentProvidersMock = vi.hoisted(() => vi.fn());
 const listAgentRunsMock = vi.hoisted(() => vi.fn());
+const createAgentRunMock = vi.hoisted(() => vi.fn());
 const getAgentRunMock = vi.hoisted(() => vi.fn());
 const cancelAgentRunMock = vi.hoisted(() => vi.fn());
 const decideAgentRunApprovalMock = vi.hoisted(() => vi.fn());
@@ -15,6 +16,7 @@ vi.mock('../../api', () => ({
   api: {
     listLocalAgentProviders: listLocalAgentProvidersMock,
     listAgentRuns: listAgentRunsMock,
+    createAgentRun: createAgentRunMock,
     getAgentRun: getAgentRunMock,
     cancelAgentRun: cancelAgentRunMock,
     decideAgentRunApproval: decideAgentRunApprovalMock,
@@ -56,6 +58,8 @@ describe('ChatPanel', () => {
     listLocalAgentProvidersMock.mockReturnValue(new Promise(() => {}));
     listAgentRunsMock.mockReset();
     listAgentRunsMock.mockResolvedValue([]);
+    createAgentRunMock.mockReset();
+    createAgentRunMock.mockResolvedValue(agentRunFixture());
     getAgentRunMock.mockReset();
     getAgentRunMock.mockResolvedValue(agentRunFixture());
     cancelAgentRunMock.mockReset();
@@ -403,13 +407,62 @@ describe('ChatPanel', () => {
     });
     expect(listAgentRunsMock).toHaveBeenCalledWith('demo');
     expect(within(runsPanel).getByText('queued')).toBeInTheDocument();
-    expect(within(runsPanel).getByText('read only')).toBeInTheDocument();
+    expect(within(runsPanel).getAllByText('read only').length).toBeGreaterThan(0);
     expect(within(runsPanel).getByText('2 logs')).toBeInTheDocument();
     expect(within(runsPanel).getByText('1 pending')).toBeInTheDocument();
     expect(within(runsPanel).getByText('Run terraform plan after reviewing the patch')).toBeInTheDocument();
     expect(within(runsPanel).getByRole('button', { name: 'Approve approval_000001 for run_000001' })).toBeInTheDocument();
     expect(within(runsPanel).getByRole('button', { name: 'Reject approval_000001 for run_000001' })).toBeInTheDocument();
     expect(within(runsPanel).getByRole('button', { name: 'View details for run_000001' })).toBeInTheDocument();
+  });
+
+  it('queues the current prompt as an audited run and refreshes the Runs tab', async () => {
+    listAgentRunsMock
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{
+        id: 'run_000001',
+        project: 'demo',
+        provider_id: 'codex',
+        mode: 'approved_execute',
+        status: 'queued',
+        prompt_preview: 'Apply the reviewed Terraform plan',
+        prompt_hash: 'sha256:abc',
+        created_at: '2026-07-01T10:00:00Z',
+        updated_at: '2026-07-01T10:00:00Z',
+        canceled: false,
+        log_count: 0,
+        patch_count: 0,
+        approval_count: 0,
+        pending_approval_count: 0,
+      }]);
+    createAgentRunMock.mockResolvedValueOnce(agentRunFixture({
+      id: 'run_000001',
+      mode: 'approved_execute',
+      status: 'queued',
+      prompt_preview: 'Apply the reviewed Terraform plan',
+    }));
+
+    render(<ChatPanel {...baseProps} projectName="demo" input="Apply the reviewed Terraform plan" />);
+    fireEvent.click(screen.getByRole('button', { name: 'Prepare deploy' }));
+    fireEvent.click(screen.getByRole('tab', { name: 'Runs' }));
+    const runsPanel = screen.getByRole('tabpanel', { name: 'Runs' });
+
+    await waitFor(() => {
+      expect(within(runsPanel).getByRole('button', { name: 'Queue current prompt as agent run' })).toBeInTheDocument();
+    });
+    expect(within(runsPanel).getByText('Apply the reviewed Terraform plan')).toBeInTheDocument();
+    expect(within(runsPanel).getByText('approved execute')).toBeInTheDocument();
+
+    fireEvent.click(within(runsPanel).getByRole('button', { name: 'Queue current prompt as agent run' }));
+
+    await waitFor(() => {
+      expect(createAgentRunMock).toHaveBeenCalledWith('demo', {
+        prompt: 'Apply the reviewed Terraform plan',
+        mode: 'approved_execute',
+      });
+      expect(listAgentRunsMock).toHaveBeenCalledTimes(2);
+      expect(within(runsPanel).getByText('queued')).toBeInTheDocument();
+    });
   });
 
   it('loads one run detail record with logs, patches, and approvals', async () => {

--- a/web/src/components/Chat/ChatPanel.test.tsx
+++ b/web/src/components/Chat/ChatPanel.test.tsx
@@ -465,6 +465,92 @@ describe('ChatPanel', () => {
     });
   });
 
+  it('ignores stale run-list responses after queue refresh wins', async () => {
+    let resolveInitialRuns: (runs: unknown[]) => void = () => {};
+    let resolveRefreshRuns: (runs: unknown[]) => void = () => {};
+    const initialList = new Promise<unknown[]>(resolve => {
+      resolveInitialRuns = resolve;
+    });
+    const refreshList = new Promise<unknown[]>(resolve => {
+      resolveRefreshRuns = resolve;
+    });
+    listAgentRunsMock
+      .mockReturnValueOnce(initialList)
+      .mockReturnValueOnce(refreshList);
+    createAgentRunMock.mockResolvedValueOnce(agentRunFixture({
+      id: 'run_000001',
+      mode: 'read_only',
+      status: 'queued',
+      prompt_preview: 'Review the current plan',
+    }));
+
+    render(<ChatPanel {...baseProps} projectName="demo" input="Review the current plan" />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Runs' }));
+    const runsPanel = screen.getByRole('tabpanel', { name: 'Runs' });
+
+    await waitFor(() => {
+      expect(within(runsPanel).getByRole('button', { name: 'Queue current prompt as agent run' })).toBeEnabled();
+    });
+
+    fireEvent.click(within(runsPanel).getByRole('button', { name: 'Queue current prompt as agent run' }));
+
+    await waitFor(() => {
+      expect(createAgentRunMock).toHaveBeenCalledWith('demo', {
+        prompt: 'Review the current plan',
+        mode: 'read_only',
+      });
+      expect(listAgentRunsMock).toHaveBeenCalledTimes(2);
+    });
+
+    await act(async () => {
+      resolveRefreshRuns([{
+        id: 'run_000001',
+        project: 'demo',
+        provider_id: 'codex',
+        mode: 'read_only',
+        status: 'queued',
+        prompt_preview: 'Review the current plan',
+        prompt_hash: 'sha256:abc',
+        created_at: '2026-07-01T10:00:00Z',
+        updated_at: '2026-07-01T10:00:00Z',
+        canceled: false,
+        log_count: 0,
+        patch_count: 0,
+        approval_count: 0,
+        pending_approval_count: 0,
+      }]);
+      await refreshList;
+    });
+
+    await waitFor(() => {
+      expect(within(runsPanel).getAllByText('Review the current plan').length).toBeGreaterThan(0);
+      expect(within(runsPanel).getByText('queued')).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      resolveInitialRuns([{
+        id: 'run_stale',
+        project: 'demo',
+        provider_id: 'codex',
+        mode: 'read_only',
+        status: 'completed',
+        prompt_preview: 'Stale pre-queue run',
+        prompt_hash: 'sha256:stale',
+        created_at: '2026-07-01T09:00:00Z',
+        updated_at: '2026-07-01T09:01:00Z',
+        canceled: false,
+        log_count: 0,
+        patch_count: 0,
+        approval_count: 0,
+        pending_approval_count: 0,
+      }]);
+      await initialList;
+    });
+
+    expect(within(runsPanel).getAllByText('Review the current plan').length).toBeGreaterThan(0);
+    expect(within(runsPanel).queryByText('Stale pre-queue run')).not.toBeInTheDocument();
+  });
+
   it('keeps the run queue action available while run summaries load', async () => {
     listAgentRunsMock.mockReturnValueOnce(new Promise(() => {}));
 

--- a/web/src/components/Chat/ChatPanel.test.tsx
+++ b/web/src/components/Chat/ChatPanel.test.tsx
@@ -423,7 +423,7 @@ describe('ChatPanel', () => {
         id: 'run_000001',
         project: 'demo',
         provider_id: 'codex',
-        mode: 'approved_execute',
+        mode: 'propose_only',
         status: 'queued',
         prompt_preview: 'Apply the reviewed Terraform plan',
         prompt_hash: 'sha256:abc',
@@ -437,7 +437,7 @@ describe('ChatPanel', () => {
       }]);
     createAgentRunMock.mockResolvedValueOnce(agentRunFixture({
       id: 'run_000001',
-      mode: 'approved_execute',
+      mode: 'propose_only',
       status: 'queued',
       prompt_preview: 'Apply the reviewed Terraform plan',
     }));
@@ -451,14 +451,14 @@ describe('ChatPanel', () => {
       expect(within(runsPanel).getByRole('button', { name: 'Queue current prompt as agent run' })).toBeInTheDocument();
     });
     expect(within(runsPanel).getByText('Apply the reviewed Terraform plan')).toBeInTheDocument();
-    expect(within(runsPanel).getByText('approved execute')).toBeInTheDocument();
+    expect(within(runsPanel).getByText('propose only')).toBeInTheDocument();
 
     fireEvent.click(within(runsPanel).getByRole('button', { name: 'Queue current prompt as agent run' }));
 
     await waitFor(() => {
       expect(createAgentRunMock).toHaveBeenCalledWith('demo', {
         prompt: 'Apply the reviewed Terraform plan',
-        mode: 'approved_execute',
+        mode: 'propose_only',
       });
       expect(listAgentRunsMock).toHaveBeenCalledTimes(2);
       expect(within(runsPanel).getByText('queued')).toBeInTheDocument();

--- a/web/src/components/Chat/ChatPanel.tsx
+++ b/web/src/components/Chat/ChatPanel.tsx
@@ -965,6 +965,7 @@ export function ChatPanel({
   const [detailLoadingRunId, setDetailLoadingRunId] = useState<string | null>(null);
   const [detailError, setDetailError] = useState<string | null>(null);
   const latestProjectNameRef = useRef(projectName);
+  const agentRunsListSeqRef = useRef(0);
   const detailRequestKeyRef = useRef<string | null>(null);
   const detailRequestSeqRef = useRef(0);
   latestProjectNameRef.current = projectName;
@@ -1027,20 +1028,27 @@ export function ChatPanel({
   useEffect(() => {
     if (activeTab !== 'runs' || !projectName) return;
     let cancelled = false;
+    agentRunsListSeqRef.current += 1;
+    const requestSeq = agentRunsListSeqRef.current;
+    const isCurrentListRequest = () => (
+      !cancelled
+      && agentRunsListSeqRef.current === requestSeq
+      && latestProjectNameRef.current === projectName
+    );
     setAgentRunsLoading(true);
     setAgentRunsError(null);
     api.listAgentRuns(projectName)
       .then(runs => {
-        if (cancelled) return;
+        if (!isCurrentListRequest()) return;
         setAgentRuns(runs);
       })
       .catch((err: unknown) => {
-        if (cancelled) return;
+        if (!isCurrentListRequest()) return;
         setAgentRuns([]);
         setAgentRunsError(err instanceof Error ? err.message : 'agent run list failed');
       })
       .finally(() => {
-        if (!cancelled) setAgentRunsLoading(false);
+        if (isCurrentListRequest()) setAgentRunsLoading(false);
       });
     return () => {
       cancelled = true;
@@ -1060,14 +1068,23 @@ export function ChatPanel({
 
   const refreshAgentRunsForProject = (requestProjectName: string) => {
     if (latestProjectNameRef.current !== requestProjectName) return Promise.resolve();
+    agentRunsListSeqRef.current += 1;
+    const requestSeq = agentRunsListSeqRef.current;
+    const isCurrentListRequest = () => (
+      agentRunsListSeqRef.current === requestSeq
+      && latestProjectNameRef.current === requestProjectName
+    );
     return api.listAgentRuns(requestProjectName)
       .then(runs => {
-        if (latestProjectNameRef.current !== requestProjectName) return;
+        if (!isCurrentListRequest()) return;
         setAgentRuns(runs);
       })
       .catch((err: unknown) => {
-        if (latestProjectNameRef.current !== requestProjectName) return;
+        if (!isCurrentListRequest()) return;
         setAgentRunsError(agentRunRefreshErrorMessage(err));
+      })
+      .finally(() => {
+        if (isCurrentListRequest()) setAgentRunsLoading(false);
       });
   };
 

--- a/web/src/components/Chat/ChatPanel.tsx
+++ b/web/src/components/Chat/ChatPanel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { CSSProperties, KeyboardEvent, ReactNode, RefObject } from 'react';
 
-import { api, type AgentRun, type AgentRunApprovalDecision, type AgentRunSummary, type LocalAgentProviderStatus } from '../../api';
+import { api, type AgentRun, type AgentRunApprovalDecision, type AgentRunMode, type AgentRunSummary, type LocalAgentProviderStatus } from '../../api';
 import { S } from '../../styles';
 
 export interface ChatMessage {
@@ -233,6 +233,10 @@ const hubStyles: Record<string, CSSProperties> = {
   providerActionHint: { color: '#77847d', fontSize: 11 },
   runsPanel: { flex: 1, minHeight: 0, overflowY: 'auto', padding: 12, display: 'flex', flexDirection: 'column', gap: 8 },
   runsEmpty: { flex: 1, minHeight: 0, padding: 16, color: 'var(--text-muted)', fontSize: 12, lineHeight: 1.55 },
+  runQueueCard: { borderWidth: 1, borderStyle: 'solid', borderColor: 'rgba(84, 184, 169, 0.32)', borderRadius: 8, background: 'rgba(84, 184, 169, 0.08)', padding: 10, minWidth: 0 },
+  runQueueHead: { display: 'flex', alignItems: 'center', gap: 8, minWidth: 0, flexWrap: 'wrap' },
+  runQueueText: { color: 'var(--text-muted)', fontSize: 12, lineHeight: 1.45, marginTop: 7, overflowWrap: 'anywhere' },
+  runQueueButton: { borderWidth: 1, borderStyle: 'solid', borderColor: 'rgba(84, 184, 169, 0.48)', borderRadius: 6, background: 'rgba(84, 184, 169, 0.18)', color: 'var(--accent-action)', cursor: 'pointer', fontSize: 11, fontFamily: 'DM Sans', fontWeight: 700, padding: '5px 8px' },
   runCard: { borderWidth: 1, borderStyle: 'solid', borderColor: 'var(--border-main)', borderRadius: 8, background: 'var(--bg-elev-2)', padding: 10, minWidth: 0 },
   runCardHead: { display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 },
   runTitle: { flex: 1, minWidth: 0, color: 'var(--text-main)', fontWeight: 700, fontSize: 12, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
@@ -467,6 +471,19 @@ function runModeLabel(mode: AgentRunSummary['mode']) {
   return mode.replaceAll('_', ' ');
 }
 
+function modeForTask(task: typeof TASK_MODES[number]): AgentRunMode {
+  switch (task) {
+    case 'Prepare deploy':
+      return 'approved_execute';
+    case 'Generate IaC':
+    case 'Fix policy':
+      return 'propose_only';
+    case 'Review project':
+    case 'Explain plan':
+      return 'read_only';
+  }
+}
+
 function isTerminalAgentRun(status: AgentRunSummary['status']) {
   return status === 'completed' || status === 'failed' || status === 'canceled';
 }
@@ -638,6 +655,49 @@ function RunDetailPanel({
   );
 }
 
+function RunQueueCard({
+  task,
+  prompt,
+  creating,
+  disabled,
+  onCreate,
+}: {
+  task: typeof TASK_MODES[number];
+  prompt: string;
+  creating: boolean;
+  disabled: boolean;
+  onCreate: () => void;
+}) {
+  const trimmedPrompt = prompt.trim();
+  const mode = modeForTask(task);
+  const blocked = disabled || creating || trimmedPrompt.length === 0;
+  return (
+    <div style={hubStyles.runQueueCard}>
+      <div style={hubStyles.runQueueHead}>
+        <strong style={{ color: 'var(--text-main)', fontSize: 12, flex: 1 }}>Queue audited run</strong>
+        <span style={hubStyles.badge}>{task}</span>
+        <span style={hubStyles.badge}>{runModeLabel(mode)}</span>
+        <button
+          type="button"
+          style={{
+            ...hubStyles.runQueueButton,
+            ...(blocked ? { cursor: creating ? 'wait' : 'not-allowed', opacity: 0.7 } : {}),
+          }}
+          disabled={blocked}
+          aria-busy={creating}
+          aria-label="Queue current prompt as agent run"
+          onClick={onCreate}
+        >
+          {creating ? 'Queueing...' : 'Queue run'}
+        </button>
+      </div>
+      <div style={hubStyles.runQueueText}>
+        {trimmedPrompt || 'Type a prompt in the message box, then queue it here as an auditable run.'}
+      </div>
+    </div>
+  );
+}
+
 function RunSummaryCard({
   run,
   canceling,
@@ -775,12 +835,16 @@ function RunsPanel({
   runs,
   loading,
   error,
+  task,
+  prompt,
+  creatingRun,
   cancelingRunId,
   selectedRun,
   selectedRunId,
   detailLoadingRunId,
   detailError,
   decidingGateKey,
+  onCreateRun,
   onCancelRun,
   onShowDetails,
   onCloseDetails,
@@ -790,12 +854,16 @@ function RunsPanel({
   runs: AgentRunSummary[];
   loading: boolean;
   error: string | null;
+  task: typeof TASK_MODES[number];
+  prompt: string;
+  creatingRun: boolean;
   cancelingRunId: string | null;
   selectedRun: AgentRun | null;
   selectedRunId: string | null;
   detailLoadingRunId: string | null;
   detailError: string | null;
   decidingGateKey: string | null;
+  onCreateRun: () => void;
   onCancelRun: (id: string) => void;
   onShowDetails: (id: string) => void;
   onCloseDetails: () => void;
@@ -820,37 +888,43 @@ function RunsPanel({
       </div>
     );
   }
-  if (runs.length === 0) {
-    return (
-      <div style={hubStyles.runsEmpty}>
-        <strong style={{ color: 'var(--text-main)' }}>No agent runs yet.</strong>
-        <div style={{ marginTop: 6 }}>
-          Future runs will show provider, task mode, approvals, proposed patches, and deployment actions in one audit trail.
-        </div>
-        <div style={{ marginTop: 10, color: '#77847d' }}>
-          This view is read-only; execution and approval gates remain behind the secure run lifecycle.
-        </div>
-      </div>
-    );
-  }
   return (
     <div style={hubStyles.runsPanel} aria-label={`${projectName} agent runs`}>
-      {runs.map(run => (
-        <RunSummaryCard
-          key={run.id}
-          run={run}
-          canceling={cancelingRunId === run.id}
-          cancelDisabled={cancelingRunId !== null || decidingGateKey !== null}
-          detailSelected={selectedRunId === run.id}
-          detailLoading={detailLoadingRunId === run.id}
-          detailsDisabled={detailLoadingRunId !== null && detailLoadingRunId !== run.id}
-          decidingGateKey={decidingGateKey}
-          decisionDisabled={cancelingRunId !== null || decidingGateKey !== null}
-          onCancel={onCancelRun}
-          onShowDetails={onShowDetails}
-          onDecideApproval={onDecideApproval}
-        />
-      ))}
+      <RunQueueCard
+        task={task}
+        prompt={prompt}
+        creating={creatingRun}
+        disabled={cancelingRunId !== null || decidingGateKey !== null || detailLoadingRunId !== null}
+        onCreate={onCreateRun}
+      />
+      {runs.length === 0 ? (
+        <div style={hubStyles.runsEmpty}>
+          <strong style={{ color: 'var(--text-main)' }}>No agent runs yet.</strong>
+          <div style={{ marginTop: 6 }}>
+            Future runs will show provider, task mode, approvals, proposed patches, and deployment actions in one audit trail.
+          </div>
+          <div style={{ marginTop: 10, color: '#77847d' }}>
+            This view is read-only; execution and approval gates remain behind the secure run lifecycle.
+          </div>
+        </div>
+      ) : (
+        runs.map(run => (
+          <RunSummaryCard
+            key={run.id}
+            run={run}
+            canceling={cancelingRunId === run.id}
+            cancelDisabled={creatingRun || cancelingRunId !== null || decidingGateKey !== null}
+            detailSelected={selectedRunId === run.id}
+            detailLoading={detailLoadingRunId === run.id}
+            detailsDisabled={creatingRun || (detailLoadingRunId !== null && detailLoadingRunId !== run.id)}
+            decidingGateKey={decidingGateKey}
+            decisionDisabled={creatingRun || cancelingRunId !== null || decidingGateKey !== null}
+            onCancel={onCancelRun}
+            onShowDetails={onShowDetails}
+            onDecideApproval={onDecideApproval}
+          />
+        ))
+      )}
       {(selectedRun || detailLoadingRunId || detailError) && (
         <RunDetailPanel
           run={selectedRun}
@@ -884,6 +958,7 @@ export function ChatPanel({
   const [agentRuns, setAgentRuns] = useState<AgentRunSummary[]>([]);
   const [agentRunsLoading, setAgentRunsLoading] = useState(false);
   const [agentRunsError, setAgentRunsError] = useState<string | null>(null);
+  const [creatingRun, setCreatingRun] = useState(false);
   const [cancelingRunId, setCancelingRunId] = useState<string | null>(null);
   const [decidingGateKey, setDecidingGateKey] = useState<string | null>(null);
   const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
@@ -975,6 +1050,7 @@ export function ChatPanel({
 
   useEffect(() => {
     detailRequestKeyRef.current = null;
+    setCreatingRun(false);
     setCancelingRunId(null);
     setDecidingGateKey(null);
     setSelectedRunId(null);
@@ -993,6 +1069,29 @@ export function ChatPanel({
       .catch((err: unknown) => {
         if (latestProjectNameRef.current !== requestProjectName) return;
         setAgentRunsError(agentRunRefreshErrorMessage(err));
+      });
+  };
+
+  const createAgentRun = () => {
+    const requestProjectName = projectName;
+    const prompt = input.trim();
+    if (!requestProjectName || prompt.length === 0 || creatingRun || cancelingRunId || decidingGateKey || detailRequestKeyRef.current) return;
+    setCreatingRun(true);
+    setAgentRunsError(null);
+    api.createAgentRun(requestProjectName, {
+      prompt,
+      mode: modeForTask(activeTask),
+    })
+      .then(() => refreshAgentRunsForProject(requestProjectName))
+      .catch((err: unknown) => {
+        if (latestProjectNameRef.current === requestProjectName) {
+          setAgentRunsError(err instanceof Error ? err.message : 'agent run create failed');
+        }
+      })
+      .finally(() => {
+        if (latestProjectNameRef.current === requestProjectName) {
+          setCreatingRun(false);
+        }
       });
   };
 
@@ -1237,12 +1336,16 @@ export function ChatPanel({
               runs={agentRuns}
               loading={agentRunsLoading}
               error={agentRunsError}
+              task={activeTask}
+              prompt={input}
+              creatingRun={creatingRun}
               cancelingRunId={cancelingRunId}
               selectedRun={selectedRun}
               selectedRunId={selectedRunId}
               detailLoadingRunId={detailLoadingRunId}
               detailError={detailError}
               decidingGateKey={decidingGateKey}
+              onCreateRun={createAgentRun}
               onCancelRun={cancelAgentRun}
               onShowDetails={showAgentRunDetails}
               onCloseDetails={closeAgentRunDetails}

--- a/web/src/components/Chat/ChatPanel.tsx
+++ b/web/src/components/Chat/ChatPanel.tsx
@@ -474,7 +474,7 @@ function runModeLabel(mode: AgentRunSummary['mode']) {
 function modeForTask(task: typeof TASK_MODES[number]): AgentRunMode {
   switch (task) {
     case 'Prepare deploy':
-      return 'approved_execute';
+      return 'propose_only';
     case 'Generate IaC':
     case 'Fix policy':
       return 'propose_only';

--- a/web/src/components/Chat/ChatPanel.tsx
+++ b/web/src/components/Chat/ChatPanel.tsx
@@ -877,17 +877,6 @@ function RunsPanel({
       </div>
     );
   }
-  if (loading) {
-    return <div style={hubStyles.runsEmpty}>Loading agent runs...</div>;
-  }
-  if (error) {
-    return (
-      <div style={hubStyles.runsEmpty}>
-        <strong style={{ color: 'var(--text-main)' }}>Could not load agent runs.</strong>
-        <div style={{ marginTop: 6 }}>{error}</div>
-      </div>
-    );
-  }
   return (
     <div style={hubStyles.runsPanel} aria-label={`${projectName} agent runs`}>
       <RunQueueCard
@@ -897,7 +886,14 @@ function RunsPanel({
         disabled={cancelingRunId !== null || decidingGateKey !== null || detailLoadingRunId !== null}
         onCreate={onCreateRun}
       />
-      {runs.length === 0 ? (
+      {loading ? (
+        <div style={hubStyles.runsEmpty}>Loading agent runs...</div>
+      ) : error ? (
+        <div style={hubStyles.runsEmpty}>
+          <strong style={{ color: 'var(--text-main)' }}>Could not load agent runs.</strong>
+          <div style={{ marginTop: 6 }}>{error}</div>
+        </div>
+      ) : runs.length === 0 ? (
         <div style={hubStyles.runsEmpty}>
           <strong style={{ color: 'var(--text-main)' }}>No agent runs yet.</strong>
           <div style={{ marginTop: 6 }}>
@@ -1084,9 +1080,13 @@ export function ChatPanel({
     })
       .then(() => refreshAgentRunsForProject(requestProjectName))
       .catch((err: unknown) => {
+        if (isConflictError(err)) {
+          return refreshAgentRunsForProject(requestProjectName);
+        }
         if (latestProjectNameRef.current === requestProjectName) {
           setAgentRunsError(err instanceof Error ? err.message : 'agent run create failed');
         }
+        return undefined;
       })
       .finally(() => {
         if (latestProjectNameRef.current === requestProjectName) {

--- a/web/src/components/Chat/ChatPanel.tsx
+++ b/web/src/components/Chat/ChatPanel.tsx
@@ -482,6 +482,9 @@ function modeForTask(task: typeof TASK_MODES[number]): AgentRunMode {
     case 'Explain plan':
       return 'read_only';
   }
+  const exhaustiveTask: never = task;
+  void exhaustiveTask;
+  return 'read_only';
 }
 
 function isTerminalAgentRun(status: AgentRunSummary['status']) {


### PR DESCRIPTION
## Summary
- add a Runs tab action that queues the current prompt through the existing agent run API
- map selected task modes to conservative run modes
- refresh run summaries after queueing

## Scope
Small frontend-only slice for issue #105. It does not add provider routing, execution workers, or streaming.

Refs #105

## Validation
- npm test -- --run src/components/Chat/ChatPanel.test.tsx
- npm run build