### PR TITLE
Address Agent Hub docs review

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Click **gear icon** in the app header to switch providers at any time.
 The Agent Hub gives AI work a reviewable run lifecycle instead of letting an
 assistant freely edit files, run commands, or touch cloud credentials.
 
-1. **Queue a run** from the Agent Hub Runs tab. New runs default to
+1. **Queue a run** from the Runs tab. New runs default to
    `read_only`; callers can also request `propose_only` or `approved_execute`.
 2. **Watch the audit trail** in the Runs tab. IaC Studio records status,
    provider, prompt preview, prompt hash, logs, proposed patches, and pending

--- a/docs/index.html
+++ b/docs/index.html
@@ -41,6 +41,7 @@
           <a href="#cloud-connections">Cloud Connections</a>
           <a href="#semantic-plan-gate">Semantic Plan Gate</a>
           <a href="#ai">AI Setup</a>
+          <a href="#agent-hub-runs">Agent Hub Runs</a>
           <a href="#mcp-server">MCP Server</a>
           <a href="#policy-security">Policy and Security</a>
           <a href="#api-reference">API Reference</a>


### PR DESCRIPTION
## Summary
- rename the README reference from "Agent Hub Runs tab" to the actual "Runs tab" UI label
- add the Agent Hub Runs section to the published docs sidebar navigation

## Review comments addressed
- https://github.com/olandodeflexy/IaCStudio/pull/134#discussion_r3525017338
- https://github.com/olandodeflexy/IaCStudio/pull/134#discussion_r3525017350

## Validation
- git diff --check -- README.md docs/index.html

Closes #105