### PR TITLE
Add Agent Hub provider connection profiles

### DIFF
--- a/internal/agentproviderconnections/profiles.go
+++ b/internal/agentproviderconnections/profiles.go
@@ -1,0 +1,699 @@
+package agentproviderconnections
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/iac-studio/iac-studio/internal/cloudconnections"
+)
+
+const (
+	profilesFileName    = ".iac-studio-agent-provider-connections.json"
+	profilesKeyFileName = ".iac-studio-agent-provider-connections.key"
+)
+
+// Profile is the persisted form of an Agent Hub model-provider connection.
+// Secrets are stored through a cloudconnections.SecretStore and must never be
+// returned directly from API handlers.
+type Profile struct {
+	ID             string            `json:"id"`
+	Name           string            `json:"name"`
+	ProviderID     string            `json:"provider_id"`
+	CredentialMode string            `json:"credential_mode"`
+	Metadata       map[string]string `json:"metadata,omitempty"`
+	CostControls   map[string]string `json:"cost_controls,omitempty"`
+	Secrets        map[string]string `json:"secrets,omitempty"`
+	SecretStore    string            `json:"secret_store,omitempty"`
+	SecretRefs     map[string]string `json:"secret_refs,omitempty"`
+	CreatedAt      time.Time         `json:"created_at"`
+	UpdatedAt      time.Time         `json:"updated_at"`
+}
+
+// PublicProfile is safe to return to browsers. It preserves connection shape
+// and secret field presence without exposing secret values or external refs.
+type PublicProfile struct {
+	ID             string            `json:"id"`
+	Name           string            `json:"name"`
+	ProviderID     string            `json:"provider_id"`
+	CredentialMode string            `json:"credential_mode"`
+	Metadata       map[string]string `json:"metadata,omitempty"`
+	CostControls   map[string]string `json:"cost_controls,omitempty"`
+	SecretFields   []string          `json:"secret_fields,omitempty"`
+	SecretStore    string            `json:"secret_store,omitempty"`
+	CreatedAt      time.Time         `json:"created_at"`
+	UpdatedAt      time.Time         `json:"updated_at"`
+}
+
+// Option customizes an Agent Hub provider profile manager.
+type Option func(*Manager)
+
+// WithSecretStore registers an additional backend for profile secrets.
+func WithSecretStore(store cloudconnections.SecretStore) Option {
+	return func(m *Manager) {
+		m.registerSecretStore(store)
+	}
+}
+
+// Manager persists Agent Hub provider connection profiles.
+type Manager struct {
+	path           string
+	secretStores   map[string]cloudconnections.SecretStore
+	secretStoresMu sync.RWMutex
+	mu             sync.Mutex
+}
+
+func NewManager(projectsDir string, opts ...Option) *Manager {
+	manager := &Manager{
+		path:         filepath.Join(projectsDir, profilesFileName),
+		secretStores: map[string]cloudconnections.SecretStore{},
+	}
+	manager.registerSecretStore(cloudconnections.NewLocalEncryptedFileSecretStore(filepath.Join(projectsDir, profilesKeyFileName)))
+	for _, opt := range opts {
+		if opt != nil {
+			opt(manager)
+		}
+	}
+	return manager
+}
+
+func (m *Manager) List() ([]PublicProfile, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	profiles, needsMigration, err := m.loadProfilesUnlocked(false)
+	if err != nil {
+		return nil, err
+	}
+	if needsMigration {
+		if err := m.saveProfilesUnlocked(profiles); err != nil {
+			return nil, err
+		}
+	}
+	out := make([]PublicProfile, 0, len(profiles))
+	for _, profile := range profiles {
+		out = append(out, publicProfile(profile))
+	}
+	return out, nil
+}
+
+func (m *Manager) Get(id string) (PublicProfile, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	profiles, needsMigration, err := m.loadProfilesUnlocked(false)
+	if err != nil {
+		return PublicProfile{}, err
+	}
+	if needsMigration {
+		if err := m.saveProfilesUnlocked(profiles); err != nil {
+			return PublicProfile{}, err
+		}
+	}
+	for _, profile := range profiles {
+		if profile.ID == strings.TrimSpace(id) {
+			return publicProfile(profile), nil
+		}
+	}
+	return PublicProfile{}, os.ErrNotExist
+}
+
+// GetForUse resolves registered external refs for future execution paths. It is
+// not used by the current read-only API.
+func (m *Manager) GetForUse(id string) (*Profile, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	profiles, _, err := m.loadProfilesUnlocked(true)
+	if err != nil {
+		return nil, err
+	}
+	for index := range profiles {
+		if profiles[index].ID == strings.TrimSpace(id) {
+			return cloneProfile(profiles[index]), nil
+		}
+	}
+	return nil, os.ErrNotExist
+}
+
+func (m *Manager) Save(input Profile) (PublicProfile, error) {
+	if err := m.normalizeAndValidate(&input); err != nil {
+		return PublicProfile{}, err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	profiles, _, err := m.loadProfilesUnlocked(false)
+	if err != nil {
+		return PublicProfile{}, err
+	}
+
+	now := time.Now().UTC()
+	replaced := false
+	if input.ID == "" {
+		input.ID = newID()
+		input.CreatedAt = now
+	} else {
+		input.CreatedAt = now
+		for index, existing := range profiles {
+			if existing.ID != input.ID {
+				continue
+			}
+			input.CreatedAt = existing.CreatedAt
+			if input.SecretStore == "" {
+				input.SecretStore = existing.SecretStore
+			}
+			input.Secrets = mergeSecrets(existing.Secrets, input.Secrets)
+			if input.SecretStore == "" || input.SecretStore == existing.SecretStore {
+				input.SecretRefs = mergeRefs(existing.SecretRefs, input.SecretRefs)
+			}
+			profiles[index] = input
+			replaced = true
+			break
+		}
+	}
+	input.UpdatedAt = now
+	applyLocalSecretReferenceDefaults(&input)
+
+	if !replaced {
+		profiles = append(profiles, input)
+	} else {
+		for index := range profiles {
+			if profiles[index].ID == input.ID {
+				profiles[index] = input
+				break
+			}
+		}
+	}
+
+	if err := m.saveProfilesUnlocked(profiles); err != nil {
+		return PublicProfile{}, err
+	}
+	return publicProfile(input), nil
+}
+
+func (m *Manager) Delete(id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	profiles, _, err := m.loadProfilesUnlocked(false)
+	if err != nil {
+		return err
+	}
+	next := profiles[:0]
+	found := false
+	for _, profile := range profiles {
+		if profile.ID == strings.TrimSpace(id) {
+			found = true
+			if err := m.deleteProfileSecrets(profile); err != nil {
+				return err
+			}
+			continue
+		}
+		next = append(next, profile)
+	}
+	if !found {
+		return os.ErrNotExist
+	}
+	return m.saveProfilesUnlocked(next)
+}
+
+func (m *Manager) loadProfilesUnlocked(resolveSecretRefs bool) ([]Profile, bool, error) {
+	profiles, err := m.readProfilesUnlocked()
+	if err != nil {
+		return nil, false, err
+	}
+	needsMigration, err := m.loadProfileSecrets(profiles, resolveSecretRefs)
+	if err != nil {
+		return nil, false, err
+	}
+	return profiles, needsMigration, nil
+}
+
+func (m *Manager) readProfilesUnlocked() ([]Profile, error) {
+	data, err := os.ReadFile(m.path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return []Profile{}, nil
+		}
+		return nil, fmt.Errorf("read agent provider connections: %w", err)
+	}
+	var profiles []Profile
+	if err := json.Unmarshal(data, &profiles); err != nil {
+		return nil, fmt.Errorf("parse agent provider connections: %w", err)
+	}
+	return profiles, nil
+}
+
+func (m *Manager) saveProfilesUnlocked(profiles []Profile) error {
+	if err := os.MkdirAll(filepath.Dir(m.path), 0o755); err != nil {
+		return fmt.Errorf("create agent provider connections directory: %w", err)
+	}
+	persisted, err := m.storeProfileSecrets(profiles)
+	if err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(persisted, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal agent provider connections: %w", err)
+	}
+	if err := writeFileAtomic(m.path, data, 0o600); err != nil {
+		return fmt.Errorf("write agent provider connections: %w", err)
+	}
+	return nil
+}
+
+func (m *Manager) storeProfileSecrets(profiles []Profile) ([]Profile, error) {
+	out := make([]Profile, 0, len(profiles))
+	for _, profile := range profiles {
+		next := profile
+		next.Metadata = cloneMap(profile.Metadata)
+		next.CostControls = cloneMap(profile.CostControls)
+		next.Secrets = cloneMap(profile.Secrets)
+		next.SecretRefs = cloneMap(profile.SecretRefs)
+		next.SecretStore = strings.TrimSpace(next.SecretStore)
+		store, ok := m.secretStoreFor(next.SecretStore)
+		if !ok {
+			if hasNonEmptySecrets(next.Secrets) {
+				return nil, fmt.Errorf("agent provider connection %s uses unsupported secret store %q with local secret values", profileLabel(next), next.SecretStore)
+			}
+			out = append(out, next)
+			continue
+		}
+		if len(next.Secrets) == 0 {
+			out = append(out, next)
+			continue
+		}
+		stored, err := store.Save(context.Background(), secretScope(next), next.Secrets)
+		if err != nil {
+			return nil, err
+		}
+		next.Secrets = stored.Values
+		next.SecretRefs = mergeRefs(next.SecretRefs, stored.Refs)
+		if len(next.Secrets) > 0 || len(next.SecretRefs) > 0 {
+			next.SecretStore = store.Kind()
+		}
+		applyLocalSecretReferenceDefaults(&next)
+		out = append(out, next)
+	}
+	return out, nil
+}
+
+func (m *Manager) loadProfileSecrets(profiles []Profile, resolveSecretRefs bool) (bool, error) {
+	needsMigration := false
+	for index := range profiles {
+		profiles[index].SecretStore = strings.TrimSpace(profiles[index].SecretStore)
+		store, ok := m.secretStoreFor(profiles[index].SecretStore)
+		if !ok {
+			if hasNonEmptySecrets(profiles[index].Secrets) {
+				return false, fmt.Errorf("agent provider connection %s uses unsupported secret store %q with local secret values", profileLabel(profiles[index]), profiles[index].SecretStore)
+			}
+			continue
+		}
+		hasStoredValues := len(profiles[index].Secrets) > 0
+		hasResolvableRefs := resolveSecretRefs && store.Kind() != cloudconnections.SecretStoreLocalEncrypted && len(profiles[index].SecretRefs) > 0
+		if !hasStoredValues && !hasResolvableRefs {
+			continue
+		}
+		loaded, err := store.Load(context.Background(), secretScope(profiles[index]), cloudconnections.StoredSecrets{
+			Values: profiles[index].Secrets,
+			Refs:   profiles[index].SecretRefs,
+		})
+		if err != nil {
+			return false, err
+		}
+		profiles[index].Secrets = loaded.Values
+		if loaded.NeedsMigration && hasNonEmptySecrets(loaded.Values) {
+			needsMigration = true
+		}
+	}
+	return needsMigration, nil
+}
+
+func (m *Manager) deleteProfileSecrets(profile Profile) error {
+	profile.SecretStore = strings.TrimSpace(profile.SecretStore)
+	store, ok := m.secretStoreFor(profile.SecretStore)
+	if !ok {
+		if hasNonEmptySecrets(profile.Secrets) {
+			return fmt.Errorf("agent provider connection %s uses unsupported secret store %q with local secret values", profileLabel(profile), profile.SecretStore)
+		}
+		if hasNonEmptySecrets(profile.SecretRefs) {
+			return fmt.Errorf("agent provider connection %s uses unsupported secret store %q with external secret refs; register the store before deleting", profileLabel(profile), profile.SecretStore)
+		}
+		return nil
+	}
+	if len(profile.Secrets) == 0 && len(profile.SecretRefs) == 0 {
+		return nil
+	}
+	return store.Delete(context.Background(), secretScope(profile), cloudconnections.StoredSecrets{
+		Values: cloneMap(profile.Secrets),
+		Refs:   cloneMap(profile.SecretRefs),
+	})
+}
+
+func (m *Manager) normalizeAndValidate(profile *Profile) error {
+	profile.ID = strings.TrimSpace(profile.ID)
+	profile.Name = strings.TrimSpace(profile.Name)
+	profile.ProviderID = strings.TrimSpace(profile.ProviderID)
+	profile.CredentialMode = strings.TrimSpace(profile.CredentialMode)
+	profile.SecretStore = strings.TrimSpace(profile.SecretStore)
+	profile.Metadata = trimMap(profile.Metadata)
+	profile.CostControls = trimMap(profile.CostControls)
+	profile.Secrets = trimMapWithoutMasked(profile.Secrets)
+	profile.SecretRefs = trimMap(profile.SecretRefs)
+
+	if profile.ID != "" && !isSafeToken(profile.ID) {
+		return errors.New("connection id contains unsupported characters")
+	}
+	if profile.Name == "" {
+		return errors.New("connection name is required")
+	}
+	if profile.ProviderID == "" {
+		return errors.New("provider_id is required")
+	}
+	if !isSafeToken(profile.ProviderID) {
+		return errors.New("provider_id contains unsupported characters")
+	}
+	if profile.CredentialMode == "" {
+		return errors.New("credential_mode is required")
+	}
+	if !isSafeToken(profile.CredentialMode) {
+		return errors.New("credential_mode contains unsupported characters")
+	}
+	for key := range profile.Metadata {
+		if !isSafeFieldKey(key) {
+			return fmt.Errorf("metadata field %q contains unsupported characters", key)
+		}
+	}
+	for key := range profile.CostControls {
+		if !isSafeFieldKey(key) {
+			return fmt.Errorf("cost control field %q contains unsupported characters", key)
+		}
+	}
+	for key := range profile.Secrets {
+		if !isSafeFieldKey(key) {
+			return fmt.Errorf("secret field %q contains unsupported characters", key)
+		}
+	}
+	for key := range profile.SecretRefs {
+		if !isSafeFieldKey(key) {
+			return fmt.Errorf("secret ref field %q contains unsupported characters", key)
+		}
+	}
+	if profile.SecretStore != "" && !m.supportsSecretStore(profile.SecretStore) && hasNonEmptySecrets(profile.Secrets) {
+		return fmt.Errorf("unsupported secret store %q", profile.SecretStore)
+	}
+	return nil
+}
+
+func (m *Manager) registerSecretStore(store cloudconnections.SecretStore) {
+	if store == nil {
+		return
+	}
+	kind := strings.TrimSpace(store.Kind())
+	if kind == "" {
+		return
+	}
+	m.secretStoresMu.Lock()
+	defer m.secretStoresMu.Unlock()
+	m.secretStores[kind] = store
+}
+
+func (m *Manager) supportsSecretStore(kind string) bool {
+	_, ok := m.secretStoreFor(kind)
+	return ok
+}
+
+func (m *Manager) secretStoreFor(kind string) (cloudconnections.SecretStore, bool) {
+	kind = strings.TrimSpace(kind)
+	if kind == "" {
+		kind = cloudconnections.SecretStoreLocalEncrypted
+	}
+	m.secretStoresMu.RLock()
+	defer m.secretStoresMu.RUnlock()
+	store, ok := m.secretStores[kind]
+	return store, ok
+}
+
+func secretScope(profile Profile) cloudconnections.SecretScope {
+	return cloudconnections.SecretScope{
+		ConnectionID: profile.ID,
+		Provider:     profile.ProviderID,
+		AuthMethod:   profile.CredentialMode,
+	}
+}
+
+func publicProfile(profile Profile) PublicProfile {
+	secretStore := strings.TrimSpace(profile.SecretStore)
+	if secretStore == "" && len(profile.Secrets) > 0 {
+		secretStore = cloudconnections.SecretStoreLocalEncrypted
+	}
+	return PublicProfile{
+		ID:             profile.ID,
+		Name:           profile.Name,
+		ProviderID:     profile.ProviderID,
+		CredentialMode: profile.CredentialMode,
+		Metadata:       cloneMap(profile.Metadata),
+		CostControls:   cloneMap(profile.CostControls),
+		SecretFields:   presentSecretFields(profile.Secrets, profile.SecretRefs),
+		SecretStore:    secretStore,
+		CreatedAt:      profile.CreatedAt,
+		UpdatedAt:      profile.UpdatedAt,
+	}
+}
+
+func applyLocalSecretReferenceDefaults(profile *Profile) {
+	if profile.SecretStore != "" && profile.SecretStore != cloudconnections.SecretStoreLocalEncrypted {
+		return
+	}
+	if len(profile.Secrets) == 0 {
+		if len(profile.SecretRefs) == 0 {
+			profile.SecretStore = ""
+		}
+		return
+	}
+	profile.SecretStore = cloudconnections.SecretStoreLocalEncrypted
+	refs := cloneMap(profile.SecretRefs)
+	if refs == nil {
+		refs = map[string]string{}
+	}
+	for key, value := range profile.Secrets {
+		if strings.TrimSpace(value) != "" {
+			refs[key] = "local://agent-provider-connections/" + profile.ID + "/" + key
+		}
+	}
+	profile.SecretRefs = refs
+}
+
+func profileLabel(profile Profile) string {
+	if profile.Name == "" {
+		return fmt.Sprintf("%q", profile.ID)
+	}
+	return fmt.Sprintf("%q (%s)", profile.ID, profile.Name)
+}
+
+func presentSecretFields(secrets, refs map[string]string) []string {
+	fields := map[string]bool{}
+	for key, value := range secrets {
+		if strings.TrimSpace(value) != "" {
+			fields[key] = true
+		}
+	}
+	for key, value := range refs {
+		if strings.TrimSpace(value) != "" {
+			fields[key] = true
+		}
+	}
+	out := make([]string, 0, len(fields))
+	for field := range fields {
+		out = append(out, field)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func mergeSecrets(existing, submitted map[string]string) map[string]string {
+	out := cloneMap(existing)
+	for key, value := range submitted {
+		if value = strings.TrimSpace(value); value != "" && !isMasked(value) {
+			if out == nil {
+				out = map[string]string{}
+			}
+			out[key] = value
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func mergeRefs(existing, submitted map[string]string) map[string]string {
+	out := cloneMap(existing)
+	for key, value := range submitted {
+		if value = strings.TrimSpace(value); value != "" {
+			if out == nil {
+				out = map[string]string{}
+			}
+			out[key] = value
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func trimMap(values map[string]string) map[string]string {
+	out := map[string]string{}
+	for key, value := range values {
+		if key = strings.TrimSpace(key); key != "" {
+			if value = strings.TrimSpace(value); value != "" {
+				out[key] = value
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func trimMapWithoutMasked(values map[string]string) map[string]string {
+	out := map[string]string{}
+	for key, value := range values {
+		if key = strings.TrimSpace(key); key != "" {
+			if value = strings.TrimSpace(value); value != "" && !isMasked(value) {
+				out[key] = value
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func cloneMap(values map[string]string) map[string]string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(values))
+	for key, value := range values {
+		out[key] = value
+	}
+	return out
+}
+
+func cloneProfile(profile Profile) *Profile {
+	copied := profile
+	copied.Metadata = cloneMap(profile.Metadata)
+	copied.CostControls = cloneMap(profile.CostControls)
+	copied.Secrets = cloneMap(profile.Secrets)
+	copied.SecretRefs = cloneMap(profile.SecretRefs)
+	return &copied
+}
+
+func hasNonEmptySecrets(secrets map[string]string) bool {
+	for _, value := range secrets {
+		if strings.TrimSpace(value) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func isMasked(value string) bool {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return false
+	}
+	for _, r := range value {
+		if r != '*' {
+			return false
+		}
+	}
+	return true
+}
+
+func isSafeToken(value string) bool {
+	if value == "" || len(value) > 128 {
+		return false
+	}
+	for _, r := range value {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func isSafeFieldKey(value string) bool {
+	if value == "" || len(value) > 128 {
+		return false
+	}
+	for _, r := range value {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' || r == '.' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func newID() string {
+	var bytes [8]byte
+	if _, err := rand.Read(bytes[:]); err != nil {
+		return fmt.Sprintf("apc_%d", time.Now().UnixNano())
+	}
+	return "apc_" + hex.EncodeToString(bytes[:])
+}
+
+func writeFileAtomic(path string, data []byte, mode os.FileMode) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	tmpFile, err := os.CreateTemp(dir, filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmpFile.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if _, err := tmpFile.Write(data); err != nil {
+		_ = tmpFile.Close()
+		return err
+	}
+	if err := tmpFile.Chmod(mode); err != nil {
+		_ = tmpFile.Close()
+		return err
+	}
+	if err := tmpFile.Sync(); err != nil {
+		_ = tmpFile.Close()
+		return err
+	}
+	if err := tmpFile.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return err
+	}
+	cleanup = false
+	return nil
+}

--- a/internal/agentproviderconnections/profiles.go
+++ b/internal/agentproviderconnections/profiles.go
@@ -22,6 +22,8 @@ const (
 	profilesKeyFileName = ".iac-studio-agent-provider-connections.key"
 )
 
+var ErrInvalidProfile = errors.New("invalid agent provider connection")
+
 // Profile is the persisted form of an Agent Hub model-provider connection.
 // Secrets are stored through a cloudconnections.SecretStore and must never be
 // returned directly from API handlers.
@@ -147,7 +149,7 @@ func (m *Manager) GetForUse(id string) (*Profile, error) {
 
 func (m *Manager) Save(input Profile) (PublicProfile, error) {
 	if err := m.normalizeAndValidate(&input); err != nil {
-		return PublicProfile{}, err
+		return PublicProfile{}, fmt.Errorf("%w: %v", ErrInvalidProfile, err)
 	}
 
 	m.mu.Lock()
@@ -621,7 +623,7 @@ func isMasked(value string) bool {
 		return false
 	}
 	for _, r := range value {
-		if r != '*' {
+		if r != '*' && r != '\u2022' {
 			return false
 		}
 	}

--- a/internal/agentproviderconnections/profiles.go
+++ b/internal/agentproviderconnections/profiles.go
@@ -159,7 +159,7 @@ func (m *Manager) Save(input Profile) (PublicProfile, error) {
 	}
 
 	now := time.Now().UTC()
-	replaced := false
+	replaceIndex := -1
 	if input.ID == "" {
 		input.ID = newID()
 		input.CreatedAt = now
@@ -177,15 +177,16 @@ func (m *Manager) Save(input Profile) (PublicProfile, error) {
 			if input.SecretStore == "" || input.SecretStore == existing.SecretStore {
 				input.SecretRefs = mergeRefs(existing.SecretRefs, input.SecretRefs)
 			}
-			profiles[index] = input
-			replaced = true
+			replaceIndex = index
 			break
 		}
 	}
 	input.UpdatedAt = now
 	applyLocalSecretReferenceDefaults(&input)
 
-	if !replaced {
+	if replaceIndex >= 0 {
+		profiles[replaceIndex] = input
+	} else {
 		profiles = append(profiles, input)
 	}
 
@@ -401,6 +402,14 @@ func (m *Manager) normalizeAndValidate(profile *Profile) error {
 	for key := range profile.SecretRefs {
 		if !isSafeFieldKey(key) {
 			return fmt.Errorf("secret ref field %q contains unsupported characters", key)
+		}
+	}
+	if len(profile.SecretRefs) > 0 {
+		if profile.SecretStore == "" {
+			return errors.New("secret_store is required when secret_refs are provided")
+		}
+		if profile.SecretStore == cloudconnections.SecretStoreLocalEncrypted {
+			return errors.New("local encrypted secret refs require stored secret values")
 		}
 	}
 	if profile.SecretStore != "" && !m.supportsSecretStore(profile.SecretStore) && hasNonEmptySecrets(profile.Secrets) {

--- a/internal/agentproviderconnections/profiles.go
+++ b/internal/agentproviderconnections/profiles.go
@@ -187,13 +187,6 @@ func (m *Manager) Save(input Profile) (PublicProfile, error) {
 
 	if !replaced {
 		profiles = append(profiles, input)
-	} else {
-		for index := range profiles {
-			if profiles[index].ID == input.ID {
-				profiles[index] = input
-				break
-			}
-		}
 	}
 
 	if err := m.saveProfilesUnlocked(profiles); err != nil {
@@ -695,5 +688,15 @@ func writeFileAtomic(path string, data []byte, mode os.FileMode) error {
 		return err
 	}
 	cleanup = false
+	syncDirBestEffort(dir)
 	return nil
+}
+
+func syncDirBestEffort(dir string) {
+	handle, err := os.Open(dir)
+	if err != nil {
+		return
+	}
+	defer func() { _ = handle.Close() }()
+	_ = handle.Sync()
 }

--- a/internal/agentproviderconnections/profiles_test.go
+++ b/internal/agentproviderconnections/profiles_test.go
@@ -160,6 +160,43 @@ func TestSavePersistsUpdatedFieldsAfterPartialUpdate(t *testing.T) {
 	}
 }
 
+func TestSaveIgnoresBulletMaskedSecretsOnPartialUpdate(t *testing.T) {
+	root := t.TempDir()
+	manager := NewManager(root)
+
+	created, err := manager.Save(Profile{
+		Name:           "OpenAI automation",
+		ProviderID:     "openai-api",
+		CredentialMode: "secret_store",
+		Secrets: map[string]string{
+			"api_key": "sk-original",
+		},
+	})
+	if err != nil {
+		t.Fatalf("save profile: %v", err)
+	}
+
+	if _, err := manager.Save(Profile{
+		ID:             created.ID,
+		Name:           "OpenAI automation",
+		ProviderID:     "openai-api",
+		CredentialMode: "secret_store",
+		Secrets: map[string]string{
+			"api_key": "\u2022\u2022\u2022\u2022",
+		},
+	}); err != nil {
+		t.Fatalf("partial update with masked secret: %v", err)
+	}
+
+	stored, err := manager.GetForUse(created.ID)
+	if err != nil {
+		t.Fatalf("GetForUse: %v", err)
+	}
+	if got := stored.Secrets["api_key"]; got != "sk-original" {
+		t.Fatalf("masked placeholder should not replace existing secret, got %q", got)
+	}
+}
+
 func TestSaveRejectsSecretRefsWithoutExplicitExternalStore(t *testing.T) {
 	manager := NewManager(t.TempDir())
 

--- a/internal/agentproviderconnections/profiles_test.go
+++ b/internal/agentproviderconnections/profiles_test.go
@@ -1,0 +1,165 @@
+package agentproviderconnections
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/iac-studio/iac-studio/internal/cloudconnections"
+)
+
+func TestSaveStoresLocalSecretsEncryptedAndReturnsRedactedProfile(t *testing.T) {
+	root := t.TempDir()
+	manager := NewManager(root)
+
+	profile, err := manager.Save(Profile{
+		Name:           "OpenAI automation",
+		ProviderID:     "openai-api",
+		CredentialMode: "secret_store",
+		Metadata: map[string]string{
+			"model": "gpt-5",
+		},
+		CostControls: map[string]string{
+			"monthly_budget": "100",
+		},
+		Secrets: map[string]string{
+			"api_key": "sk-test-secret",
+		},
+	})
+	if err != nil {
+		t.Fatalf("save profile: %v", err)
+	}
+	if profile.ID == "" {
+		t.Fatal("profile should include generated id")
+	}
+	if profile.SecretStore != cloudconnections.SecretStoreLocalEncrypted {
+		t.Fatalf("secret store = %q", profile.SecretStore)
+	}
+	if !slices.Equal(profile.SecretFields, []string{"api_key"}) {
+		t.Fatalf("secret fields = %#v", profile.SecretFields)
+	}
+
+	data, err := os.ReadFile(filepath.Join(root, profilesFileName))
+	if err != nil {
+		t.Fatalf("read profiles file: %v", err)
+	}
+	if strings.Contains(string(data), "sk-test-secret") {
+		t.Fatalf("plaintext secret leaked into profile store: %s", string(data))
+	}
+	if !strings.Contains(string(data), "iacstudio:v1:") {
+		t.Fatalf("expected encrypted secret envelope in profile store: %s", string(data))
+	}
+}
+
+func TestSavePreservesExternalSecretRefsOnPartialUpdate(t *testing.T) {
+	root := t.TempDir()
+	manager := NewManager(root)
+
+	created, err := manager.Save(Profile{
+		Name:           "Anthropic team gateway",
+		ProviderID:     "anthropic-api",
+		CredentialMode: "secret_store",
+		Metadata: map[string]string{
+			"model": "claude-sonnet",
+		},
+		SecretStore: "vault",
+		SecretRefs: map[string]string{
+			"api_key": "vault://llm/anthropic/api_key",
+		},
+	})
+	if err != nil {
+		t.Fatalf("save external ref profile: %v", err)
+	}
+
+	updated, err := manager.Save(Profile{
+		ID:             created.ID,
+		Name:           "Anthropic team gateway",
+		ProviderID:     "anthropic-api",
+		CredentialMode: "secret_store",
+		Metadata: map[string]string{
+			"model": "claude-opus",
+		},
+		CostControls: map[string]string{
+			"monthly_budget": "250",
+		},
+	})
+	if err != nil {
+		t.Fatalf("partial update profile: %v", err)
+	}
+	if updated.SecretStore != "vault" {
+		t.Fatalf("secret store = %q", updated.SecretStore)
+	}
+	if !slices.Equal(updated.SecretFields, []string{"api_key"}) {
+		t.Fatalf("secret fields = %#v", updated.SecretFields)
+	}
+
+	data, err := os.ReadFile(filepath.Join(root, profilesFileName))
+	if err != nil {
+		t.Fatalf("read profiles file: %v", err)
+	}
+	if !strings.Contains(string(data), "vault://llm/anthropic/api_key") {
+		t.Fatalf("external secret ref was not preserved: %s", string(data))
+	}
+}
+
+func TestSaveUsesRegisteredExternalSecretStore(t *testing.T) {
+	root := t.TempDir()
+	manager := NewManager(root, WithSecretStore(fakeSecretStore{kind: "vault"}))
+
+	profile, err := manager.Save(Profile{
+		Name:           "OpenAI team key",
+		ProviderID:     "openai-api",
+		CredentialMode: "secret_store",
+		SecretStore:    "vault",
+		Secrets: map[string]string{
+			"api_key": "sk-external-secret",
+		},
+	})
+	if err != nil {
+		t.Fatalf("save profile with external store: %v", err)
+	}
+	if profile.SecretStore != "vault" {
+		t.Fatalf("secret store = %q", profile.SecretStore)
+	}
+	if !slices.Equal(profile.SecretFields, []string{"api_key"}) {
+		t.Fatalf("secret fields = %#v", profile.SecretFields)
+	}
+
+	data, err := os.ReadFile(filepath.Join(root, profilesFileName))
+	if err != nil {
+		t.Fatalf("read profiles file: %v", err)
+	}
+	if strings.Contains(string(data), "sk-external-secret") {
+		t.Fatalf("plaintext external secret leaked into profile store: %s", string(data))
+	}
+	if !strings.Contains(string(data), "vault://"+profile.ID+"/api_key") {
+		t.Fatalf("external secret ref was not persisted: %s", string(data))
+	}
+}
+
+type fakeSecretStore struct {
+	kind string
+}
+
+func (s fakeSecretStore) Kind() string {
+	return s.kind
+}
+
+func (s fakeSecretStore) Save(_ context.Context, scope cloudconnections.SecretScope, secrets map[string]string) (cloudconnections.StoredSecrets, error) {
+	refs := map[string]string{}
+	for key := range secrets {
+		refs[key] = s.kind + "://" + scope.ConnectionID + "/" + key
+	}
+	return cloudconnections.StoredSecrets{Refs: refs}, nil
+}
+
+func (s fakeSecretStore) Load(_ context.Context, _ cloudconnections.SecretScope, _ cloudconnections.StoredSecrets) (cloudconnections.LoadedSecrets, error) {
+	return cloudconnections.LoadedSecrets{}, nil
+}
+
+func (s fakeSecretStore) Delete(context.Context, cloudconnections.SecretScope, cloudconnections.StoredSecrets) error {
+	return nil
+}

--- a/internal/agentproviderconnections/profiles_test.go
+++ b/internal/agentproviderconnections/profiles_test.go
@@ -2,6 +2,7 @@ package agentproviderconnections
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"slices"
@@ -102,6 +103,79 @@ func TestSavePreservesExternalSecretRefsOnPartialUpdate(t *testing.T) {
 	}
 	if !strings.Contains(string(data), "vault://llm/anthropic/api_key") {
 		t.Fatalf("external secret ref was not preserved: %s", string(data))
+	}
+}
+
+func TestSavePersistsUpdatedFieldsAfterPartialUpdate(t *testing.T) {
+	root := t.TempDir()
+	manager := NewManager(root)
+
+	created, err := manager.Save(Profile{
+		Name:           "OpenAI automation",
+		ProviderID:     "openai-api",
+		CredentialMode: "secret_store",
+		Secrets: map[string]string{
+			"api_key": "sk-original",
+		},
+	})
+	if err != nil {
+		t.Fatalf("save profile: %v", err)
+	}
+
+	updated, err := manager.Save(Profile{
+		ID:             created.ID,
+		Name:           "OpenAI automation",
+		ProviderID:     "openai-api",
+		CredentialMode: "secret_store",
+		Metadata: map[string]string{
+			"model": "gpt-5",
+		},
+	})
+	if err != nil {
+		t.Fatalf("partial update profile: %v", err)
+	}
+	if updated.UpdatedAt.IsZero() {
+		t.Fatal("updated response should include UpdatedAt")
+	}
+
+	data, err := os.ReadFile(filepath.Join(root, profilesFileName))
+	if err != nil {
+		t.Fatalf("read profiles file: %v", err)
+	}
+	var persisted []Profile
+	if err := json.Unmarshal(data, &persisted); err != nil {
+		t.Fatalf("parse persisted profiles: %v", err)
+	}
+	if len(persisted) != 1 {
+		t.Fatalf("persisted profiles = %#v", persisted)
+	}
+	if !persisted[0].UpdatedAt.Equal(updated.UpdatedAt) {
+		t.Fatalf("persisted UpdatedAt = %s, response UpdatedAt = %s", persisted[0].UpdatedAt, updated.UpdatedAt)
+	}
+	if persisted[0].SecretStore != cloudconnections.SecretStoreLocalEncrypted {
+		t.Fatalf("persisted secret store = %q", persisted[0].SecretStore)
+	}
+	if strings.TrimSpace(persisted[0].SecretRefs["api_key"]) == "" {
+		t.Fatalf("persisted secret refs should retain api_key presence: %#v", persisted[0].SecretRefs)
+	}
+}
+
+func TestSaveRejectsSecretRefsWithoutExplicitExternalStore(t *testing.T) {
+	manager := NewManager(t.TempDir())
+
+	_, err := manager.Save(Profile{
+		Name:           "OpenAI external ref",
+		ProviderID:     "openai-api",
+		CredentialMode: "secret_store",
+		SecretRefs: map[string]string{
+			"api_key": "vault://llm/openai/api_key",
+		},
+	})
+	if err == nil {
+		t.Fatal("Save should reject secret refs without an explicit secret store")
+	}
+	if !strings.Contains(err.Error(), "secret_store is required") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/internal/api/agent_provider_connections_test.go
+++ b/internal/api/agent_provider_connections_test.go
@@ -1,0 +1,149 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestAgentProviderConnectionRoutesRedactSecrets(t *testing.T) {
+	root := t.TempDir()
+	srv := httptest.NewServer(fullRouterForTest(t, root))
+	defer srv.Close()
+
+	body := `{
+		"name":"OpenAI automation",
+		"provider_id":"openai-api",
+		"credential_mode":"secret_store",
+		"metadata":{"model":"gpt-5"},
+		"cost_controls":{"monthly_budget":"100"},
+		"secrets":{"api_key":"sk-agent-secret"}
+	}`
+	resp, err := http.Post(srv.URL+"/api/agent-hub/provider-connections", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST provider connection: %v", err)
+	}
+	defer closeBody(resp.Body)
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create should 201, got %d", resp.StatusCode)
+	}
+
+	var created struct {
+		ID             string            `json:"id"`
+		Name           string            `json:"name"`
+		ProviderID     string            `json:"provider_id"`
+		CredentialMode string            `json:"credential_mode"`
+		Metadata       map[string]string `json:"metadata"`
+		CostControls   map[string]string `json:"cost_controls"`
+		SecretFields   []string          `json:"secret_fields"`
+		SecretStore    string            `json:"secret_store"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create: %v", err)
+	}
+	if created.ID == "" {
+		t.Fatal("created provider connection should include id")
+	}
+	if got := created.SecretStore; got != "local_encrypted" {
+		t.Fatalf("secret store = %q", got)
+	}
+	if len(created.SecretFields) != 1 || created.SecretFields[0] != "api_key" {
+		t.Fatalf("secret fields = %#v", created.SecretFields)
+	}
+
+	resp, err = http.Get(srv.URL + "/api/agent-hub/provider-connections")
+	if err != nil {
+		t.Fatalf("GET provider connections: %v", err)
+	}
+	defer closeBody(resp.Body)
+	var raw bytes.Buffer
+	if _, err := raw.ReadFrom(resp.Body); err != nil {
+		t.Fatalf("read list: %v", err)
+	}
+	bodyText := raw.String()
+	if strings.Contains(bodyText, "sk-agent-secret") || strings.Contains(bodyText, "secret_refs") || strings.Contains(bodyText, `"secrets"`) {
+		t.Fatalf("secret material leaked in list response: %s", bodyText)
+	}
+	if !strings.Contains(bodyText, "api_key") {
+		t.Fatalf("secret field presence should be returned: %s", bodyText)
+	}
+}
+
+func TestAgentProviderConnectionPartialUpdatePreservesSecretFields(t *testing.T) {
+	root := t.TempDir()
+	srv := httptest.NewServer(fullRouterForTest(t, root))
+	defer srv.Close()
+
+	createBody := `{
+		"name":"Anthropic automation",
+		"provider_id":"anthropic-api",
+		"credential_mode":"secret_store",
+		"metadata":{"model":"claude-sonnet"},
+		"secrets":{"api_key":"sk-anthropic-secret"}
+	}`
+	resp, err := http.Post(srv.URL+"/api/agent-hub/provider-connections", "application/json", strings.NewReader(createBody))
+	if err != nil {
+		t.Fatalf("POST provider connection: %v", err)
+	}
+	defer closeBody(resp.Body)
+	var created struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create: %v", err)
+	}
+
+	updateBody := `{
+		"name":"Anthropic automation",
+		"provider_id":"anthropic-api",
+		"credential_mode":"secret_store",
+		"metadata":{"model":"claude-opus"},
+		"cost_controls":{"monthly_budget":"250"}
+	}`
+	req, err := http.NewRequest(http.MethodPut, srv.URL+"/api/agent-hub/provider-connections/"+created.ID, strings.NewReader(updateBody))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT provider connection: %v", err)
+	}
+	defer closeBody(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("update should 200, got %d", resp.StatusCode)
+	}
+	var updated struct {
+		SecretFields []string `json:"secret_fields"`
+		SecretStore  string   `json:"secret_store"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&updated); err != nil {
+		t.Fatalf("decode update: %v", err)
+	}
+	if updated.SecretStore != "local_encrypted" {
+		t.Fatalf("secret store = %q", updated.SecretStore)
+	}
+	if len(updated.SecretFields) != 1 || updated.SecretFields[0] != "api_key" {
+		t.Fatalf("secret fields were not preserved: %#v", updated.SecretFields)
+	}
+
+	resp, err = http.Get(srv.URL + "/api/agent-hub/provider-connections/" + created.ID)
+	if err != nil {
+		t.Fatalf("GET provider connection: %v", err)
+	}
+	defer closeBody(resp.Body)
+	var raw bytes.Buffer
+	if _, err := raw.ReadFrom(resp.Body); err != nil {
+		t.Fatalf("read get: %v", err)
+	}
+	bodyText := raw.String()
+	if strings.Contains(bodyText, "sk-anthropic-secret") || strings.Contains(bodyText, "secret_refs") || strings.Contains(bodyText, `"secrets"`) {
+		t.Fatalf("secret material leaked in get response: %s", bodyText)
+	}
+	if !strings.Contains(bodyText, "claude-opus") || !strings.Contains(bodyText, "api_key") {
+		t.Fatalf("updated metadata and secret field should be returned: %s", bodyText)
+	}
+}

--- a/internal/api/agent_provider_connections_test.go
+++ b/internal/api/agent_provider_connections_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -145,5 +147,74 @@ func TestAgentProviderConnectionPartialUpdatePreservesSecretFields(t *testing.T)
 	}
 	if !strings.Contains(bodyText, "claude-opus") || !strings.Contains(bodyText, "api_key") {
 		t.Fatalf("updated metadata and secret field should be returned: %s", bodyText)
+	}
+}
+
+func TestAgentProviderConnectionRoutesHideInternalErrors(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".iac-studio-agent-provider-connections.json"), []byte(`{`), 0o600); err != nil {
+		t.Fatalf("write invalid profile store: %v", err)
+	}
+	srv := httptest.NewServer(fullRouterForTest(t, root))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/agent-hub/provider-connections")
+	if err != nil {
+		t.Fatalf("GET provider connections: %v", err)
+	}
+	defer closeBody(resp.Body)
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", resp.StatusCode)
+	}
+	var raw bytes.Buffer
+	if _, err := raw.ReadFrom(resp.Body); err != nil {
+		t.Fatalf("read error response: %v", err)
+	}
+	bodyText := raw.String()
+	if strings.Contains(bodyText, "parse agent provider connections") ||
+		strings.Contains(bodyText, root) ||
+		strings.Contains(bodyText, ".iac-studio-agent-provider-connections.json") {
+		t.Fatalf("internal detail leaked in response: %s", bodyText)
+	}
+	if !strings.Contains(bodyText, "agent provider connection operation failed") {
+		t.Fatalf("expected generic internal error, got %s", bodyText)
+	}
+}
+
+func TestAgentProviderConnectionSaveHidesSecretStoreErrors(t *testing.T) {
+	root := t.TempDir()
+	keyPath := filepath.Join(root, ".iac-studio-agent-provider-connections.key")
+	if err := os.MkdirAll(keyPath, 0o755); err != nil {
+		t.Fatalf("create directory at key path: %v", err)
+	}
+	srv := httptest.NewServer(fullRouterForTest(t, root))
+	defer srv.Close()
+
+	body := `{
+		"name":"OpenAI automation",
+		"provider_id":"openai-api",
+		"credential_mode":"secret_store",
+		"secrets":{"api_key":"sk-agent-secret"}
+	}`
+	resp, err := http.Post(srv.URL+"/api/agent-hub/provider-connections", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST provider connection: %v", err)
+	}
+	defer closeBody(resp.Body)
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", resp.StatusCode)
+	}
+	var raw bytes.Buffer
+	if _, err := raw.ReadFrom(resp.Body); err != nil {
+		t.Fatalf("read error response: %v", err)
+	}
+	bodyText := raw.String()
+	if strings.Contains(bodyText, keyPath) ||
+		strings.Contains(bodyText, root) ||
+		strings.Contains(bodyText, ".iac-studio-agent-provider-connections.key") {
+		t.Fatalf("secret-store detail leaked in response: %s", bodyText)
+	}
+	if !strings.Contains(bodyText, "agent provider connection operation failed") {
+		t.Fatalf("expected generic internal error, got %s", bodyText)
 	}
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1034,6 +1034,19 @@ func requireOptionalJSONContentType(w http.ResponseWriter, r *http.Request) bool
 	return true
 }
 
+func writeAgentProviderProfileInternalError(w http.ResponseWriter, operation string, err error) {
+	log.Printf("agent provider connection %s failed: %v", operation, err)
+	http.Error(w, "agent provider connection operation failed", http.StatusInternalServerError)
+}
+
+func writeAgentProviderProfileSaveError(w http.ResponseWriter, operation string, err error) {
+	if errors.Is(err, agentproviderconnections.ErrInvalidProfile) {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	writeAgentProviderProfileInternalError(w, operation, err)
+}
+
 // RouterOptions allows callers to provide services and configuration that need
 // explicit ownership outside the router.
 type RouterOptions struct {
@@ -1123,7 +1136,7 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 	mux.HandleFunc("GET /api/agent-hub/provider-connections", func(w http.ResponseWriter, _ *http.Request) {
 		profiles, err := agentProviderProfiles.List()
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			writeAgentProviderProfileInternalError(w, "list", err)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -1143,7 +1156,7 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 		req.ID = ""
 		profile, err := agentProviderProfiles.Save(req)
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
+			writeAgentProviderProfileSaveError(w, "create", err)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -1158,7 +1171,7 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 				http.Error(w, "agent provider connection not found", http.StatusNotFound)
 				return
 			}
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			writeAgentProviderProfileInternalError(w, "get", err)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -1176,7 +1189,7 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 				http.Error(w, "agent provider connection not found", http.StatusNotFound)
 				return
 			}
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			writeAgentProviderProfileInternalError(w, "check update target", err)
 			return
 		}
 		var req agentproviderconnections.Profile
@@ -1187,7 +1200,7 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 		req.ID = id
 		profile, err := agentProviderProfiles.Save(req)
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
+			writeAgentProviderProfileSaveError(w, "update", err)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -1200,7 +1213,7 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 				http.Error(w, "agent provider connection not found", http.StatusNotFound)
 				return
 			}
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			writeAgentProviderProfileInternalError(w, "delete", err)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/iac-studio/iac-studio/internal/agentproviderconnections"
 	"github.com/iac-studio/iac-studio/internal/agentproviders"
 	"github.com/iac-studio/iac-studio/internal/agentruns"
 	"github.com/iac-studio/iac-studio/internal/ai"
@@ -1038,6 +1039,7 @@ func requireOptionalJSONContentType(w http.ResponseWriter, r *http.Request) bool
 type RouterOptions struct {
 	MCPAirlock               *mcpairlock.Manager
 	AgentRuns                *agentruns.Store
+	AgentProviderProfiles    *agentproviderconnections.Manager
 	AppVersion               string
 	LocalAgentProviders      func() []agentproviders.LocalProviderStatus
 	AgentProviderConnections func() []agentproviders.ConnectionProviderDefinition
@@ -1080,6 +1082,10 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 	if agentRuns == nil {
 		agentRuns = agentruns.NewStore()
 	}
+	agentProviderProfiles := opts.AgentProviderProfiles
+	if agentProviderProfiles == nil {
+		agentProviderProfiles = agentproviderconnections.NewManager(projectsDir)
+	}
 	if fw != nil {
 		fw.OnChange(func(file, _ string) {
 			invalidatePlanForChangedFile(projectsDir, file)
@@ -1113,6 +1119,94 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 			"providers": opts.agentProviderConnections(),
 		})
 	})
+
+	mux.HandleFunc("GET /api/agent-hub/provider-connections", func(w http.ResponseWriter, _ *http.Request) {
+		profiles, err := agentProviderProfiles.List()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"connections": profiles})
+	})
+
+	mux.HandleFunc("POST /api/agent-hub/provider-connections", func(w http.ResponseWriter, r *http.Request) {
+		limitBody(w, r)
+		if !requireJSONContentType(w, r) {
+			return
+		}
+		var req agentproviderconnections.Profile
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+		req.ID = ""
+		profile, err := agentProviderProfiles.Save(req)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(profile)
+	})
+
+	mux.HandleFunc("GET /api/agent-hub/provider-connections/{id}", func(w http.ResponseWriter, r *http.Request) {
+		profile, err := agentProviderProfiles.Get(r.PathValue("id"))
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				http.Error(w, "agent provider connection not found", http.StatusNotFound)
+				return
+			}
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(profile)
+	})
+
+	mux.HandleFunc("PUT /api/agent-hub/provider-connections/{id}", func(w http.ResponseWriter, r *http.Request) {
+		limitBody(w, r)
+		if !requireJSONContentType(w, r) {
+			return
+		}
+		id := r.PathValue("id")
+		if _, err := agentProviderProfiles.Get(id); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				http.Error(w, "agent provider connection not found", http.StatusNotFound)
+				return
+			}
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		var req agentproviderconnections.Profile
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+		req.ID = id
+		profile, err := agentProviderProfiles.Save(req)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(profile)
+	})
+
+	mux.HandleFunc("DELETE /api/agent-hub/provider-connections/{id}", func(w http.ResponseWriter, r *http.Request) {
+		if err := agentProviderProfiles.Delete(r.PathValue("id")); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				http.Error(w, "agent provider connection not found", http.StatusNotFound)
+				return
+			}
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "deleted"})
+	})
+
 	registerAgentRunRoutes(mux, projectsDir, agentRuns)
 
 	// Resource catalog — returns all resources for a tool, optionally filtered by provider

--- a/internal/cloudconnections/local_encrypted_store.go
+++ b/internal/cloudconnections/local_encrypted_store.go
@@ -25,6 +25,25 @@ func newLocalEncryptedSecretStore(keyForEncrypt, keyForDecrypt func() ([]byte, e
 	}
 }
 
+// NewLocalEncryptedFileSecretStore returns the same local encrypted secret
+// backend used by Cloud Connections, backed by key material at keyPath.
+func NewLocalEncryptedFileSecretStore(keyPath string) SecretStore {
+	return newLocalEncryptedSecretStore(
+		func() ([]byte, error) {
+			if key, ok := environmentEncryptionKey(); ok {
+				return key, nil
+			}
+			return loadOrCreateLocalKey(keyPath)
+		},
+		func() ([]byte, error) {
+			if key, ok := environmentEncryptionKey(); ok {
+				return key, nil
+			}
+			return loadExistingLocalKey(keyPath)
+		},
+	)
+}
+
 func (s *localEncryptedSecretStore) Kind() string {
 	return SecretStoreLocalEncrypted
 }

--- a/internal/cloudconnections/local_encrypted_store.go
+++ b/internal/cloudconnections/local_encrypted_store.go
@@ -33,15 +33,24 @@ func NewLocalEncryptedFileSecretStore(keyPath string) SecretStore {
 			if key, ok := environmentEncryptionKey(); ok {
 				return key, nil
 			}
-			return loadOrCreateLocalKey(keyPath)
+			key, err := loadOrCreateLocalKey(keyPath)
+			return key, wrapLocalEncryptedKeyPathError(keyPath, err)
 		},
 		func() ([]byte, error) {
 			if key, ok := environmentEncryptionKey(); ok {
 				return key, nil
 			}
-			return loadExistingLocalKey(keyPath)
+			key, err := loadExistingLocalKey(keyPath)
+			return key, wrapLocalEncryptedKeyPathError(keyPath, err)
 		},
 	)
+}
+
+func wrapLocalEncryptedKeyPathError(keyPath string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("local encrypted secret store key %q: %w", keyPath, err)
 }
 
 func (s *localEncryptedSecretStore) Kind() string {

--- a/internal/cloudconnections/local_encrypted_store_test.go
+++ b/internal/cloudconnections/local_encrypted_store_test.go
@@ -3,6 +3,7 @@ package cloudconnections
 import (
 	"context"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -113,5 +114,26 @@ func TestLocalEncryptedSecretStoreMemoizesKeysPerInstance(t *testing.T) {
 	}
 	if decryptLoads != 1 {
 		t.Fatalf("decryption key should load once per store instance, got %d loads", decryptLoads)
+	}
+}
+
+func TestNewLocalEncryptedFileSecretStoreReportsKeyPathOnLoadError(t *testing.T) {
+	keyPath := filepath.Join(t.TempDir(), "agent-provider-connections.key")
+	store := NewLocalEncryptedFileSecretStore(keyPath)
+
+	_, err := store.Load(context.Background(), SecretScope{
+		ConnectionID: "apc_test",
+		Provider:     "openai-api",
+		AuthMethod:   "secret_store",
+	}, StoredSecrets{
+		Values: map[string]string{
+			"api_key": encryptedSecretPrefix + "AAAAAAAAAAAAAAAA:AA",
+		},
+	})
+	if err == nil {
+		t.Fatal("Load should fail when the file-backed key is missing")
+	}
+	if !strings.Contains(err.Error(), keyPath) {
+		t.Fatalf("error should include concrete key path %q, got %q", keyPath, err.Error())
 	}
 }

--- a/internal/cloudconnections/local_encrypted_store_test.go
+++ b/internal/cloudconnections/local_encrypted_store_test.go
@@ -118,6 +118,7 @@ func TestLocalEncryptedSecretStoreMemoizesKeysPerInstance(t *testing.T) {
 }
 
 func TestNewLocalEncryptedFileSecretStoreReportsKeyPathOnLoadError(t *testing.T) {
+	t.Setenv(connectionsKeyEnv, "")
 	keyPath := filepath.Join(t.TempDir(), "agent-provider-connections.key")
 	store := NewLocalEncryptedFileSecretStore(keyPath)
 


### PR DESCRIPTION
Refs #106. Adds backend Agent Hub provider connection profiles with redacted public responses, local encrypted secret storage, external secret refs, and partial update tests. Validation: GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/...