### PR TITLE
Add fail-closed Agent Hub tool authorization

### DIFF
--- a/internal/agentrouting/decision.go
+++ b/internal/agentrouting/decision.go
@@ -65,7 +65,7 @@ func Evaluate(policy Policy, request Request, airlock mcpairlock.ToolDecision) D
 	}
 
 	switch {
-	case airlock.Status == "blocked" && !airlock.Allowed && !airlock.ApprovalRequired:
+	case airlock.Status == "blocked" && !airlock.Allowed && !airlock.ApprovalRequired && airlock.UntrustedOutput:
 		return denied(ReasonAirlockBlocked)
 	case airlock.Status == "approval_required" && !airlock.Allowed && airlock.ApprovalRequired && airlock.UntrustedOutput:
 		return approvalRequired()

--- a/internal/agentrouting/decision.go
+++ b/internal/agentrouting/decision.go
@@ -1,0 +1,115 @@
+package agentrouting
+
+import (
+	"github.com/iac-studio/iac-studio/internal/agentruns"
+	"github.com/iac-studio/iac-studio/internal/mcpairlock"
+)
+
+// DecisionStatus is the authorization outcome for one Agent Hub tool route.
+type DecisionStatus string
+
+const (
+	DecisionDenied           DecisionStatus = "denied"
+	DecisionApprovalRequired DecisionStatus = "approval_required"
+	DecisionAllowed          DecisionStatus = "allowed"
+)
+
+// DecisionReason is a stable machine-readable explanation for an outcome.
+type DecisionReason string
+
+const (
+	ReasonInvalidRequest         DecisionReason = "invalid_request"
+	ReasonInvalidPolicy          DecisionReason = "invalid_policy"
+	ReasonModeRiskMismatch       DecisionReason = "mode_risk_mismatch"
+	ReasonNoMatchingRule         DecisionReason = "no_matching_rule"
+	ReasonPolicyDenied           DecisionReason = "policy_denied"
+	ReasonAirlockRiskMismatch    DecisionReason = "airlock_risk_mismatch"
+	ReasonInvalidAirlockDecision DecisionReason = "invalid_airlock_decision"
+	ReasonAirlockBlocked         DecisionReason = "airlock_blocked"
+	ReasonApprovalRequired       DecisionReason = "approval_required"
+	ReasonAllowed                DecisionReason = "allowed"
+)
+
+// Decision combines the scoped route policy with MCP Airlock's firewall
+// result. External MCP output remains untrusted for every outcome.
+type Decision struct {
+	Status           DecisionStatus `json:"status"`
+	Reason           DecisionReason `json:"reason"`
+	Allowed          bool           `json:"allowed"`
+	ApprovalRequired bool           `json:"approval_required"`
+	UntrustedOutput  bool           `json:"untrusted_output"`
+}
+
+// Evaluate intersects the route policy, agent mode, and Airlock firewall
+// result. Missing, malformed, or contradictory inputs always fail closed.
+func Evaluate(policy Policy, request Request, airlock mcpairlock.ToolDecision) Decision {
+	if request.Validate() != nil {
+		return denied(ReasonInvalidRequest)
+	}
+	if !modeAllowsRisk(request.Mode, request.Risk) {
+		return denied(ReasonModeRiskMismatch)
+	}
+	if policy.Validate() != nil {
+		return denied(ReasonInvalidPolicy)
+	}
+
+	rule, matched := policy.matchValidated(request)
+	if !matched {
+		return denied(ReasonNoMatchingRule)
+	}
+	if rule.Effect == EffectDeny {
+		return denied(ReasonPolicyDenied)
+	}
+	if airlock.Risk != request.Risk {
+		return denied(ReasonAirlockRiskMismatch)
+	}
+
+	switch {
+	case airlock.Status == "blocked" && !airlock.Allowed && !airlock.ApprovalRequired:
+		return denied(ReasonAirlockBlocked)
+	case airlock.Status == "approval_required" && !airlock.Allowed && airlock.ApprovalRequired && airlock.UntrustedOutput:
+		return approvalRequired()
+	case airlock.Status == "allowed" && airlock.Allowed && !airlock.ApprovalRequired && airlock.UntrustedOutput:
+		if rule.ApprovalRequired {
+			return approvalRequired()
+		}
+		return allowed()
+	default:
+		return denied(ReasonInvalidAirlockDecision)
+	}
+}
+
+func modeAllowsRisk(mode agentruns.Mode, risk mcpairlock.ToolRisk) bool {
+	switch mode {
+	case agentruns.ModeReadOnly:
+		return risk == mcpairlock.RiskReadOnly
+	case agentruns.ModeProposeOnly:
+		return risk == mcpairlock.RiskReadOnly || risk == mcpairlock.RiskGenerateCode
+	case agentruns.ModeApprovedExecute:
+		return risk != mcpairlock.RiskUnknown
+	default:
+		return false
+	}
+}
+
+func denied(reason DecisionReason) Decision {
+	return Decision{Status: DecisionDenied, Reason: reason, UntrustedOutput: true}
+}
+
+func approvalRequired() Decision {
+	return Decision{
+		Status:           DecisionApprovalRequired,
+		Reason:           ReasonApprovalRequired,
+		ApprovalRequired: true,
+		UntrustedOutput:  true,
+	}
+}
+
+func allowed() Decision {
+	return Decision{
+		Status:          DecisionAllowed,
+		Reason:          ReasonAllowed,
+		Allowed:         true,
+		UntrustedOutput: true,
+	}
+}

--- a/internal/agentrouting/decision_test.go
+++ b/internal/agentrouting/decision_test.go
@@ -1,0 +1,153 @@
+package agentrouting
+
+import (
+	"testing"
+
+	"github.com/iac-studio/iac-studio/internal/agentruns"
+	"github.com/iac-studio/iac-studio/internal/mcpairlock"
+)
+
+func readOnlyEvaluation() (Policy, Request, mcpairlock.ToolDecision) {
+	request := validRequest()
+	request.Mode = agentruns.ModeReadOnly
+	request.Risk = mcpairlock.RiskReadOnly
+
+	rule := validRule()
+	rule.Modes = []agentruns.Mode{request.Mode}
+	rule.Risk = request.Risk
+	rule.ApprovalRequired = false
+
+	airlock := mcpairlock.ToolDecision{
+		Status:          "allowed",
+		Allowed:         true,
+		Risk:            request.Risk,
+		UntrustedOutput: true,
+	}
+	return Policy{Rules: []Rule{rule}}, request, airlock
+}
+
+func TestEvaluateAllowsOnlyWhenBothLayersAllow(t *testing.T) {
+	policy, request, airlock := readOnlyEvaluation()
+	decision := Evaluate(policy, request, airlock)
+	if decision.Status != DecisionAllowed || !decision.Allowed || decision.ApprovalRequired || !decision.UntrustedOutput {
+		t.Fatalf("Evaluate() = %+v, want allowed untrusted output", decision)
+	}
+}
+
+func TestEvaluateRequiresApprovalFromEitherLayer(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*Policy, *mcpairlock.ToolDecision)
+	}{
+		{name: "route policy", mutate: func(policy *Policy, _ *mcpairlock.ToolDecision) {
+			policy.Rules[0].ApprovalRequired = true
+		}},
+		{name: "airlock", mutate: func(_ *Policy, airlock *mcpairlock.ToolDecision) {
+			airlock.Status = "approval_required"
+			airlock.Allowed = false
+			airlock.ApprovalRequired = true
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			policy, request, airlock := readOnlyEvaluation()
+			test.mutate(&policy, &airlock)
+			decision := Evaluate(policy, request, airlock)
+			if decision.Status != DecisionApprovalRequired || decision.Allowed || !decision.ApprovalRequired || !decision.UntrustedOutput {
+				t.Fatalf("Evaluate() = %+v, want approval required", decision)
+			}
+		})
+	}
+}
+
+func TestModeAllowsRisk(t *testing.T) {
+	tests := []struct {
+		name string
+		mode agentruns.Mode
+		risk mcpairlock.ToolRisk
+		want bool
+	}{
+		{name: "read-only inventory", mode: agentruns.ModeReadOnly, risk: mcpairlock.RiskReadOnly, want: true},
+		{name: "read-only generation", mode: agentruns.ModeReadOnly, risk: mcpairlock.RiskGenerateCode, want: false},
+		{name: "propose inventory", mode: agentruns.ModeProposeOnly, risk: mcpairlock.RiskReadOnly, want: true},
+		{name: "propose generation", mode: agentruns.ModeProposeOnly, risk: mcpairlock.RiskGenerateCode, want: true},
+		{name: "propose workspace mutation", mode: agentruns.ModeProposeOnly, risk: mcpairlock.RiskModifyWorkspace, want: false},
+		{name: "approved cloud mutation", mode: agentruns.ModeApprovedExecute, risk: mcpairlock.RiskCloudMutation, want: true},
+		{name: "approved destructive", mode: agentruns.ModeApprovedExecute, risk: mcpairlock.RiskDestructive, want: true},
+		{name: "approved unknown", mode: agentruns.ModeApprovedExecute, risk: mcpairlock.RiskUnknown, want: false},
+		{name: "unknown mode", mode: "execute", risk: mcpairlock.RiskReadOnly, want: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := modeAllowsRisk(test.mode, test.risk); got != test.want {
+				t.Fatalf("modeAllowsRisk(%q, %q) = %v, want %v", test.mode, test.risk, got, test.want)
+			}
+		})
+	}
+}
+
+func TestEvaluateFailsClosed(t *testing.T) {
+	tests := []struct {
+		name       string
+		mutate     func(*Policy, *Request, *mcpairlock.ToolDecision)
+		wantReason DecisionReason
+	}{
+		{name: "invalid request", mutate: func(_ *Policy, request *Request, _ *mcpairlock.ToolDecision) {
+			request.ConnectionID = ""
+		}, wantReason: ReasonInvalidRequest},
+		{name: "unsafe mode and risk", mutate: func(policy *Policy, request *Request, airlock *mcpairlock.ToolDecision) {
+			request.Risk = mcpairlock.RiskCloudMutation
+			policy.Rules[0].Risk = request.Risk
+			policy.Rules[0].ApprovalRequired = true
+			airlock.Risk = request.Risk
+		}, wantReason: ReasonModeRiskMismatch},
+		{name: "invalid policy", mutate: func(policy *Policy, _ *Request, _ *mcpairlock.ToolDecision) {
+			bad := validRule()
+			bad.ConnectionID = ""
+			policy.Rules = append(policy.Rules, bad)
+		}, wantReason: ReasonInvalidPolicy},
+		{name: "no matching rule", mutate: func(policy *Policy, _ *Request, _ *mcpairlock.ToolDecision) {
+			policy.Rules[0].ToolName = "other_tool"
+		}, wantReason: ReasonNoMatchingRule},
+		{name: "deny rule", mutate: func(policy *Policy, _ *Request, _ *mcpairlock.ToolDecision) {
+			policy.Rules[0].Effect = EffectDeny
+		}, wantReason: ReasonPolicyDenied},
+		{name: "airlock risk mismatch", mutate: func(_ *Policy, _ *Request, airlock *mcpairlock.ToolDecision) {
+			airlock.Risk = mcpairlock.RiskGenerateCode
+		}, wantReason: ReasonAirlockRiskMismatch},
+		{name: "airlock blocked", mutate: func(_ *Policy, _ *Request, airlock *mcpairlock.ToolDecision) {
+			airlock.Status = "blocked"
+			airlock.Allowed = false
+		}, wantReason: ReasonAirlockBlocked},
+		{name: "contradictory airlock flags", mutate: func(_ *Policy, _ *Request, airlock *mcpairlock.ToolDecision) {
+			airlock.ApprovalRequired = true
+		}, wantReason: ReasonInvalidAirlockDecision},
+		{name: "trusted airlock output", mutate: func(_ *Policy, _ *Request, airlock *mcpairlock.ToolDecision) {
+			airlock.UntrustedOutput = false
+		}, wantReason: ReasonInvalidAirlockDecision},
+		{name: "unknown airlock status", mutate: func(_ *Policy, _ *Request, airlock *mcpairlock.ToolDecision) {
+			airlock.Status = "unknown"
+		}, wantReason: ReasonInvalidAirlockDecision},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			policy, request, airlock := readOnlyEvaluation()
+			test.mutate(&policy, &request, &airlock)
+			decision := Evaluate(policy, request, airlock)
+			if decision.Status != DecisionDenied || decision.Allowed || decision.ApprovalRequired || decision.Reason != test.wantReason || !decision.UntrustedOutput {
+				t.Fatalf("Evaluate() = %+v, want denied reason %q", decision, test.wantReason)
+			}
+		})
+	}
+}
+
+func TestPolicyMatchRejectsEntireInvalidPolicy(t *testing.T) {
+	request := validRequest()
+	bad := validRule()
+	bad.ConnectionID = ""
+	policy := Policy{Rules: []Rule{validRule(), bad}}
+	if matched, ok := policy.Match(request); ok {
+		t.Fatalf("Match() = %+v, true; want invalid policy to fail closed", matched)
+	}
+}

