### PR TITLE
Define scoped Agent Hub tool routing policy

### DIFF
--- a/internal/agentrouting/policy.go
+++ b/internal/agentrouting/policy.go
@@ -140,6 +140,19 @@ func (r Rule) Matches(request Request) bool {
 	return false
 }
 
+// Validate checks every rule in the policy and returns the first error found.
+// Callers should call Validate when loading a policy so that misconfigured
+// rules (e.g. empty required fields after a config write bug) are reported at
+// load time rather than silently skipped during Match.
+func (p Policy) Validate() error {
+	for i, rule := range p.Rules {
+		if err := rule.Validate(); err != nil {
+			return fmt.Errorf("rule[%d]: %w", i, err)
+		}
+	}
+	return nil
+}
+
 // Match returns the first matching rule. Callers must treat a false result as
 // deny; this package does not provide an implicit allow decision.
 func (p Policy) Match(request Request) (Rule, bool) {

--- a/internal/agentrouting/policy.go
+++ b/internal/agentrouting/policy.go
@@ -1,0 +1,188 @@
+// Package agentrouting defines the scoped policy contract used before an
+// Agent Hub run can call an external infrastructure tool.
+package agentrouting
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/iac-studio/iac-studio/internal/agentruns"
+	"github.com/iac-studio/iac-studio/internal/mcpairlock"
+)
+
+var (
+	ErrInvalidRequest = errors.New("invalid tool route request")
+	ErrInvalidRule    = errors.New("invalid tool route rule")
+)
+
+type fieldValue struct {
+	name  string
+	value string
+}
+
+// Effect is the outcome a matching policy rule assigns to a tool route.
+type Effect string
+
+const (
+	EffectAllow Effect = "allow"
+	EffectDeny  Effect = "deny"
+)
+
+// Request identifies one attempted Agent Hub to MCP tool route. Every scope
+// field is required so later enforcement cannot accidentally fall back to a
+// provider-wide or project-wide credential choice.
+type Request struct {
+	Project      string              `json:"project"`
+	ProviderID   string              `json:"provider_id"`
+	ConnectionID string              `json:"connection_id"`
+	ServerID     string              `json:"server_id"`
+	ToolName     string              `json:"tool_name"`
+	Mode         agentruns.Mode      `json:"mode"`
+	Risk         mcpairlock.ToolRisk `json:"risk"`
+}
+
+// Rule matches one fully scoped route. Modes are explicit rather than
+// inferred from risk so a read-only request cannot silently become a write.
+type Rule struct {
+	Project          string              `json:"project"`
+	ProviderID       string              `json:"provider_id"`
+	ConnectionID     string              `json:"connection_id"`
+	ServerID         string              `json:"server_id"`
+	ToolName         string              `json:"tool_name"`
+	Modes            []agentruns.Mode    `json:"modes"`
+	Risk             mcpairlock.ToolRisk `json:"risk"`
+	Effect           Effect              `json:"effect"`
+	ApprovalRequired bool                `json:"approval_required,omitempty"`
+}
+
+// Policy is intentionally only a contract in this first slice. An empty
+// policy has no matches and therefore remains fail-closed until a later
+// enforcement layer is wired to it.
+type Policy struct {
+	Rules []Rule `json:"rules"`
+}
+
+func (r Request) Validate() error {
+	if err := validateRequiredFields(ErrInvalidRequest,
+		fieldValue{name: "project", value: r.Project},
+		fieldValue{name: "provider_id", value: r.ProviderID},
+		fieldValue{name: "connection_id", value: r.ConnectionID},
+		fieldValue{name: "server_id", value: r.ServerID},
+		fieldValue{name: "tool_name", value: r.ToolName},
+	); err != nil {
+		return err
+	}
+	if !validMode(r.Mode) {
+		return fmt.Errorf("%w: unsupported mode %q", ErrInvalidRequest, r.Mode)
+	}
+	if !validRisk(r.Risk) {
+		return fmt.Errorf("%w: unsupported risk %q", ErrInvalidRequest, r.Risk)
+	}
+	return nil
+}
+
+func (r Rule) Validate() error {
+	if err := validateRequiredFields(ErrInvalidRule,
+		fieldValue{name: "project", value: r.Project},
+		fieldValue{name: "provider_id", value: r.ProviderID},
+		fieldValue{name: "connection_id", value: r.ConnectionID},
+		fieldValue{name: "server_id", value: r.ServerID},
+		fieldValue{name: "tool_name", value: r.ToolName},
+	); err != nil {
+		return err
+	}
+	if len(r.Modes) == 0 {
+		return fmt.Errorf("%w: at least one mode is required", ErrInvalidRule)
+	}
+	for _, mode := range r.Modes {
+		if !validMode(mode) {
+			return fmt.Errorf("%w: unsupported mode %q", ErrInvalidRule, mode)
+		}
+	}
+	if !validRisk(r.Risk) {
+		return fmt.Errorf("%w: unsupported risk %q", ErrInvalidRule, r.Risk)
+	}
+	if r.Effect != EffectAllow && r.Effect != EffectDeny {
+		return fmt.Errorf("%w: unsupported effect %q", ErrInvalidRule, r.Effect)
+	}
+	if r.Effect == EffectDeny && r.ApprovalRequired {
+		return fmt.Errorf("%w: deny rules cannot require approval", ErrInvalidRule)
+	}
+	if r.Effect == EffectAllow && r.Risk == mcpairlock.RiskUnknown {
+		return fmt.Errorf("%w: unknown risk cannot be allowed", ErrInvalidRule)
+	}
+	if r.Effect == EffectAllow && r.Risk != mcpairlock.RiskReadOnly && !r.ApprovalRequired {
+		return fmt.Errorf("%w: non-read-only allow rules require approval", ErrInvalidRule)
+	}
+	return nil
+}
+
+// Matches reports whether a validated route request is covered by the rule.
+// Matching is exact across all scope and risk fields, including action mode.
+func (r Rule) Matches(request Request) bool {
+	if r.Validate() != nil || request.Validate() != nil {
+		return false
+	}
+	if r.Project != request.Project ||
+		r.ProviderID != request.ProviderID ||
+		r.ConnectionID != request.ConnectionID ||
+		r.ServerID != request.ServerID ||
+		r.ToolName != request.ToolName ||
+		r.Risk != request.Risk {
+		return false
+	}
+	for _, mode := range r.Modes {
+		if mode == request.Mode {
+			return true
+		}
+	}
+	return false
+}
+
+// Match returns the first matching rule. Callers must treat a false result as
+// deny; this package does not provide an implicit allow decision.
+func (p Policy) Match(request Request) (Rule, bool) {
+	if request.Validate() != nil {
+		return Rule{}, false
+	}
+	for _, rule := range p.Rules {
+		if rule.Matches(request) {
+			return rule, true
+		}
+	}
+	return Rule{}, false
+}
+
+func validMode(mode agentruns.Mode) bool {
+	switch mode {
+	case agentruns.ModeReadOnly, agentruns.ModeProposeOnly, agentruns.ModeApprovedExecute:
+		return true
+	default:
+		return false
+	}
+}
+
+func validateRequiredFields(root error, fields ...fieldValue) error {
+	for _, field := range fields {
+		if strings.TrimSpace(field.value) == "" {
+			return fmt.Errorf("%w: %s is required", root, field.name)
+		}
+	}
+	return nil
+}
+
+func validRisk(risk mcpairlock.ToolRisk) bool {
+	switch risk {
+	case mcpairlock.RiskReadOnly,
+		mcpairlock.RiskGenerateCode,
+		mcpairlock.RiskModifyWorkspace,
+		mcpairlock.RiskCloudMutation,
+		mcpairlock.RiskSecretSensitive,
+		mcpairlock.RiskDestructive,
+		mcpairlock.RiskUnknown:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/agentrouting/policy.go
+++ b/internal/agentrouting/policy.go
@@ -73,7 +73,7 @@ func (r Request) Validate() error {
 	); err != nil {
 		return err
 	}
-	if !validMode(r.Mode) {
+	if !r.Mode.Valid() {
 		return fmt.Errorf("%w: unsupported mode %q", ErrInvalidRequest, r.Mode)
 	}
 	if !validRisk(r.Risk) {
@@ -96,7 +96,7 @@ func (r Rule) Validate() error {
 		return fmt.Errorf("%w: at least one mode is required", ErrInvalidRule)
 	}
 	for _, mode := range r.Modes {
-		if !validMode(mode) {
+		if !mode.Valid() {
 			return fmt.Errorf("%w: unsupported mode %q", ErrInvalidRule, mode)
 		}
 	}
@@ -170,15 +170,6 @@ func (p Policy) Match(request Request) (Rule, bool) {
 		}
 	}
 	return Rule{}, false
-}
-
-func validMode(mode agentruns.Mode) bool {
-	switch mode {
-	case agentruns.ModeReadOnly, agentruns.ModeProposeOnly, agentruns.ModeApprovedExecute:
-		return true
-	default:
-		return false
-	}
 }
 
 func validateRequiredFields(root error, fields ...fieldValue) error {

--- a/internal/agentrouting/policy.go
+++ b/internal/agentrouting/policy.go
@@ -118,12 +118,17 @@ func (r Rule) Validate() error {
 	return nil
 }
 
-// Matches reports whether a validated route request is covered by the rule.
-// Matching is exact across all scope and risk fields, including action mode.
+// Matches reports whether a route request is covered by the rule. Invalid
+// rules and requests fail closed. Matching is exact across every scope field,
+// risk, and action mode.
 func (r Rule) Matches(request Request) bool {
 	if r.Validate() != nil || request.Validate() != nil {
 		return false
 	}
+	return r.matchesValidated(request)
+}
+
+func (r Rule) matchesValidated(request Request) bool {
 	if r.Project != request.Project ||
 		r.ProviderID != request.ProviderID ||
 		r.ConnectionID != request.ConnectionID ||
@@ -160,7 +165,7 @@ func (p Policy) Match(request Request) (Rule, bool) {
 		return Rule{}, false
 	}
 	for _, rule := range p.Rules {
-		if rule.Matches(request) {
+		if rule.Validate() == nil && rule.matchesValidated(request) {
 			return rule, true
 		}
 	}
@@ -178,8 +183,12 @@ func validMode(mode agentruns.Mode) bool {
 
 func validateRequiredFields(root error, fields ...fieldValue) error {
 	for _, field := range fields {
-		if strings.TrimSpace(field.value) == "" {
+		trimmed := strings.TrimSpace(field.value)
+		if trimmed == "" {
 			return fmt.Errorf("%w: %s is required", root, field.name)
+		}
+		if trimmed != field.value {
+			return fmt.Errorf("%w: %s must not contain leading or trailing whitespace", root, field.name)
 		}
 	}
 	return nil

--- a/internal/agentrouting/policy_test.go
+++ b/internal/agentrouting/policy_test.go
@@ -1,0 +1,137 @@
+package agentrouting
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/iac-studio/iac-studio/internal/agentruns"
+	"github.com/iac-studio/iac-studio/internal/mcpairlock"
+)
+
+func validRequest() Request {
+	return Request{
+		Project:      "platform-prod",
+		ProviderID:   "aws-bedrock",
+		ConnectionID: "aws-prod",
+		ServerID:     "terraform-official",
+		ToolName:     "plan_workspace",
+		Mode:         agentruns.ModeProposeOnly,
+		Risk:         mcpairlock.RiskGenerateCode,
+	}
+}
+
+func validRule() Rule {
+	request := validRequest()
+	return Rule{
+		Project:          request.Project,
+		ProviderID:       request.ProviderID,
+		ConnectionID:     request.ConnectionID,
+		ServerID:         request.ServerID,
+		ToolName:         request.ToolName,
+		Modes:            []agentruns.Mode{request.Mode},
+		Risk:             request.Risk,
+		Effect:           EffectAllow,
+		ApprovalRequired: true,
+	}
+}
+
+func TestRequestValidationRequiresCompleteScope(t *testing.T) {
+	base := validRequest()
+	tests := []struct {
+		name   string
+		mutate func(*Request)
+	}{
+		{name: "project", mutate: func(request *Request) { request.Project = "" }},
+		{name: "provider", mutate: func(request *Request) { request.ProviderID = "" }},
+		{name: "connection", mutate: func(request *Request) { request.ConnectionID = "" }},
+		{name: "server", mutate: func(request *Request) { request.ServerID = "" }},
+		{name: "tool", mutate: func(request *Request) { request.ToolName = "" }},
+		{name: "mode", mutate: func(request *Request) { request.Mode = "execute" }},
+		{name: "risk", mutate: func(request *Request) { request.Risk = "unclassified" }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			request := base
+			test.mutate(&request)
+			if err := request.Validate(); err == nil || !errors.Is(err, ErrInvalidRequest) {
+				t.Fatalf("Validate() error = %v, want ErrInvalidRequest", err)
+			}
+		})
+	}
+}
+
+func TestRuleMatchesEverySecurityDimension(t *testing.T) {
+	rule := validRule()
+	if err := rule.Validate(); err != nil {
+		t.Fatalf("Validate(): %v", err)
+	}
+	request := validRequest()
+	if !rule.Matches(request) {
+		t.Fatal("valid request should match rule")
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*Request)
+	}{
+		{name: "project", mutate: func(request *Request) { request.Project = "platform-dev" }},
+		{name: "provider", mutate: func(request *Request) { request.ProviderID = "openai-api" }},
+		{name: "connection", mutate: func(request *Request) { request.ConnectionID = "aws-dev" }},
+		{name: "server", mutate: func(request *Request) { request.ServerID = "aws-readonly" }},
+		{name: "tool", mutate: func(request *Request) { request.ToolName = "apply_workspace" }},
+		{name: "mode", mutate: func(request *Request) { request.Mode = agentruns.ModeApprovedExecute }},
+		{name: "risk", mutate: func(request *Request) { request.Risk = mcpairlock.RiskCloudMutation }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			candidate := request
+			test.mutate(&candidate)
+			if rule.Matches(candidate) {
+				t.Fatal("route with changed security dimension should not match")
+			}
+		})
+	}
+}
+
+func TestPolicyDefaultsToDenyAndMatchesExplicitRules(t *testing.T) {
+	request := validRequest()
+	policy := Policy{Rules: []Rule{validRule()}}
+
+	if matched, ok := policy.Match(request); !ok || matched.Effect != EffectAllow || !matched.ApprovalRequired {
+		t.Fatalf("Match() = %#v, %v; want approved allow rule", matched, ok)
+	}
+	request.ToolName = "apply_workspace"
+	if _, ok := policy.Match(request); ok {
+		t.Fatal("unmatched route should fail closed")
+	}
+}
+
+func TestRuleRejectsApprovalOnDeny(t *testing.T) {
+	rule := validRule()
+	rule.Effect = EffectDeny
+	if err := rule.Validate(); err == nil || !errors.Is(err, ErrInvalidRule) {
+		t.Fatalf("Validate() error = %v, want ErrInvalidRule", err)
+	}
+}
+
+func TestRuleRejectsUnsafeAllowDefaults(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*Rule)
+	}{
+		{name: "unknown risk", mutate: func(rule *Rule) { rule.Risk = mcpairlock.RiskUnknown }},
+		{name: "mutation without approval", mutate: func(rule *Rule) {
+			rule.Risk = mcpairlock.RiskCloudMutation
+			rule.ApprovalRequired = false
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rule := validRule()
+			test.mutate(&rule)
+			if err := rule.Validate(); err == nil || !errors.Is(err, ErrInvalidRule) {
+				t.Fatalf("Validate() error = %v, want ErrInvalidRule", err)
+			}
+		})
+	}
+}

--- a/internal/agentrouting/policy_test.go
+++ b/internal/agentrouting/policy_test.go
@@ -114,6 +114,35 @@ func TestRuleRejectsApprovalOnDeny(t *testing.T) {
 	}
 }
 
+func TestPolicyValidateSurfacesMisconfiguredRules(t *testing.T) {
+	good := validRule()
+
+	badRule := validRule()
+	badRule.ConnectionID = ""
+
+	tests := []struct {
+		name    string
+		policy  Policy
+		wantErr bool
+	}{
+		{name: "valid policy", policy: Policy{Rules: []Rule{good}}, wantErr: false},
+		{name: "empty policy", policy: Policy{}, wantErr: false},
+		{name: "invalid rule at index 0", policy: Policy{Rules: []Rule{badRule}}, wantErr: true},
+		{name: "invalid rule after valid rule", policy: Policy{Rules: []Rule{good, badRule}}, wantErr: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.policy.Validate()
+			if (err != nil) != test.wantErr {
+				t.Fatalf("Policy.Validate() error = %v, wantErr %v", err, test.wantErr)
+			}
+			if test.wantErr && !errors.Is(err, ErrInvalidRule) {
+				t.Fatalf("Policy.Validate() error = %v, want ErrInvalidRule", err)
+			}
+		})
+	}
+}
+
 func TestRuleRejectsUnsafeAllowDefaults(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/agentrouting/policy_test.go
+++ b/internal/agentrouting/policy_test.go
@@ -46,6 +46,8 @@ func TestRequestValidationRequiresCompleteScope(t *testing.T) {
 		{name: "connection", mutate: func(request *Request) { request.ConnectionID = "" }},
 		{name: "server", mutate: func(request *Request) { request.ServerID = "" }},
 		{name: "tool", mutate: func(request *Request) { request.ToolName = "" }},
+		{name: "padded server", mutate: func(request *Request) { request.ServerID = " terraform-official" }},
+		{name: "padded tool", mutate: func(request *Request) { request.ToolName = "plan_workspace\t" }},
 		{name: "mode", mutate: func(request *Request) { request.Mode = "execute" }},
 		{name: "risk", mutate: func(request *Request) { request.Risk = "unclassified" }},
 	}
@@ -58,6 +60,24 @@ func TestRequestValidationRequiresCompleteScope(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRuleMatchesRejectsInvalidInputs(t *testing.T) {
+	t.Run("invalid request", func(t *testing.T) {
+		request := validRequest()
+		request.ServerID = " terraform-official"
+		if validRule().Matches(request) {
+			t.Fatal("rule should not match an invalid request")
+		}
+	})
+
+	t.Run("invalid rule", func(t *testing.T) {
+		rule := validRule()
+		rule.ConnectionID = ""
+		if rule.Matches(validRequest()) {
+			t.Fatal("invalid rule should not match a request")
+		}
+	})
 }
 
 func TestRuleMatchesEverySecurityDimension(t *testing.T) {
@@ -119,6 +139,8 @@ func TestPolicyValidateSurfacesMisconfiguredRules(t *testing.T) {
 
 	badRule := validRule()
 	badRule.ConnectionID = ""
+	paddedRule := validRule()
+	paddedRule.ServerID = "terraform-official "
 
 	tests := []struct {
 		name    string
@@ -129,6 +151,7 @@ func TestPolicyValidateSurfacesMisconfiguredRules(t *testing.T) {
 		{name: "empty policy", policy: Policy{}, wantErr: false},
 		{name: "invalid rule at index 0", policy: Policy{Rules: []Rule{badRule}}, wantErr: true},
 		{name: "invalid rule after valid rule", policy: Policy{Rules: []Rule{good, badRule}}, wantErr: true},
+		{name: "whitespace-padded rule", policy: Policy{Rules: []Rule{paddedRule}}, wantErr: true},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/agentruns/store.go
+++ b/internal/agentruns/store.go
@@ -41,6 +41,16 @@ const (
 	ModeApprovedExecute Mode = "approved_execute"
 )
 
+// Valid reports whether the mode is supported by agent runs.
+func (m Mode) Valid() bool {
+	switch m {
+	case ModeReadOnly, ModeProposeOnly, ModeApprovedExecute:
+		return true
+	default:
+		return false
+	}
+}
+
 type LogLevel string
 
 const (
@@ -215,7 +225,7 @@ func (s *Store) Create(req CreateRequest) (Run, error) {
 	if mode == "" {
 		mode = ModeReadOnly
 	}
-	if !validMode(mode) {
+	if !mode.Valid() {
 		return Run{}, fmt.Errorf("invalid agent run mode: %s", mode)
 	}
 
@@ -544,15 +554,6 @@ var (
 	ErrApprovalDecided  = errors.New("approval gate is already decided")
 	ErrUnsafePatchPath  = errors.New("patch path must be a relative path within the project")
 )
-
-func validMode(mode Mode) bool {
-	switch mode {
-	case ModeReadOnly, ModeProposeOnly, ModeApprovedExecute:
-		return true
-	default:
-		return false
-	}
-}
 
 func validStatus(status Status) bool {
 	switch status {

--- a/internal/agentruns/store_test.go
+++ b/internal/agentruns/store_test.go
@@ -13,6 +13,24 @@ import (
 
 var testPromptHashKey = []byte("01234567890123456789012345678901")
 
+func TestModeValid(t *testing.T) {
+	tests := []struct {
+		mode Mode
+		want bool
+	}{
+		{mode: ModeReadOnly, want: true},
+		{mode: ModeProposeOnly, want: true},
+		{mode: ModeApprovedExecute, want: true},
+		{mode: "", want: false},
+		{mode: "unsafe", want: false},
+	}
+	for _, test := range tests {
+		if got := test.mode.Valid(); got != test.want {
+			t.Errorf("Mode(%q).Valid() = %v, want %v", test.mode, got, test.want)
+		}
+	}
+}
+
 func TestStoreCreateRedactsPromptAndDefaultsReadOnly(t *testing.T) {
 	now := fixedClock()
 	store := NewStore(WithClock(now.now), WithPromptHashKey(testPromptHashKey))


### PR DESCRIPTION
## Summary

Part of #107.

This PR adds the provider-neutral policy contract for Agent Hub to MCP tool routing:

- Requires project, provider, cloud connection, MCP server, tool, action mode, and risk on every route request.
- Supports exact scoped allow/deny rules with explicit action modes.
- Defaults unmatched routes to deny.
- Rejects unknown-risk allows and non-read-only allows without approval.
- Does not execute tools or change existing Airlock behavior; enforcement is a follow-up PR.

## Validation

- go test ./internal/agentrouting
- go test ./...
- go vet ./internal/agentrouting
- git diff --check

The local untracked CODE_REVIEW.md file was intentionally excluded.