### PR TITLE
Coordinate Agent Hub route authorization

### DIFF
--- a/internal/agentrouting/router.go
+++ b/internal/agentrouting/router.go
@@ -1,0 +1,56 @@
+package agentrouting
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/iac-studio/iac-studio/internal/agentruns"
+)
+
+var (
+	ErrAuthorizerRequired  = errors.New("tool route authorizer is required")
+	ErrRunRecorderRequired = errors.New("tool route run recorder is required")
+)
+
+// RouteResult contains an authorization decision only after that decision has
+// been recorded on the referenced Agent Run.
+type RouteResult struct {
+	Decision Decision      `json:"decision"`
+	Run      agentruns.Run `json:"run"`
+}
+
+// Router coordinates authorization and Agent Run recording. It never invokes
+// an external MCP tool or reads cloud credentials.
+type Router struct {
+	authorizer *Authorizer
+	recorder   *RunRecorder
+}
+
+func NewRouter(authorizer *Authorizer, recorder *RunRecorder) (*Router, error) {
+	if authorizer == nil {
+		return nil, ErrAuthorizerRequired
+	}
+	if recorder == nil {
+		return nil, ErrRunRecorderRequired
+	}
+	return &Router{authorizer: authorizer, recorder: recorder}, nil
+}
+
+// Route authorizes one fully scoped tool route and records the outcome before
+// returning it. Recorder failures return a zero result so callers cannot act
+// on an authorization decision that was not audited.
+func (r *Router) Route(runID string, request Request) (RouteResult, error) {
+	if r == nil || r.authorizer == nil {
+		return RouteResult{}, ErrAuthorizerRequired
+	}
+	if r.recorder == nil {
+		return RouteResult{}, ErrRunRecorderRequired
+	}
+
+	decision := r.authorizer.Authorize(request)
+	run, err := r.recorder.Record(runID, request, decision)
+	if err != nil {
+		return RouteResult{}, fmt.Errorf("record tool route authorization: %w", err)
+	}
+	return RouteResult{Decision: decision, Run: run}, nil
+}

