### PR TITLE
Auto-refresh active agent runs

### DIFF
--- a/web/src/components/Chat/ChatPanel.test.tsx
+++ b/web/src/components/Chat/ChatPanel.test.tsx
@@ -723,6 +723,14 @@ describe('ChatPanel', () => {
         updated_at: '2026-07-01T10:00:05Z',
         completed_at: '2026-07-01T10:00:05Z',
         log_count: 1,
+      })])
+      .mockResolvedValue([agentRunSummaryFixture({
+        id: 'run_000001',
+        status: 'completed',
+        prompt_preview: 'Watch the live run',
+        updated_at: '2026-07-01T10:00:05Z',
+        completed_at: '2026-07-01T10:00:05Z',
+        log_count: 1,
       })]);
 
     render(<ChatPanel {...baseProps} projectName="demo" />);
@@ -806,7 +814,7 @@ describe('ChatPanel', () => {
     expect(getAgentRunMock).toHaveBeenCalledTimes(2);
   });
 
-  it('does not block showAgentRunDetails or createAgentRun while a detail poll is in flight', async () => {
+  it('does not block switching run details while a detail poll is in flight', async () => {
     vi.useFakeTimers();
 
     // Two active runs so both detail buttons are visible
@@ -818,14 +826,12 @@ describe('ChatPanel', () => {
     // First user-initiated detail fetch for run_000001 (running)
     // Then poll fires for run_000001
     // Then user switches to run_000002
-    let resolveFirstPoll!: (v: AgentRun) => void;
+    let resolveFirstPoll!: (_value: AgentRun) => void;
     const firstPollPromise = new Promise<AgentRun>(res => { resolveFirstPoll = res; });
     getAgentRunMock
       .mockResolvedValueOnce(agentRunFixture({ id: 'run_000001', status: 'running' }))
       .mockReturnValueOnce(firstPollPromise) // stalled poll for run_000001
       .mockResolvedValue(agentRunFixture({ id: 'run_000002', status: 'running' }));
-
-    createAgentRunMock.mockResolvedValue(undefined);
 
     render(<ChatPanel {...baseProps} projectName="demo" input="new task" />);
     fireEvent.click(screen.getByRole('tab', { name: 'Runs' }));

--- a/web/src/components/Chat/ChatPanel.test.tsx
+++ b/web/src/components/Chat/ChatPanel.test.tsx
@@ -806,6 +806,52 @@ describe('ChatPanel', () => {
     expect(getAgentRunMock).toHaveBeenCalledTimes(2);
   });
 
+  it('does not block showAgentRunDetails or createAgentRun while a detail poll is in flight', async () => {
+    vi.useFakeTimers();
+
+    // Two active runs so both detail buttons are visible
+    listAgentRunsMock.mockResolvedValue([
+      agentRunSummaryFixture({ id: 'run_000001', status: 'running', prompt_preview: 'Run one' }),
+      agentRunSummaryFixture({ id: 'run_000002', status: 'running', prompt_preview: 'Run two' }),
+    ]);
+
+    // First user-initiated detail fetch for run_000001 (running)
+    // Then poll fires for run_000001
+    // Then user switches to run_000002
+    let resolveFirstPoll!: (v: AgentRun) => void;
+    const firstPollPromise = new Promise<AgentRun>(res => { resolveFirstPoll = res; });
+    getAgentRunMock
+      .mockResolvedValueOnce(agentRunFixture({ id: 'run_000001', status: 'running' }))
+      .mockReturnValueOnce(firstPollPromise) // stalled poll for run_000001
+      .mockResolvedValue(agentRunFixture({ id: 'run_000002', status: 'running' }));
+
+    createAgentRunMock.mockResolvedValue(undefined);
+
+    render(<ChatPanel {...baseProps} projectName="demo" input="new task" />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Runs' }));
+    const runsPanel = screen.getByRole('tabpanel', { name: 'Runs' });
+
+    await flushAsyncUpdates();
+
+    // Open details for run_000001
+    fireEvent.click(within(runsPanel).getByRole('button', { name: 'View details for run_000001' }));
+    await flushAsyncUpdates();
+    expect(within(runsPanel).getByRole('region', { name: 'run_000001 details' })).toBeInTheDocument();
+
+    // Advance timer so the detail poll fires (firstPollPromise stalls in flight)
+    await act(async () => { await vi.advanceTimersByTimeAsync(5000); });
+    expect(getAgentRunMock).toHaveBeenCalledTimes(2); // 1 user-init + 1 poll
+
+    // While poll is stalled, switching to run_000002 must succeed immediately
+    fireEvent.click(within(runsPanel).getByRole('button', { name: 'View details for run_000002' }));
+    await flushAsyncUpdates();
+    expect(within(runsPanel).getByRole('region', { name: 'run_000002 details' })).toBeInTheDocument();
+
+    // Resolve the stalled poll — its response must be silently discarded
+    await act(async () => { resolveFirstPoll(agentRunFixture({ id: 'run_000001', status: 'running' })); });
+    expect(within(runsPanel).getByRole('region', { name: 'run_000002 details' })).toBeInTheDocument();
+  });
+
   it('loads one run detail record with logs, patches, and approvals', async () => {
     listAgentRunsMock.mockResolvedValueOnce([{
       id: 'run_000001',

--- a/web/src/components/Chat/ChatPanel.test.tsx
+++ b/web/src/components/Chat/ChatPanel.test.tsx
@@ -1,8 +1,8 @@
 import { createRef } from 'react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 
-import type { AgentRun } from '../../api';
+import type { AgentRun, AgentRunSummary } from '../../api';
 import { ChatPanel } from './ChatPanel';
 
 const listLocalAgentProvidersMock = vi.hoisted(() => vi.fn());
@@ -52,6 +52,29 @@ describe('ChatPanel', () => {
     approvals: [],
     ...overrides,
   });
+  const agentRunSummaryFixture = (overrides: Partial<AgentRunSummary> = {}): AgentRunSummary => ({
+    id: 'run_fixture',
+    project: 'demo',
+    provider_id: 'codex',
+    mode: 'read_only',
+    status: 'completed',
+    prompt_preview: 'Fixture run',
+    prompt_hash: 'sha256:fixture',
+    created_at: '2026-07-01T10:00:00Z',
+    updated_at: '2026-07-01T10:00:00Z',
+    canceled: false,
+    log_count: 0,
+    patch_count: 0,
+    approval_count: 0,
+    pending_approval_count: 0,
+    ...overrides,
+  });
+  const flushAsyncUpdates = async () => {
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  };
 
   beforeEach(() => {
     listLocalAgentProvidersMock.mockReset();
@@ -67,6 +90,10 @@ describe('ChatPanel', () => {
     decideAgentRunApprovalMock.mockReset();
     decideAgentRunApprovalMock.mockResolvedValue({});
     window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('renders the empty-state hint when no messages are present', () => {
@@ -679,6 +706,104 @@ describe('ChatPanel', () => {
       expect(within(runsPanel).getByText('running')).toBeInTheDocument();
     });
     expect(within(runsPanel).queryByText('agent run changed before queueing')).not.toBeInTheDocument();
+  });
+
+  it('auto-refreshes active run summaries while the Runs tab is open', async () => {
+    vi.useFakeTimers();
+    listAgentRunsMock
+      .mockResolvedValueOnce([agentRunSummaryFixture({
+        id: 'run_000001',
+        status: 'running',
+        prompt_preview: 'Watch the live run',
+      })])
+      .mockResolvedValueOnce([agentRunSummaryFixture({
+        id: 'run_000001',
+        status: 'completed',
+        prompt_preview: 'Watch the live run',
+        updated_at: '2026-07-01T10:00:05Z',
+        completed_at: '2026-07-01T10:00:05Z',
+        log_count: 1,
+      })]);
+
+    render(<ChatPanel {...baseProps} projectName="demo" />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Runs' }));
+    const runsPanel = screen.getByRole('tabpanel', { name: 'Runs' });
+
+    await flushAsyncUpdates();
+    expect(within(runsPanel).getByText('running')).toBeInTheDocument();
+    expect(listAgentRunsMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+
+    expect(within(runsPanel).getByText('completed')).toBeInTheDocument();
+    expect(listAgentRunsMock).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+    expect(listAgentRunsMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('auto-refreshes open active run details', async () => {
+    vi.useFakeTimers();
+    listAgentRunsMock
+      .mockResolvedValueOnce([agentRunSummaryFixture({
+        id: 'run_000001',
+        status: 'running',
+        prompt_preview: 'Watch detail logs',
+      })])
+      .mockResolvedValue([agentRunSummaryFixture({
+        id: 'run_000001',
+        status: 'completed',
+        prompt_preview: 'Watch detail logs',
+        updated_at: '2026-07-01T10:00:05Z',
+        completed_at: '2026-07-01T10:00:05Z',
+        log_count: 1,
+      })]);
+    getAgentRunMock
+      .mockResolvedValueOnce(agentRunFixture({
+        id: 'run_000001',
+        status: 'running',
+        prompt_preview: 'Watch detail logs',
+      }))
+      .mockResolvedValueOnce(agentRunFixture({
+        id: 'run_000001',
+        status: 'completed',
+        prompt_preview: 'Watch detail logs',
+        log_count: 1,
+        logs: [{
+          id: 'log_000001',
+          at: '2026-07-01T10:00:05Z',
+          level: 'info',
+          message: 'Finished live run',
+        }],
+      }));
+
+    render(<ChatPanel {...baseProps} projectName="demo" />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Runs' }));
+    const runsPanel = screen.getByRole('tabpanel', { name: 'Runs' });
+
+    await flushAsyncUpdates();
+    expect(within(runsPanel).getByRole('button', { name: 'View details for run_000001' })).toBeInTheDocument();
+    fireEvent.click(within(runsPanel).getByRole('button', { name: 'View details for run_000001' }));
+
+    await flushAsyncUpdates();
+    expect(within(runsPanel).getByRole('region', { name: 'run_000001 details' })).toBeInTheDocument();
+    expect(getAgentRunMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+
+    expect(within(runsPanel).getByText('Finished live run')).toBeInTheDocument();
+    expect(getAgentRunMock).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+    expect(getAgentRunMock).toHaveBeenCalledTimes(2);
   });
 
   it('loads one run detail record with logs, patches, and approvals', async () => {

--- a/web/src/components/Chat/ChatPanel.test.tsx
+++ b/web/src/components/Chat/ChatPanel.test.tsx
@@ -754,6 +754,45 @@ describe('ChatPanel', () => {
     expect(listAgentRunsMock).toHaveBeenCalledTimes(2);
   });
 
+  it('clears transient summary polling errors after a successful refresh', async () => {
+    vi.useFakeTimers();
+    listAgentRunsMock
+      .mockResolvedValueOnce([agentRunSummaryFixture({
+        id: 'run_000001',
+        status: 'running',
+        prompt_preview: 'Watch the live run',
+      })])
+      .mockRejectedValueOnce(new Error('temporary outage'))
+      .mockResolvedValue([agentRunSummaryFixture({
+        id: 'run_000001',
+        status: 'running',
+        prompt_preview: 'Watch the live run after recovery',
+        updated_at: '2026-07-01T10:00:10Z',
+        log_count: 1,
+      })]);
+
+    render(<ChatPanel {...baseProps} projectName="demo" />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Runs' }));
+    const runsPanel = screen.getByRole('tabpanel', { name: 'Runs' });
+
+    await flushAsyncUpdates();
+    expect(within(runsPanel).getByText('Watch the live run')).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+
+    expect(within(runsPanel).getByText('agent run refresh failed: temporary outage')).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+
+    expect(within(runsPanel).queryByText('Could not load agent runs.')).not.toBeInTheDocument();
+    expect(within(runsPanel).queryByText('agent run refresh failed: temporary outage')).not.toBeInTheDocument();
+    expect(within(runsPanel).getByText('Watch the live run after recovery')).toBeInTheDocument();
+  });
+
   it('auto-refreshes open active run details', async () => {
     vi.useFakeTimers();
     listAgentRunsMock

--- a/web/src/components/Chat/ChatPanel.tsx
+++ b/web/src/components/Chat/ChatPanel.tsx
@@ -68,6 +68,7 @@ const TASK_MODES = [
   'Fix policy',
   'Prepare deploy',
 ] as const;
+const AGENT_RUN_REFRESH_INTERVAL_MS = 5000;
 
 const AGENT_HUB_STORAGE_KEYS = {
   activeTab: 'iac-studio.agentHub.activeTab',
@@ -1021,6 +1022,7 @@ export function ChatPanel({
   const [detailError, setDetailError] = useState<string | null>(null);
   const latestProjectNameRef = useRef(projectName);
   const agentRunsListSeqRef = useRef(0);
+  const agentRunsRefreshInFlightRef = useRef(false);
   const detailRequestKeyRef = useRef<string | null>(null);
   const detailRequestSeqRef = useRef(0);
   latestProjectNameRef.current = projectName;
@@ -1054,6 +1056,7 @@ export function ChatPanel({
     () => selectedRunProviderId(runProviderTab, selectedProviders[runProviderTab]),
     [runProviderTab, selectedProviders],
   );
+  const hasActiveAgentRuns = agentRuns.some(run => !isTerminalAgentRun(run.status));
 
   const panelStyle = (tab: AgentHubTab) => (
     activeTab === tab ? hubStyles.tabPanel : hubStyles.hiddenTabPanel
@@ -1148,6 +1151,75 @@ export function ChatPanel({
         if (isCurrentListRequest()) setAgentRunsLoading(false);
       });
   };
+
+  useEffect(() => {
+    if (activeTab !== 'runs' || !projectName || !hasActiveAgentRuns || agentRunsLoading) return;
+    let cancelled = false;
+    const timer = window.setInterval(() => {
+      if (agentRunsRefreshInFlightRef.current) return;
+      agentRunsRefreshInFlightRef.current = true;
+      void refreshAgentRunsForProject(projectName).finally(() => {
+        if (!cancelled) agentRunsRefreshInFlightRef.current = false;
+      });
+    }, AGENT_RUN_REFRESH_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      agentRunsRefreshInFlightRef.current = false;
+      window.clearInterval(timer);
+    };
+  }, [activeTab, projectName, hasActiveAgentRuns, agentRunsLoading]);
+
+  useEffect(() => {
+    const requestProjectName = projectName;
+    const requestRun = selectedRun;
+    const requestRunId = requestRun?.id;
+    if (
+      activeTab !== 'runs'
+      || !requestProjectName
+      || !requestRunId
+      || isTerminalAgentRun(requestRun.status)
+    ) {
+      return;
+    }
+
+    let cancelled = false;
+    const timer = window.setInterval(() => {
+      if (detailRequestKeyRef.current) return;
+      detailRequestSeqRef.current += 1;
+      const requestKey = `${requestProjectName}:${requestRunId}:poll:${detailRequestSeqRef.current}`;
+      detailRequestKeyRef.current = requestKey;
+      const isCurrentDetailRequest = () => (
+        !cancelled
+        && detailRequestKeyRef.current === requestKey
+        && latestProjectNameRef.current === requestProjectName
+        && selectedRunId === requestRunId
+      );
+      api.getAgentRun(requestProjectName, requestRunId)
+        .then(run => {
+          if (!isCurrentDetailRequest()) return;
+          setSelectedRunId(run.id);
+          setSelectedRun(run);
+          setDetailError(null);
+        })
+        .catch((err: unknown) => {
+          if (!isCurrentDetailRequest()) return;
+          setDetailError(agentRunDetailErrorMessage(err));
+        })
+        .finally(() => {
+          if (detailRequestKeyRef.current === requestKey) {
+            detailRequestKeyRef.current = null;
+          }
+        });
+    }, AGENT_RUN_REFRESH_INTERVAL_MS);
+
+    return () => {
+      cancelled = true;
+      if (detailRequestKeyRef.current?.startsWith(`${requestProjectName}:${requestRunId}:poll:`)) {
+        detailRequestKeyRef.current = null;
+      }
+      window.clearInterval(timer);
+    };
+  }, [activeTab, projectName, selectedRun?.id, selectedRun?.status, selectedRunId]);
 
   const createAgentRun = () => {
     const requestProjectName = projectName;

--- a/web/src/components/Chat/ChatPanel.tsx
+++ b/web/src/components/Chat/ChatPanel.tsx
@@ -1159,10 +1159,28 @@ export function ChatPanel({
     let cancelled = false;
     const timer = window.setInterval(() => {
       if (agentRunsRefreshInFlightRef.current) return;
+      const requestProjectName = projectName;
+      agentRunsListSeqRef.current += 1;
+      const requestSeq = agentRunsListSeqRef.current;
+      const isCurrentListRequest = () => (
+        !cancelled
+        && agentRunsListSeqRef.current === requestSeq
+        && latestProjectNameRef.current === requestProjectName
+      );
       agentRunsRefreshInFlightRef.current = true;
-      void refreshAgentRunsForProject(projectName).finally(() => {
-        if (!cancelled) agentRunsRefreshInFlightRef.current = false;
-      });
+      void api.listAgentRuns(requestProjectName)
+        .then(runs => {
+          if (!isCurrentListRequest()) return;
+          setAgentRuns(runs);
+        })
+        .catch((err: unknown) => {
+          if (!isCurrentListRequest()) return;
+          setAgentRunsError(agentRunRefreshErrorMessage(err));
+        })
+        .finally(() => {
+          if (isCurrentListRequest()) setAgentRunsLoading(false);
+          if (!cancelled) agentRunsRefreshInFlightRef.current = false;
+        });
     }, AGENT_RUN_REFRESH_INTERVAL_MS);
     return () => {
       cancelled = true;

--- a/web/src/components/Chat/ChatPanel.tsx
+++ b/web/src/components/Chat/ChatPanel.tsx
@@ -1024,6 +1024,7 @@ export function ChatPanel({
   const agentRunsListSeqRef = useRef(0);
   const agentRunsRefreshInFlightRef = useRef(false);
   const detailRequestKeyRef = useRef<string | null>(null);
+  const detailPollInFlightRef = useRef(false);
   const detailRequestSeqRef = useRef(0);
   latestProjectNameRef.current = projectName;
 
@@ -1121,6 +1122,7 @@ export function ChatPanel({
 
   useEffect(() => {
     detailRequestKeyRef.current = null;
+    detailPollInFlightRef.current = false;
     setCreatingRun(false);
     setCancelingRunId(null);
     setDecidingGateKey(null);
@@ -1184,39 +1186,32 @@ export function ChatPanel({
 
     let cancelled = false;
     const timer = window.setInterval(() => {
-      if (detailRequestKeyRef.current) return;
-      detailRequestSeqRef.current += 1;
-      const requestKey = `${requestProjectName}:${requestRunId}:poll:${detailRequestSeqRef.current}`;
-      detailRequestKeyRef.current = requestKey;
-      const isCurrentDetailRequest = () => (
+      if (detailRequestKeyRef.current || detailPollInFlightRef.current) return;
+      detailPollInFlightRef.current = true;
+      const isCurrentDetailPoll = () => (
         !cancelled
-        && detailRequestKeyRef.current === requestKey
         && latestProjectNameRef.current === requestProjectName
         && selectedRunId === requestRunId
       );
       api.getAgentRun(requestProjectName, requestRunId)
         .then(run => {
-          if (!isCurrentDetailRequest()) return;
+          if (!isCurrentDetailPoll()) return;
           setSelectedRunId(run.id);
           setSelectedRun(run);
           setDetailError(null);
         })
         .catch((err: unknown) => {
-          if (!isCurrentDetailRequest()) return;
+          if (!isCurrentDetailPoll()) return;
           setDetailError(agentRunDetailErrorMessage(err));
         })
         .finally(() => {
-          if (detailRequestKeyRef.current === requestKey) {
-            detailRequestKeyRef.current = null;
-          }
+          if (!cancelled) detailPollInFlightRef.current = false;
         });
     }, AGENT_RUN_REFRESH_INTERVAL_MS);
 
     return () => {
       cancelled = true;
-      if (detailRequestKeyRef.current?.startsWith(`${requestProjectName}:${requestRunId}:poll:`)) {
-        detailRequestKeyRef.current = null;
-      }
+      detailPollInFlightRef.current = false;
       window.clearInterval(timer);
     };
   }, [activeTab, projectName, selectedRun?.id, selectedRun?.status, selectedRunId]);

--- a/web/src/components/Chat/ChatPanel.tsx
+++ b/web/src/components/Chat/ChatPanel.tsx
@@ -1172,6 +1172,7 @@ export function ChatPanel({
         .then(runs => {
           if (!isCurrentListRequest()) return;
           setAgentRuns(runs);
+          setAgentRunsError(null);
         })
         .catch((err: unknown) => {
           if (!isCurrentListRequest()) return;


### PR DESCRIPTION
## Summary
- auto-refresh run summaries every 5 seconds while the Runs tab is open and active runs are present
- auto-refresh the open run detail panel while the selected run is still active
- stop polling when runs become terminal, the user leaves the Runs tab, or detail polling is already in flight

## Validation
- npm test -- ChatPanel.test.tsx --run
- npm test -- --run
- npm run lint (passes with existing warnings)

Refs #105