### PR TITLE
Document Agent Hub run lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ start the local server for you.
 | **Import Projects** | Browse filesystem, scan existing .tf/.yml files, auto-detect topology |
 | **Cloud Connections** | Save, test, and select named AWS, Azure, or GCP targets before plan/apply |
 | **MCP Server** | Local stdio server for AI clients to inspect projects, classify plans, run policy/drift checks, and draft remediation workflows |
+| **Agent Hub Runs** | Queue AI tasks as auditable read-only, propose-only, or approved-execute runs with logs, patches, approval gates, and cancellation |
 | **Semantic Plan Gate** | Classifies Terraform/OpenTofu changes as safe, risky, destructive, or unknown before apply |
 | **Live Code Preview** | Every canvas change updates the code in real time |
 | **Project Persistence** | Auto-save canvas state, restore on reopen |
@@ -94,6 +95,7 @@ Browser (React/TS)                   Go Backend (single binary)
 │ Resource Palette     │◄────────────►│ File Watcher (debounce)     │
 │ Properties Panel     │              │ SafeRunner (timeouts/kill)  │
 │ AI Chat + Fix        │              │ AI Bridge (Ollama/OpenAI)   │
+│ Agent Hub Runs       │              │ Agent Run Store             │
 │ Code Preview         │              │ Security Scanner            │
 │ Terminal             │              │ Drift Detector              │
 │ Smart Suggestions    │              │ Recovery Checkpoints        │
@@ -123,6 +125,33 @@ IaC Studio works with **any AI provider**:
 | **Any OpenAI-compatible API** | Set endpoint + key in settings | Varies |
 
 Click **gear icon** in the app header to switch providers at any time.
+
+## Agent Hub Run Lifecycle
+
+The Agent Hub gives AI work a reviewable run lifecycle instead of letting an
+assistant freely edit files, run commands, or touch cloud credentials.
+
+1. **Queue a run** from the Agent Hub Runs tab. New runs default to
+   `read_only`; callers can also request `propose_only` or `approved_execute`.
+2. **Watch the audit trail** in the Runs tab. IaC Studio records status,
+   provider, prompt preview, prompt hash, logs, proposed patches, and pending
+   approval gates for the active project only.
+3. **Review gates before action.** File writes, command execution, IaC actions,
+   cloud writes, secret reads, and networked MCP calls are represented as
+   explicit approval gates. Rejected gates fail closed.
+4. **Cancel when needed.** Non-terminal runs can be canceled from the UI, and
+   active run summaries/details refresh while the Runs tab is open.
+
+Run modes are intentionally conservative:
+
+| Mode | Behavior |
+|------|----------|
+| `read_only` | Inspect project context and produce logs without proposing mutations |
+| `propose_only` | Produce diffs or review artifacts, but do not apply them |
+| `approved_execute` | Allow gated actions only after explicit approval |
+
+The run model stores prompt previews and HMAC fingerprints instead of raw prompt
+history. Cloud secrets are not returned in run responses or logs.
 
 ## MCP Server for AI Clients
 
@@ -201,6 +230,7 @@ IaC Studio runs locally and is designed to be secure by default:
 - **Semantic plan review** — Terraform/OpenTofu plans are classified before apply; risky, destructive, or unknown changes require explicit acknowledgement
 - **Recovery checkpoints** — successful apply-style runs write metadata and state/plan hashes under `.iac-studio/snapshots`; rollback requests generate review artifacts, not automatic undo actions
 - **Review-branch handoff** — drift and rollback PR workflows create local branches that commit only generated `.iac-studio/remediations` or `.iac-studio/rollbacks` artifacts, reject unrelated dirty source files, and return explicit `git push` / `gh pr create` commands instead of collecting GitHub tokens
+- **Agent run lifecycle** — AI tasks are auditable and cancellable, default to read-only, expose proposed patches as diffs, and require approval gates for file writes, commands, IaC actions, cloud writes, secret reads, and networked MCP calls
 - **MCP approval and audit** — AI clients can inspect and propose, while mutating or high-risk MCP tools require explicit approval and are logged to `.iac-studio/mcp-audit.jsonl`
 - **Cloud target checks** — selected Cloud Connections are tested before command execution
 - **Encrypted local secrets** — Cloud Connection secret fields are encrypted at rest and never echoed in API responses, terminal messages, or generated IaC
@@ -270,6 +300,7 @@ All flags have sensible defaults. Just run `iac-studio` and go.
 - [x] Reviewed rollback proposal artifacts from recovery checkpoints
 - [x] PR-ready local review branches for drift and rollback artifacts
 - [x] MCP server for AI-native project inspection, plan classification, drift/policy checks, runbooks, and approval-gated workflows
+- [x] Agent Hub run lifecycle with logs, proposed patches, approval gates, cancellation, and run history
 - [x] Cost estimation (30+ resource types)
 - [x] CI/CD pipeline generator (GitHub Actions, GitLab CI)
 - [x] Environment promotion (dev/staging/prod workspaces)

--- a/docs/index.html
+++ b/docs/index.html
@@ -733,6 +733,47 @@ ANTHROPIC_MODEL=claude-opus-4-7 \
           </div>
         </section>
 
