### PR TITLE
Add Airlock-backed Agent Hub authorizer

### DIFF
--- a/internal/agentrouting/authorizer.go
+++ b/internal/agentrouting/authorizer.go
@@ -62,10 +62,11 @@ func (a *Authorizer) Authorize(request Request) Decision {
 		return denied(ReasonAirlockUnavailable)
 	}
 	if entry.ServerID != request.ServerID ||
-		entry.Name != request.ToolName ||
-		entry.Risk != request.Risk ||
-		entry.Risk != entry.Decision.Risk {
+		entry.Name != request.ToolName {
 		return denied(ReasonAirlockToolMismatch)
+	}
+	if entry.Risk != entry.Decision.Risk {
+		return denied(ReasonInvalidAirlockDecision)
 	}
 	return evaluateMatched(rule, request, entry.Decision)
 }

--- a/internal/agentrouting/authorizer.go
+++ b/internal/agentrouting/authorizer.go
@@ -46,6 +46,9 @@ func (a *Authorizer) Authorize(request Request) Decision {
 	if a == nil || missingToolEvaluator(a.evaluator) {
 		return denied(ReasonAirlockUnavailable)
 	}
+	if a.policy.Validate() != nil {
+		return denied(ReasonInvalidPolicy)
+	}
 	rule, matched := a.policy.matchValidated(request)
 	if !matched {
 		return denied(ReasonNoMatchingRule)
@@ -73,7 +76,7 @@ func missingToolEvaluator(evaluator ToolEvaluator) bool {
 	}
 	value := reflect.ValueOf(evaluator)
 	switch value.Kind() {
-	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
 		return value.IsNil()
 	default:
 		return false

--- a/internal/agentrouting/authorizer.go
+++ b/internal/agentrouting/authorizer.go
@@ -60,6 +60,7 @@ func (a *Authorizer) Authorize(request Request) Decision {
 	}
 	if entry.ServerID != request.ServerID ||
 		entry.Name != request.ToolName ||
+		entry.Risk != request.Risk ||
 		entry.Risk != entry.Decision.Risk {
 		return denied(ReasonAirlockToolMismatch)
 	}

--- a/internal/agentrouting/authorizer.go
+++ b/internal/agentrouting/authorizer.go
@@ -1,0 +1,89 @@
+package agentrouting
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+
+	"github.com/iac-studio/iac-studio/internal/agentruns"
+	"github.com/iac-studio/iac-studio/internal/mcpairlock"
+)
+
+var ErrToolEvaluatorRequired = errors.New("tool evaluator is required")
+
+// ToolEvaluator is the read-only MCP Airlock boundary used to retrieve one
+// discovered tool's current firewall decision.
+type ToolEvaluator interface {
+	EvaluateTool(serverID, project, toolName string) (mcpairlock.ToolInventoryEntry, error)
+}
+
+// Authorizer combines an immutable routing policy snapshot with live MCP
+// Airlock inventory decisions. It never invokes an external tool.
+type Authorizer struct {
+	policy    Policy
+	evaluator ToolEvaluator
+}
+
+// NewAuthorizer validates and snapshots the routing policy before it can be
+// used. Later caller mutations cannot widen the authorizer's permissions.
+func NewAuthorizer(policy Policy, evaluator ToolEvaluator) (*Authorizer, error) {
+	if missingToolEvaluator(evaluator) {
+		return nil, ErrToolEvaluatorRequired
+	}
+	snapshot := clonePolicy(policy)
+	if err := snapshot.Validate(); err != nil {
+		return nil, fmt.Errorf("validate routing policy: %w", err)
+	}
+	return &Authorizer{policy: snapshot, evaluator: evaluator}, nil
+}
+
+// Authorize evaluates the current Airlock decision for one fully scoped tool
+// route. Airlock errors and inconsistent inventory identities fail closed.
+func (a *Authorizer) Authorize(request Request) Decision {
+	if decision, stop := preflight(request); stop {
+		return decision
+	}
+	if a == nil || missingToolEvaluator(a.evaluator) {
+		return denied(ReasonAirlockUnavailable)
+	}
+	rule, matched := a.policy.matchValidated(request)
+	if !matched {
+		return denied(ReasonNoMatchingRule)
+	}
+	if rule.Effect == EffectDeny {
+		return denied(ReasonPolicyDenied)
+	}
+
+	entry, err := a.evaluator.EvaluateTool(request.ServerID, request.Project, request.ToolName)
+	if err != nil {
+		return denied(ReasonAirlockUnavailable)
+	}
+	if entry.ServerID != request.ServerID ||
+		entry.Name != request.ToolName ||
+		entry.Risk != entry.Decision.Risk {
+		return denied(ReasonAirlockToolMismatch)
+	}
+	return evaluateMatched(rule, request, entry.Decision)
+}
+
+func missingToolEvaluator(evaluator ToolEvaluator) bool {
+	if evaluator == nil {
+		return true
+	}
+	value := reflect.ValueOf(evaluator)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
+}
+
+func clonePolicy(policy Policy) Policy {
+	rules := make([]Rule, len(policy.Rules))
+	copy(rules, policy.Rules)
+	for i := range rules {
+		rules[i].Modes = append([]agentruns.Mode(nil), rules[i].Modes...)
+	}
+	return Policy{Rules: rules}
+}

--- a/internal/agentrouting/authorizer.go
+++ b/internal/agentrouting/authorizer.go
@@ -61,8 +61,10 @@ func (a *Authorizer) Authorize(request Request) Decision {
 	if err != nil {
 		return denied(ReasonAirlockUnavailable)
 	}
-	if entry.ServerID != request.ServerID ||
-		entry.Name != request.ToolName {
+	if entry.ServerID != request.ServerID {
+		return denied(ReasonAirlockServerMismatch)
+	}
+	if entry.Name != request.ToolName {
 		return denied(ReasonAirlockToolMismatch)
 	}
 	if entry.Risk != entry.Decision.Risk {

--- a/internal/agentrouting/authorizer_test.go
+++ b/internal/agentrouting/authorizer_test.go
@@ -151,6 +151,18 @@ func TestAuthorizerSnapshotsValidatedPolicy(t *testing.T) {
 	}
 }
 
+func TestAuthorizerRejectsInvalidStoredPolicyBeforeCallingAirlock(t *testing.T) {
+	policy, request, decision := readOnlyEvaluation()
+	policy.Rules[0].Effect = "unsupported"
+	evaluator := &fakeToolEvaluator{entry: evaluationEntry(request, decision)}
+	authorizer := &Authorizer{policy: policy, evaluator: evaluator}
+
+	got := authorizer.Authorize(request)
+	if got.Status != DecisionDenied || got.Reason != ReasonInvalidPolicy || evaluator.calls != 0 {
+		t.Fatalf("Authorize() = %+v, calls = %d; want invalid policy denial without Airlock call", got, evaluator.calls)
+	}
+}
+
 func TestNewAuthorizerRejectsInvalidDependencies(t *testing.T) {
 	policy, _, _ := readOnlyEvaluation()
 	if _, err := NewAuthorizer(policy, nil); !errors.Is(err, ErrToolEvaluatorRequired) {

--- a/internal/agentrouting/authorizer_test.go
+++ b/internal/agentrouting/authorizer_test.go
@@ -105,7 +105,7 @@ func TestAuthorizerFailsClosedOnAirlockErrorsAndMismatches(t *testing.T) {
 		}, wantReason: ReasonAirlockUnavailable},
 		{name: "server mismatch", mutate: func(evaluator *fakeToolEvaluator) {
 			evaluator.entry.ServerID = "other-server"
-		}, wantReason: ReasonAirlockToolMismatch},
+		}, wantReason: ReasonAirlockServerMismatch},
 		{name: "tool mismatch", mutate: func(evaluator *fakeToolEvaluator) {
 			evaluator.entry.Name = "other_tool"
 		}, wantReason: ReasonAirlockToolMismatch},

--- a/internal/agentrouting/authorizer_test.go
+++ b/internal/agentrouting/authorizer_test.go
@@ -112,6 +112,10 @@ func TestAuthorizerFailsClosedOnAirlockErrorsAndMismatches(t *testing.T) {
 		{name: "inventory risk mismatch", mutate: func(evaluator *fakeToolEvaluator) {
 			evaluator.entry.Risk = mcpairlock.RiskCloudMutation
 		}, wantReason: ReasonAirlockToolMismatch},
+		{name: "consistent entry risk differs from request risk", mutate: func(evaluator *fakeToolEvaluator) {
+			evaluator.entry.Risk = mcpairlock.RiskGenerateCode
+			evaluator.entry.Decision.Risk = mcpairlock.RiskGenerateCode
+		}, wantReason: ReasonAirlockToolMismatch},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/agentrouting/authorizer_test.go
+++ b/internal/agentrouting/authorizer_test.go
@@ -109,13 +109,13 @@ func TestAuthorizerFailsClosedOnAirlockErrorsAndMismatches(t *testing.T) {
 		{name: "tool mismatch", mutate: func(evaluator *fakeToolEvaluator) {
 			evaluator.entry.Name = "other_tool"
 		}, wantReason: ReasonAirlockToolMismatch},
-		{name: "inventory risk mismatch", mutate: func(evaluator *fakeToolEvaluator) {
+		{name: "inventory and decision risk mismatch", mutate: func(evaluator *fakeToolEvaluator) {
 			evaluator.entry.Risk = mcpairlock.RiskCloudMutation
-		}, wantReason: ReasonAirlockToolMismatch},
-		{name: "consistent entry risk differs from request risk", mutate: func(evaluator *fakeToolEvaluator) {
+		}, wantReason: ReasonInvalidAirlockDecision},
+		{name: "airlock risk differs from request", mutate: func(evaluator *fakeToolEvaluator) {
 			evaluator.entry.Risk = mcpairlock.RiskGenerateCode
 			evaluator.entry.Decision.Risk = mcpairlock.RiskGenerateCode
-		}, wantReason: ReasonAirlockToolMismatch},
+		}, wantReason: ReasonAirlockRiskMismatch},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/agentrouting/authorizer_test.go
+++ b/internal/agentrouting/authorizer_test.go
@@ -1,0 +1,165 @@
+package agentrouting
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/iac-studio/iac-studio/internal/mcpairlock"
+)
+
+type fakeToolEvaluator struct {
+	entry    mcpairlock.ToolInventoryEntry
+	err      error
+	calls    int
+	serverID string
+	project  string
+	toolName string
+}
+
+func (f *fakeToolEvaluator) EvaluateTool(serverID, project, toolName string) (mcpairlock.ToolInventoryEntry, error) {
+	f.calls++
+	f.serverID = serverID
+	f.project = project
+	f.toolName = toolName
+	return f.entry, f.err
+}
+
+func evaluationEntry(request Request, decision mcpairlock.ToolDecision) mcpairlock.ToolInventoryEntry {
+	return mcpairlock.ToolInventoryEntry{
+		ServerID: request.ServerID,
+		Name:     request.ToolName,
+		Risk:     decision.Risk,
+		Decision: decision,
+	}
+}
+
+func TestAuthorizerForwardsExactAirlockScope(t *testing.T) {
+	policy, request, decision := readOnlyEvaluation()
+	evaluator := &fakeToolEvaluator{entry: evaluationEntry(request, decision)}
+	authorizer, err := NewAuthorizer(policy, evaluator)
+	if err != nil {
+		t.Fatalf("NewAuthorizer(): %v", err)
+	}
+
+	got := authorizer.Authorize(request)
+	if got.Status != DecisionAllowed || !got.Allowed {
+		t.Fatalf("Authorize() = %+v, want allowed", got)
+	}
+	if evaluator.calls != 1 || evaluator.serverID != request.ServerID || evaluator.project != request.Project || evaluator.toolName != request.ToolName {
+		t.Fatalf("EvaluateTool calls = %d (%q, %q, %q), want exact request scope", evaluator.calls, evaluator.serverID, evaluator.project, evaluator.toolName)
+	}
+}
+
+func TestAuthorizerRejectsBeforeCallingAirlock(t *testing.T) {
+	tests := []struct {
+		name         string
+		mutatePolicy func(*Policy)
+		mutate       func(*Request)
+		wantReason   DecisionReason
+	}{
+		{name: "invalid request", mutate: func(request *Request) {
+			request.ConnectionID = ""
+		}, wantReason: ReasonInvalidRequest},
+		{name: "unsafe mode and risk", mutate: func(request *Request) {
+			request.Risk = mcpairlock.RiskCloudMutation
+		}, wantReason: ReasonModeRiskMismatch},
+		{name: "no matching rule", mutatePolicy: func(policy *Policy) {
+			policy.Rules[0].ToolName = "other_tool"
+		}, wantReason: ReasonNoMatchingRule},
+		{name: "deny rule", mutatePolicy: func(policy *Policy) {
+			policy.Rules[0].Effect = EffectDeny
+		}, wantReason: ReasonPolicyDenied},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			policy, request, decision := readOnlyEvaluation()
+			evaluator := &fakeToolEvaluator{entry: evaluationEntry(request, decision)}
+			if test.mutatePolicy != nil {
+				test.mutatePolicy(&policy)
+			}
+			authorizer, err := NewAuthorizer(policy, evaluator)
+			if err != nil {
+				t.Fatalf("NewAuthorizer(): %v", err)
+			}
+			if test.mutate != nil {
+				test.mutate(&request)
+			}
+
+			got := authorizer.Authorize(request)
+			if got.Status != DecisionDenied || got.Reason != test.wantReason || evaluator.calls != 0 {
+				t.Fatalf("Authorize() = %+v, calls = %d; want denied %q without Airlock call", got, evaluator.calls, test.wantReason)
+			}
+		})
+	}
+}
+
+func TestAuthorizerFailsClosedOnAirlockErrorsAndMismatches(t *testing.T) {
+	airlockErr := errors.New("inventory unavailable")
+	tests := []struct {
+		name       string
+		mutate     func(*fakeToolEvaluator)
+		wantReason DecisionReason
+	}{
+		{name: "evaluation error", mutate: func(evaluator *fakeToolEvaluator) {
+			evaluator.err = airlockErr
+		}, wantReason: ReasonAirlockUnavailable},
+		{name: "server mismatch", mutate: func(evaluator *fakeToolEvaluator) {
+			evaluator.entry.ServerID = "other-server"
+		}, wantReason: ReasonAirlockToolMismatch},
+		{name: "tool mismatch", mutate: func(evaluator *fakeToolEvaluator) {
+			evaluator.entry.Name = "other_tool"
+		}, wantReason: ReasonAirlockToolMismatch},
+		{name: "inventory risk mismatch", mutate: func(evaluator *fakeToolEvaluator) {
+			evaluator.entry.Risk = mcpairlock.RiskCloudMutation
+		}, wantReason: ReasonAirlockToolMismatch},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			policy, request, decision := readOnlyEvaluation()
+			evaluator := &fakeToolEvaluator{entry: evaluationEntry(request, decision)}
+			test.mutate(evaluator)
+			authorizer, err := NewAuthorizer(policy, evaluator)
+			if err != nil {
+				t.Fatalf("NewAuthorizer(): %v", err)
+			}
+
+			got := authorizer.Authorize(request)
+			if got.Status != DecisionDenied || got.Reason != test.wantReason || got.Allowed || got.ApprovalRequired {
+				t.Fatalf("Authorize() = %+v, want denied %q", got, test.wantReason)
+			}
+		})
+	}
+}
+
+func TestAuthorizerSnapshotsValidatedPolicy(t *testing.T) {
+	policy, request, decision := readOnlyEvaluation()
+	evaluator := &fakeToolEvaluator{entry: evaluationEntry(request, decision)}
+	authorizer, err := NewAuthorizer(policy, evaluator)
+	if err != nil {
+		t.Fatalf("NewAuthorizer(): %v", err)
+	}
+
+	policy.Rules[0].Effect = EffectDeny
+	policy.Rules[0].Modes[0] = "invalid"
+	got := authorizer.Authorize(request)
+	if got.Status != DecisionAllowed || !got.Allowed {
+		t.Fatalf("Authorize() = %+v, want immutable policy snapshot to remain allowed", got)
+	}
+}
+
+func TestNewAuthorizerRejectsInvalidDependencies(t *testing.T) {
+	policy, _, _ := readOnlyEvaluation()
+	if _, err := NewAuthorizer(policy, nil); !errors.Is(err, ErrToolEvaluatorRequired) {
+		t.Fatalf("NewAuthorizer(nil) error = %v, want ErrToolEvaluatorRequired", err)
+	}
+	var typedNil *fakeToolEvaluator
+	if _, err := NewAuthorizer(policy, typedNil); !errors.Is(err, ErrToolEvaluatorRequired) {
+		t.Fatalf("NewAuthorizer(typed nil) error = %v, want ErrToolEvaluatorRequired", err)
+	}
+
+	bad := validRule()
+	bad.ConnectionID = ""
+	if _, err := NewAuthorizer(Policy{Rules: []Rule{bad}}, &fakeToolEvaluator{}); !errors.Is(err, ErrInvalidRule) {
+		t.Fatalf("NewAuthorizer(invalid policy) error = %v, want ErrInvalidRule", err)
+	}
+}

