### PR TITLE
Add Agent Hub provider connection catalog

### DIFF
--- a/internal/agentproviders/connections.go
+++ b/internal/agentproviders/connections.go
@@ -28,6 +28,8 @@ type ConnectionProviderDefinition struct {
 	SetupHint         string   `json:"setup_hint"`
 }
 
+// DefaultConnectionProviders returns the built-in API and enterprise provider
+// connection catalog without resolved credential values.
 func DefaultConnectionProviders() []ConnectionProviderDefinition {
 	return []ConnectionProviderDefinition{
 		{
@@ -110,7 +112,7 @@ func DefaultConnectionProviders() []ConnectionProviderDefinition {
 			Family:         "bedrock",
 			Category:       ConnectionCategoryAPI,
 			CredentialMode: ConnectionCredentialCloudConnection,
-			RequiredFields: []string{"region", "model_id", "cloud_connection_id"},
+			RequiredFields: []string{"region", "model_id", "connection_id"},
 			SecretFields:   []string{},
 			Capabilities: []string{
 				"chat",
@@ -133,7 +135,7 @@ func DefaultConnectionProviders() []ConnectionProviderDefinition {
 			Family:         "vertex",
 			Category:       ConnectionCategoryAPI,
 			CredentialMode: ConnectionCredentialCloudConnection,
-			RequiredFields: []string{"project_id", "location", "model", "cloud_connection_id"},
+			RequiredFields: []string{"project_id", "location", "model", "connection_id"},
 			SecretFields:   []string{},
 			Capabilities: []string{
 				"chat",

--- a/internal/agentproviders/connections.go
+++ b/internal/agentproviders/connections.go
@@ -1,0 +1,181 @@
+package agentproviders
+
+const (
+	ConnectionCategoryAPI        = "api"
+	ConnectionCategoryEnterprise = "enterprise_gateway"
+
+	ConnectionCredentialSecretStore     = "secret_store"
+	ConnectionCredentialCloudConnection = "cloud_connection"
+	ConnectionCredentialEnterpriseSSO   = "enterprise_sso"
+)
+
+// ConnectionProviderDefinition describes an API or enterprise model-provider
+// connection path. It is metadata only: credentials are represented as field
+// names and storage hints, never as resolved secret values.
+type ConnectionProviderDefinition struct {
+	ID                string   `json:"id"`
+	Name              string   `json:"name"`
+	Family            string   `json:"family"`
+	Category          string   `json:"category"`
+	CredentialMode    string   `json:"credential_mode"`
+	RequiredFields    []string `json:"required_fields"`
+	SecretFields      []string `json:"secret_fields"`
+	Capabilities      []string `json:"capabilities"`
+	CostControls      []string `json:"cost_controls"`
+	BillingHint       string   `json:"billing_hint"`
+	DataHandlingHint  string   `json:"data_handling_hint"`
+	SecretStorageHint string   `json:"secret_storage_hint"`
+	SetupHint         string   `json:"setup_hint"`
+}
+
+func DefaultConnectionProviders() []ConnectionProviderDefinition {
+	return []ConnectionProviderDefinition{
+		{
+			ID:             "openai-api",
+			Name:           "OpenAI API",
+			Family:         "openai",
+			Category:       ConnectionCategoryAPI,
+			CredentialMode: ConnectionCredentialSecretStore,
+			RequiredFields: []string{"model"},
+			SecretFields:   []string{"api_key"},
+			Capabilities: []string{
+				"chat",
+				"code_editing",
+				"iac_assistance",
+				"tool_calling",
+				"vision",
+			},
+			CostControls: []string{
+				"monthly_budget",
+				"per_run_token_limit",
+				"allowed_models",
+			},
+			BillingHint:       "Billed through the OpenAI Platform API account, separate from ChatGPT subscriptions.",
+			DataHandlingHint:  "Prompts and selected project context are sent to the configured OpenAI API endpoint.",
+			SecretStorageHint: "Store API keys through IaC Studio secret stores; keys are never returned to the browser after save.",
+			SetupHint:         "Use for automation, hosted workflows, or centrally billed platform usage.",
+		},
+		{
+			ID:             "anthropic-api",
+			Name:           "Anthropic API",
+			Family:         "anthropic",
+			Category:       ConnectionCategoryAPI,
+			CredentialMode: ConnectionCredentialSecretStore,
+			RequiredFields: []string{"model"},
+			SecretFields:   []string{"api_key"},
+			Capabilities: []string{
+				"chat",
+				"code_editing",
+				"iac_assistance",
+				"tool_calling",
+				"vision",
+			},
+			CostControls: []string{
+				"monthly_budget",
+				"per_run_token_limit",
+				"allowed_models",
+			},
+			BillingHint:       "Billed through Anthropic API usage, separate from Claude or Claude Code subscriptions.",
+			DataHandlingHint:  "Prompts and selected project context are sent to the configured Anthropic API endpoint.",
+			SecretStorageHint: "Store API keys through IaC Studio secret stores; keys are never returned to the browser after save.",
+			SetupHint:         "Use for hosted runs, service accounts, or team automation.",
+		},
+		{
+			ID:             "azure-openai",
+			Name:           "Azure OpenAI",
+			Family:         "openai",
+			Category:       ConnectionCategoryAPI,
+			CredentialMode: ConnectionCredentialSecretStore,
+			RequiredFields: []string{"endpoint", "deployment"},
+			SecretFields:   []string{"api_key"},
+			Capabilities: []string{
+				"chat",
+				"code_editing",
+				"iac_assistance",
+				"tool_calling",
+			},
+			CostControls: []string{
+				"monthly_budget",
+				"deployment_allowlist",
+				"per_run_token_limit",
+			},
+			BillingHint:       "Billed through the selected Azure subscription and Azure OpenAI resource.",
+			DataHandlingHint:  "Prompts and selected project context are sent to the configured Azure OpenAI endpoint.",
+			SecretStorageHint: "Store Azure OpenAI keys through IaC Studio secret stores or a future Azure Key Vault adapter.",
+			SetupHint:         "Use when teams need Azure tenant controls, private networking, or centralized Azure billing.",
+		},
+		{
+			ID:             "aws-bedrock",
+			Name:           "Amazon Bedrock",
+			Family:         "bedrock",
+			Category:       ConnectionCategoryAPI,
+			CredentialMode: ConnectionCredentialCloudConnection,
+			RequiredFields: []string{"region", "model_id", "cloud_connection_id"},
+			SecretFields:   []string{},
+			Capabilities: []string{
+				"chat",
+				"iac_assistance",
+				"tool_calling",
+			},
+			CostControls: []string{
+				"monthly_budget",
+				"allowed_model_ids",
+				"per_run_token_limit",
+			},
+			BillingHint:       "Billed through the selected AWS account and Bedrock model usage.",
+			DataHandlingHint:  "Prompts and selected project context are sent to Bedrock in the selected AWS region.",
+			SecretStorageHint: "Reuse an approved AWS Cloud Connection instead of storing model-provider keys.",
+			SetupHint:         "Use for AWS-governed deployments that need IAM, region, and account controls.",
+		},
+		{
+			ID:             "vertex-ai",
+			Name:           "Vertex AI",
+			Family:         "vertex",
+			Category:       ConnectionCategoryAPI,
+			CredentialMode: ConnectionCredentialCloudConnection,
+			RequiredFields: []string{"project_id", "location", "model", "cloud_connection_id"},
+			SecretFields:   []string{},
+			Capabilities: []string{
+				"chat",
+				"iac_assistance",
+				"tool_calling",
+				"vision",
+			},
+			CostControls: []string{
+				"monthly_budget",
+				"allowed_models",
+				"per_run_token_limit",
+			},
+			BillingHint:       "Billed through the selected Google Cloud project and Vertex AI usage.",
+			DataHandlingHint:  "Prompts and selected project context are sent to Vertex AI in the selected project and location.",
+			SecretStorageHint: "Reuse an approved GCP Cloud Connection instead of storing model-provider keys.",
+			SetupHint:         "Use for GCP-governed deployments that need project, region, and IAM controls.",
+		},
+		{
+			ID:             "enterprise-gateway",
+			Name:           "Enterprise Gateway",
+			Family:         "gateway",
+			Category:       ConnectionCategoryEnterprise,
+			CredentialMode: ConnectionCredentialEnterpriseSSO,
+			RequiredFields: []string{"endpoint", "tenant"},
+			SecretFields:   []string{},
+			Capabilities: []string{
+				"chat",
+				"code_editing",
+				"iac_assistance",
+				"tool_calling",
+				"audit_controls",
+				"policy_routing",
+			},
+			CostControls: []string{
+				"workspace_budget",
+				"allowed_models",
+				"team_quota",
+			},
+			BillingHint:       "Billed through the organization's gateway or enterprise model platform.",
+			DataHandlingHint:  "Prompts and selected project context follow the configured enterprise gateway routing policy.",
+			SecretStorageHint: "Use SSO or gateway-managed credentials; IaC Studio should not collect individual API keys for this path.",
+			SetupHint:         "Use for private routing, SSO, audit, and platform-team rollouts.",
+		},
+	}
+}

--- a/internal/agentproviders/discovery_test.go
+++ b/internal/agentproviders/discovery_test.go
@@ -26,6 +26,40 @@ func TestDefaultLocalProviderOrder(t *testing.T) {
 	}
 }
 
+func TestDefaultConnectionProviderOrderAndSecurityMetadata(t *testing.T) {
+	definitions := DefaultConnectionProviders()
+	got := make([]string, 0, len(definitions))
+	for _, definition := range definitions {
+		got = append(got, definition.ID)
+		if definition.Name == "" || definition.Family == "" || definition.Category == "" {
+			t.Fatalf("provider %q missing identity metadata: %+v", definition.ID, definition)
+		}
+		if definition.BillingHint == "" || definition.DataHandlingHint == "" || definition.SecretStorageHint == "" || definition.SetupHint == "" {
+			t.Fatalf("provider %q missing user-facing hints: %+v", definition.ID, definition)
+		}
+		if len(definition.Capabilities) == 0 || len(definition.CostControls) == 0 {
+			t.Fatalf("provider %q missing capabilities or cost controls: %+v", definition.ID, definition)
+		}
+	}
+	want := []string{"openai-api", "anthropic-api", "azure-openai", "aws-bedrock", "vertex-ai", "enterprise-gateway"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("connection provider order = %#v, want %#v", got, want)
+	}
+}
+
+func TestDefaultConnectionProvidersDoNotContainSecretValues(t *testing.T) {
+	data, err := json.Marshal(DefaultConnectionProviders())
+	if err != nil {
+		t.Fatalf("marshal connection providers: %v", err)
+	}
+	got := string(data)
+	for _, leaked := range []string{"sk-", "AKIA", "secret_value", "access_token", "refresh_token"} {
+		if strings.Contains(got, leaked) {
+			t.Fatalf("connection provider metadata leaked secret-like value %q in %s", leaked, got)
+		}
+	}
+}
+
 func TestDefaultOpenAICompatibleLocalEndpointCandidates(t *testing.T) {
 	definitions := DefaultLocalProviders()
 	var endpoints []EndpointCandidate

--- a/internal/agentproviders/discovery_test.go
+++ b/internal/agentproviders/discovery_test.go
@@ -45,6 +45,16 @@ func TestDefaultConnectionProviderOrderAndSecurityMetadata(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("connection provider order = %#v, want %#v", got, want)
 	}
+	for _, definition := range definitions {
+		if definition.ID == "aws-bedrock" || definition.ID == "vertex-ai" {
+			if !containsString(definition.RequiredFields, "connection_id") {
+				t.Fatalf("%s required fields = %#v, want connection_id", definition.ID, definition.RequiredFields)
+			}
+			if containsString(definition.RequiredFields, "cloud_connection_id") {
+				t.Fatalf("%s required fields should use connection_id convention: %#v", definition.ID, definition.RequiredFields)
+			}
+		}
+	}
 }
 
 func TestDefaultConnectionProvidersDoNotContainSecretValues(t *testing.T) {
@@ -308,6 +318,15 @@ func TestStatusNormalizesListFieldsForJSONConsumers(t *testing.T) {
 func containsAny(s string, needles []string) bool {
 	for _, needle := range needles {
 		if len(needle) > 0 && strings.Contains(s, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
 			return true
 		}
 	}

--- a/internal/api/agent_providers_test.go
+++ b/internal/api/agent_providers_test.go
@@ -51,6 +51,9 @@ func TestAgentHubLocalProvidersRouteUsesConfiguredDiscovery(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d", rec.Code)
 	}
+	if got := rec.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("content type = %q, want application/json", got)
+	}
 	var body struct {
 		Providers []agentproviders.LocalProviderStatus `json:"providers"`
 	}
@@ -105,6 +108,9 @@ func TestAgentHubProviderConnectionsRouteUsesConfiguredCatalog(t *testing.T) {
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d", rec.Code)
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("content type = %q, want application/json", got)
 	}
 	var body struct {
 		Providers []agentproviders.ConnectionProviderDefinition `json:"providers"`

--- a/internal/api/agent_providers_test.go
+++ b/internal/api/agent_providers_test.go
@@ -65,3 +65,58 @@ func TestAgentHubLocalProvidersRouteUsesConfiguredDiscovery(t *testing.T) {
 		t.Fatalf("unexpected provider payload: %+v", got)
 	}
 }
+
+func TestAgentHubProviderConnectionsRouteUsesConfiguredCatalog(t *testing.T) {
+	root := t.TempDir()
+	hub := NewHub()
+	go hub.Run()
+	t.Cleanup(hub.Close)
+	fw := watcher.New(hub)
+	t.Cleanup(fw.Close)
+
+	router := NewRouterWithOptions(
+		hub,
+		fw,
+		ai.NewClient("http://127.0.0.1:1", "ignored"),
+		runner.NewSafeRunner(runner.DefaultSafetyConfig()),
+		root,
+		RouterOptions{AgentProviderConnections: func() []agentproviders.ConnectionProviderDefinition {
+			return []agentproviders.ConnectionProviderDefinition{{
+				ID:                "openai-api",
+				Name:              "OpenAI API",
+				Family:            "openai",
+				Category:          agentproviders.ConnectionCategoryAPI,
+				CredentialMode:    agentproviders.ConnectionCredentialSecretStore,
+				RequiredFields:    []string{"model"},
+				SecretFields:      []string{"api_key"},
+				Capabilities:      []string{"chat", "tool_calling"},
+				CostControls:      []string{"monthly_budget"},
+				BillingHint:       "Billed through OpenAI Platform API usage.",
+				DataHandlingHint:  "Prompts are sent to the configured endpoint.",
+				SecretStorageHint: "Keys are stored through secret stores and never returned.",
+				SetupHint:         "Use for automation.",
+			}}
+		}},
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/agent-hub/providers/connections", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	var body struct {
+		Providers []agentproviders.ConnectionProviderDefinition `json:"providers"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(body.Providers) != 1 {
+		t.Fatalf("providers = %+v", body.Providers)
+	}
+	got := body.Providers[0]
+	if got.ID != "openai-api" || got.CredentialMode != agentproviders.ConnectionCredentialSecretStore || len(got.SecretFields) != 1 || got.SecretFields[0] != "api_key" {
+		t.Fatalf("unexpected provider connection payload: %+v", got)
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1102,6 +1102,7 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 	// absolute executable paths; local endpoint checks only call loopback
 	// /v1/models probes with short timeouts and no credentials.
 	mux.HandleFunc("GET /api/agent-hub/providers/local", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"providers": opts.localAgentProviders(),
 		})

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1107,6 +1107,7 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 		})
 	})
 	mux.HandleFunc("GET /api/agent-hub/providers/connections", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"providers": opts.agentProviderConnections(),
 		})

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1036,10 +1036,11 @@ func requireOptionalJSONContentType(w http.ResponseWriter, r *http.Request) bool
 // RouterOptions allows callers to provide services and configuration that need
 // explicit ownership outside the router.
 type RouterOptions struct {
-	MCPAirlock          *mcpairlock.Manager
-	AgentRuns           *agentruns.Store
-	AppVersion          string
-	LocalAgentProviders func() []agentproviders.LocalProviderStatus
+	MCPAirlock               *mcpairlock.Manager
+	AgentRuns                *agentruns.Store
+	AppVersion               string
+	LocalAgentProviders      func() []agentproviders.LocalProviderStatus
+	AgentProviderConnections func() []agentproviders.ConnectionProviderDefinition
 }
 
 const defaultAppVersion = "0.1.0"
@@ -1057,6 +1058,13 @@ func (opts RouterOptions) localAgentProviders() []agentproviders.LocalProviderSt
 		return opts.LocalAgentProviders()
 	}
 	return agentproviders.DiscoverLocal()
+}
+
+func (opts RouterOptions) agentProviderConnections() []agentproviders.ConnectionProviderDefinition {
+	if opts.AgentProviderConnections != nil {
+		return opts.AgentProviderConnections()
+	}
+	return agentproviders.DefaultConnectionProviders()
 }
 
 // NewRouter creates the HTTP router with all endpoints.
@@ -1096,6 +1104,11 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 	mux.HandleFunc("GET /api/agent-hub/providers/local", func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"providers": opts.localAgentProviders(),
+		})
+	})
+	mux.HandleFunc("GET /api/agent-hub/providers/connections", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"providers": opts.agentProviderConnections(),
 		})
 	})
 	registerAgentRunRoutes(mux, projectsDir, agentRuns)

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -261,6 +261,54 @@ describe('api.listLocalAgentProviders', () => {
   });
 });
 
+describe('api.listAgentProviderConnections', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('fetches redacted API and enterprise provider connection metadata', async () => {
+    const response = {
+      providers: [{
+        id: 'openai-api',
+        name: 'OpenAI API',
+        family: 'openai',
+        category: 'api',
+        credential_mode: 'secret_store',
+        required_fields: ['model'],
+        secret_fields: ['api_key'],
+        capabilities: ['chat', 'tool_calling'],
+        cost_controls: ['monthly_budget'],
+        billing_hint: 'Billed through OpenAI Platform API usage.',
+        data_handling_hint: 'Prompts are sent to the configured endpoint.',
+        secret_storage_hint: 'Keys are stored through secret stores and never returned.',
+        setup_hint: 'Use for automation.',
+      }],
+    };
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(response), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(api.listAgentProviderConnections()).resolves.toEqual(response.providers);
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/agent-hub/providers/connections');
+  });
+
+  it('coerces null provider connection responses to an empty array', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response('null', {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    ));
+
+    await expect(api.listAgentProviderConnections()).resolves.toEqual([]);
+  });
+});
+
 describe('api.agentRuns', () => {
   afterEach(() => {
     vi.unstubAllGlobals();

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -261,6 +261,37 @@ export interface LocalAgentProvidersResponse {
   providers: LocalAgentProviderStatus[];
 }
 
+export type AgentProviderConnectionCategory =
+  | 'api'
+  | 'enterprise_gateway'
+  | (string & Record<never, never>);
+
+export type AgentProviderConnectionCredentialMode =
+  | 'secret_store'
+  | 'cloud_connection'
+  | 'enterprise_sso'
+  | (string & Record<never, never>);
+
+export interface AgentProviderConnectionDefinition {
+  id: string;
+  name: string;
+  family: string;
+  category: AgentProviderConnectionCategory;
+  credential_mode: AgentProviderConnectionCredentialMode;
+  required_fields: string[];
+  secret_fields: string[];
+  capabilities: string[];
+  cost_controls: string[];
+  billing_hint: string;
+  data_handling_hint: string;
+  secret_storage_hint: string;
+  setup_hint: string;
+}
+
+export interface AgentProviderConnectionsResponse {
+  providers: AgentProviderConnectionDefinition[];
+}
+
 export type AgentRunMode = 'read_only' | 'propose_only' | 'approved_execute';
 export type AgentRunStatus =
   | 'queued'
@@ -641,6 +672,14 @@ export const api = {
     const body = (await (await check(res)).json()) as unknown;
     if (!body || typeof body !== 'object') return [];
     const providers = (body as Partial<LocalAgentProvidersResponse>).providers;
+    return Array.isArray(providers) ? providers : [];
+  },
+
+  async listAgentProviderConnections(): Promise<AgentProviderConnectionDefinition[]> {
+    const res = await fetch(`${BASE}/api/agent-hub/providers/connections`);
+    const body = (await (await check(res)).json()) as unknown;
+    if (!body || typeof body !== 'object') return [];
+    const providers = (body as Partial<AgentProviderConnectionsResponse>).providers;
     return Array.isArray(providers) ? providers : [];
   },
 


### PR DESCRIPTION
## Summary
- add a metadata-only Agent Hub provider connection catalog for OpenAI API, Anthropic API, Azure OpenAI, Bedrock, Vertex AI, and enterprise gateways
- expose the catalog at GET /api/agent-hub/providers/connections
- add frontend API types/client method for the redacted connection metadata contract

## Security
- this PR does not store, resolve, or return provider credential values
- secret fields are field names only, so later secret-store wiring can keep keys server-side
- Bedrock and Vertex are modeled through Cloud Connection references rather than raw model-provider keys

## Validation
- GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/agentproviders ./internal/api
- npm test -- api.test.ts --run

Refs #106