--- a/internal/agentrouting/router_test.go
+++ b/internal/agentrouting/router_test.go
@@ -1,0 +1,128 @@
+package agentrouting
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/iac-studio/iac-studio/internal/agentruns"
+	"github.com/iac-studio/iac-studio/internal/mcpairlock"
+)
+
+func routerFixture(t *testing.T, policy Policy, request Request, airlock mcpairlock.ToolDecision) (*Router, *fakeToolEvaluator, *agentruns.Store, agentruns.Run) {
+	t.Helper()
+	evaluator := &fakeToolEvaluator{entry: evaluationEntry(request, airlock)}
+	authorizer, err := NewAuthorizer(policy, evaluator)
+	if err != nil {
+		t.Fatalf("NewAuthorizer(): %v", err)
+	}
+	recorder, store, run := recorderFixture(t, request)
+	router, err := NewRouter(authorizer, recorder)
+	if err != nil {
+		t.Fatalf("NewRouter(): %v", err)
+	}
+	return router, evaluator, store, run
+}
+
+func TestRouterAuthorizesAndRecordsOutcomes(t *testing.T) {
+	tests := []struct {
+		name          string
+		mutate        func(*Policy, *mcpairlock.ToolDecision)
+		wantDecision  DecisionStatus
+		wantRun       agentruns.Status
+		wantAirlock   int
+		wantApprovals int
+	}{
+		{
+			name:         "allowed",
+			wantDecision: DecisionAllowed,
+			wantRun:      agentruns.StatusQueued,
+			wantAirlock:  1,
+		},
+		{
+			name: "approval required",
+			mutate: func(_ *Policy, airlock *mcpairlock.ToolDecision) {
+				airlock.Status = "approval_required"
+				airlock.Allowed = false
+				airlock.ApprovalRequired = true
+			},
+			wantDecision:  DecisionApprovalRequired,
+			wantRun:       agentruns.StatusWaitingApproval,
+			wantAirlock:   1,
+			wantApprovals: 1,
+		},
+		{
+			name: "policy denied",
+			mutate: func(policy *Policy, _ *mcpairlock.ToolDecision) {
+				policy.Rules[0].Effect = EffectDeny
+			},
+			wantDecision: DecisionDenied,
+			wantRun:      agentruns.StatusFailed,
+			wantAirlock:  0,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			policy, request, airlock := readOnlyEvaluation()
+			if test.mutate != nil {
+				test.mutate(&policy, &airlock)
+			}
+			router, evaluator, _, run := routerFixture(t, policy, request, airlock)
+
+			result, err := router.Route(run.ID, request)
+			if err != nil {
+				t.Fatalf("Route(): %v", err)
+			}
+			if result.Decision.Status != test.wantDecision || result.Run.Status != test.wantRun {
+				t.Fatalf("Route() = %+v, want %q decision and %q run", result, test.wantDecision, test.wantRun)
+			}
+			if evaluator.calls != test.wantAirlock || len(result.Run.Approvals) != test.wantApprovals {
+				t.Fatalf("Route() Airlock calls = %d, approvals = %d; want %d, %d", evaluator.calls, len(result.Run.Approvals), test.wantAirlock, test.wantApprovals)
+			}
+		})
+	}
+}
+
+func TestRouterDoesNotExposeUnrecordedDecision(t *testing.T) {
+	policy, request, airlock := readOnlyEvaluation()
+	router, evaluator, store, run := routerFixture(t, policy, request, airlock)
+	if _, err := store.Fail(run.ID, "already terminal"); err != nil {
+		t.Fatalf("Fail(): %v", err)
+	}
+
+	result, err := router.Route(run.ID, request)
+	if !errors.Is(err, agentruns.ErrTerminated) {
+		t.Fatalf("Route() error = %v, want ErrTerminated", err)
+	}
+	if result.Decision != (Decision{}) || result.Run.ID != "" {
+		t.Fatalf("Route() result = %+v, want zero result after recorder failure", result)
+	}
+	if evaluator.calls != 1 {
+		t.Fatalf("EvaluateTool calls = %d, want one authorization attempt", evaluator.calls)
+	}
+	terminal, ok := store.Get(run.ID)
+	if !ok || terminal.Status != agentruns.StatusFailed || len(terminal.Logs) != 1 || len(terminal.Approvals) != 0 {
+		t.Fatalf("terminal run mutated after Route(): %+v", terminal)
+	}
+}
+
+func TestRouterRejectsMissingDependencies(t *testing.T) {
+	policy, request, airlock := readOnlyEvaluation()
+	evaluator := &fakeToolEvaluator{entry: evaluationEntry(request, airlock)}
+	authorizer, err := NewAuthorizer(policy, evaluator)
+	if err != nil {
+		t.Fatalf("NewAuthorizer(): %v", err)
+	}
+	recorder, _, _ := recorderFixture(t, request)
+
+	if _, err := NewRouter(nil, recorder); !errors.Is(err, ErrAuthorizerRequired) {
+		t.Fatalf("NewRouter(nil authorizer) error = %v, want ErrAuthorizerRequired", err)
+	}
+	if _, err := NewRouter(authorizer, nil); !errors.Is(err, ErrRunRecorderRequired) {
+		t.Fatalf("NewRouter(nil recorder) error = %v, want ErrRunRecorderRequired", err)
+	}
+	var nilRouter *Router
+	if _, err := nilRouter.Route("run_000001", request); !errors.Is(err, ErrAuthorizerRequired) {
+		t.Fatalf("nil Route() error = %v, want ErrAuthorizerRequired", err)
+	}
+}

--- a/internal/agentrouting/router_test.go
+++ b/internal/agentrouting/router_test.go
@@ -106,6 +106,28 @@ func TestRouterDoesNotExposeUnrecordedDecision(t *testing.T) {
 	}
 }
 
