### PR TITLE
Release file lock around secret store I/O

### DIFF
--- a/internal/cloudconnections/connections.go
+++ b/internal/cloudconnections/connections.go
@@ -261,32 +261,24 @@ func (m *Manager) Save(input Connection) (PublicConnection, error) {
 		return PublicConnection{}, err
 	}
 
-	// Re-read after the backend call so local file migrations discovered by a
-	// concurrent reader are preserved. Save/Delete mutations are serialized by
-	// mutationsMu, but the file mutex is intentionally not held during I/O.
-	current, _, err := m.loadSnapshot(false)
-	if err != nil {
-		return PublicConnection{}, err
-	}
-	persisted, err := m.storeConnectionSecrets(current)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	current, err := m.readConnectionsUnlocked()
 	if err != nil {
 		return PublicConnection{}, err
 	}
 	committed := false
-	for index, existing := range persisted {
+	for index, existing := range current {
 		if existing.ID == input.ID {
-			persisted[index] = persistedInput[0]
+			current[index] = persistedInput[0]
 			committed = true
 			break
 		}
 	}
 	if !committed {
-		persisted = append(persisted, persistedInput[0])
+		current = append(current, persistedInput[0])
 	}
-
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if err := m.writeConnectionsUnlocked(persisted); err != nil {
+	if err := m.writeConnectionsUnlocked(current); err != nil {
 		return PublicConnection{}, err
 	}
 	return publicConnection(input), nil

--- a/internal/cloudconnections/connections.go
+++ b/internal/cloudconnections/connections.go
@@ -256,18 +256,6 @@ func (m *Manager) Save(input Connection) (PublicConnection, error) {
 	input.SecretRefs = secretRefsMetadata(input.AuthMethod, input.SecretRefs)
 	applySecretReferenceDefaults(&input)
 
-	replaced := false
-	for index, existing := range connections {
-		if existing.ID == input.ID {
-			connections[index] = input
-			replaced = true
-			break
-		}
-	}
-	if !replaced {
-		connections = append(connections, input)
-	}
-
 	persistedInput, err := m.storeConnectionSecrets([]Connection{input})
 	if err != nil {
 		return PublicConnection{}, err
@@ -526,22 +514,6 @@ func (m *Manager) saveUnlocked(connections []Connection) error {
 	if err != nil {
 		return err
 	}
-	return m.writeConnectionsUnlocked(persisted)
-}
-
-func (m *Manager) saveOneUnlocked(connections []Connection, index int) error {
-	if index < 0 || index >= len(connections) {
-		return os.ErrNotExist
-	}
-	if err := os.MkdirAll(filepath.Dir(m.path), 0o755); err != nil {
-		return fmt.Errorf("create cloud connections directory: %w", err)
-	}
-	persistedOne, err := m.storeConnectionSecrets([]Connection{connections[index]})
-	if err != nil {
-		return err
-	}
-	persisted := slices.Clone(connections)
-	persisted[index] = persistedOne[0]
 	return m.writeConnectionsUnlocked(persisted)
 }
 

--- a/internal/cloudconnections/connections.go
+++ b/internal/cloudconnections/connections.go
@@ -114,6 +114,7 @@ type Manager struct {
 	secretStores   map[string]SecretStore
 	secretStoresMu sync.RWMutex
 	mu             sync.RWMutex
+	mutationsMu    sync.Mutex
 }
 
 func NewManager(projectsDir string, opts ...Option) *Manager {
@@ -226,10 +227,10 @@ func (m *Manager) Save(input Connection) (PublicConnection, error) {
 		return PublicConnection{}, err
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	m.mutationsMu.Lock()
+	defer m.mutationsMu.Unlock()
 
-	connections, err := m.loadUnlocked()
+	connections, _, err := m.loadSnapshot(false)
 	if err != nil {
 		return PublicConnection{}, err
 	}
@@ -267,28 +268,78 @@ func (m *Manager) Save(input Connection) (PublicConnection, error) {
 		connections = append(connections, input)
 	}
 
-	if err := m.saveUnlocked(connections); err != nil {
+	persistedInput, err := m.storeConnectionSecrets([]Connection{input})
+	if err != nil {
+		return PublicConnection{}, err
+	}
+
+	// Re-read after the backend call so local file migrations discovered by a
+	// concurrent reader are preserved. Save/Delete mutations are serialized by
+	// mutationsMu, but the file mutex is intentionally not held during I/O.
+	current, _, err := m.loadSnapshot(false)
+	if err != nil {
+		return PublicConnection{}, err
+	}
+	persisted, err := m.storeConnectionSecrets(current)
+	if err != nil {
+		return PublicConnection{}, err
+	}
+	committed := false
+	for index, existing := range persisted {
+		if existing.ID == input.ID {
+			persisted[index] = persistedInput[0]
+			committed = true
+			break
+		}
+	}
+	if !committed {
+		persisted = append(persisted, persistedInput[0])
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if err := m.writeConnectionsUnlocked(persisted); err != nil {
 		return PublicConnection{}, err
 	}
 	return publicConnection(input), nil
 }
 
 func (m *Manager) Delete(id string) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	m.mutationsMu.Lock()
+	defer m.mutationsMu.Unlock()
 
+	m.mu.RLock()
 	connections, err := m.readConnectionsUnlocked()
+	m.mu.RUnlock()
 	if err != nil {
 		return err
 	}
-	next := connections[:0]
+
+	var target *Connection
+	for index := range connections {
+		if connections[index].ID == id {
+			target = cloneConnection(connections[index])
+			break
+		}
+	}
+	if target == nil {
+		return os.ErrNotExist
+	}
+	if err := m.deleteConnectionSecrets(*target); err != nil {
+		return err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	connections, err = m.readConnectionsUnlocked()
+	if err != nil {
+		return err
+	}
+	next := make([]Connection, 0, len(connections)-1)
 	found := false
 	for _, connection := range connections {
 		if connection.ID == id {
 			found = true
-			if err := m.deleteConnectionSecrets(connection); err != nil {
-				return err
-			}
 			continue
 		}
 		next = append(next, connection)
@@ -296,7 +347,7 @@ func (m *Manager) Delete(id string) error {
 	if !found {
 		return os.ErrNotExist
 	}
-	return m.saveUnlocked(next)
+	return m.writeConnectionsUnlocked(next)
 }
 
 func (m *Manager) Test(id string) (TestResult, error) {
@@ -325,9 +376,7 @@ func (m *Manager) Test(id string) (TestResult, error) {
 }
 
 func (m *Manager) load() ([]Connection, error) {
-	m.mu.RLock()
-	connections, needsMigration, err := m.loadUnlockedWithMigrationFlag(false)
-	m.mu.RUnlock()
+	connections, needsMigration, err := m.loadSnapshot(false)
 	if err != nil {
 		return nil, err
 	}
@@ -335,25 +384,14 @@ func (m *Manager) load() ([]Connection, error) {
 		return connections, nil
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	connections, needsMigration, err = m.loadUnlockedWithMigrationFlag(false)
-	if err != nil {
-		return nil, err
-	}
-	if !needsMigration {
-		return connections, nil
-	}
-	if err := m.saveUnlocked(connections); err != nil {
+	if err := m.persistMigration(false); err != nil {
 		return nil, err
 	}
 	return connections, nil
 }
 
 func (m *Manager) loadOne(id string, resolveSecretRefs bool) (*Connection, error) {
-	m.mu.RLock()
-	connections, index, needsMigration, err := m.loadOneUnlockedWithMigrationFlag(id, resolveSecretRefs)
-	m.mu.RUnlock()
+	connections, index, needsMigration, err := m.loadOneSnapshot(id, resolveSecretRefs)
 	if err != nil {
 		return nil, err
 	}
@@ -364,22 +402,10 @@ func (m *Manager) loadOne(id string, resolveSecretRefs bool) (*Connection, error
 		return cloneConnection(connections[index]), nil
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	connections, index, needsMigration, err = m.loadOneUnlockedWithMigrationFlag(id, resolveSecretRefs)
-	if err != nil {
+	if err := m.persistOneMigration(id, resolveSecretRefs); err != nil {
 		return nil, err
 	}
-	if index < 0 {
-		return nil, os.ErrNotExist
-	}
-	if !needsMigration {
-		return cloneConnection(connections[index]), nil
-	}
-	if err := m.saveOneUnlocked(connections, index); err != nil {
-		return nil, err
-	}
-	connections, index, _, err = m.loadOneUnlockedWithMigrationFlag(id, resolveSecretRefs)
+	connections, index, _, err = m.loadOneSnapshot(id, resolveSecretRefs)
 	if err != nil {
 		return nil, err
 	}
@@ -389,13 +415,13 @@ func (m *Manager) loadOne(id string, resolveSecretRefs bool) (*Connection, error
 	return cloneConnection(connections[index]), nil
 }
 
-func (m *Manager) loadUnlocked() ([]Connection, error) {
-	connections, _, err := m.loadUnlockedWithMigrationFlag(false)
-	return connections, err
-}
-
-func (m *Manager) loadUnlockedWithMigrationFlag(resolveSecretRefs bool) ([]Connection, bool, error) {
+// loadSnapshot reads the connection file under the file lock, then resolves
+// any requested secret values after releasing it. This keeps network-backed
+// SecretStore calls out of Manager.mu.
+func (m *Manager) loadSnapshot(resolveSecretRefs bool) ([]Connection, bool, error) {
+	m.mu.RLock()
 	connections, err := m.readConnectionsUnlocked()
+	m.mu.RUnlock()
 	if err != nil {
 		return nil, false, err
 	}
@@ -409,8 +435,10 @@ func (m *Manager) loadUnlockedWithMigrationFlag(resolveSecretRefs bool) ([]Conne
 	return connections, needsMigration, nil
 }
 
-func (m *Manager) loadOneUnlockedWithMigrationFlag(id string, resolveSecretRefs bool) ([]Connection, int, bool, error) {
+func (m *Manager) loadOneSnapshot(id string, resolveSecretRefs bool) ([]Connection, int, bool, error) {
+	m.mu.RLock()
 	connections, err := m.readConnectionsUnlocked()
+	m.mu.RUnlock()
 	if err != nil {
 		return nil, -1, false, err
 	}
@@ -428,6 +456,51 @@ func (m *Manager) loadOneUnlockedWithMigrationFlag(id string, resolveSecretRefs 
 		return connections, index, needsMigration, nil
 	}
 	return connections, -1, false, nil
+}
+
+func (m *Manager) persistMigration(resolveSecretRefs bool) error {
+	m.mutationsMu.Lock()
+	defer m.mutationsMu.Unlock()
+
+	connections, needsMigration, err := m.loadSnapshot(resolveSecretRefs)
+	if err != nil || !needsMigration {
+		return err
+	}
+	persisted, err := m.storeConnectionSecrets(connections)
+	if err != nil {
+		return err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.writeConnectionsUnlocked(persisted)
+}
+
+func (m *Manager) persistOneMigration(id string, resolveSecretRefs bool) error {
+	m.mutationsMu.Lock()
+	defer m.mutationsMu.Unlock()
+
+	connections, index, needsMigration, err := m.loadOneSnapshot(id, resolveSecretRefs)
+	if err != nil || index < 0 || !needsMigration {
+		return err
+	}
+	persisted, err := m.storeConnectionSecrets([]Connection{connections[index]})
+	if err != nil {
+		return err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	current, err := m.readConnectionsUnlocked()
+	if err != nil {
+		return err
+	}
+	for currentIndex := range current {
+		if current[currentIndex].ID == id {
+			current[currentIndex] = persisted[0]
+			return m.writeConnectionsUnlocked(current)
+		}
+	}
+	return os.ErrNotExist
 }
 
 func (m *Manager) readConnectionsUnlocked() ([]Connection, error) {

--- a/internal/cloudconnections/connections_test.go
+++ b/internal/cloudconnections/connections_test.go
@@ -177,18 +177,23 @@ func TestManagerDoesNotHoldFileLockDuringSecretStoreLoad(t *testing.T) {
 	}()
 	<-store.started
 
-	listDone := make(chan error, 1)
+	saveDone := make(chan error, 1)
 	go func() {
-		_, err := manager.List()
-		listDone <- err
+		_, err := manager.Save(Connection{
+			Name:       "writer",
+			Provider:   ProviderAWS,
+			AuthMethod: "aws_profile",
+			Metadata:   map[string]string{"profile": "writer"},
+		})
+		saveDone <- err
 	}()
 	select {
-	case err := <-listDone:
+	case err := <-saveDone:
 		if err != nil {
-			t.Fatalf("List while secret store Load is blocked: %v", err)
+			t.Fatalf("Save while secret store Load is blocked: %v", err)
 		}
 	case <-time.After(time.Second):
-		t.Fatal("List blocked behind secret store Load")
+		t.Fatal("Save blocked behind secret store Load")
 	}
 
 	close(store.release)

--- a/internal/cloudconnections/connections_test.go
+++ b/internal/cloudconnections/connections_test.go
@@ -68,6 +68,221 @@ func (s *fakeSecretStore) Delete(_ context.Context, _ SecretScope, stored Stored
 	return nil
 }
 
+type blockingSecretStore struct {
+	fakeSecretStore
+	operation string
+	started   chan struct{}
+	release   chan struct{}
+	startOnce sync.Once
+}
+
+func (s *blockingSecretStore) block(operation string) {
+	if s.operation != operation {
+		return
+	}
+	s.startOnce.Do(func() { close(s.started) })
+	<-s.release
+}
+
+func (s *blockingSecretStore) Save(ctx context.Context, scope SecretScope, secrets map[string]string) (StoredSecrets, error) {
+	s.block("save")
+	return s.fakeSecretStore.Save(ctx, scope, secrets)
+}
+
+func (s *blockingSecretStore) Load(ctx context.Context, scope SecretScope, stored StoredSecrets) (LoadedSecrets, error) {
+	s.block("load")
+	return s.fakeSecretStore.Load(ctx, scope, stored)
+}
+
+func (s *blockingSecretStore) Delete(ctx context.Context, scope SecretScope, stored StoredSecrets) error {
+	s.block("delete")
+	return s.fakeSecretStore.Delete(ctx, scope, stored)
+}
+
+func TestManagerDoesNotHoldFileLockDuringSecretStoreSave(t *testing.T) {
+	store := &blockingSecretStore{
+		fakeSecretStore: fakeSecretStore{kind: "vault"},
+		operation:       "save",
+		started:         make(chan struct{}),
+		release:         make(chan struct{}),
+	}
+	manager := NewManager(t.TempDir(), WithSecretStore(store))
+	saveDone := make(chan error, 1)
+	go func() {
+		_, err := manager.Save(Connection{
+			Name:        "external",
+			Provider:    ProviderAWS,
+			AuthMethod:  "aws_static",
+			Metadata:    map[string]string{"access_key_id": "AKIAEXAMPLE"},
+			Secrets:     map[string]string{"secret_access_key": "super-secret"},
+			SecretStore: "vault",
+		})
+		saveDone <- err
+	}()
+
+	<-store.started
+	listDone := make(chan error, 1)
+	go func() {
+		_, err := manager.List()
+		listDone <- err
+	}()
+	select {
+	case err := <-listDone:
+		if err != nil {
+			t.Fatalf("List while secret store Save is blocked: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("List blocked behind secret store Save")
+	}
+
+	close(store.release)
+	if err := <-saveDone; err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+}
+
+func TestManagerDoesNotHoldFileLockDuringSecretStoreLoad(t *testing.T) {
+	ref := "vault://connections/conn_external/secret_access_key"
+	store := &blockingSecretStore{
+		fakeSecretStore: fakeSecretStore{
+			kind:   "vault",
+			values: map[string]string{ref: "super-secret"},
+		},
+		operation: "load",
+		started:   make(chan struct{}),
+		release:   make(chan struct{}),
+	}
+	manager := NewManager(t.TempDir(), WithSecretStore(store))
+	record := []Connection{{
+		ID:          "conn_external",
+		Name:        "external",
+		Provider:    ProviderAWS,
+		AuthMethod:  "aws_static",
+		Metadata:    map[string]string{"access_key_id": "AKIAEXAMPLE"},
+		SecretStore: "vault",
+		SecretRefs:  map[string]string{"secret_access_key": ref},
+	}}
+	data, err := json.Marshal(record)
+	if err != nil {
+		t.Fatalf("marshal external connection: %v", err)
+	}
+	if err := os.WriteFile(manager.path, data, 0o600); err != nil {
+		t.Fatalf("write external connection: %v", err)
+	}
+
+	loadDone := make(chan error, 1)
+	go func() {
+		_, err := manager.GetForUse("conn_external")
+		loadDone <- err
+	}()
+	<-store.started
+
+	listDone := make(chan error, 1)
+	go func() {
+		_, err := manager.List()
+		listDone <- err
+	}()
+	select {
+	case err := <-listDone:
+		if err != nil {
+			t.Fatalf("List while secret store Load is blocked: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("List blocked behind secret store Load")
+	}
+
+	close(store.release)
+	if err := <-loadDone; err != nil {
+		t.Fatalf("GetForUse: %v", err)
+	}
+}
+
+func TestManagerDoesNotHoldFileLockDuringSecretStoreDelete(t *testing.T) {
+	store := &blockingSecretStore{fakeSecretStore: fakeSecretStore{kind: "vault"}}
+	manager := NewManager(t.TempDir(), WithSecretStore(store))
+	created, err := manager.Save(Connection{
+		Name:        "external",
+		Provider:    ProviderAWS,
+		AuthMethod:  "aws_static",
+		Metadata:    map[string]string{"access_key_id": "AKIAEXAMPLE"},
+		Secrets:     map[string]string{"secret_access_key": "super-secret"},
+		SecretStore: "vault",
+	})
+	if err != nil {
+		t.Fatalf("initial Save: %v", err)
+	}
+	store.operation = "delete"
+	store.started = make(chan struct{})
+	store.release = make(chan struct{})
+	store.startOnce = sync.Once{}
+
+	deleteDone := make(chan error, 1)
+	go func() { deleteDone <- manager.Delete(created.ID) }()
+	<-store.started
+
+	listDone := make(chan error, 1)
+	go func() {
+		_, err := manager.List()
+		listDone <- err
+	}()
+	select {
+	case err := <-listDone:
+		if err != nil {
+			t.Fatalf("List while secret store Delete is blocked: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("List blocked behind secret store Delete")
+	}
+
+	close(store.release)
+	if err := <-deleteDone; err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+}
+
+func TestManagerSerializesConcurrentSavesWithoutDroppingConnections(t *testing.T) {
+	manager := NewManager(t.TempDir())
+	inputs := []Connection{
+		{
+			Name:       "first",
+			Provider:   ProviderAWS,
+			AuthMethod: "aws_profile",
+			Metadata:   map[string]string{"profile": "first"},
+		},
+		{
+			Name:       "second",
+			Provider:   ProviderAWS,
+			AuthMethod: "aws_profile",
+			Metadata:   map[string]string{"profile": "second"},
+		},
+	}
+	errs := make(chan error, len(inputs))
+	var waitGroup sync.WaitGroup
+	for _, input := range inputs {
+		waitGroup.Add(1)
+		go func(input Connection) {
+			defer waitGroup.Done()
+			_, err := manager.Save(input)
+			errs <- err
+		}(input)
+	}
+	waitGroup.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent Save: %v", err)
+		}
+	}
+
+	connections, err := manager.List()
+	if err != nil {
+		t.Fatalf("List after concurrent Save: %v", err)
+	}
+	if len(connections) != len(inputs) {
+		t.Fatalf("concurrent Save dropped a connection: got %d, want %d", len(connections), len(inputs))
+	}
+}
+
 func TestManagerRedactsStaticSecrets(t *testing.T) {
 	manager := NewManager(t.TempDir())
 


### PR DESCRIPTION
## Summary

Fixes #102.

- Keeps the connection file mutex limited to reads and atomic writes.
- Serializes Save/Delete mutations without holding the file mutex during SecretStore calls.
- Resolves external refs and performs migration work outside the file mutex.
- Adds latency, concurrency, and race-regression coverage for Save, Load, Delete, and concurrent saves.

## Validation

- go test -race ./internal/cloudconnections
- go test ./...
- git diff --check

The local untracked CODE_REVIEW.md file was intentionally excluded.