### PR TITLE
Record tool authorization in Agent Runs

### DIFF
--- a/internal/agentrouting/decision.go
+++ b/internal/agentrouting/decision.go
@@ -1,9 +1,14 @@
 package agentrouting
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/iac-studio/iac-studio/internal/agentruns"
 	"github.com/iac-studio/iac-studio/internal/mcpairlock"
 )
+
+var ErrInvalidDecision = errors.New("invalid tool authorization decision")
 
 // DecisionStatus is the authorization outcome for one Agent Hub tool route.
 type DecisionStatus string
@@ -41,6 +46,50 @@ type Decision struct {
 	Allowed          bool           `json:"allowed"`
 	ApprovalRequired bool           `json:"approval_required"`
 	UntrustedOutput  bool           `json:"untrusted_output"`
+}
+
+// Validate rejects contradictory or incomplete authorization outcomes before
+// they can mutate Agent Run state.
+func (d Decision) Validate() error {
+	if !d.UntrustedOutput {
+		return fmt.Errorf("%w: external MCP output must remain untrusted", ErrInvalidDecision)
+	}
+	switch d.Status {
+	case DecisionDenied:
+		if d.Allowed || d.ApprovalRequired || !validDeniedReason(d.Reason) {
+			return fmt.Errorf("%w: inconsistent denied outcome", ErrInvalidDecision)
+		}
+	case DecisionApprovalRequired:
+		if d.Allowed || !d.ApprovalRequired || d.Reason != ReasonApprovalRequired {
+			return fmt.Errorf("%w: inconsistent approval outcome", ErrInvalidDecision)
+		}
+	case DecisionAllowed:
+		if !d.Allowed || d.ApprovalRequired || d.Reason != ReasonAllowed {
+			return fmt.Errorf("%w: inconsistent allowed outcome", ErrInvalidDecision)
+		}
+	default:
+		return fmt.Errorf("%w: unsupported status %q", ErrInvalidDecision, d.Status)
+	}
+	return nil
+}
+
+func validDeniedReason(reason DecisionReason) bool {
+	switch reason {
+	case ReasonInvalidRequest,
+		ReasonInvalidPolicy,
+		ReasonModeRiskMismatch,
+		ReasonNoMatchingRule,
+		ReasonPolicyDenied,
+		ReasonAirlockUnavailable,
+		ReasonAirlockServerMismatch,
+		ReasonAirlockToolMismatch,
+		ReasonAirlockRiskMismatch,
+		ReasonInvalidAirlockDecision,
+		ReasonAirlockBlocked:
+		return true
+	default:
+		return false
+	}
 }
 
 // Evaluate intersects the route policy, agent mode, and Airlock firewall