--- a/internal/agentrouting/decision_test.go
+++ b/internal/agentrouting/decision_test.go
@@ -119,6 +119,11 @@ func TestEvaluateFailsClosed(t *testing.T) {
 			airlock.Status = "blocked"
 			airlock.Allowed = false
 		}, wantReason: ReasonAirlockBlocked},
+		{name: "blocked trusted output", mutate: func(_ *Policy, _ *Request, airlock *mcpairlock.ToolDecision) {
+			airlock.Status = "blocked"
+			airlock.Allowed = false
+			airlock.UntrustedOutput = false
+		}, wantReason: ReasonInvalidAirlockDecision},
 		{name: "contradictory airlock flags", mutate: func(_ *Policy, _ *Request, airlock *mcpairlock.ToolDecision) {
 			airlock.ApprovalRequired = true
 		}, wantReason: ReasonInvalidAirlockDecision},

--- a/internal/agentrouting/policy.go
+++ b/internal/agentrouting/policy.go
@@ -161,11 +161,15 @@ func (p Policy) Validate() error {
 // Match returns the first matching rule. Callers must treat a false result as
 // deny; this package does not provide an implicit allow decision.
 func (p Policy) Match(request Request) (Rule, bool) {
-	if request.Validate() != nil {
+	if request.Validate() != nil || p.Validate() != nil {
 		return Rule{}, false
 	}
+	return p.matchValidated(request)
+}
+
+func (p Policy) matchValidated(request Request) (Rule, bool) {
 	for _, rule := range p.Rules {
-		if rule.Validate() == nil && rule.matchesValidated(request) {
+		if rule.matchesValidated(request) {
 			return rule, true
 		}
 	}


### PR DESCRIPTION
## Summary
- combine scoped routing policy with MCP Airlock firewall decisions
- enforce read-only, propose-only, and approved-execute risk boundaries
- fail closed on invalid policies, missing routes, risk mismatches, contradictory Airlock state, and trusted-output claims
- require approval when either policy layer requires it

## Security properties
- validates the entire policy before matching
- allows a route only when both policy and Airlock explicitly allow it
- keeps all external MCP output marked untrusted
- does not execute tools, access credentials, or add network/API behavior

## Validation
- `GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/agentrouting`
- `GOCACHE=/private/tmp/iacstudio-go-cache go test ./...`
- `GOCACHE=/private/tmp/iacstudio-go-cache go vet ./internal/agentrouting`

Part of #107