+        <section id="agent-hub-runs" class="doc-section" data-title="agent hub runs lifecycle approval gates patches cancellation read only propose approved execute">
+          <h2>Agent Hub Runs</h2>
+          <p>
+            Agent Hub runs turn AI work into an auditable project-scoped workflow.
+            The goal is to let assistants inspect, propose, and request gated actions
+            without receiving unrestricted filesystem, shell, cloud, or secret access.
+          </p>
+
+          <ol class="steps">
+            <li><strong>Queue a run.</strong> The Runs tab creates a project-scoped run with provider metadata, a prompt preview, and a prompt fingerprint.</li>
+            <li><strong>Follow status.</strong> Runs move through <code>queued</code>, <code>running</code>, <code>waiting_approval</code>, and terminal states such as <code>completed</code>, <code>failed</code>, or <code>canceled</code>.</li>
+            <li><strong>Review output.</strong> Logs, proposed patches, and pending gates are visible before any risky action proceeds.</li>
+            <li><strong>Approve or reject gates.</strong> Rejected gates fail closed. Non-terminal runs can be canceled from the UI.</li>
+          </ol>
+
+          <div class="feature-grid compact">
+            <article>
+              <h3>Read-only</h3>
+              <p><code>read_only</code> is the default mode. It records inspection work and logs without proposing mutations.</p>
+            </article>
+            <article>
+              <h3>Propose-only</h3>
+              <p><code>propose_only</code> can produce diffs or review artifacts, but the run lifecycle does not apply them automatically.</p>
+            </article>
+            <article>
+              <h3>Approved execute</h3>
+              <p><code>approved_execute</code> still requires explicit gates before file writes, commands, IaC actions, cloud writes, secret reads, or networked MCP calls.</p>
+            </article>
+            <article>
+              <h3>Near-live view</h3>
+              <p>The Runs tab refreshes active summaries and open run details while work is in progress, then stops polling after terminal states.</p>
+            </article>
+          </div>
+
+          <div class="callout">
+            Agent run responses do not return raw cloud credentials. Prompt history is represented
+            by a bounded preview and HMAC fingerprint, and proposed file changes are surfaced as
+            diffs before any apply path should be considered.
+          </div>
+        </section>
+
         <section id="mcp-server" class="doc-section" data-title="mcp server ai clients claude cursor codex tools approval audit">
           <h2>MCP Server</h2>
           <p>
@@ -837,6 +878,10 @@ ANTHROPIC_MODEL=claude-opus-4-7 \
               <p>Infrastructure commands run through a safe runner with timeouts, captured logs, and a kill path.</p>
             </article>
             <article>
+              <h3>Agent run gates</h3>
+              <p>AI tasks default to read-only, keep an audit trail, surface patches as diffs, and require explicit approval for high-risk actions.</p>
+            </article>
+            <article>
               <h3>Cloud target context</h3>
               <p>Selected Cloud Connections are validated before command execution and inject provider env only for that run.</p>
             </article>
@@ -898,6 +943,11 @@ ANTHROPIC_MODEL=claude-opus-4-7 \
                   <td>AI</td>
                   <td><code>POST /api/ai/chat</code><br><code>POST /api/ai/chat/stream</code><br><code>POST /api/ai/topology</code><br><code>POST /api/ai/topology/image</code><br><code>POST /api/ai/fix</code><br><code>POST /api/ai/suggest</code><br><code>POST /api/ai/settings</code></td>
                   <td>Chat, streaming responses, topology generation, image import, plan fixes, suggestions, and provider settings.</td>
+                </tr>
+                <tr>
+                  <td>Agent runs</td>
+                  <td><code>GET /api/projects/{name}/agent-runs</code><br><code>POST /api/projects/{name}/agent-runs</code><br><code>GET /api/projects/{name}/agent-runs/{id}</code><br><code>POST /api/projects/{name}/agent-runs/{id}/cancel</code><br><code>POST /api/projects/{name}/agent-runs/{id}/approvals/{approvalID}/decision</code></td>
+                  <td>Create project-scoped AI runs, list summaries, load audit details, cancel non-terminal work, and approve or reject pending gates.</td>
                 </tr>
                 <tr>
                   <td>Policy and scanning</td>

--- a/docs/index.html
+++ b/docs/index.html
@@ -946,7 +946,7 @@ ANTHROPIC_MODEL=claude-opus-4-7 \
                 </tr>
                 <tr>
                   <td>Agent runs</td>
-                  <td><code>GET /api/projects/{name}/agent-runs</code><br><code>POST /api/projects/{name}/agent-runs</code><br><code>GET /api/projects/{name}/agent-runs/{id}</code><br><code>POST /api/projects/{name}/agent-runs/{id}/cancel</code><br><code>POST /api/projects/{name}/agent-runs/{id}/approvals/{approvalID}/decision</code></td>
+                  <td><code>GET /api/projects/{name}/agent-runs</code><br><code>POST /api/projects/{name}/agent-runs</code><br><code>GET /api/projects/{name}/agent-runs/{id}</code><br><code>POST /api/projects/{name}/agent-runs/{id}/cancel</code><br><code>POST /api/projects/{name}/agent-runs/{id}/approvals/{approval_id}/decision</code></td>
                   <td>Create project-scoped AI runs, list summaries, load audit details, cancel non-terminal work, and approve or reject pending gates.</td>
                 </tr>
                 <tr>


### PR DESCRIPTION
## Summary
- document the Agent Hub run lifecycle, modes, approval gates, and cancellation behavior in README
- add the same Agent Hub Runs section to the published docs
- list the agent run REST endpoints in the docs API reference

## Validation
- git diff --check -- README.md docs/index.html

Closes #105