--- a/internal/agentrouting/run_recorder.go
+++ b/internal/agentrouting/run_recorder.go
@@ -44,13 +44,16 @@ func (r *RunRecorder) Record(runID string, request Request, decision Decision) (
 	if err := decision.Validate(); err != nil {
 		return agentruns.Run{}, err
 	}
-	if !modeAllowsRisk(request.Mode, request.Risk) {
+	modeRiskAllowed := modeAllowsRisk(request.Mode, request.Risk)
+	if !modeRiskAllowed {
 		if decision.Status != DecisionDenied {
 			return agentruns.Run{}, fmt.Errorf("%w: mode %q cannot authorize risk %q", ErrInvalidRequest, request.Mode, request.Risk)
 		}
 		if decision.Reason != ReasonModeRiskMismatch {
 			return agentruns.Run{}, fmt.Errorf("%w: unsafe mode and risk require reason %q", ErrInvalidDecision, ReasonModeRiskMismatch)
 		}
+	} else if decision.Status == DecisionDenied && decision.Reason == ReasonModeRiskMismatch {
+		return agentruns.Run{}, fmt.Errorf("%w: reason %q requires an unsafe mode and risk pair", ErrInvalidDecision, ReasonModeRiskMismatch)
 	}
 	if decision.Status == DecisionAllowed && request.Risk != mcpairlock.RiskReadOnly {
 		return agentruns.Run{}, fmt.Errorf("%w: non-read-only risks require approval", ErrInvalidDecision)

--- a/internal/agentrouting/run_recorder.go
+++ b/internal/agentrouting/run_recorder.go
@@ -12,6 +12,7 @@ import (
 var (
 	ErrRunStoreRequired = errors.New("agent run store is required")
 	ErrRunIDRequired    = errors.New("agent run id is required")
+	ErrInvalidRunID     = errors.New("agent run id must not contain leading or trailing whitespace")
 	ErrRunScopeMismatch = errors.New("agent run scope does not match tool route")
 )
 
@@ -35,8 +36,11 @@ func (r *RunRecorder) Record(runID string, request Request, decision Decision) (
 		return agentruns.Run{}, ErrRunStoreRequired
 	}
 	trimmedRunID := strings.TrimSpace(runID)
-	if trimmedRunID == "" || trimmedRunID != runID {
+	if trimmedRunID == "" {
 		return agentruns.Run{}, ErrRunIDRequired
+	}
+	if trimmedRunID != runID {
+		return agentruns.Run{}, ErrInvalidRunID
 	}
 	if err := request.Validate(); err != nil {
 		return agentruns.Run{}, err

--- a/internal/agentrouting/run_recorder.go
+++ b/internal/agentrouting/run_recorder.go
@@ -44,8 +44,13 @@ func (r *RunRecorder) Record(runID string, request Request, decision Decision) (
 	if err := decision.Validate(); err != nil {
 		return agentruns.Run{}, err
 	}
-	if decision.Status != DecisionDenied && !modeAllowsRisk(request.Mode, request.Risk) {
-		return agentruns.Run{}, fmt.Errorf("%w: mode %q cannot authorize risk %q", ErrInvalidRequest, request.Mode, request.Risk)
+	if !modeAllowsRisk(request.Mode, request.Risk) {
+		if decision.Status != DecisionDenied {
+			return agentruns.Run{}, fmt.Errorf("%w: mode %q cannot authorize risk %q", ErrInvalidRequest, request.Mode, request.Risk)
+		}
+		if decision.Reason != ReasonModeRiskMismatch {
+			return agentruns.Run{}, fmt.Errorf("%w: unsafe mode and risk require reason %q", ErrInvalidDecision, ReasonModeRiskMismatch)
+		}
 	}
 	if decision.Status == DecisionAllowed && request.Risk != mcpairlock.RiskReadOnly {
 		return agentruns.Run{}, fmt.Errorf("%w: non-read-only risks require approval", ErrInvalidDecision)

--- a/internal/agentrouting/run_recorder.go
+++ b/internal/agentrouting/run_recorder.go
@@ -61,7 +61,11 @@ func (r *RunRecorder) Record(runID string, request Request, decision Decision) (
 
 	switch decision.Status {
 	case DecisionDenied:
-		return r.store.Fail(runID, "tool authorization denied: "+string(decision.Reason))
+		return r.store.Fail(runID, fmt.Sprintf(
+			"MCP tool %q on server %q for connection %q authorization denied (%s risk, %s mode): %s.",
+			request.ToolName, request.ServerID, request.ConnectionID,
+			request.Risk, request.Mode, decision.Reason,
+		))
 	case DecisionApprovalRequired:
 		kind, ok := approvalKind(request.Risk)
 		if !ok {

--- a/internal/agentrouting/run_recorder.go
+++ b/internal/agentrouting/run_recorder.go
@@ -48,6 +48,9 @@ func (r *RunRecorder) Record(runID string, request Request, decision Decision) (
 	if err := decision.Validate(); err != nil {
 		return agentruns.Run{}, err
 	}
+	if decision.Status == DecisionDenied && decision.Reason == ReasonInvalidRequest {
+		return agentruns.Run{}, fmt.Errorf("%w: reason %q requires an invalid request", ErrInvalidDecision, ReasonInvalidRequest)
+	}
 	modeRiskAllowed := modeAllowsRisk(request.Mode, request.Risk)
 	if !modeRiskAllowed {
 		if decision.Status != DecisionDenied {

--- a/internal/agentrouting/run_recorder.go
+++ b/internal/agentrouting/run_recorder.go
@@ -1,0 +1,108 @@
+package agentrouting
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/iac-studio/iac-studio/internal/agentruns"
+	"github.com/iac-studio/iac-studio/internal/mcpairlock"
+)
+
+var (
+	ErrRunStoreRequired = errors.New("agent run store is required")
+	ErrRunIDRequired    = errors.New("agent run id is required")
+	ErrRunScopeMismatch = errors.New("agent run scope does not match tool route")
+)
+
+// RunRecorder persists authorization outcomes without invoking an external
+// tool. The referenced run must already exist.
+type RunRecorder struct {
+	store *agentruns.Store
+}
+
+func NewRunRecorder(store *agentruns.Store) (*RunRecorder, error) {
+	if store == nil {
+		return nil, ErrRunStoreRequired
+	}
+	return &RunRecorder{store: store}, nil
+}
+
+// Record verifies the run and route scopes before applying exactly one state
+// mutation for the authorization outcome.
+func (r *RunRecorder) Record(runID string, request Request, decision Decision) (agentruns.Run, error) {
+	if r == nil || r.store == nil {
+		return agentruns.Run{}, ErrRunStoreRequired
+	}
+	trimmedRunID := strings.TrimSpace(runID)
+	if trimmedRunID == "" || trimmedRunID != runID {
+		return agentruns.Run{}, ErrRunIDRequired
+	}
+	if err := request.Validate(); err != nil {
+		return agentruns.Run{}, err
+	}
+	if err := decision.Validate(); err != nil {
+		return agentruns.Run{}, err
+	}
+	if decision.Status != DecisionDenied && !modeAllowsRisk(request.Mode, request.Risk) {
+		return agentruns.Run{}, fmt.Errorf("%w: mode %q cannot authorize risk %q", ErrInvalidRequest, request.Mode, request.Risk)
+	}
+	if decision.Status == DecisionAllowed && request.Risk != mcpairlock.RiskReadOnly {
+		return agentruns.Run{}, fmt.Errorf("%w: non-read-only risks require approval", ErrInvalidDecision)
+	}
+
+	run, ok := r.store.Get(runID)
+	if !ok {
+		return agentruns.Run{}, agentruns.ErrNotFound
+	}
+	if run.Project != request.Project || run.ProviderID != request.ProviderID || run.Mode != request.Mode {
+		return agentruns.Run{}, ErrRunScopeMismatch
+	}
+
+	switch decision.Status {
+	case DecisionDenied:
+		return r.store.Fail(runID, "tool authorization denied: "+string(decision.Reason))
+	case DecisionApprovalRequired:
+		kind, ok := approvalKind(request.Risk)
+		if !ok {
+			return agentruns.Run{}, fmt.Errorf("%w: no approval mapping for risk %q", ErrInvalidDecision, request.Risk)
+		}
+		return r.store.AddApproval(runID, agentruns.ApprovalGate{
+			Kind:    kind,
+			Summary: routeAuditMessage("Authorize", request),
+		})
+	case DecisionAllowed:
+		return r.store.AddLog(runID, agentruns.LogAudit, routeAuditMessage("Allowed", request))
+	default:
+		return agentruns.Run{}, ErrInvalidDecision
+	}
+}
+
+func approvalKind(risk mcpairlock.ToolRisk) (agentruns.ApprovalKind, bool) {
+	switch risk {
+	case mcpairlock.RiskReadOnly, mcpairlock.RiskGenerateCode:
+		return agentruns.ApprovalMCPNetwork, true
+	case mcpairlock.RiskModifyWorkspace:
+		return agentruns.ApprovalFileWrite, true
+	case mcpairlock.RiskCloudMutation:
+		return agentruns.ApprovalCloudWrite, true
+	case mcpairlock.RiskSecretSensitive:
+		return agentruns.ApprovalSecretRead, true
+	case mcpairlock.RiskDestructive:
+		return agentruns.ApprovalIaCAction, true
+	default:
+		return "", false
+	}
+}
+
+func routeAuditMessage(action string, request Request) string {
+	return fmt.Sprintf(
+		"%s MCP tool %q on server %q for connection %q (%s risk, %s mode).",
+		action,
+		request.ToolName,
+		request.ServerID,
+		request.ConnectionID,
+		request.Risk,
+		request.Mode,
+	)
+}

--- a/internal/agentrouting/run_recorder_test.go
+++ b/internal/agentrouting/run_recorder_test.go
@@ -173,6 +173,20 @@ func TestRunRecorderRejectsScopeMismatchWithoutMutation(t *testing.T) {
 	}
 }
 
+func TestRunRecorderRejectsMalformedRequestWithoutMutation(t *testing.T) {
+	_, request, _ := readOnlyEvaluation()
+	recorder, store, run := recorderFixture(t, request)
+	request.ToolName = ""
+
+	if _, err := recorder.Record(run.ID, request, allowed()); !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("Record(malformed request) error = %v, want ErrInvalidRequest", err)
+	}
+	unchanged, ok := store.Get(run.ID)
+	if !ok || unchanged.Status != agentruns.StatusQueued || len(unchanged.Logs) != 0 || len(unchanged.Approvals) != 0 {
+		t.Fatalf("run mutated after malformed request: %+v", unchanged)
+	}
+}
+
 func TestRunRecorderRejectsMalformedDecisionWithoutMutation(t *testing.T) {
 	_, request, _ := readOnlyEvaluation()
 	tests := []Decision{

--- a/internal/agentrouting/run_recorder_test.go
+++ b/internal/agentrouting/run_recorder_test.go
@@ -222,6 +222,9 @@ func TestRunRecorderRejectsMissingDependenciesAndRuns(t *testing.T) {
 	if _, err := recorder.Record("", request, allowed()); !errors.Is(err, ErrRunIDRequired) {
 		t.Fatalf("Record(empty id) error = %v, want ErrRunIDRequired", err)
 	}
+	if _, err := recorder.Record(" run_000001", request, allowed()); !errors.Is(err, ErrInvalidRunID) {
+		t.Fatalf("Record(padded id) error = %v, want ErrInvalidRunID", err)
+	}
 	if _, err := recorder.Record("run_missing", request, allowed()); !errors.Is(err, agentruns.ErrNotFound) {
 		t.Fatalf("Record(missing run) error = %v, want ErrNotFound", err)
 	}

--- a/internal/agentrouting/run_recorder_test.go
+++ b/internal/agentrouting/run_recorder_test.go
@@ -89,6 +89,19 @@ func TestRunRecorderRejectsMisleadingUnsafeDenialWithoutMutation(t *testing.T) {
 	}
 }
 
+func TestRunRecorderRejectsContradictoryModeMismatchReasonWithoutMutation(t *testing.T) {
+	_, request, _ := readOnlyEvaluation()
+	recorder, store, run := recorderFixture(t, request)
+
+	if _, err := recorder.Record(run.ID, request, denied(ReasonModeRiskMismatch)); !errors.Is(err, ErrInvalidDecision) {
+		t.Fatalf("Record(contradictory mode mismatch) error = %v, want ErrInvalidDecision", err)
+	}
+	unchanged, ok := store.Get(run.ID)
+	if !ok || unchanged.Status != agentruns.StatusQueued || len(unchanged.Logs) != 0 || len(unchanged.Approvals) != 0 {
+		t.Fatalf("run mutated after contradictory mode mismatch denial: %+v", unchanged)
+	}
+}
+
 func TestRunRecorderMapsApprovalKinds(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/agentrouting/run_recorder_test.go
+++ b/internal/agentrouting/run_recorder_test.go
@@ -1,0 +1,198 @@
+package agentrouting
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/iac-studio/iac-studio/internal/agentruns"
+	"github.com/iac-studio/iac-studio/internal/mcpairlock"
+)
+
+func recorderFixture(t *testing.T, request Request) (*RunRecorder, *agentruns.Store, agentruns.Run) {
+	t.Helper()
+	store := agentruns.NewStore(agentruns.WithPromptHashKey([]byte("recorder-test-key")))
+	run, err := store.Create(agentruns.CreateRequest{
+		Project:    request.Project,
+		ProviderID: request.ProviderID,
+		Mode:       request.Mode,
+		Prompt:     "authorize a tool",
+	})
+	if err != nil {
+		t.Fatalf("Create(): %v", err)
+	}
+	recorder, err := NewRunRecorder(store)
+	if err != nil {
+		t.Fatalf("NewRunRecorder(): %v", err)
+	}
+	return recorder, store, run
+}
+
+func TestRunRecorderRecordsAllowedAudit(t *testing.T) {
+	_, request, _ := readOnlyEvaluation()
+	recorder, _, run := recorderFixture(t, request)
+
+	got, err := recorder.Record(run.ID, request, allowed())
+	if err != nil {
+		t.Fatalf("Record(): %v", err)
+	}
+	if got.Status != agentruns.StatusQueued || len(got.Logs) != 1 || got.Logs[0].Level != agentruns.LogAudit || len(got.Approvals) != 0 {
+		t.Fatalf("recorded run = %+v, want one allowed audit entry", got)
+	}
+	if !strings.Contains(got.Logs[0].Message, "Allowed MCP tool") {
+		t.Fatalf("audit message = %q, want allowed tool event", got.Logs[0].Message)
+	}
+}
+
+func TestRunRecorderFailsDeniedRun(t *testing.T) {
+	_, request, _ := readOnlyEvaluation()
+	recorder, _, run := recorderFixture(t, request)
+
+	got, err := recorder.Record(run.ID, request, denied(ReasonPolicyDenied))
+	if err != nil {
+		t.Fatalf("Record(): %v", err)
+	}
+	if got.Status != agentruns.StatusFailed || got.Error != "tool authorization denied: policy_denied" || len(got.Logs) != 1 || got.Logs[0].Level != agentruns.LogAudit {
+		t.Fatalf("recorded run = %+v, want failed run with denial audit", got)
+	}
+}
+
+func TestRunRecorderRecordsUnsafeModeDenial(t *testing.T) {
+	request := validRequest()
+	request.Mode = agentruns.ModeReadOnly
+	request.Risk = mcpairlock.RiskCloudMutation
+	recorder, _, run := recorderFixture(t, request)
+
+	got, err := recorder.Record(run.ID, request, denied(ReasonModeRiskMismatch))
+	if err != nil {
+		t.Fatalf("Record(): %v", err)
+	}
+	if got.Status != agentruns.StatusFailed || got.Error != "tool authorization denied: mode_risk_mismatch" || len(got.Logs) != 1 {
+		t.Fatalf("recorded run = %+v, want unsafe mode denial audit", got)
+	}
+}
+
+func TestRunRecorderMapsApprovalKinds(t *testing.T) {
+	tests := []struct {
+		name string
+		mode agentruns.Mode
+		risk mcpairlock.ToolRisk
+		kind agentruns.ApprovalKind
+	}{
+		{name: "read only", mode: agentruns.ModeReadOnly, risk: mcpairlock.RiskReadOnly, kind: agentruns.ApprovalMCPNetwork},
+		{name: "generate code", mode: agentruns.ModeProposeOnly, risk: mcpairlock.RiskGenerateCode, kind: agentruns.ApprovalMCPNetwork},
+		{name: "workspace", mode: agentruns.ModeApprovedExecute, risk: mcpairlock.RiskModifyWorkspace, kind: agentruns.ApprovalFileWrite},
+		{name: "cloud", mode: agentruns.ModeApprovedExecute, risk: mcpairlock.RiskCloudMutation, kind: agentruns.ApprovalCloudWrite},
+		{name: "secret", mode: agentruns.ModeApprovedExecute, risk: mcpairlock.RiskSecretSensitive, kind: agentruns.ApprovalSecretRead},
+		{name: "destructive", mode: agentruns.ModeApprovedExecute, risk: mcpairlock.RiskDestructive, kind: agentruns.ApprovalIaCAction},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			request := validRequest()
+			request.Mode = test.mode
+			request.Risk = test.risk
+			recorder, _, run := recorderFixture(t, request)
+
+			got, err := recorder.Record(run.ID, request, approvalRequired())
+			if err != nil {
+				t.Fatalf("Record(): %v", err)
+			}
+			if got.Status != agentruns.StatusWaitingApproval || len(got.Approvals) != 1 || got.Approvals[0].Kind != test.kind || got.Approvals[0].Status != agentruns.ApprovalPending {
+				t.Fatalf("recorded run = %+v, want pending %q gate", got, test.kind)
+			}
+		})
+	}
+}
+
+func TestRunRecorderRejectsScopeMismatchWithoutMutation(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*Request)
+	}{
+		{name: "project", mutate: func(request *Request) { request.Project = "other-project" }},
+		{name: "provider", mutate: func(request *Request) { request.ProviderID = "other-provider" }},
+		{name: "mode", mutate: func(request *Request) { request.Mode = agentruns.ModeApprovedExecute }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, request, _ := readOnlyEvaluation()
+			recorder, store, run := recorderFixture(t, request)
+			test.mutate(&request)
+
+			if _, err := recorder.Record(run.ID, request, allowed()); !errors.Is(err, ErrRunScopeMismatch) {
+				t.Fatalf("Record() error = %v, want ErrRunScopeMismatch", err)
+			}
+			unchanged, ok := store.Get(run.ID)
+			if !ok || unchanged.Status != agentruns.StatusQueued || len(unchanged.Logs) != 0 || len(unchanged.Approvals) != 0 {
+				t.Fatalf("run mutated after scope mismatch: %+v", unchanged)
+			}
+		})
+	}
+}
+
+func TestRunRecorderRejectsMalformedDecisionWithoutMutation(t *testing.T) {
+	_, request, _ := readOnlyEvaluation()
+	tests := []Decision{
+		{Status: DecisionAllowed, Reason: ReasonAllowed, UntrustedOutput: true},
+		{Status: DecisionApprovalRequired, Reason: ReasonApprovalRequired, Allowed: true, ApprovalRequired: true, UntrustedOutput: true},
+		{Status: DecisionDenied, Reason: ReasonAllowed, UntrustedOutput: true},
+		{Status: DecisionDenied, Reason: ReasonPolicyDenied},
+	}
+	for _, decision := range tests {
+		recorder, store, run := recorderFixture(t, request)
+		if _, err := recorder.Record(run.ID, request, decision); !errors.Is(err, ErrInvalidDecision) {
+			t.Fatalf("Record(%+v) error = %v, want ErrInvalidDecision", decision, err)
+		}
+		unchanged, ok := store.Get(run.ID)
+		if !ok || unchanged.Status != agentruns.StatusQueued || len(unchanged.Logs) != 0 || len(unchanged.Approvals) != 0 {
+			t.Fatalf("run mutated after malformed decision: %+v", unchanged)
+		}
+	}
+}
+
+func TestRunRecorderRejectsAllowedWriteWithoutMutation(t *testing.T) {
+	request := validRequest()
+	recorder, store, run := recorderFixture(t, request)
+
+	if _, err := recorder.Record(run.ID, request, allowed()); !errors.Is(err, ErrInvalidDecision) {
+		t.Fatalf("Record(allowed write) error = %v, want ErrInvalidDecision", err)
+	}
+	unchanged, ok := store.Get(run.ID)
+	if !ok || unchanged.Status != agentruns.StatusQueued || len(unchanged.Logs) != 0 || len(unchanged.Approvals) != 0 {
+		t.Fatalf("run mutated after allowed write: %+v", unchanged)
+	}
+}
+
+func TestRunRecorderRejectsUnsafeApprovalWithoutMutation(t *testing.T) {
+	request := validRequest()
+	request.Mode = agentruns.ModeReadOnly
+	request.Risk = mcpairlock.RiskCloudMutation
+	recorder, store, run := recorderFixture(t, request)
+
+	if _, err := recorder.Record(run.ID, request, approvalRequired()); !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("Record(unsafe approval) error = %v, want ErrInvalidRequest", err)
+	}
+	unchanged, ok := store.Get(run.ID)
+	if !ok || unchanged.Status != agentruns.StatusQueued || len(unchanged.Logs) != 0 || len(unchanged.Approvals) != 0 {
+		t.Fatalf("run mutated after unsafe approval: %+v", unchanged)
+	}
+}
+
+func TestRunRecorderRejectsMissingDependenciesAndRuns(t *testing.T) {
+	_, request, _ := readOnlyEvaluation()
+	if _, err := NewRunRecorder(nil); !errors.Is(err, ErrRunStoreRequired) {
+		t.Fatalf("NewRunRecorder(nil) error = %v, want ErrRunStoreRequired", err)
+	}
+	var nilRecorder *RunRecorder
+	if _, err := nilRecorder.Record("run_000001", request, allowed()); !errors.Is(err, ErrRunStoreRequired) {
+		t.Fatalf("nil Record() error = %v, want ErrRunStoreRequired", err)
+	}
+
+	recorder, _, _ := recorderFixture(t, request)
+	if _, err := recorder.Record("", request, allowed()); !errors.Is(err, ErrRunIDRequired) {
+		t.Fatalf("Record(empty id) error = %v, want ErrRunIDRequired", err)
+	}
+	if _, err := recorder.Record("run_missing", request, allowed()); !errors.Is(err, agentruns.ErrNotFound) {
+		t.Fatalf("Record(missing run) error = %v, want ErrNotFound", err)
+	}
+}

--- a/internal/agentrouting/run_recorder_test.go
+++ b/internal/agentrouting/run_recorder_test.go
@@ -52,7 +52,8 @@ func TestRunRecorderFailsDeniedRun(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Record(): %v", err)
 	}
-	if got.Status != agentruns.StatusFailed || got.Error != "tool authorization denied: policy_denied" || len(got.Logs) != 1 || got.Logs[0].Level != agentruns.LogAudit {
+	wantError := `MCP tool "plan_workspace" on server "terraform-official" for connection "aws-prod" authorization denied (read_only risk, read_only mode): policy_denied.`
+	if got.Status != agentruns.StatusFailed || got.Error != wantError || len(got.Logs) != 1 || got.Logs[0].Level != agentruns.LogAudit {
 		t.Fatalf("recorded run = %+v, want failed run with denial audit", got)
 	}
 }
@@ -67,7 +68,8 @@ func TestRunRecorderRecordsUnsafeModeDenial(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Record(): %v", err)
 	}
-	if got.Status != agentruns.StatusFailed || got.Error != "tool authorization denied: mode_risk_mismatch" || len(got.Logs) != 1 {
+	wantError := `MCP tool "plan_workspace" on server "terraform-official" for connection "aws-prod" authorization denied (cloud_mutation risk, read_only mode): mode_risk_mismatch.`
+	if got.Status != agentruns.StatusFailed || got.Error != wantError || len(got.Logs) != 1 {
 		t.Fatalf("recorded run = %+v, want unsafe mode denial audit", got)
 	}
 }
@@ -194,5 +196,32 @@ func TestRunRecorderRejectsMissingDependenciesAndRuns(t *testing.T) {
 	}
 	if _, err := recorder.Record("run_missing", request, allowed()); !errors.Is(err, agentruns.ErrNotFound) {
 		t.Fatalf("Record(missing run) error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestRunRecorderRejectsTerminalRunWithoutDuplicateMutation(t *testing.T) {
+	_, request, _ := readOnlyEvaluation()
+	outcomes := []Decision{
+		allowed(),
+		denied(ReasonPolicyDenied),
+		approvalRequired(),
+	}
+	for _, outcome := range outcomes {
+		t.Run(string(outcome.Status), func(t *testing.T) {
+			recorder, store, run := recorderFixture(t, request)
+			if _, err := store.Fail(run.ID, "pre-terminal"); err != nil {
+				t.Fatalf("Fail(): %v", err)
+			}
+			if _, err := recorder.Record(run.ID, request, outcome); !errors.Is(err, agentruns.ErrTerminated) {
+				t.Fatalf("Record(terminal run, %s) error = %v, want ErrTerminated", outcome.Status, err)
+			}
+			terminal, ok := store.Get(run.ID)
+			if !ok {
+				t.Fatal("run evicted unexpectedly")
+			}
+			if terminal.Status != agentruns.StatusFailed || len(terminal.Logs) != 1 || len(terminal.Approvals) != 0 {
+				t.Fatalf("terminal run mutated after Record(): %+v", terminal)
+			}
+		})
 	}
 }

--- a/internal/agentrouting/run_recorder_test.go
+++ b/internal/agentrouting/run_recorder_test.go
@@ -102,6 +102,19 @@ func TestRunRecorderRejectsContradictoryModeMismatchReasonWithoutMutation(t *tes
 	}
 }
 
+func TestRunRecorderRejectsContradictoryInvalidRequestReasonWithoutMutation(t *testing.T) {
+	_, request, _ := readOnlyEvaluation()
+	recorder, store, run := recorderFixture(t, request)
+
+	if _, err := recorder.Record(run.ID, request, denied(ReasonInvalidRequest)); !errors.Is(err, ErrInvalidDecision) {
+		t.Fatalf("Record(contradictory invalid_request) error = %v, want ErrInvalidDecision", err)
+	}
+	unchanged, ok := store.Get(run.ID)
+	if !ok || unchanged.Status != agentruns.StatusQueued || len(unchanged.Logs) != 0 || len(unchanged.Approvals) != 0 {
+		t.Fatalf("run mutated after contradictory invalid_request denial: %+v", unchanged)
+	}
+}
+
 func TestRunRecorderMapsApprovalKinds(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/agentrouting/run_recorder_test.go
+++ b/internal/agentrouting/run_recorder_test.go
@@ -74,6 +74,21 @@ func TestRunRecorderRecordsUnsafeModeDenial(t *testing.T) {
 	}
 }
 
+func TestRunRecorderRejectsMisleadingUnsafeDenialWithoutMutation(t *testing.T) {
+	request := validRequest()
+	request.Mode = agentruns.ModeReadOnly
+	request.Risk = mcpairlock.RiskCloudMutation
+	recorder, store, run := recorderFixture(t, request)
+
+	if _, err := recorder.Record(run.ID, request, denied(ReasonPolicyDenied)); !errors.Is(err, ErrInvalidDecision) {
+		t.Fatalf("Record(misleading denial) error = %v, want ErrInvalidDecision", err)
+	}
+	unchanged, ok := store.Get(run.ID)
+	if !ok || unchanged.Status != agentruns.StatusQueued || len(unchanged.Logs) != 0 || len(unchanged.Approvals) != 0 {
+		t.Fatalf("run mutated after misleading denial: %+v", unchanged)
+	}
+}
+
 func TestRunRecorderMapsApprovalKinds(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Summary
- validate authorization decisions before they can mutate Agent Run state
- verify run project, provider, and mode against the scoped tool request
- fail denied runs through the existing redacted audit path
- persist typed approval gates and move runs to waiting_approval
- append an audit event for allowed read-only routes

## Security properties
- malformed or contradictory decisions do not mutate runs
- non-read-only allowed outcomes are rejected
- unsafe mode/risk denials are still recorded and audited
- run-scope mismatches do not mutate the referenced run
- approval kinds distinguish MCP network, file write, cloud write, secret read, and destructive IaC actions
- each accepted outcome performs exactly one Store mutation
- no external tool execution or credential access

## Validation
- `GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/agentrouting`
- `GOCACHE=/private/tmp/iacstudio-go-cache go test ./...`
- `GOCACHE=/private/tmp/iacstudio-go-cache go vet ./internal/agentrouting`

Part of #107