### PR TITLE
Show Agent Hub provider connection catalog

### DIFF
--- a/web/src/components/Chat/ChatPanel.test.tsx
+++ b/web/src/components/Chat/ChatPanel.test.tsx
@@ -212,6 +212,21 @@ describe('ChatPanel', () => {
         secret_storage_hint: 'Use SSO or gateway-managed credentials; IaC Studio should not collect individual API keys for this path.',
         setup_hint: 'Use for private routing, SSO, audit, and platform-team rollouts.',
       },
+      {
+        id: 'minimal-openai',
+        name: 'Minimal OpenAI',
+        family: 'openai',
+        category: 'api',
+        credential_mode: 'secret_store',
+        required_fields: ['model'],
+        secret_fields: [],
+        capabilities: [],
+        cost_controls: [],
+        billing_hint: 'Billed through the configured platform account.',
+        data_handling_hint: 'Prompts follow the configured provider route.',
+        secret_storage_hint: 'Credentials stay in a secret store.',
+        setup_hint: 'Use for minimal API wiring.',
+      },
     ]);
 
     render(<ChatPanel {...baseProps} />);
@@ -226,9 +241,12 @@ describe('ChatPanel', () => {
     expect(within(catalog).getByText(/separate from ChatGPT subscriptions/)).toBeInTheDocument();
     expect(within(catalog).getByText(/configured OpenAI API endpoint/)).toBeInTheDocument();
     expect(within(catalog).getByText(/keys are never returned to the browser after save/)).toBeInTheDocument();
-    expect(within(catalog).getByText('Secret store')).toBeInTheDocument();
+    expect(within(catalog).getAllByText('Secret store').length).toBeGreaterThan(0);
     expect(within(catalog).getByText('monthly budget')).toBeInTheDocument();
     expect(within(catalog).getByText('Enterprise SSO')).toBeInTheDocument();
+    expect(within(catalog).getByLabelText('Minimal OpenAI connection')).toBeInTheDocument();
+    expect(within(catalog).queryByLabelText('Minimal OpenAI capabilities')).not.toBeInTheDocument();
+    expect(within(catalog).queryByLabelText('Minimal OpenAI cost controls')).not.toBeInTheDocument();
     expect(within(catalog).queryByText('sk-test-secret')).not.toBeInTheDocument();
   });
 

--- a/web/src/components/Chat/ChatPanel.test.tsx
+++ b/web/src/components/Chat/ChatPanel.test.tsx
@@ -6,6 +6,7 @@ import type { AgentRun, AgentRunSummary } from '../../api';
 import { ChatPanel } from './ChatPanel';
 
 const listLocalAgentProvidersMock = vi.hoisted(() => vi.fn());
+const listAgentProviderConnectionsMock = vi.hoisted(() => vi.fn());
 const listAgentRunsMock = vi.hoisted(() => vi.fn());
 const createAgentRunMock = vi.hoisted(() => vi.fn());
 const getAgentRunMock = vi.hoisted(() => vi.fn());
