### PR TITLE
Store scoped Agent Hub route policies

### DIFF
--- a/internal/agentrouting/policy_store.go
+++ b/internal/agentrouting/policy_store.go
@@ -1,0 +1,84 @@
+package agentrouting
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+)
+
+var (
+	ErrPolicyStoreRequired = errors.New("tool route policy store is required")
+	ErrInvalidPolicyScope  = errors.New("invalid tool route policy scope")
+	ErrPolicyNotFound      = errors.New("tool route policy not found")
+	ErrPolicyScopeMismatch = errors.New("tool route policy contains a rule outside its scope")
+)
+
+// PolicyScope identifies one server-owned route policy. Policies never fall
+// back across projects or model providers.
+type PolicyScope struct {
+	Project    string `json:"project"`
+	ProviderID string `json:"provider_id"`
+}
+
+func (s PolicyScope) Validate() error {
+	return validateRequiredFields(ErrInvalidPolicyScope,
+		fieldValue{name: "project", value: s.Project},
+		fieldValue{name: "provider_id", value: s.ProviderID},
+	)
+}
+
+// PolicyStore keeps validated, immutable policy snapshots by exact project
+// and provider scope. Missing policies fail closed with ErrPolicyNotFound.
+type PolicyStore struct {
+	mu       sync.RWMutex
+	policies map[PolicyScope]Policy
+}
+
+func NewPolicyStore() *PolicyStore {
+	return &PolicyStore{policies: make(map[PolicyScope]Policy)}
+}
+
+// Save validates and snapshots a policy before replacing its scoped entry.
+func (s *PolicyStore) Save(scope PolicyScope, policy Policy) error {
+	if s == nil {
+		return ErrPolicyStoreRequired
+	}
+	if err := scope.Validate(); err != nil {
+		return err
+	}
+	snapshot := clonePolicy(policy)
+	if err := snapshot.Validate(); err != nil {
+		return fmt.Errorf("validate tool route policy: %w", err)
+	}
+	for i, rule := range snapshot.Rules {
+		if rule.Project != scope.Project || rule.ProviderID != scope.ProviderID {
+			return fmt.Errorf("%w: rule[%d] targets project %q and provider %q", ErrPolicyScopeMismatch, i, rule.Project, rule.ProviderID)
+		}
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.policies == nil {
+		s.policies = make(map[PolicyScope]Policy)
+	}
+	s.policies[scope] = snapshot
+	return nil
+}
+
+// Get returns a detached policy snapshot for one exact project/provider scope.
+func (s *PolicyStore) Get(scope PolicyScope) (Policy, error) {
+	if s == nil {
+		return Policy{}, ErrPolicyStoreRequired
+	}
+	if err := scope.Validate(); err != nil {
+		return Policy{}, err
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	policy, ok := s.policies[scope]
+	if !ok {
+		return Policy{}, ErrPolicyNotFound
+	}
+	return clonePolicy(policy), nil
+}

--- a/internal/agentrouting/policy_store.go
+++ b/internal/agentrouting/policy_store.go
@@ -75,8 +75,8 @@ func (s *PolicyStore) Get(scope PolicyScope) (Policy, error) {
 	}
 
 	s.mu.RLock()
-	defer s.mu.RUnlock()
 	policy, ok := s.policies[scope]
+	s.mu.RUnlock()
 	if !ok {
 		return Policy{}, ErrPolicyNotFound
 	}

--- a/internal/agentrouting/policy_store_test.go
+++ b/internal/agentrouting/policy_store_test.go
@@ -2,6 +2,7 @@ package agentrouting
 
 import (
 	"errors"
+	"sync"
 	"testing"
 
 	"github.com/iac-studio/iac-studio/internal/agentruns"
@@ -120,4 +121,27 @@ func TestPolicyStoreFailsClosedForMissingOrInvalidScopes(t *testing.T) {
 	if _, err := nilStore.Get(scope); !errors.Is(err, ErrPolicyStoreRequired) {
 		t.Fatalf("nil Get() error = %v, want ErrPolicyStoreRequired", err)
 	}
+}
+
+func TestPolicyStoreConcurrentSaveAndGetAreRaceFree(t *testing.T) {
+	scope, policy := validPolicyStoreInput()
+	store := NewPolicyStore()
+	if err := store.Save(scope, policy); err != nil {
+		t.Fatalf("Save(): %v", err)
+	}
+
+	const goroutines = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines * 2)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			_ = store.Save(scope, policy)
+		}()
+		go func() {
+			defer wg.Done()
+			_, _ = store.Get(scope)
+		}()
+	}
+	wg.Wait()
 }

--- a/internal/agentrouting/policy_store_test.go
+++ b/internal/agentrouting/policy_store_test.go
@@ -132,16 +132,24 @@ func TestPolicyStoreConcurrentSaveAndGetAreRaceFree(t *testing.T) {
 
 	const goroutines = 50
 	var wg sync.WaitGroup
+	errs := make(chan error, goroutines*2)
 	wg.Add(goroutines * 2)
 	for range goroutines {
 		go func() {
 			defer wg.Done()
-			_ = store.Save(scope, policy)
+			errs <- store.Save(scope, policy)
 		}()
 		go func() {
 			defer wg.Done()
-			_, _ = store.Get(scope)
+			_, err := store.Get(scope)
+			errs <- err
 		}()
 	}
 	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Errorf("concurrent policy-store operation failed: %v", err)
+		}
+	}
 }

