### PR TITLE
Add approval decision audit logs

### DIFF
--- a/internal/agentruns/store.go
+++ b/internal/agentruns/store.go
@@ -341,12 +341,7 @@ func (s *Store) AddLog(id string, level LogLevel, message string) (Run, error) {
 		if terminalStatus(run.Status) {
 			return ErrTerminated
 		}
-		run.Logs = append(run.Logs, LogEntry{
-			ID:      fmt.Sprintf("log_%06d", len(run.Logs)+1),
-			At:      now,
-			Level:   level,
-			Message: truncate(redactText(message), maxLogMessageLen),
-		})
+		appendLog(run, now, level, message)
 		return nil
 	})
 }
@@ -406,6 +401,12 @@ func (s *Store) DecideApproval(id, approvalID string, decision ApprovalStatus, d
 				run.Approvals[i].Status = decision
 				run.Approvals[i].DecidedAt = timePtr(now)
 				run.Approvals[i].DecidedBy = truncate(redactText(decidedBy), maxLogMessageLen)
+				appendLog(run, now, LogAudit, fmt.Sprintf(
+					"Approval gate %s (%s) %s.",
+					run.Approvals[i].ID,
+					run.Approvals[i].Kind,
+					decision,
+				))
 				if decision == ApprovalRejected {
 					run.Status = StatusFailed
 					run.Error = "approval gate rejected"
@@ -424,6 +425,15 @@ func (s *Store) DecideApproval(id, approvalID string, decision ApprovalStatus, d
 			}
 		}
 		return ErrApprovalNotFound
+	})
+}
+
+func appendLog(run *Run, at time.Time, level LogLevel, message string) {
+	run.Logs = append(run.Logs, LogEntry{
+		ID:      fmt.Sprintf("log_%06d", len(run.Logs)+1),
+		At:      at,
+		Level:   level,
+		Message: truncate(redactText(message), maxLogMessageLen),
 	})
 }
 

--- a/internal/agentruns/store_test.go
+++ b/internal/agentruns/store_test.go
@@ -553,6 +553,19 @@ func TestStoreDecideApproval(t *testing.T) {
 	if a.DecidedAt == nil || *a.DecidedAt != decideTime {
 		t.Fatalf("decided_at = %v, want %s", a.DecidedAt, decideTime)
 	}
+	if len(run.Logs) != 1 {
+		t.Fatalf("approval decision logs = %+v, want one audit log", run.Logs)
+	}
+	auditLog := run.Logs[0]
+	if auditLog.ID != "log_000001" || auditLog.Level != LogAudit || auditLog.At != decideTime {
+		t.Fatalf("approval audit log metadata = %+v, want first audit log at %s", auditLog, decideTime)
+	}
+	if auditLog.Message != "Approval gate approval_000001 (command) approved." {
+		t.Fatalf("approval audit log message = %q", auditLog.Message)
+	}
+	if strings.Contains(auditLog.Message, "abc123") {
+		t.Fatalf("approval audit log leaked decided_by token: %q", auditLog.Message)
+	}
 
 	// Re-deciding an already-decided gate should error.
 	if _, err := store.DecideApproval(run.ID, approvalID, ApprovalApproved, "alice"); err == nil {
@@ -640,6 +653,12 @@ func TestStoreDecideApprovalRejectsRun(t *testing.T) {
 	}
 	if run.CompletedAt == nil || *run.CompletedAt != rejectTime {
 		t.Fatalf("completed_at = %v, want %s", run.CompletedAt, rejectTime)
+	}
+	if len(run.Logs) != 1 {
+		t.Fatalf("rejected approval logs = %+v, want one audit log", run.Logs)
+	}
+	if got := run.Logs[0].Message; got != "Approval gate approval_000001 (command) rejected." {
+		t.Fatalf("rejected approval audit log = %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add sanitized audit log entries when agent approval gates are approved or rejected
- reuse the store log helper so audit entries get the same redaction and truncation path as normal logs
- cover approved and rejected approval decisions in store tests

## Validation
- GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/...

Refs #105