### PR TITLE
Show saved Agent Hub provider profiles

### DIFF
--- a/web/src/components/Chat/ChatPanel.test.tsx
+++ b/web/src/components/Chat/ChatPanel.test.tsx
@@ -7,6 +7,7 @@ import { ChatPanel } from './ChatPanel';
 
 const listLocalAgentProvidersMock = vi.hoisted(() => vi.fn());
 const listAgentProviderConnectionsMock = vi.hoisted(() => vi.fn());
+const listAgentProviderConnectionProfilesMock = vi.hoisted(() => vi.fn());
 const listAgentRunsMock = vi.hoisted(() => vi.fn());
 const createAgentRunMock = vi.hoisted(() => vi.fn());
 const getAgentRunMock = vi.hoisted(() => vi.fn());
@@ -17,6 +18,7 @@ vi.mock('../../api', () => ({
   api: {
     listLocalAgentProviders: listLocalAgentProvidersMock,
     listAgentProviderConnections: listAgentProviderConnectionsMock,
+    listAgentProviderConnectionProfiles: listAgentProviderConnectionProfilesMock,
     listAgentRuns: listAgentRunsMock,
     createAgentRun: createAgentRunMock,
     getAgentRun: getAgentRunMock,
@@ -83,6 +85,8 @@ describe('ChatPanel', () => {
     listLocalAgentProvidersMock.mockReturnValue(new Promise(() => {}));
     listAgentProviderConnectionsMock.mockReset();
     listAgentProviderConnectionsMock.mockReturnValue(new Promise(() => {}));
+    listAgentProviderConnectionProfilesMock.mockReset();
+    listAgentProviderConnectionProfilesMock.mockReturnValue(new Promise(() => {}));
     listAgentRunsMock.mockReset();
     listAgentRunsMock.mockResolvedValue([]);
     createAgentRunMock.mockReset();
@@ -256,8 +260,71 @@ describe('ChatPanel', () => {
     expect(within(catalog).queryByText('sk-test-secret')).not.toBeInTheDocument();
   });
 
+  it('shows redacted saved provider profiles for the matching provider lane', async () => {
+    listAgentProviderConnectionsMock.mockResolvedValueOnce([
+      {
+        id: 'openai-api',
+        name: 'OpenAI API',
+        family: 'openai',
+        category: 'api',
+        credential_mode: 'secret_store',
+        required_fields: ['model'],
+        secret_fields: ['api_key'],
+        capabilities: ['chat'],
+        cost_controls: ['monthly_budget'],
+        billing_hint: 'Billed through the OpenAI Platform API account.',
+        data_handling_hint: 'Prompts are sent to the configured OpenAI API endpoint.',
+        secret_storage_hint: 'Keys stay in a secret store.',
+        setup_hint: 'Use for automation.',
+      },
+    ]);
+    listAgentProviderConnectionProfilesMock.mockResolvedValueOnce([
+      {
+        id: 'agent_provider_connection_000001',
+        name: 'OpenAI prod automation',
+        provider_id: 'openai-api',
+        credential_mode: 'secret_store',
+        metadata: { model: 'gpt-5' },
+        cost_controls: { monthly_budget: '100' },
+        secret_fields: ['api_key'],
+        secret_store: 'local_encrypted',
+        created_at: '2026-07-01T10:00:00Z',
+        updated_at: '2026-07-01T10:00:00Z',
+      },
+      {
+        id: 'agent_provider_connection_000002',
+        name: 'Anthropic team automation',
+        provider_id: 'anthropic-api',
+        credential_mode: 'secret_store',
+        secret_fields: ['api_key'],
+        secret_store: 'local_encrypted',
+        created_at: '2026-07-01T10:00:00Z',
+        updated_at: '2026-07-01T10:00:00Z',
+      },
+    ]);
+
+    render(<ChatPanel {...baseProps} />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Codex' }));
+    const codexPanel = screen.getByRole('tabpanel', { name: 'Codex' });
+
+    await waitFor(() => {
+      expect(within(codexPanel).getByRole('region', { name: 'Codex saved provider connections' })).toBeInTheDocument();
+    });
+    const savedProfiles = within(codexPanel).getByRole('region', { name: 'Codex saved provider connections' });
+    const openAiProfile = within(savedProfiles).getByLabelText('OpenAI prod automation saved provider connection');
+    expect(openAiProfile).toBeInTheDocument();
+    expect(within(openAiProfile).getByText('local_encrypted')).toBeInTheDocument();
+    expect(within(openAiProfile).getByText('1 secret field')).toBeInTheDocument();
+    expect(within(openAiProfile).getByText('model')).toBeInTheDocument();
+    expect(within(openAiProfile).getByText('monthly budget')).toBeInTheDocument();
+    expect(within(savedProfiles).getByText(/Secret values and external refs are never shown/)).toBeInTheDocument();
+    expect(within(savedProfiles).queryByText('Anthropic team automation')).not.toBeInTheDocument();
+    expect(within(savedProfiles).queryByText('sk-test-secret')).not.toBeInTheDocument();
+  });
+
   it('keeps provider panels usable when the connection catalog cannot load', async () => {
     listAgentProviderConnectionsMock.mockRejectedValueOnce(new Error('catalog unavailable'));
+    listAgentProviderConnectionProfilesMock.mockRejectedValueOnce(new Error('profiles unavailable'));
 
     render(<ChatPanel {...baseProps} />);
     fireEvent.click(screen.getByRole('tab', { name: 'Codex' }));

--- a/web/src/components/Chat/ChatPanel.tsx
+++ b/web/src/components/Chat/ChatPanel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { CSSProperties, KeyboardEvent, ReactNode, RefObject } from 'react';
 
-import { api, type AgentProviderConnectionDefinition, type AgentRun, type AgentRunApprovalDecision, type AgentRunMode, type AgentRunSummary, type LocalAgentProviderStatus } from '../../api';
+import { api, type AgentProviderConnectionDefinition, type AgentProviderConnectionProfile, type AgentRun, type AgentRunApprovalDecision, type AgentRunMode, type AgentRunSummary, type LocalAgentProviderStatus } from '../../api';
 import { S } from '../../styles';
 
 export interface ChatMessage {
@@ -313,6 +313,31 @@ function connectionProvidersForTab(
   return providers.filter(provider => families.includes(provider.family));
 }
 
+function inferredProviderConnectionFamily(providerId: string) {
+  const id = providerId.toLowerCase();
+  if (id.includes('azure') && id.includes('openai')) return 'azure_openai';
+  if (id.includes('openai')) return 'openai';
+  if (id.includes('anthropic') || id.includes('claude')) return 'anthropic';
+  if (id.includes('bedrock')) return 'bedrock';
+  if (id.includes('vertex') || id.includes('gemini')) return 'vertex';
+  if (id.includes('gateway') || id.includes('enterprise')) return 'gateway';
+  return '';
+}
+
+function connectionProfilesForTab(
+  tab: ProviderTab,
+  profiles: AgentProviderConnectionProfile[],
+  providers: AgentProviderConnectionDefinition[],
+) {
+  const families = PROVIDER_CONNECTION_FAMILIES[tab];
+  if (families.length === 0) return [];
+  const familiesByProviderID = new Map(providers.map(provider => [provider.id, provider.family]));
+  return profiles.filter(profile => {
+    const family = familiesByProviderID.get(profile.provider_id) || inferredProviderConnectionFamily(profile.provider_id);
+    return families.includes(family);
+  });
+}
+
 function providerDisplay(provider: Pick<ProviderDefinition, 'state' | 'note'>, status?: LocalAgentProviderStatus) {
   if (!status) {
     return { state: provider.state, note: provider.note };
@@ -506,11 +531,70 @@ function ConnectionCatalog({
   );
 }
 
+function SavedConnectionProfiles({
+  title,
+  profiles,
+}: {
+  title: string;
+  profiles: AgentProviderConnectionProfile[];
+}) {
+  if (profiles.length === 0) return null;
+  return (
+    <section
+      role="region"
+      aria-label={`${title} saved provider connections`}
+      style={hubStyles.connectionCatalog}
+    >
+      <div style={hubStyles.connectionCatalogIntro}>
+        <strong style={{ color: 'var(--text-main)' }}>Saved provider profiles</strong>
+        <span> - redacted inventory only. Secret values and external refs are never shown here.</span>
+      </div>
+      {profiles.map(profile => (
+        <article key={profile.id} style={hubStyles.connectionCard} aria-label={`${profile.name} saved provider connection`}>
+          <div style={hubStyles.providerHead}>
+            <span style={{ ...hubStyles.providerName, flex: 1 }}>{profile.name}</span>
+            <span style={hubStyles.badge}>{profile.provider_id}</span>
+          </div>
+          <div style={hubStyles.providerMeta}>
+            <span style={hubStyles.badge}>{credentialLabel(profile.credential_mode)}</span>
+            <span style={hubStyles.badge}>{profile.secret_store || 'No secret store'}</span>
+            <span style={hubStyles.badge}>
+              {(profile.secret_fields || []).length} secret {(profile.secret_fields || []).length === 1 ? 'field' : 'fields'}
+            </span>
+          </div>
+          <div style={hubStyles.providerDetailsGrid}>
+            <div>
+              <div style={hubStyles.providerDetailLabel}>Metadata</div>
+              <div style={hubStyles.providerDetailValue} title={compactList(Object.keys(profile.metadata || {}))}>
+                {compactList(Object.keys(profile.metadata || {}))}
+              </div>
+            </div>
+            <div>
+              <div style={hubStyles.providerDetailLabel}>Cost controls</div>
+              <div style={hubStyles.providerDetailValue} title={compactList(Object.keys(profile.cost_controls || {}))}>
+                {compactList(Object.keys(profile.cost_controls || {}))}
+              </div>
+            </div>
+          </div>
+          {(profile.secret_fields || []).length > 0 && (
+            <div style={hubStyles.providerCapabilityList} aria-label={`${profile.name} secret fields`}>
+              {(profile.secret_fields || []).map(field => (
+                <span key={field} style={hubStyles.badge}>{field.replaceAll('_', ' ')}</span>
+              ))}
+            </div>
+          )}
+        </article>
+      ))}
+    </section>
+  );
+}
+
 function ProviderGroup({
   tab,
   active,
   localProviders,
   connectionProviders,
+  connectionProfiles,
   selectedProviderName,
   onSelectProvider,
 }: {
@@ -518,11 +602,13 @@ function ProviderGroup({
   active: boolean;
   localProviders: Record<string, LocalAgentProviderStatus>;
   connectionProviders: AgentProviderConnectionDefinition[];
+  connectionProfiles: AgentProviderConnectionProfile[];
   selectedProviderName?: string;
   onSelectProvider: (tab: ProviderTab, providerName: string) => void;
 }) {
   const group = PROVIDER_GROUPS[tab];
   const visibleConnectionProviders = connectionProvidersForTab(tab, connectionProviders);
+  const visibleConnectionProfiles = connectionProfilesForTab(tab, connectionProfiles, connectionProviders);
   const selectedProvider = group.providers.find(provider => provider.name === selectedProviderName) ?? group.providers[0];
   const selectedLocalStatus = selectedProvider.localProviderId ? localProviders[selectedProvider.localProviderId] : undefined;
   const selectedDisplay = providerDisplay(selectedProvider, selectedLocalStatus);
@@ -587,6 +673,7 @@ function ProviderGroup({
         localStatus={selectedLocalStatus}
       />
       <ConnectionCatalog title={group.title} providers={visibleConnectionProviders} />
+      <SavedConnectionProfiles title={group.title} profiles={visibleConnectionProfiles} />
     </div>
   );
 }
@@ -1110,6 +1197,7 @@ export function ChatPanel({
   const [selectedProviders, setSelectedProviders] = useState<Partial<Record<ProviderTab, string>>>({});
   const [localProviders, setLocalProviders] = useState<Record<string, LocalAgentProviderStatus>>({});
   const [connectionProviders, setConnectionProviders] = useState<AgentProviderConnectionDefinition[]>([]);
+  const [connectionProfiles, setConnectionProfiles] = useState<AgentProviderConnectionProfile[]>([]);
   const [agentRuns, setAgentRuns] = useState<AgentRunSummary[]>([]);
   const [agentRunsLoading, setAgentRunsLoading] = useState(false);
   const [agentRunsError, setAgentRunsError] = useState<string | null>(null);
@@ -1151,6 +1239,20 @@ export function ChatPanel({
       })
       .catch(() => {
         if (!cancelled) setConnectionProviders([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    api.listAgentProviderConnectionProfiles()
+      .then(profiles => {
+        if (!cancelled) setConnectionProfiles(profiles);
+      })
+      .catch(() => {
+        if (!cancelled) setConnectionProfiles([]);
       });
     return () => {
       cancelled = true;
@@ -1602,6 +1704,7 @@ export function ChatPanel({
               active={activeTab === tab}
               localProviders={localProviders}
               connectionProviders={connectionProviders}
+              connectionProfiles={connectionProfiles}
               selectedProviderName={selectedProviders[tab]}
               onSelectProvider={selectProvider}
             />


### PR DESCRIPTION
Refs #106.\n\nAdds a read-only Agent Hub UI section for saved provider connection profiles. Profiles are filtered into the matching provider lane and show redacted credential inventory only: provider id, credential mode, secret store, secret field names, metadata keys, and cost-control keys. No secret values or external refs are rendered.\n\nValidation:\n- npm test -- --run src/components/Chat/ChatPanel.test.tsx\n- npm run build