--- a/internal/agentrouting/decision.go
+++ b/internal/agentrouting/decision.go
@@ -23,6 +23,8 @@ const (
 	ReasonModeRiskMismatch       DecisionReason = "mode_risk_mismatch"
 	ReasonNoMatchingRule         DecisionReason = "no_matching_rule"
 	ReasonPolicyDenied           DecisionReason = "policy_denied"
+	ReasonAirlockUnavailable     DecisionReason = "airlock_unavailable"
+	ReasonAirlockToolMismatch    DecisionReason = "airlock_tool_mismatch"
 	ReasonAirlockRiskMismatch    DecisionReason = "airlock_risk_mismatch"
 	ReasonInvalidAirlockDecision DecisionReason = "invalid_airlock_decision"
 	ReasonAirlockBlocked         DecisionReason = "airlock_blocked"
@@ -43,20 +45,24 @@ type Decision struct {
 // Evaluate intersects the route policy, agent mode, and Airlock firewall
 // result. Missing, malformed, or contradictory inputs always fail closed.
 func Evaluate(policy Policy, request Request, airlock mcpairlock.ToolDecision) Decision {
-	if request.Validate() != nil {
-		return denied(ReasonInvalidRequest)
-	}
-	if !modeAllowsRisk(request.Mode, request.Risk) {
-		return denied(ReasonModeRiskMismatch)
+	if decision, stop := preflight(request); stop {
+		return decision
 	}
 	if policy.Validate() != nil {
 		return denied(ReasonInvalidPolicy)
 	}
+	return evaluateValidated(policy, request, airlock)
+}
 
+func evaluateValidated(policy Policy, request Request, airlock mcpairlock.ToolDecision) Decision {
 	rule, matched := policy.matchValidated(request)
 	if !matched {
 		return denied(ReasonNoMatchingRule)
 	}
+	return evaluateMatched(rule, request, airlock)
+}
+
+func evaluateMatched(rule Rule, request Request, airlock mcpairlock.ToolDecision) Decision {
 	if rule.Effect == EffectDeny {
 		return denied(ReasonPolicyDenied)
 	}
@@ -77,6 +83,16 @@ func Evaluate(policy Policy, request Request, airlock mcpairlock.ToolDecision) D
 	default:
 		return denied(ReasonInvalidAirlockDecision)
 	}
+}
+
+func preflight(request Request) (Decision, bool) {
+	if request.Validate() != nil {
+		return denied(ReasonInvalidRequest), true
+	}
+	if !modeAllowsRisk(request.Mode, request.Risk) {
+		return denied(ReasonModeRiskMismatch), true
+	}
+	return Decision{}, false
 }
 
 func modeAllowsRisk(mode agentruns.Mode, risk mcpairlock.ToolRisk) bool {

--- a/internal/agentrouting/decision.go
+++ b/internal/agentrouting/decision.go
@@ -24,6 +24,7 @@ const (
 	ReasonNoMatchingRule         DecisionReason = "no_matching_rule"
 	ReasonPolicyDenied           DecisionReason = "policy_denied"
 	ReasonAirlockUnavailable     DecisionReason = "airlock_unavailable"
+	ReasonAirlockServerMismatch  DecisionReason = "airlock_server_mismatch"
 	ReasonAirlockToolMismatch    DecisionReason = "airlock_tool_mismatch"
 	ReasonAirlockRiskMismatch    DecisionReason = "airlock_risk_mismatch"
 	ReasonInvalidAirlockDecision DecisionReason = "invalid_airlock_decision"


### PR DESCRIPTION
## Summary
- add a read-only authorizer boundary over MCP Airlock `EvaluateTool`
- validate and deep-copy routing policy at construction
- reject invalid requests, unsafe mode/risk pairs, missing routes, and deny rules before querying Airlock
- verify returned server, tool, and risk identity before combining decisions
- fail closed on evaluator errors and nil dependencies

## Security properties
- unauthorized routes never query Airlock
- caller mutations cannot widen the validated policy snapshot
- typed-nil evaluators are rejected
- Airlock error details are not exposed in authorization output
- no tool execution, server lifecycle, credential access, API routes, or Agent Run writes

## Validation
- `GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/agentrouting`
- `GOCACHE=/private/tmp/iacstudio-go-cache go test ./...`
- `GOCACHE=/private/tmp/iacstudio-go-cache go vet ./internal/agentrouting`

Part of #107