+func TestRouterBlocksAllowedOnWaitingApprovalRun(t *testing.T) {
+	policy, request, airlock := readOnlyEvaluation()
+	router, _, store, run := routerFixture(t, policy, request, airlock)
+
+	// Pre-transition the run to StatusWaitingApproval by adding an approval gate directly.
+	if _, err := store.AddApproval(run.ID, agentruns.ApprovalGate{
+		Kind:    agentruns.ApprovalMCPNetwork,
+		Summary: "pending approval",
+	}); err != nil {
+		t.Fatalf("AddApproval(): %v", err)
+	}
+
+	// The airlock would allow this call, but the recorder must block it.
+	result, err := router.Route(run.ID, request)
+	if !errors.Is(err, ErrInvalidDecision) {
+		t.Fatalf("Route() error = %v, want ErrInvalidDecision", err)
+	}
+	if result.Decision != (Decision{}) || result.Run.ID != "" {
+		t.Fatalf("Route() result = %+v, want zero result after recorder rejection", result)
+	}
+}
+
 func TestRouterRejectsMissingDependencies(t *testing.T) {
 	policy, request, airlock := readOnlyEvaluation()
 	evaluator := &fakeToolEvaluator{entry: evaluationEntry(request, airlock)}

--- a/internal/agentrouting/run_recorder.go
+++ b/internal/agentrouting/run_recorder.go
@@ -73,9 +73,6 @@ func (r *RunRecorder) Record(runID string, request Request, decision Decision) (
 	if run.Project != request.Project || run.ProviderID != request.ProviderID || run.Mode != request.Mode {
 		return agentruns.Run{}, ErrRunScopeMismatch
 	}
-	if run.Status == agentruns.StatusWaitingApproval && decision.Status == DecisionAllowed {
-		return agentruns.Run{}, fmt.Errorf("%w: cannot record an allowed decision for a run with pending approval gates", ErrInvalidDecision)
-	}
 
 	switch decision.Status {
 	case DecisionDenied:
@@ -94,7 +91,11 @@ func (r *RunRecorder) Record(runID string, request Request, decision Decision) (
 			Summary: routeAuditMessage("Authorize", request),
 		})
 	case DecisionAllowed:
-		return r.store.AddLog(runID, agentruns.LogAudit, routeAuditMessage("Allowed", request))
+		recorded, err := r.store.AddLogIfNoPendingApprovals(runID, agentruns.LogAudit, routeAuditMessage("Allowed", request))
+		if errors.Is(err, agentruns.ErrApprovalPending) {
+			return agentruns.Run{}, fmt.Errorf("%w: cannot record an allowed decision for a run with pending approval gates", ErrInvalidDecision)
+		}
+		return recorded, err
 	default:
 		return agentruns.Run{}, ErrInvalidDecision
 	}

--- a/internal/agentrouting/run_recorder.go
+++ b/internal/agentrouting/run_recorder.go
@@ -73,6 +73,9 @@ func (r *RunRecorder) Record(runID string, request Request, decision Decision) (
 	if run.Project != request.Project || run.ProviderID != request.ProviderID || run.Mode != request.Mode {
 		return agentruns.Run{}, ErrRunScopeMismatch
 	}
+	if run.Status == agentruns.StatusWaitingApproval && decision.Status == DecisionAllowed {
+		return agentruns.Run{}, fmt.Errorf("%w: cannot record an allowed decision for a run with pending approval gates", ErrInvalidDecision)
+	}
 
 	switch decision.Status {
 	case DecisionDenied:

--- a/internal/agentrouting/run_recorder.go
+++ b/internal/agentrouting/run_recorder.go
@@ -93,7 +93,7 @@ func (r *RunRecorder) Record(runID string, request Request, decision Decision) (
 	case DecisionAllowed:
 		recorded, err := r.store.AddLogIfNoPendingApprovals(runID, agentruns.LogAudit, routeAuditMessage("Allowed", request))
 		if errors.Is(err, agentruns.ErrApprovalPending) {
-			return agentruns.Run{}, fmt.Errorf("%w: cannot record an allowed decision for a run with pending approval gates", ErrInvalidDecision)
+			return agentruns.Run{}, fmt.Errorf("%w: cannot record authorization while approval gates are pending", ErrInvalidDecision)
 		}
 		return recorded, err
 	default:

--- a/internal/agentrouting/run_recorder_test.go
+++ b/internal/agentrouting/run_recorder_test.go
@@ -269,8 +269,12 @@ func TestRunRecorderRejectsAllowedOnWaitingApprovalRunWithoutMutation(t *testing
 		t.Fatalf("run not in waiting_approval after approval gate: %+v", waiting)
 	}
 
-	if _, err := recorder.Record(run.ID, request, allowed()); !errors.Is(err, ErrInvalidDecision) {
+	_, err := recorder.Record(run.ID, request, allowed())
+	if !errors.Is(err, ErrInvalidDecision) {
 		t.Fatalf("Record(allowed on waiting_approval run) error = %v, want ErrInvalidDecision", err)
+	}
+	if strings.Contains(strings.ToLower(err.Error()), "allowed") {
+		t.Fatalf("Record() error leaked withheld decision: %v", err)
 	}
 	unchanged, ok := store.Get(run.ID)
 	if !ok || unchanged.Status != agentruns.StatusWaitingApproval || len(unchanged.Logs) != 0 || len(unchanged.Approvals) != 1 {

--- a/internal/agentrouting/run_recorder_test.go
+++ b/internal/agentrouting/run_recorder_test.go
@@ -257,6 +257,27 @@ func TestRunRecorderRejectsMissingDependenciesAndRuns(t *testing.T) {
 	}
 }
 
+func TestRunRecorderRejectsAllowedOnWaitingApprovalRunWithoutMutation(t *testing.T) {
+	_, request, _ := readOnlyEvaluation()
+	recorder, store, run := recorderFixture(t, request)
+
+	if _, err := recorder.Record(run.ID, request, approvalRequired()); err != nil {
+		t.Fatalf("Record(approval_required): %v", err)
+	}
+	waiting, ok := store.Get(run.ID)
+	if !ok || waiting.Status != agentruns.StatusWaitingApproval {
+		t.Fatalf("run not in waiting_approval after approval gate: %+v", waiting)
+	}
+
+	if _, err := recorder.Record(run.ID, request, allowed()); !errors.Is(err, ErrInvalidDecision) {
+		t.Fatalf("Record(allowed on waiting_approval run) error = %v, want ErrInvalidDecision", err)
+	}
+	unchanged, ok := store.Get(run.ID)
+	if !ok || unchanged.Status != agentruns.StatusWaitingApproval || len(unchanged.Logs) != 0 || len(unchanged.Approvals) != 1 {
+		t.Fatalf("run mutated after allowed on waiting_approval run: %+v", unchanged)
+	}
+}
+
 func TestRunRecorderRejectsTerminalRunWithoutDuplicateMutation(t *testing.T) {
 	_, request, _ := readOnlyEvaluation()
 	outcomes := []Decision{

--- a/internal/agentruns/store.go
+++ b/internal/agentruns/store.go
@@ -351,12 +351,25 @@ func (s *Store) Fail(id string, message string) (Run, error) {
 }
 
 func (s *Store) AddLog(id string, level LogLevel, message string) (Run, error) {
+	return s.addLog(id, level, message, false)
+}
+
+// AddLogIfNoPendingApprovals appends a log only when the run has no unresolved
+// approval gates. The check and append occur under the same store lock.
+func (s *Store) AddLogIfNoPendingApprovals(id string, level LogLevel, message string) (Run, error) {
+	return s.addLog(id, level, message, true)
+}
+
+func (s *Store) addLog(id string, level LogLevel, message string, rejectPendingApprovals bool) (Run, error) {
 	if !validLogLevel(level) {
 		return Run{}, fmt.Errorf("invalid agent log level: %s", level)
 	}
 	return s.update(id, func(run *Run, now time.Time) error {
 		if terminalStatus(run.Status) {
 			return ErrTerminated
+		}
+		if rejectPendingApprovals && (run.Status == StatusWaitingApproval || hasPendingApprovals(run.Approvals)) {
+			return ErrApprovalPending
 		}
 		appendLog(run, now, level, message)
 		return nil
@@ -550,6 +563,7 @@ func (s *Store) evictLocked() {
 var (
 	ErrNotFound         = errors.New("agent run not found")
 	ErrTerminated       = errors.New("agent run is already in a terminal state")
+	ErrApprovalPending  = errors.New("agent run has pending approval gates")
 	ErrApprovalNotFound = errors.New("approval gate not found")
 	ErrApprovalDecided  = errors.New("approval gate is already decided")
 	ErrUnsafePatchPath  = errors.New("patch path must be a relative path within the project")

--- a/internal/agentruns/store.go
+++ b/internal/agentruns/store.go
@@ -354,8 +354,9 @@ func (s *Store) AddLog(id string, level LogLevel, message string) (Run, error) {
 	return s.addLog(id, level, message, false)
 }
 
-// AddLogIfNoPendingApprovals appends a log only when the run has no unresolved
-// approval gates. The check and append occur under the same store lock.
+// AddLogIfNoPendingApprovals appends a log only when the run is not waiting for
+// approval and has no unresolved approval gates. The check and append occur
+// under the same store lock.
 func (s *Store) AddLogIfNoPendingApprovals(id string, level LogLevel, message string) (Run, error) {
 	return s.addLog(id, level, message, true)
 }

--- a/internal/agentruns/store_test.go
+++ b/internal/agentruns/store_test.go
@@ -578,6 +578,9 @@ func TestStoreTerminalStateGuard(t *testing.T) {
 	if _, err := store.AddLog(run.ID, LogInfo, "late log"); !errors.Is(err, ErrTerminated) {
 		t.Fatalf("AddLog on completed run: got %v, want ErrTerminated", err)
 	}
+	if _, err := store.AddLogIfNoPendingApprovals(run.ID, LogAudit, "late authorization"); !errors.Is(err, ErrTerminated) {
+		t.Fatalf("AddLogIfNoPendingApprovals on completed run: got %v, want ErrTerminated", err)
+	}
 	if _, err := store.AddApproval(run.ID, ApprovalGate{Kind: ApprovalCommand, Summary: "x"}); !errors.Is(err, ErrTerminated) {
 		t.Fatalf("AddApproval on completed run: got %v, want ErrTerminated", err)
 	}
@@ -586,6 +589,26 @@ func TestStoreTerminalStateGuard(t *testing.T) {
 	}
 	if _, err := store.DecideApproval(run.ID, approvalID, ApprovalApproved, "alice"); !errors.Is(err, ErrTerminated) {
 		t.Fatalf("DecideApproval on completed run: got %v, want ErrTerminated", err)
+	}
+}
+
+func TestStoreAddLogIfNoPendingApprovalsRejectsAtomically(t *testing.T) {
+	store := NewStore(WithClock(fixedClock().now))
+	run, err := store.Create(CreateRequest{Project: "prod", Prompt: "x"})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	run, err = store.AddApproval(run.ID, ApprovalGate{Kind: ApprovalMCPNetwork, Summary: "authorize route"})
+	if err != nil {
+		t.Fatalf("AddApproval returned error: %v", err)
+	}
+
+	if _, err := store.AddLogIfNoPendingApprovals(run.ID, LogAudit, "allowed route"); !errors.Is(err, ErrApprovalPending) {
+		t.Fatalf("AddLogIfNoPendingApprovals error = %v, want ErrApprovalPending", err)
+	}
+	unchanged, ok := store.Get(run.ID)
+	if !ok || unchanged.Status != StatusWaitingApproval || len(unchanged.Logs) != 0 || len(unchanged.Approvals) != 1 {
+		t.Fatalf("run mutated after pending-approval rejection: %+v", unchanged)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add a non-executing Agent Hub router that composes route authorization with Agent Run recording
- return authorization results only after the outcome is persisted
- return a zero result when recording fails so callers cannot act on an unaudited allow
- cover allowed, approval-required, denied, dependency, and recorder-failure paths

## Security

The router does not invoke external MCP tools or read cloud credentials. It preserves fail-closed behavior by withholding every decision when its audit/state mutation fails.

## Validation

- `go test ./internal/agentrouting`
- `go vet ./internal/agentrouting`
- `go test ./internal/...`
- `go vet ./internal/...`

Part of #107.