### PR TITLE
Show provider names in run badges

### DIFF
--- a/web/src/components/Chat/ChatPanel.test.tsx
+++ b/web/src/components/Chat/ChatPanel.test.tsx
@@ -409,6 +409,7 @@ describe('ChatPanel', () => {
     expect(within(runsPanel).getByText('queued')).toBeInTheDocument();
     expect(within(runsPanel).getAllByText('read only').length).toBeGreaterThan(0);
     expect(within(runsPanel).getByText('Codex CLI')).toBeInTheDocument();
+    expect(within(runsPanel).getByTitle('codex')).toBeInTheDocument();
     expect(within(runsPanel).getByText('2 logs')).toBeInTheDocument();
     expect(within(runsPanel).getByText('1 pending')).toBeInTheDocument();
     expect(within(runsPanel).getByText('Run terraform plan after reviewing the patch')).toBeInTheDocument();
@@ -490,6 +491,35 @@ describe('ChatPanel', () => {
         provider_id: 'codex-openai-api',
       });
     });
+  });
+
+  it('falls back to raw provider ids for unknown run providers', async () => {
+    listAgentRunsMock.mockResolvedValueOnce([{
+      id: 'run_000001',
+      project: 'demo',
+      provider_id: 'custom-provider-bridge',
+      mode: 'read_only',
+      status: 'queued',
+      prompt_preview: 'Review this project for custom policy checks',
+      prompt_hash: 'sha256:xyz',
+      created_at: '2026-07-01T10:00:00Z',
+      updated_at: '2026-07-01T10:00:00Z',
+      canceled: false,
+      log_count: 0,
+      patch_count: 0,
+      approval_count: 0,
+      pending_approval_count: 0,
+    }]);
+
+    render(<ChatPanel {...baseProps} projectName="demo" />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Runs' }));
+    const runsPanel = screen.getByRole('tabpanel', { name: 'Runs' });
+
+    await waitFor(() => {
+      expect(within(runsPanel).getByText('Review this project for custom policy checks')).toBeInTheDocument();
+    });
+    expect(within(runsPanel).getByText('custom-provider-bridge')).toBeInTheDocument();
+    expect(within(runsPanel).getByTitle('custom-provider-bridge')).toBeInTheDocument();
   });
 
   it('ignores stale run-list responses after queue refresh wins', async () => {

--- a/web/src/components/Chat/ChatPanel.test.tsx
+++ b/web/src/components/Chat/ChatPanel.test.tsx
@@ -408,6 +408,7 @@ describe('ChatPanel', () => {
     expect(listAgentRunsMock).toHaveBeenCalledWith('demo');
     expect(within(runsPanel).getByText('queued')).toBeInTheDocument();
     expect(within(runsPanel).getAllByText('read only').length).toBeGreaterThan(0);
+    expect(within(runsPanel).getByText('Codex CLI')).toBeInTheDocument();
     expect(within(runsPanel).getByText('2 logs')).toBeInTheDocument();
     expect(within(runsPanel).getByText('1 pending')).toBeInTheDocument();
     expect(within(runsPanel).getByText('Run terraform plan after reviewing the patch')).toBeInTheDocument();
@@ -452,7 +453,7 @@ describe('ChatPanel', () => {
     });
     expect(within(runsPanel).getByText('Apply the reviewed Terraform plan')).toBeInTheDocument();
     expect(within(runsPanel).getByText('propose only')).toBeInTheDocument();
-    expect(within(runsPanel).getByText('ollama')).toBeInTheDocument();
+    expect(within(runsPanel).getByText('Ollama')).toBeInTheDocument();
 
     fireEvent.click(within(runsPanel).getByRole('button', { name: 'Queue current prompt as agent run' }));
 
@@ -478,7 +479,7 @@ describe('ChatPanel', () => {
     await waitFor(() => {
       expect(within(runsPanel).getByRole('button', { name: 'Queue current prompt as agent run' })).toBeEnabled();
     });
-    expect(within(runsPanel).getByText('codex-openai-api')).toBeInTheDocument();
+    expect(within(runsPanel).getByText('OpenAI API')).toBeInTheDocument();
 
     fireEvent.click(within(runsPanel).getByRole('button', { name: 'Queue current prompt as agent run' }));
 
@@ -724,6 +725,7 @@ describe('ChatPanel', () => {
     });
 
     const details = within(runsPanel).getByRole('region', { name: 'run_000001 details' });
+    expect(within(details).getByText('Codex CLI')).toBeInTheDocument();
     expect(within(details).getByText('Started read-only project review')).toBeInTheDocument();
     expect(within(details).getByText('Restrict S3 bucket ACL')).toBeInTheDocument();
     expect(within(details).getByText(/public-read/)).toBeInTheDocument();

--- a/web/src/components/Chat/ChatPanel.tsx
+++ b/web/src/components/Chat/ChatPanel.tsx
@@ -46,6 +46,7 @@ type ProviderLane =
   | 'OpenAI-compatible';
 type ProviderActionLabel = 'Configure API' | 'Use enterprise policy' | 'Use local CLI';
 type ProviderDefinition = { name: string; lane: ProviderLane; state: ProviderState; note: string; localProviderId?: string };
+type RunProviderIdentity = { id: string; label: string };
 
 const PROVIDER_TABS: ProviderTab[] = ['codex', 'claude', 'gemini', 'copilot', 'local', 'mcp'];
 
@@ -335,6 +336,17 @@ function selectedRunProviderId(tab: ProviderTab, selectedProviderName?: string) 
   return providerIdForRun(tab, provider);
 }
 
+function providerIdentityForRunId(providerId?: string): RunProviderIdentity | null {
+  if (!providerId) return null;
+  for (const tab of PROVIDER_TABS) {
+    for (const provider of PROVIDER_GROUPS[tab].providers) {
+      const id = providerIdForRun(tab, provider);
+      if (id === providerId) return { id, label: provider.name };
+    }
+  }
+  return { id: providerId, label: providerId };
+}
+
 function ProviderDetails({
   provider,
   displayState,
@@ -547,6 +559,20 @@ function RunDetailSection({
   );
 }
 
+function ProviderBadge({ providerId }: { providerId?: string }) {
+  const provider = providerIdentityForRunId(providerId);
+  if (!provider) return null;
+  return (
+    <span
+      style={hubStyles.badge}
+      title={provider.id}
+      aria-label={`Provider ${provider.label}`}
+    >
+      {provider.label}
+    </span>
+  );
+}
+
 function RunDetailPanel({
   run,
   selectedRunId,
@@ -618,7 +644,7 @@ function RunDetailPanel({
       <div style={hubStyles.runPreview}>{run.prompt_preview || 'Prompt preview unavailable'}</div>
       <div style={hubStyles.runMeta}>
         <span style={hubStyles.badge}>{runModeLabel(run.mode)}</span>
-        {run.provider_id && <span style={hubStyles.badge}>{run.provider_id}</span>}
+        <ProviderBadge providerId={run.provider_id} />
         <span style={hubStyles.badge}>{run.prompt_hash}</span>
       </div>
 
@@ -701,7 +727,7 @@ function RunQueueCard({
         <strong style={{ color: 'var(--text-main)', fontSize: 12, flex: 1 }}>Queue audited run</strong>
         <span style={hubStyles.badge}>{task}</span>
         <span style={hubStyles.badge}>{runModeLabel(mode)}</span>
-        <span style={hubStyles.badge}>{providerId}</span>
+        <ProviderBadge providerId={providerId} />
         <button
           type="button"
           style={{
@@ -764,7 +790,7 @@ function RunSummaryCard({
       </div>
       <div style={hubStyles.runMeta}>
         <span style={hubStyles.badge}>{runModeLabel(run.mode)}</span>
-        {run.provider_id && <span style={hubStyles.badge}>{run.provider_id}</span>}
+        <ProviderBadge providerId={run.provider_id} />
         <span style={hubStyles.badge}>{run.log_count} logs</span>
         <span style={hubStyles.badge}>{run.patch_count} patches</span>
         <span style={hubStyles.badge}>{run.approval_count} approvals</span>


### PR DESCRIPTION
## Summary
- resolve stored provider_id values to friendly provider names in run queue, summary, and detail badges
- preserve raw provider ids as badge titles and keep create-agent-run payloads unchanged
- keep unknown provider ids visible by falling back to the raw id

## Validation
- npm test -- ChatPanel.test.tsx --run
- npm test -- --run
- npm run lint (passes with existing warnings)

Refs #105