@@ -15,6 +16,7 @@ const decideAgentRunApprovalMock = vi.hoisted(() => vi.fn());
 vi.mock('../../api', () => ({
   api: {
     listLocalAgentProviders: listLocalAgentProvidersMock,
+    listAgentProviderConnections: listAgentProviderConnectionsMock,
     listAgentRuns: listAgentRunsMock,
     createAgentRun: createAgentRunMock,
     getAgentRun: getAgentRunMock,
@@ -79,6 +81,8 @@ describe('ChatPanel', () => {
   beforeEach(() => {
     listLocalAgentProvidersMock.mockReset();
     listLocalAgentProvidersMock.mockReturnValue(new Promise(() => {}));
+    listAgentProviderConnectionsMock.mockReset();
+    listAgentProviderConnectionsMock.mockReturnValue(new Promise(() => {}));
     listAgentRunsMock.mockReset();
     listAgentRunsMock.mockResolvedValue([]);
     createAgentRunMock.mockReset();
@@ -174,6 +178,71 @@ describe('ChatPanel', () => {
     expect(within(codexPanel).getAllByText('External login').length).toBeGreaterThan(0);
     expect(within(codexPanel).getByText('Version unknown')).toBeInTheDocument();
     expect(within(codexPanel).getAllByText('local cli').length).toBeGreaterThan(0);
+  });
+
+  it('shows API and enterprise provider connection catalog metadata without secret values', async () => {
+    listAgentProviderConnectionsMock.mockResolvedValueOnce([
+      {
+        id: 'openai-api',
+        name: 'OpenAI API',
+        family: 'openai',
+        category: 'api',
+        credential_mode: 'secret_store',
+        required_fields: ['model'],
+        secret_fields: ['api_key'],
+        capabilities: ['chat', 'code_editing', 'iac_assistance', 'tool_calling', 'vision'],
+        cost_controls: ['monthly_budget', 'per_run_token_limit', 'allowed_models'],
+        billing_hint: 'Billed through the OpenAI Platform API account, separate from ChatGPT subscriptions.',
+        data_handling_hint: 'Prompts and selected project context are sent to the configured OpenAI API endpoint.',
+        secret_storage_hint: 'Store API keys through IaC Studio secret stores; keys are never returned to the browser after save.',
+        setup_hint: 'Use for automation, hosted workflows, or centrally billed platform usage.',
+      },
+      {
+        id: 'enterprise-gateway',
+        name: 'Enterprise Gateway',
+        family: 'gateway',
+        category: 'enterprise_gateway',
+        credential_mode: 'enterprise_sso',
+        required_fields: ['endpoint', 'tenant'],
+        secret_fields: [],
+        capabilities: ['chat', 'code_editing', 'iac_assistance', 'tool_calling', 'audit_controls', 'policy_routing'],
+        cost_controls: ['workspace_budget', 'allowed_models', 'team_quota'],
+        billing_hint: "Billed through the organization's gateway or enterprise model platform.",
+        data_handling_hint: 'Prompts and selected project context follow the configured enterprise gateway routing policy.',
+        secret_storage_hint: 'Use SSO or gateway-managed credentials; IaC Studio should not collect individual API keys for this path.',
+        setup_hint: 'Use for private routing, SSO, audit, and platform-team rollouts.',
+      },
+    ]);
+
+    render(<ChatPanel {...baseProps} />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Codex' }));
+    const codexPanel = screen.getByRole('tabpanel', { name: 'Codex' });
+
+    await waitFor(() => {
+      expect(within(codexPanel).getByRole('region', { name: 'Codex API and enterprise connection catalog' })).toBeInTheDocument();
+    });
+    const catalog = within(codexPanel).getByRole('region', { name: 'Codex API and enterprise connection catalog' });
+    expect(within(catalog).getByLabelText('OpenAI API connection')).toBeInTheDocument();
+    expect(within(catalog).getByText(/separate from ChatGPT subscriptions/)).toBeInTheDocument();
+    expect(within(catalog).getByText(/configured OpenAI API endpoint/)).toBeInTheDocument();
+    expect(within(catalog).getByText(/keys are never returned to the browser after save/)).toBeInTheDocument();
+    expect(within(catalog).getByText('Secret store')).toBeInTheDocument();
+    expect(within(catalog).getByText('monthly budget')).toBeInTheDocument();
+    expect(within(catalog).getByText('Enterprise SSO')).toBeInTheDocument();
+    expect(within(catalog).queryByText('sk-test-secret')).not.toBeInTheDocument();
+  });
+
+  it('keeps provider panels usable when the connection catalog cannot load', async () => {
+    listAgentProviderConnectionsMock.mockRejectedValueOnce(new Error('catalog unavailable'));
+
+    render(<ChatPanel {...baseProps} />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Codex' }));
+    const codexPanel = screen.getByRole('tabpanel', { name: 'Codex' });
+
+    await flushAsyncUpdates();
+
+    expect(within(codexPanel).getByRole('button', { name: /Codex CLI/ })).toBeInTheDocument();
+    expect(within(codexPanel).queryByRole('region', { name: 'Codex API and enterprise connection catalog' })).not.toBeInTheDocument();
   });
 
   it('shows read-only details for the selected provider card', () => {

--- a/web/src/components/Chat/ChatPanel.test.tsx
+++ b/web/src/components/Chat/ChatPanel.test.tsx
@@ -191,7 +191,7 @@ describe('ChatPanel', () => {
         required_fields: ['model'],
         secret_fields: ['api_key'],
         capabilities: ['chat', 'code_editing', 'iac_assistance', 'tool_calling', 'vision'],
-        cost_controls: ['monthly_budget', 'per_run_token_limit', 'allowed_models'],
+        cost_controls: ['monthly_budget', 'per_run_token_limit', 'allowed_models', 'hard_stop'],
         billing_hint: 'Billed through the OpenAI Platform API account, separate from ChatGPT subscriptions.',
         data_handling_hint: 'Prompts and selected project context are sent to the configured OpenAI API endpoint.',
         secret_storage_hint: 'Store API keys through IaC Studio secret stores; keys are never returned to the browser after save.',
@@ -213,9 +213,9 @@ describe('ChatPanel', () => {
         setup_hint: 'Use for private routing, SSO, audit, and platform-team rollouts.',
       },
       {
-        id: 'minimal-openai',
-        name: 'Minimal OpenAI',
-        family: 'openai',
+        id: 'minimal-azure-openai',
+        name: 'Minimal Azure OpenAI',
+        family: 'azure_openai',
         category: 'api',
         credential_mode: 'secret_store',
         required_fields: ['model'],
@@ -237,16 +237,22 @@ describe('ChatPanel', () => {
       expect(within(codexPanel).getByRole('region', { name: 'Codex API and enterprise connection catalog' })).toBeInTheDocument();
     });
     const catalog = within(codexPanel).getByRole('region', { name: 'Codex API and enterprise connection catalog' });
-    expect(within(catalog).getByLabelText('OpenAI API connection')).toBeInTheDocument();
+    const openAiConnection = within(catalog).getByLabelText('OpenAI API connection');
+    expect(openAiConnection).toBeInTheDocument();
     expect(within(catalog).getByText(/separate from ChatGPT subscriptions/)).toBeInTheDocument();
     expect(within(catalog).getByText(/configured OpenAI API endpoint/)).toBeInTheDocument();
     expect(within(catalog).getByText(/keys are never returned to the browser after save/)).toBeInTheDocument();
     expect(within(catalog).getAllByText('Secret store').length).toBeGreaterThan(0);
-    expect(within(catalog).getByText('monthly budget')).toBeInTheDocument();
+    expect(within(catalog).getByText('azure openai')).toBeInTheDocument();
+    expect(within(openAiConnection).getByText('monthly budget')).toBeInTheDocument();
+    expect(within(openAiConnection).getByText('per run token limit')).toBeInTheDocument();
+    expect(within(openAiConnection).getByText('allowed models')).toBeInTheDocument();
+    expect(within(openAiConnection).getByText('hard stop')).toBeInTheDocument();
+    expect(within(openAiConnection).getByText('vision')).toBeInTheDocument();
     expect(within(catalog).getByText('Enterprise SSO')).toBeInTheDocument();
-    expect(within(catalog).getByLabelText('Minimal OpenAI connection')).toBeInTheDocument();
-    expect(within(catalog).queryByLabelText('Minimal OpenAI capabilities')).not.toBeInTheDocument();
-    expect(within(catalog).queryByLabelText('Minimal OpenAI cost controls')).not.toBeInTheDocument();
+    expect(within(catalog).getByLabelText('Minimal Azure OpenAI connection')).toBeInTheDocument();
+    expect(within(catalog).queryByLabelText('Minimal Azure OpenAI capabilities')).not.toBeInTheDocument();
+    expect(within(catalog).queryByLabelText('Minimal Azure OpenAI cost controls')).not.toBeInTheDocument();
     expect(within(catalog).queryByText('sk-test-secret')).not.toBeInTheDocument();
   });
 

--- a/web/src/components/Chat/ChatPanel.tsx
+++ b/web/src/components/Chat/ChatPanel.tsx
@@ -137,7 +137,7 @@ const PROVIDER_GROUPS: Record<ProviderTab, {
 };
 
 const PROVIDER_CONNECTION_FAMILIES: Record<ProviderTab, string[]> = {
-  codex: ['openai', 'gateway'],
+  codex: ['openai', 'azure_openai', 'gateway'],
   claude: ['anthropic', 'gateway'],
   gemini: ['vertex', 'gateway'],
   copilot: ['gateway'],
@@ -467,7 +467,7 @@ function ConnectionCatalog({
           </div>
           <div style={hubStyles.providerMeta}>
             <span style={hubStyles.badge}>{credentialLabel(provider.credential_mode)}</span>
-            <span style={hubStyles.badge}>{provider.family}</span>
+            <span style={hubStyles.badge}>{provider.family.replaceAll('_', ' ')}</span>
           </div>
           <div style={hubStyles.connectionHint}>{provider.billing_hint}</div>
           <div style={hubStyles.connectionHint}>{provider.data_handling_hint}</div>
@@ -488,14 +488,14 @@ function ConnectionCatalog({
           </div>
           {provider.capabilities.length > 0 && (
             <div style={hubStyles.providerCapabilityList} aria-label={`${provider.name} capabilities`}>
-              {provider.capabilities.slice(0, 4).map(capability => (
+              {provider.capabilities.map(capability => (
                 <span key={capability} style={hubStyles.badge}>{capability.replaceAll('_', ' ')}</span>
               ))}
             </div>
           )}
           {provider.cost_controls.length > 0 && (
             <div style={hubStyles.providerCapabilityList} aria-label={`${provider.name} cost controls`}>
-              {provider.cost_controls.slice(0, 3).map(control => (
+              {provider.cost_controls.map(control => (
                 <span key={control} style={hubStyles.badge}>{control.replaceAll('_', ' ')}</span>
               ))}
             </div>

--- a/web/src/components/Chat/ChatPanel.tsx
+++ b/web/src/components/Chat/ChatPanel.tsx
@@ -486,16 +486,20 @@ function ConnectionCatalog({
               </div>
             </div>
           </div>
-          <div style={hubStyles.providerCapabilityList} aria-label={`${provider.name} capabilities`}>
-            {provider.capabilities.slice(0, 4).map(capability => (
-              <span key={capability} style={hubStyles.badge}>{capability.replaceAll('_', ' ')}</span>
-            ))}
-          </div>
-          <div style={hubStyles.providerCapabilityList} aria-label={`${provider.name} cost controls`}>
-            {provider.cost_controls.slice(0, 3).map(control => (
-              <span key={control} style={hubStyles.badge}>{control.replaceAll('_', ' ')}</span>
-            ))}
-          </div>
+          {provider.capabilities.length > 0 && (
+            <div style={hubStyles.providerCapabilityList} aria-label={`${provider.name} capabilities`}>
+              {provider.capabilities.slice(0, 4).map(capability => (
+                <span key={capability} style={hubStyles.badge}>{capability.replaceAll('_', ' ')}</span>
+              ))}
+            </div>
+          )}
+          {provider.cost_controls.length > 0 && (
+            <div style={hubStyles.providerCapabilityList} aria-label={`${provider.name} cost controls`}>
+              {provider.cost_controls.slice(0, 3).map(control => (
+                <span key={control} style={hubStyles.badge}>{control.replaceAll('_', ' ')}</span>
+              ))}
+            </div>
+          )}
         </article>
       ))}
     </section>

--- a/web/src/components/Chat/ChatPanel.tsx
+++ b/web/src/components/Chat/ChatPanel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { CSSProperties, KeyboardEvent, ReactNode, RefObject } from 'react';
 
-import { api, type AgentRun, type AgentRunApprovalDecision, type AgentRunMode, type AgentRunSummary, type LocalAgentProviderStatus } from '../../api';
+import { api, type AgentProviderConnectionDefinition, type AgentRun, type AgentRunApprovalDecision, type AgentRunMode, type AgentRunSummary, type LocalAgentProviderStatus } from '../../api';
 import { S } from '../../styles';
 
 export interface ChatMessage {
@@ -136,6 +136,15 @@ const PROVIDER_GROUPS: Record<ProviderTab, {
   },
 };
 
+const PROVIDER_CONNECTION_FAMILIES: Record<ProviderTab, string[]> = {
+  codex: ['openai', 'gateway'],
+  claude: ['anthropic', 'gateway'],
+  gemini: ['vertex', 'gateway'],
+  copilot: ['gateway'],
+  local: [],
+  mcp: ['bedrock', 'vertex', 'gateway'],
+};
+
 const stateLabels: Record<ProviderState, string> = {
   available: 'Available',
   setup: 'Setup',
@@ -238,6 +247,10 @@ const hubStyles: Record<string, CSSProperties> = {
   providerActions: { display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', marginTop: 10 },
   providerActionButton: { borderWidth: 1, borderStyle: 'solid', borderColor: 'var(--border-soft)', borderRadius: 6, background: 'var(--bg-elev-3)', color: 'var(--text-muted)', cursor: 'not-allowed', fontSize: 11, fontFamily: 'DM Sans', fontWeight: 700, padding: '6px 9px', opacity: 0.72 },
   providerActionHint: { color: '#77847d', fontSize: 11 },
+  connectionCatalog: { gridColumn: '1 / -1', borderTop: '1px solid var(--border-soft)', paddingTop: 10, marginTop: 2, display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(210px, 1fr))', gap: 8 },
+  connectionCatalogIntro: { gridColumn: '1 / -1', color: 'var(--text-muted)', fontSize: 12, lineHeight: 1.45 },
+  connectionCard: { borderWidth: 1, borderStyle: 'solid', borderColor: 'var(--border-main)', borderRadius: 8, background: 'rgba(23, 29, 27, 0.68)', padding: 10, minWidth: 0 },
+  connectionHint: { color: '#77847d', fontSize: 11, lineHeight: 1.4, marginTop: 6, overflowWrap: 'anywhere' },
   runsPanel: { flex: 1, minHeight: 0, overflowY: 'auto', padding: 12, display: 'flex', flexDirection: 'column', gap: 8 },
   runsEmpty: { flex: 1, minHeight: 0, padding: 16, color: 'var(--text-muted)', fontSize: 12, lineHeight: 1.55 },
   runQueueCard: { borderWidth: 1, borderStyle: 'solid', borderColor: 'rgba(84, 184, 169, 0.32)', borderRadius: 8, background: 'rgba(84, 184, 169, 0.08)', padding: 10, minWidth: 0 },
@@ -280,7 +293,24 @@ function providerStatus(state: ProviderState) {
 function credentialLabel(mode: string) {
   if (mode === 'none') return 'No credentials';
   if (mode === 'external_login') return 'External login';
+  if (mode === 'secret_store') return 'Secret store';
+  if (mode === 'cloud_connection') return 'Cloud Connection';
+  if (mode === 'enterprise_sso') return 'Enterprise SSO';
   return mode;
+}
+
+function compactList(items: string[], empty = 'None') {
+  if (items.length === 0) return empty;
+  return items.map(item => item.replaceAll('_', ' ')).join(', ');
+}
+
+function connectionProvidersForTab(
+  tab: ProviderTab,
+  providers: AgentProviderConnectionDefinition[],
+) {
+  const families = PROVIDER_CONNECTION_FAMILIES[tab];
+  if (families.length === 0) return [];
+  return providers.filter(provider => families.includes(provider.family));
 }
 
 function providerDisplay(provider: Pick<ProviderDefinition, 'state' | 'note'>, status?: LocalAgentProviderStatus) {
@@ -411,20 +441,84 @@ function ProviderDetails({
   );
 }
 
+function ConnectionCatalog({
+  title,
+  providers,
+}: {
+  title: string;
+  providers: AgentProviderConnectionDefinition[];
+}) {
+  if (providers.length === 0) return null;
+  return (
+    <section
+      role="region"
+      aria-label={`${title} API and enterprise connection catalog`}
+      style={hubStyles.connectionCatalog}
+    >
+      <div style={hubStyles.connectionCatalogIntro}>
+        <strong style={{ color: 'var(--text-main)' }}>API and enterprise connections</strong>
+        <span> - read-only catalog metadata. Credentials stay behind local or external secret stores.</span>
+      </div>
+      {providers.map(provider => (
+        <article key={provider.id} style={hubStyles.connectionCard} aria-label={`${provider.name} connection`}>
+          <div style={hubStyles.providerHead}>
+            <span style={{ ...hubStyles.providerName, flex: 1 }}>{provider.name}</span>
+            <span style={hubStyles.badge}>{provider.category.replaceAll('_', ' ')}</span>
+          </div>
+          <div style={hubStyles.providerMeta}>
+            <span style={hubStyles.badge}>{credentialLabel(provider.credential_mode)}</span>
+            <span style={hubStyles.badge}>{provider.family}</span>
+          </div>
+          <div style={hubStyles.connectionHint}>{provider.billing_hint}</div>
+          <div style={hubStyles.connectionHint}>{provider.data_handling_hint}</div>
+          <div style={hubStyles.connectionHint}>{provider.secret_storage_hint}</div>
+          <div style={hubStyles.providerDetailsGrid}>
+            <div>
+              <div style={hubStyles.providerDetailLabel}>Required</div>
+              <div style={hubStyles.providerDetailValue} title={compactList(provider.required_fields)}>
+                {compactList(provider.required_fields)}
+              </div>
+            </div>
+            <div>
+              <div style={hubStyles.providerDetailLabel}>Secrets</div>
+              <div style={hubStyles.providerDetailValue} title={compactList(provider.secret_fields)}>
+                {compactList(provider.secret_fields)}
+              </div>
+            </div>
+          </div>
+          <div style={hubStyles.providerCapabilityList} aria-label={`${provider.name} capabilities`}>
+            {provider.capabilities.slice(0, 4).map(capability => (
+              <span key={capability} style={hubStyles.badge}>{capability.replaceAll('_', ' ')}</span>
+            ))}
+          </div>
+          <div style={hubStyles.providerCapabilityList} aria-label={`${provider.name} cost controls`}>
+            {provider.cost_controls.slice(0, 3).map(control => (
+              <span key={control} style={hubStyles.badge}>{control.replaceAll('_', ' ')}</span>
+            ))}
+          </div>
+        </article>
+      ))}
+    </section>
+  );
+}
+
 function ProviderGroup({
   tab,
   active,
   localProviders,
+  connectionProviders,
   selectedProviderName,
   onSelectProvider,
 }: {
   tab: ProviderTab;
   active: boolean;
   localProviders: Record<string, LocalAgentProviderStatus>;
+  connectionProviders: AgentProviderConnectionDefinition[];
   selectedProviderName?: string;
   onSelectProvider: (tab: ProviderTab, providerName: string) => void;
 }) {
   const group = PROVIDER_GROUPS[tab];
+  const visibleConnectionProviders = connectionProvidersForTab(tab, connectionProviders);
   const selectedProvider = group.providers.find(provider => provider.name === selectedProviderName) ?? group.providers[0];
   const selectedLocalStatus = selectedProvider.localProviderId ? localProviders[selectedProvider.localProviderId] : undefined;
   const selectedDisplay = providerDisplay(selectedProvider, selectedLocalStatus);
@@ -488,6 +582,7 @@ function ProviderGroup({
         displayNote={selectedDisplay.note}
         localStatus={selectedLocalStatus}
       />
+      <ConnectionCatalog title={group.title} providers={visibleConnectionProviders} />
     </div>
   );
 }
@@ -1010,6 +1105,7 @@ export function ChatPanel({
   const [activeTask, setActiveTask] = useState<typeof TASK_MODES[number]>(() => readStoredTaskMode());
   const [selectedProviders, setSelectedProviders] = useState<Partial<Record<ProviderTab, string>>>({});
   const [localProviders, setLocalProviders] = useState<Record<string, LocalAgentProviderStatus>>({});
+  const [connectionProviders, setConnectionProviders] = useState<AgentProviderConnectionDefinition[]>([]);
   const [agentRuns, setAgentRuns] = useState<AgentRunSummary[]>([]);
   const [agentRunsLoading, setAgentRunsLoading] = useState(false);
   const [agentRunsError, setAgentRunsError] = useState<string | null>(null);
@@ -1037,6 +1133,20 @@ export function ChatPanel({
       })
       .catch(() => {
         if (!cancelled) setLocalProviders({});
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    api.listAgentProviderConnections()
+      .then(providers => {
+        if (!cancelled) setConnectionProviders(providers);
+      })
+      .catch(() => {
+        if (!cancelled) setConnectionProviders([]);
       });
     return () => {
       cancelled = true;
@@ -1487,6 +1597,7 @@ export function ChatPanel({
               tab={tab}
               active={activeTab === tab}
               localProviders={localProviders}
+              connectionProviders={connectionProviders}
               selectedProviderName={selectedProviders[tab]}
               onSelectProvider={selectProvider}
             />


### PR DESCRIPTION
Refs #106

## Summary
- fetch the Agent Hub API/enterprise provider connection catalog in ChatPanel
- render read-only connection metadata in relevant provider tabs
- show billing, data-handling, credential mode, required fields, capabilities, and cost controls without adding credential entry or save flows

## Validation
- npm test -- ChatPanel.test.tsx --run
- npx eslint src/components/Chat/ChatPanel.tsx src/components/Chat/ChatPanel.test.tsx (warnings only from existing unused callback arg patterns)
- npm run build
- git diff --check