--- a/internal/agentrouting/policy_store_test.go
+++ b/internal/agentrouting/policy_store_test.go
@@ -1,0 +1,123 @@
+package agentrouting
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/iac-studio/iac-studio/internal/agentruns"
+)
+
+func validPolicyStoreInput() (PolicyScope, Policy) {
+	rule := validRule()
+	return PolicyScope{Project: rule.Project, ProviderID: rule.ProviderID}, Policy{Rules: []Rule{rule}}
+}
+
+func TestPolicyStoreReturnsImmutableScopedSnapshots(t *testing.T) {
+	scope, policy := validPolicyStoreInput()
+	store := NewPolicyStore()
+	if err := store.Save(scope, policy); err != nil {
+		t.Fatalf("Save(): %v", err)
+	}
+
+	policy.Rules[0].Effect = EffectDeny
+	policy.Rules[0].Modes[0] = "invalid"
+	stored, err := store.Get(scope)
+	if err != nil {
+		t.Fatalf("Get(): %v", err)
+	}
+	if stored.Rules[0].Effect != EffectAllow || stored.Rules[0].Modes[0] != agentruns.ModeProposeOnly {
+		t.Fatalf("stored policy changed with Save caller: %+v", stored)
+	}
+
+	stored.Rules[0].Effect = EffectDeny
+	stored.Rules[0].Modes[0] = "invalid"
+	again, err := store.Get(scope)
+	if err != nil {
+		t.Fatalf("Get() again: %v", err)
+	}
+	if again.Rules[0].Effect != EffectAllow || again.Rules[0].Modes[0] != agentruns.ModeProposeOnly {
+		t.Fatalf("stored policy changed with Get caller: %+v", again)
+	}
+}
+
+func TestPolicyStoreRejectsInvalidReplacementWithoutMutation(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*Policy)
+		wantErr error
+	}{
+		{
+			name: "cross-project rule",
+			mutate: func(policy *Policy) {
+				policy.Rules[0].Project = "other-project"
+			},
+			wantErr: ErrPolicyScopeMismatch,
+		},
+		{
+			name: "cross-provider rule",
+			mutate: func(policy *Policy) {
+				policy.Rules[0].ProviderID = "other-provider"
+			},
+			wantErr: ErrPolicyScopeMismatch,
+		},
+		{
+			name: "invalid rule",
+			mutate: func(policy *Policy) {
+				policy.Rules[0].Effect = "unsupported"
+			},
+			wantErr: ErrInvalidRule,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			scope, existing := validPolicyStoreInput()
+			store := NewPolicyStore()
+			if err := store.Save(scope, existing); err != nil {
+				t.Fatalf("Save(existing): %v", err)
+			}
+			candidate := clonePolicy(existing)
+			test.mutate(&candidate)
+
+			if err := store.Save(scope, candidate); !errors.Is(err, test.wantErr) {
+				t.Fatalf("Save(invalid) error = %v, want %v", err, test.wantErr)
+			}
+			stored, err := store.Get(scope)
+			if err != nil {
+				t.Fatalf("Get(): %v", err)
+			}
+			if stored.Rules[0].Effect != EffectAllow || stored.Rules[0].Project != scope.Project || stored.Rules[0].ProviderID != scope.ProviderID {
+				t.Fatalf("invalid replacement mutated stored policy: %+v", stored)
+			}
+		})
+	}
+}
+
+func TestPolicyStoreFailsClosedForMissingOrInvalidScopes(t *testing.T) {
+	scope, policy := validPolicyStoreInput()
+	store := NewPolicyStore()
+	if _, err := store.Get(scope); !errors.Is(err, ErrPolicyNotFound) {
+		t.Fatalf("Get(missing) error = %v, want ErrPolicyNotFound", err)
+	}
+
+	invalidScopes := []PolicyScope{
+		{ProviderID: scope.ProviderID},
+		{Project: scope.Project, ProviderID: " " + scope.ProviderID},
+	}
+	for _, invalid := range invalidScopes {
+		if err := store.Save(invalid, policy); !errors.Is(err, ErrInvalidPolicyScope) {
+			t.Fatalf("Save(%+v) error = %v, want ErrInvalidPolicyScope", invalid, err)
+		}
+		if _, err := store.Get(invalid); !errors.Is(err, ErrInvalidPolicyScope) {
+			t.Fatalf("Get(%+v) error = %v, want ErrInvalidPolicyScope", invalid, err)
+		}
+	}
+
+	var nilStore *PolicyStore
+	if err := nilStore.Save(scope, policy); !errors.Is(err, ErrPolicyStoreRequired) {
+		t.Fatalf("nil Save() error = %v, want ErrPolicyStoreRequired", err)
+	}
+	if _, err := nilStore.Get(scope); !errors.Is(err, ErrPolicyStoreRequired) {
+		t.Fatalf("nil Get() error = %v, want ErrPolicyStoreRequired", err)
+	}
+}


### PR DESCRIPTION
## Summary

- add a server-owned Agent Hub route policy store keyed by exact project and provider scope
- validate every policy before replacement and reject rules targeting another scope
- deep-copy policies on save and read so callers cannot widen stored permissions
- fail closed when a scoped policy does not exist

## Security

This slice intentionally adds no HTTP write path. It prevents future route requests from carrying their own allow policy and provides no project-wide or provider-wide fallback.

## Validation

- `go test ./internal/agentrouting`
- `go test -race ./internal/agentrouting`
- `go vet ./internal/agentrouting`
- `go test ./internal/...`
- `go vet ./internal/...`

Part of #107.