### PR TITLE
Resolve scoped Agent Hub policies at authorization time

### DIFF
--- a/internal/agentrouting/authorizer.go
+++ b/internal/agentrouting/authorizer.go
@@ -17,10 +17,11 @@ type ToolEvaluator interface {
 	EvaluateTool(serverID, project, toolName string) (mcpairlock.ToolInventoryEntry, error)
 }
 
-// Authorizer combines an immutable routing policy snapshot with live MCP
-// Airlock inventory decisions. It never invokes an external tool.
+// Authorizer combines a routing policy with live MCP Airlock inventory
+// decisions. It never invokes an external tool.
 type Authorizer struct {
 	policy    Policy
+	policies  *PolicyStore
 	evaluator ToolEvaluator
 }
 
@@ -37,6 +38,18 @@ func NewAuthorizer(policy Policy, evaluator ToolEvaluator) (*Authorizer, error) 
 	return &Authorizer{policy: snapshot, evaluator: evaluator}, nil
 }
 
+// NewStoreAuthorizer resolves the exact project/provider policy snapshot for
+// every request. Missing scoped policies fail closed without calling Airlock.
+func NewStoreAuthorizer(policies *PolicyStore, evaluator ToolEvaluator) (*Authorizer, error) {
+	if policies == nil {
+		return nil, ErrPolicyStoreRequired
+	}
+	if missingToolEvaluator(evaluator) {
+		return nil, ErrToolEvaluatorRequired
+	}
+	return &Authorizer{policies: policies, evaluator: evaluator}, nil
+}
+
 // Authorize evaluates the current Airlock decision for one fully scoped tool
 // route. Airlock errors and inconsistent inventory identities fail closed.
 func (a *Authorizer) Authorize(request Request) Decision {
@@ -46,10 +59,21 @@ func (a *Authorizer) Authorize(request Request) Decision {
 	if a == nil || missingToolEvaluator(a.evaluator) {
 		return denied(ReasonAirlockUnavailable)
 	}
-	if a.policy.Validate() != nil {
+	policy := a.policy
+	if a.policies != nil {
+		var err error
+		policy, err = a.policies.Get(PolicyScope{
+			Project:    request.Project,
+			ProviderID: request.ProviderID,
+		})
+		if err != nil {
+			return denied(ReasonPolicyUnavailable)
+		}
+	}
+	if policy.Validate() != nil {
 		return denied(ReasonInvalidPolicy)
 	}
-	rule, matched := a.policy.matchValidated(request)
+	rule, matched := policy.matchValidated(request)
 	if !matched {
 		return denied(ReasonNoMatchingRule)
 	}

--- a/internal/agentrouting/authorizer_test.go
+++ b/internal/agentrouting/authorizer_test.go
@@ -151,6 +151,71 @@ func TestAuthorizerSnapshotsValidatedPolicy(t *testing.T) {
 	}
 }
 
+func TestStoreAuthorizerResolvesCurrentScopedPolicy(t *testing.T) {
+	policy, request, decision := readOnlyEvaluation()
+	store := NewPolicyStore()
+	scope := PolicyScope{Project: request.Project, ProviderID: request.ProviderID}
+	if err := store.Save(scope, policy); err != nil {
+		t.Fatalf("Save(allow): %v", err)
+	}
+	evaluator := &fakeToolEvaluator{entry: evaluationEntry(request, decision)}
+	authorizer, err := NewStoreAuthorizer(store, evaluator)
+	if err != nil {
+		t.Fatalf("NewStoreAuthorizer(): %v", err)
+	}
+
+	if got := authorizer.Authorize(request); got.Status != DecisionAllowed {
+		t.Fatalf("Authorize(allow) = %+v, want allowed", got)
+	}
+	deniedPolicy := clonePolicy(policy)
+	deniedPolicy.Rules[0].Effect = EffectDeny
+	if err := store.Save(scope, deniedPolicy); err != nil {
+		t.Fatalf("Save(deny): %v", err)
+	}
+	if got := authorizer.Authorize(request); got.Status != DecisionDenied || got.Reason != ReasonPolicyDenied {
+		t.Fatalf("Authorize(deny) = %+v, want policy denial", got)
+	}
+	if evaluator.calls != 1 {
+		t.Fatalf("EvaluateTool calls = %d, want only the allowed-policy call", evaluator.calls)
+	}
+}
+
+func TestStoreAuthorizerFailsClosedWithoutExactScopedPolicy(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*Rule)
+	}{
+		{name: "other project", mutate: func(rule *Rule) { rule.Project = "other-project" }},
+		{name: "other provider", mutate: func(rule *Rule) { rule.ProviderID = "other-provider" }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			policy, request, decision := readOnlyEvaluation()
+			test.mutate(&policy.Rules[0])
+			store := NewPolicyStore()
+			if err := store.Save(PolicyScope{
+				Project:    policy.Rules[0].Project,
+				ProviderID: policy.Rules[0].ProviderID,
+			}, policy); err != nil {
+				t.Fatalf("Save(%s): %v", test.name, err)
+			}
+			evaluator := &fakeToolEvaluator{entry: evaluationEntry(request, decision)}
+			authorizer, err := NewStoreAuthorizer(store, evaluator)
+			if err != nil {
+				t.Fatalf("NewStoreAuthorizer(): %v", err)
+			}
+
+			got := authorizer.Authorize(request)
+			if got.Status != DecisionDenied || got.Reason != ReasonPolicyUnavailable || evaluator.calls != 0 {
+				t.Fatalf("Authorize() = %+v, calls = %d; want unavailable policy denial without Airlock call", got, evaluator.calls)
+			}
+			if err := got.Validate(); err != nil {
+				t.Fatalf("Authorize() decision validation: %v", err)
+			}
+		})
+	}
+}
+
 func TestAuthorizerRejectsInvalidStoredPolicyBeforeCallingAirlock(t *testing.T) {
 	policy, request, decision := readOnlyEvaluation()
 	policy.Rules[0].Effect = "unsupported"
@@ -171,6 +236,12 @@ func TestNewAuthorizerRejectsInvalidDependencies(t *testing.T) {
 	var typedNil *fakeToolEvaluator
 	if _, err := NewAuthorizer(policy, typedNil); !errors.Is(err, ErrToolEvaluatorRequired) {
 		t.Fatalf("NewAuthorizer(typed nil) error = %v, want ErrToolEvaluatorRequired", err)
+	}
+	if _, err := NewStoreAuthorizer(nil, &fakeToolEvaluator{}); !errors.Is(err, ErrPolicyStoreRequired) {
+		t.Fatalf("NewStoreAuthorizer(nil store) error = %v, want ErrPolicyStoreRequired", err)
+	}
+	if _, err := NewStoreAuthorizer(NewPolicyStore(), nil); !errors.Is(err, ErrToolEvaluatorRequired) {
+		t.Fatalf("NewStoreAuthorizer(nil evaluator) error = %v, want ErrToolEvaluatorRequired", err)
 	}
 
 	bad := validRule()

--- a/internal/agentrouting/decision.go
+++ b/internal/agentrouting/decision.go
@@ -25,6 +25,7 @@ type DecisionReason string
 const (
 	ReasonInvalidRequest         DecisionReason = "invalid_request"
 	ReasonInvalidPolicy          DecisionReason = "invalid_policy"
+	ReasonPolicyUnavailable      DecisionReason = "policy_unavailable"
 	ReasonModeRiskMismatch       DecisionReason = "mode_risk_mismatch"
 	ReasonNoMatchingRule         DecisionReason = "no_matching_rule"
 	ReasonPolicyDenied           DecisionReason = "policy_denied"
@@ -77,6 +78,7 @@ func validDeniedReason(reason DecisionReason) bool {
 	switch reason {
 	case ReasonInvalidRequest,
 		ReasonInvalidPolicy,
+		ReasonPolicyUnavailable,
 		ReasonModeRiskMismatch,
 		ReasonNoMatchingRule,
 		ReasonPolicyDenied,


### PR DESCRIPTION
## Summary

- add a store-backed Agent Hub authorizer that resolves policy by exact project and provider scope for every request
- apply policy replacements without rebuilding the authorizer
- fail closed with a stable `policy_unavailable` decision when no exact policy exists
- avoid Airlock evaluation when policy resolution fails

## Security

The request is validated before policy lookup, and there is no project-wide or provider-wide fallback. This slice adds no HTTP policy surface, cloud credential access, MCP invocation, or tool execution.

## Validation

- `go test ./internal/agentrouting`
- `go test -race ./internal/agentrouting`
- `go vet ./internal/agentrouting`
- `go test ./internal/...`
- `go vet ./internal/...`

Part of #107.