### PR TITLE
Expose audited Agent Hub tool route authorization

### DIFF
--- a/internal/api/agent_tool_route_idempotency.go
+++ b/internal/api/agent_tool_route_idempotency.go
@@ -1,0 +1,135 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/iac-studio/iac-studio/internal/agentrouting"
+)
+
+const (
+	agentToolRouteIdempotencyHeader       = "Idempotency-Key"
+	maxAgentToolRouteIdempotencyKeyLength = 128
+	maxAgentToolRouteAttempts             = 1024
+)
+
+var (
+	errAgentToolRouteIdempotencyConflict = errors.New("idempotency key reused for a different tool route")
+	errAgentToolRouteAttemptCapacity     = errors.New("tool route idempotency capacity reached")
+)
+
+type agentToolRouteAttemptKey struct {
+	runID string
+	key   string
+}
+
+type agentToolRouteAttempt struct {
+	request  agentrouting.Request
+	done     chan struct{}
+	decision agentrouting.Decision
+	err      error
+}
+
+// agentToolRouteAttemptStore coalesces concurrent retries and retains a
+// bounded replay window for successful, already-audited decisions.
+type agentToolRouteAttemptStore struct {
+	mu         sync.Mutex
+	entries    map[agentToolRouteAttemptKey]*agentToolRouteAttempt
+	completed  []agentToolRouteAttemptKey
+	maxEntries int
+}
+
+func newAgentToolRouteAttemptStore(maxEntries int) *agentToolRouteAttemptStore {
+	if maxEntries <= 0 {
+		maxEntries = 1
+	}
+	return &agentToolRouteAttemptStore{
+		entries:    make(map[agentToolRouteAttemptKey]*agentToolRouteAttempt),
+		maxEntries: maxEntries,
+	}
+}
+
+func (s *agentToolRouteAttemptStore) authorize(
+	ctx context.Context,
+	runID string,
+	idempotencyKey string,
+	request agentrouting.Request,
+	route func() (agentrouting.RouteResult, error),
+) (agentrouting.RouteResult, bool, error) {
+	key := agentToolRouteAttemptKey{runID: runID, key: idempotencyKey}
+
+	s.mu.Lock()
+	if attempt, ok := s.entries[key]; ok {
+		if attempt.request != request {
+			s.mu.Unlock()
+			return agentrouting.RouteResult{}, false, errAgentToolRouteIdempotencyConflict
+		}
+		done := attempt.done
+		s.mu.Unlock()
+
+		select {
+		case <-done:
+			if attempt.err != nil {
+				return agentrouting.RouteResult{}, true, attempt.err
+			}
+			return agentrouting.RouteResult{Decision: attempt.decision}, true, nil
+		case <-ctx.Done():
+			return agentrouting.RouteResult{}, true, ctx.Err()
+		}
+	}
+	if !s.makeRoomLocked() {
+		s.mu.Unlock()
+		return agentrouting.RouteResult{}, false, errAgentToolRouteAttemptCapacity
+	}
+	attempt := &agentToolRouteAttempt{request: request, done: make(chan struct{})}
+	s.entries[key] = attempt
+	s.mu.Unlock()
+
+	result, err := route()
+
+	s.mu.Lock()
+	attempt.err = err
+	if err == nil {
+		attempt.decision = result.Decision
+		s.completed = append(s.completed, key)
+	} else {
+		delete(s.entries, key)
+	}
+	close(attempt.done)
+	s.mu.Unlock()
+
+	return result, false, err
+}
+
+func (s *agentToolRouteAttemptStore) makeRoomLocked() bool {
+	for len(s.entries) >= s.maxEntries && len(s.completed) > 0 {
+		oldest := s.completed[0]
+		s.completed = s.completed[1:]
+		delete(s.entries, oldest)
+	}
+	return len(s.entries) < s.maxEntries
+}
+
+func requireAgentToolRouteIdempotencyKey(w http.ResponseWriter, r *http.Request) (string, bool) {
+	values := r.Header.Values(agentToolRouteIdempotencyHeader)
+	if len(values) != 1 || !validAgentToolRouteIdempotencyKey(values[0]) {
+		http.Error(w, "a valid Idempotency-Key header is required", http.StatusBadRequest)
+		return "", false
+	}
+	return values[0], true
+}
+
+func validAgentToolRouteIdempotencyKey(key string) bool {
+	if key == "" || len(key) > maxAgentToolRouteIdempotencyKeyLength || strings.TrimSpace(key) != key {
+		return false
+	}
+	for i := range len(key) {
+		if key[i] < 0x21 || key[i] > 0x7e {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/api/agent_tool_route_idempotency_test.go
+++ b/internal/api/agent_tool_route_idempotency_test.go
@@ -1,0 +1,93 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/iac-studio/iac-studio/internal/agentrouting"
+)
+
+type agentToolRouteAttemptOutcome struct {
+	result   agentrouting.RouteResult
+	replayed bool
+	err      error
+}
+
+func TestAgentToolRouteAttemptStoreCoalescesConcurrentRetries(t *testing.T) {
+	store := newAgentToolRouteAttemptStore(2)
+	request := agentrouting.Request{
+		Project:      "demo",
+		ProviderID:   "codex",
+		ConnectionID: "aws-prod",
+		ServerID:     "aws",
+		ToolName:     "list_buckets",
+		Mode:         "read_only",
+		Risk:         "read_only",
+	}
+	want := agentrouting.RouteResult{Decision: agentrouting.Decision{
+		Status:          agentrouting.DecisionAllowed,
+		Reason:          agentrouting.ReasonAllowed,
+		Allowed:         true,
+		UntrustedOutput: true,
+	}}
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var calls atomic.Int32
+	route := func() (agentrouting.RouteResult, error) {
+		if calls.Add(1) == 1 {
+			close(started)
+		}
+		<-release
+		return want, nil
+	}
+
+	results := make(chan agentToolRouteAttemptOutcome, 2)
+	authorize := func() {
+		result, replayed, err := store.authorize(context.Background(), "run_000001", "same-attempt", request, route)
+		results <- agentToolRouteAttemptOutcome{result: result, replayed: replayed, err: err}
+	}
+	go authorize()
+	<-started
+	go authorize()
+	close(release)
+
+	replayed := 0
+	for range 2 {
+		outcome := <-results
+		if outcome.err != nil || outcome.result.Decision != want.Decision {
+			t.Fatalf("authorize outcome = %+v, want recorded decision", outcome)
+		}
+		if outcome.replayed {
+			replayed++
+		}
+	}
+	if calls.Load() != 1 || replayed != 1 {
+		t.Fatalf("route calls = %d, replayed responses = %d; want 1, 1", calls.Load(), replayed)
+	}
+}
+
+func TestAgentToolRouteAttemptStoreReleasesFailedAttempts(t *testing.T) {
+	store := newAgentToolRouteAttemptStore(1)
+	request := agentrouting.Request{Project: "demo"}
+	wantErr := errors.New("temporary route failure")
+
+	if _, replayed, err := store.authorize(context.Background(), "run_000001", "retryable", request, func() (agentrouting.RouteResult, error) {
+		return agentrouting.RouteResult{}, wantErr
+	}); !errors.Is(err, wantErr) || replayed {
+		t.Fatalf("first authorize error = %v, replayed = %t; want retryable failure", err, replayed)
+	}
+
+	want := agentrouting.RouteResult{Decision: agentrouting.Decision{
+		Status:          agentrouting.DecisionDenied,
+		Reason:          agentrouting.ReasonPolicyDenied,
+		UntrustedOutput: true,
+	}}
+	got, replayed, err := store.authorize(context.Background(), "run_000001", "retryable", request, func() (agentrouting.RouteResult, error) {
+		return want, nil
+	})
+	if err != nil || replayed || got.Decision != want.Decision {
+		t.Fatalf("second authorize = %+v, replayed = %t, error = %v; want fresh success", got, replayed, err)
+	}
+}

--- a/internal/api/agent_tool_routes.go
+++ b/internal/api/agent_tool_routes.go
@@ -1,0 +1,116 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"log"
+	"net/http"
+
+	"github.com/iac-studio/iac-studio/internal/agentrouting"
+	"github.com/iac-studio/iac-studio/internal/agentruns"
+	"github.com/iac-studio/iac-studio/internal/mcpairlock"
+)
+
+// AgentToolRouter authorizes and records one fully scoped tool route without
+// invoking the external tool.
+type AgentToolRouter interface {
+	Route(runID string, request agentrouting.Request) (agentrouting.RouteResult, error)
+}
+
+type agentToolRouteAuthorizeRequest struct {
+	ConnectionID string              `json:"connection_id"`
+	ServerID     string              `json:"server_id"`
+	ToolName     string              `json:"tool_name"`
+	Risk         mcpairlock.ToolRisk `json:"risk"`
+}
+
+func registerAgentToolRouteRoutes(
+	mux *http.ServeMux,
+	projectsDir string,
+	store *agentruns.Store,
+	router AgentToolRouter,
+) {
+	if router == nil {
+		return
+	}
+
+	mux.HandleFunc("POST /api/projects/{name}/agent-runs/{id}/tool-routes/authorize", func(w http.ResponseWriter, r *http.Request) {
+		limitBody(w, r)
+		if !requireJSONContentType(w, r) {
+			return
+		}
+		name := r.PathValue("name")
+		if !requireExistingAgentRunProject(w, projectsDir, name) {
+			return
+		}
+		run, ok := store.Get(r.PathValue("id"))
+		if !ok || run.Project != name {
+			http.Error(w, "agent run not found", http.StatusNotFound)
+			return
+		}
+		if run.ProviderID == "" {
+			http.Error(w, "agent run provider is not configured", http.StatusConflict)
+			return
+		}
+
+		var req agentToolRouteAuthorizeRequest
+		decoder := json.NewDecoder(r.Body)
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(&req); err != nil {
+			writeAgentToolRouteBodyError(w, err)
+			return
+		}
+		if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+			writeAgentToolRouteBodyError(w, err)
+			return
+		}
+
+		routeRequest := agentrouting.Request{
+			Project:      run.Project,
+			ProviderID:   run.ProviderID,
+			ConnectionID: req.ConnectionID,
+			ServerID:     req.ServerID,
+			ToolName:     req.ToolName,
+			Mode:         run.Mode,
+			Risk:         req.Risk,
+		}
+		if err := routeRequest.Validate(); err != nil {
+			http.Error(w, "invalid tool route request", http.StatusBadRequest)
+			return
+		}
+
+		result, err := router.Route(run.ID, routeRequest)
+		if err != nil {
+			writeAgentToolRouteError(w, err)
+			return
+		}
+		setAgentRunJSONHeader(w)
+		_ = json.NewEncoder(w).Encode(result)
+	})
+}
+
+func writeAgentToolRouteBodyError(w http.ResponseWriter, err error) {
+	var maxBytes *http.MaxBytesError
+	if errors.As(err, &maxBytes) {
+		http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+		return
+	}
+	http.Error(w, "invalid request body", http.StatusBadRequest)
+}
+
+func writeAgentToolRouteError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, agentrouting.ErrInvalidRequest):
+		http.Error(w, "invalid tool route request", http.StatusBadRequest)
+	case errors.Is(err, agentruns.ErrNotFound):
+		http.Error(w, "agent run not found", http.StatusNotFound)
+	case errors.Is(err, agentruns.ErrTerminated),
+		errors.Is(err, agentrouting.ErrRunScopeMismatch),
+		errors.Is(err, agentrouting.ErrInvalidDecision):
+		http.Error(w, "agent run cannot authorize this tool route", http.StatusConflict)
+	default:
+		log.Printf("agent tool route authorization failed (%T)", err)
+		http.Error(w, "agent tool route authorization failed", http.StatusInternalServerError)
+	}
+}

--- a/internal/api/agent_tool_routes.go
+++ b/internal/api/agent_tool_routes.go
@@ -34,10 +34,15 @@ func registerAgentToolRouteRoutes(
 	if router == nil {
 		return
 	}
+	attempts := newAgentToolRouteAttemptStore(maxAgentToolRouteAttempts)
 
 	mux.HandleFunc("POST /api/projects/{name}/agent-runs/{id}/tool-routes/authorize", func(w http.ResponseWriter, r *http.Request) {
 		limitBody(w, r)
 		if !requireJSONContentType(w, r) {
+			return
+		}
+		idempotencyKey, ok := requireAgentToolRouteIdempotencyKey(w, r)
+		if !ok {
 			return
 		}
 		name := r.PathValue("name")
@@ -80,10 +85,21 @@ func registerAgentToolRouteRoutes(
 			return
 		}
 
-		result, err := router.Route(run.ID, routeRequest)
+		result, replayed, err := attempts.authorize(r.Context(), run.ID, idempotencyKey, routeRequest, func() (agentrouting.RouteResult, error) {
+			return router.Route(run.ID, routeRequest)
+		})
 		if err != nil {
 			writeAgentToolRouteError(w, err)
 			return
+		}
+		if replayed {
+			current, ok := store.Get(run.ID)
+			if !ok {
+				http.Error(w, "agent run not found", http.StatusNotFound)
+				return
+			}
+			result.Run = current
+			w.Header().Set("Idempotency-Replayed", "true")
 		}
 		setAgentRunJSONHeader(w)
 		_ = json.NewEncoder(w).Encode(result)
@@ -101,6 +117,10 @@ func writeAgentToolRouteBodyError(w http.ResponseWriter, err error) {
 
 func writeAgentToolRouteError(w http.ResponseWriter, err error) {
 	switch {
+	case errors.Is(err, errAgentToolRouteIdempotencyConflict):
+		http.Error(w, "idempotency key was already used for a different tool route", http.StatusConflict)
+	case errors.Is(err, errAgentToolRouteAttemptCapacity):
+		http.Error(w, "tool route authorization is temporarily unavailable", http.StatusServiceUnavailable)
 	case errors.Is(err, agentrouting.ErrInvalidRequest):
 		http.Error(w, "invalid tool route request", http.StatusBadRequest)
 	case errors.Is(err, agentruns.ErrNotFound):
@@ -110,7 +130,19 @@ func writeAgentToolRouteError(w http.ResponseWriter, err error) {
 		errors.Is(err, agentrouting.ErrInvalidDecision):
 		http.Error(w, "agent run cannot authorize this tool route", http.StatusConflict)
 	default:
-		log.Printf("agent tool route authorization failed (%T)", err)
+		log.Printf("agent tool route authorization failed (%T)", agentToolRouteRootError(err))
 		http.Error(w, "agent tool route authorization failed", http.StatusInternalServerError)
 	}
+}
+
+func agentToolRouteRootError(err error) error {
+	const maxUnwrapDepth = 32
+	for range maxUnwrapDepth {
+		unwrapped := errors.Unwrap(err)
+		if unwrapped == nil {
+			return err
+		}
+		err = unwrapped
+	}
+	return err
 }

--- a/internal/api/agent_tool_routes_test.go
+++ b/internal/api/agent_tool_routes_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -16,15 +17,25 @@ import (
 type fakeAgentToolRouter struct {
 	result  agentrouting.RouteResult
 	err     error
+	route   func(string, agentrouting.Request) (agentrouting.RouteResult, error)
 	calls   int
 	runID   string
 	request agentrouting.Request
+}
+
+type agentToolRouteTestRootError struct{}
+
+func (e *agentToolRouteTestRootError) Error() string {
+	return "root"
 }
 
 func (f *fakeAgentToolRouter) Route(runID string, request agentrouting.Request) (agentrouting.RouteResult, error) {
 	f.calls++
 	f.runID = runID
 	f.request = request
+	if f.route != nil {
+		return f.route(runID, request)
+	}
 	return f.result, f.err
 }
 
@@ -51,6 +62,10 @@ func agentToolRouteMux(root string, store *agentruns.Store, router AgentToolRout
 }
 
 func postAgentToolRoute(mux *http.ServeMux, project, runID, body, contentType string) *httptest.ResponseRecorder {
+	return postAgentToolRouteWithKey(mux, project, runID, body, contentType, "route-attempt-1")
+}
+
+func postAgentToolRouteWithKey(mux *http.ServeMux, project, runID, body, contentType, idempotencyKey string) *httptest.ResponseRecorder {
 	req := httptest.NewRequest(
 		http.MethodPost,
 		"/api/projects/"+project+"/agent-runs/"+runID+"/tool-routes/authorize",
@@ -58,6 +73,9 @@ func postAgentToolRoute(mux *http.ServeMux, project, runID, body, contentType st
 	)
 	if contentType != "" {
 		req.Header.Set("Content-Type", contentType)
+	}
+	if idempotencyKey != "" {
+		req.Header.Set(agentToolRouteIdempotencyHeader, idempotencyKey)
 	}
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
@@ -170,6 +188,76 @@ func TestAgentToolRouteRejectsInvalidRequestsBeforeRouting(t *testing.T) {
 	}
 }
 
+func TestAgentToolRouteRequiresIdempotencyKey(t *testing.T) {
+	root, store, run := agentToolRouteFixture(t, "codex")
+	fake := &fakeAgentToolRouter{}
+	mux := agentToolRouteMux(root, store, fake)
+	body := `{"connection_id":"aws-prod","server_id":"aws","tool_name":"list_buckets","risk":"read_only"}`
+
+	tests := []struct {
+		name string
+		key  string
+	}{
+		{name: "missing"},
+		{name: "padded", key: " padded "},
+		{name: "too long", key: strings.Repeat("x", maxAgentToolRouteIdempotencyKeyLength+1)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rec := postAgentToolRouteWithKey(mux, "demo", run.ID, body, "application/json", test.key)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d, body = %s", rec.Code, http.StatusBadRequest, rec.Body.String())
+			}
+		})
+	}
+	if fake.calls != 0 {
+		t.Fatalf("Route calls = %d, want none without a valid idempotency key", fake.calls)
+	}
+}
+
+func TestAgentToolRouteReplaysRecordedDecisionWithoutDuplicateMutation(t *testing.T) {
+	root, store, run := agentToolRouteFixture(t, "codex")
+	decision := agentrouting.Decision{
+		Status:           agentrouting.DecisionApprovalRequired,
+		Reason:           agentrouting.ReasonApprovalRequired,
+		Allowed:          true,
+		ApprovalRequired: true,
+		UntrustedOutput:  true,
+	}
+	fake := &fakeAgentToolRouter{}
+	fake.route = func(_ string, _ agentrouting.Request) (agentrouting.RouteResult, error) {
+		updated, err := store.AddApproval(run.ID, agentruns.ApprovalGate{
+			Kind:    agentruns.ApprovalMCPNetwork,
+			Summary: "authorize list_buckets",
+		})
+		return agentrouting.RouteResult{Decision: decision, Run: updated}, err
+	}
+	mux := agentToolRouteMux(root, store, fake)
+	body := `{"connection_id":"aws-prod","server_id":"aws","tool_name":"list_buckets","risk":"read_only"}`
+
+	first := postAgentToolRouteWithKey(mux, "demo", run.ID, body, "application/json", "same-attempt")
+	second := postAgentToolRouteWithKey(mux, "demo", run.ID, body, "application/json", "same-attempt")
+	if first.Code != http.StatusOK || second.Code != http.StatusOK {
+		t.Fatalf("statuses = %d, %d; want two successful responses", first.Code, second.Code)
+	}
+	if second.Header().Get("Idempotency-Replayed") != "true" {
+		t.Fatalf("replay header = %q, want true", second.Header().Get("Idempotency-Replayed"))
+	}
+	current, ok := store.Get(run.ID)
+	if !ok || fake.calls != 1 || len(current.Approvals) != 1 {
+		t.Fatalf("Route calls = %d, approvals = %d; want one recorded attempt", fake.calls, len(current.Approvals))
+	}
+
+	conflictBody := `{"connection_id":"aws-prod","server_id":"aws","tool_name":"get_bucket","risk":"read_only"}`
+	conflict := postAgentToolRouteWithKey(mux, "demo", run.ID, conflictBody, "application/json", "same-attempt")
+	if conflict.Code != http.StatusConflict {
+		t.Fatalf("conflict status = %d, want %d, body = %s", conflict.Code, http.StatusConflict, conflict.Body.String())
+	}
+	if fake.calls != 1 {
+		t.Fatalf("Route calls = %d, want no call after conflicting key reuse", fake.calls)
+	}
+}
+
 func TestAgentToolRouteSanitizesRouterErrors(t *testing.T) {
 	root, store, run := agentToolRouteFixture(t, "codex")
 	fake := &fakeAgentToolRouter{err: errors.New("token=router-secret")}
@@ -186,5 +274,14 @@ func TestAgentToolRouteSanitizesRouterErrors(t *testing.T) {
 	}
 	if strings.Contains(rec.Body.String(), "router-secret") {
 		t.Fatalf("response leaked router error: %s", rec.Body.String())
+	}
+}
+
+func TestAgentToolRouteRootErrorReturnsDeepestWrappedType(t *testing.T) {
+	funcError := &agentToolRouteTestRootError{}
+	wrapped := fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", funcError))
+
+	if got := agentToolRouteRootError(wrapped); got != funcError {
+		t.Fatalf("root error = %T, want %T", got, funcError)
 	}
 }

--- a/internal/api/agent_tool_routes_test.go
+++ b/internal/api/agent_tool_routes_test.go
@@ -1,0 +1,190 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/iac-studio/iac-studio/internal/agentrouting"
+	"github.com/iac-studio/iac-studio/internal/agentruns"
+	"github.com/iac-studio/iac-studio/internal/mcpairlock"
+)
+
+type fakeAgentToolRouter struct {
+	result  agentrouting.RouteResult
+	err     error
+	calls   int
+	runID   string
+	request agentrouting.Request
+}
+
+func (f *fakeAgentToolRouter) Route(runID string, request agentrouting.Request) (agentrouting.RouteResult, error) {
+	f.calls++
+	f.runID = runID
+	f.request = request
+	return f.result, f.err
+}
+
+func agentToolRouteFixture(t *testing.T, providerID string) (string, *agentruns.Store, agentruns.Run) {
+	t.Helper()
+	root := scaffoldAgentRunProject(t)
+	store := agentruns.NewStore()
+	run, err := store.Create(agentruns.CreateRequest{
+		Project:    "demo",
+		Prompt:     "inventory the project",
+		ProviderID: providerID,
+		Mode:       agentruns.ModeReadOnly,
+	})
+	if err != nil {
+		t.Fatalf("Create(): %v", err)
+	}
+	return root, store, run
+}
+
+func agentToolRouteMux(root string, store *agentruns.Store, router AgentToolRouter) *http.ServeMux {
+	mux := http.NewServeMux()
+	registerAgentToolRouteRoutes(mux, root, store, router)
+	return mux
+}
+
+func postAgentToolRoute(mux *http.ServeMux, project, runID, body, contentType string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/projects/"+project+"/agent-runs/"+runID+"/tool-routes/authorize",
+		strings.NewReader(body),
+	)
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestAgentToolRouteUsesServerOwnedRunScope(t *testing.T) {
+	root, store, run := agentToolRouteFixture(t, "codex")
+	wantDecision := agentrouting.Decision{
+		Status:          agentrouting.DecisionAllowed,
+		Reason:          agentrouting.ReasonAllowed,
+		Allowed:         true,
+		UntrustedOutput: true,
+	}
+	fake := &fakeAgentToolRouter{result: agentrouting.RouteResult{Decision: wantDecision, Run: run}}
+	mux := agentToolRouteMux(root, store, fake)
+
+	rec := postAgentToolRoute(mux, "demo", run.ID, `{
+		"connection_id":"aws-prod",
+		"server_id":"aws",
+		"tool_name":"list_buckets",
+		"risk":"read_only"
+	}`, "application/json")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("authorize status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	requireJSONResponse(t, rec)
+	if fake.calls != 1 || fake.runID != run.ID {
+		t.Fatalf("Route calls = %d, run ID = %q; want one call for %q", fake.calls, fake.runID, run.ID)
+	}
+	wantRequest := agentrouting.Request{
+		Project:      "demo",
+		ProviderID:   "codex",
+		ConnectionID: "aws-prod",
+		ServerID:     "aws",
+		ToolName:     "list_buckets",
+		Mode:         agentruns.ModeReadOnly,
+		Risk:         mcpairlock.RiskReadOnly,
+	}
+	if fake.request != wantRequest {
+		t.Fatalf("Route request = %+v, want server-owned scope %+v", fake.request, wantRequest)
+	}
+	var result agentrouting.RouteResult
+	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if result.Decision != wantDecision || result.Run.ID != run.ID {
+		t.Fatalf("response = %+v, want audited router result", result)
+	}
+}
+
+func TestAgentToolRouteRejectsClientScopeAndCrossProjectRuns(t *testing.T) {
+	root, store, run := agentToolRouteFixture(t, "codex")
+	fake := &fakeAgentToolRouter{}
+	mux := agentToolRouteMux(root, store, fake)
+
+	clientScope := postAgentToolRoute(mux, "demo", run.ID, `{
+		"connection_id":"aws-prod",
+		"server_id":"aws",
+		"tool_name":"list_buckets",
+		"risk":"read_only",
+		"provider_id":"other-provider"
+	}`, "application/json")
+	if clientScope.Code != http.StatusBadRequest {
+		t.Fatalf("client scope status = %d, want %d, body = %s", clientScope.Code, http.StatusBadRequest, clientScope.Body.String())
+	}
+
+	crossProject := postAgentToolRoute(mux, "other", run.ID, `{
+		"connection_id":"aws-prod",
+		"server_id":"aws",
+		"tool_name":"list_buckets",
+		"risk":"read_only"
+	}`, "application/json")
+	if crossProject.Code != http.StatusNotFound {
+		t.Fatalf("cross-project status = %d, want %d, body = %s", crossProject.Code, http.StatusNotFound, crossProject.Body.String())
+	}
+	if fake.calls != 0 {
+		t.Fatalf("Route calls = %d, want none for rejected scope", fake.calls)
+	}
+}
+
+func TestAgentToolRouteRejectsInvalidRequestsBeforeRouting(t *testing.T) {
+	root, store, run := agentToolRouteFixture(t, "codex")
+	fake := &fakeAgentToolRouter{}
+	mux := agentToolRouteMux(root, store, fake)
+	validBody := `{"connection_id":"aws-prod","server_id":"aws","tool_name":"list_buckets","risk":"read_only"}`
+
+	tests := []struct {
+		name        string
+		body        string
+		contentType string
+		wantStatus  int
+	}{
+		{name: "missing content type", body: validBody, wantStatus: http.StatusUnsupportedMediaType},
+		{name: "malformed JSON", body: "{not-json", contentType: "application/json", wantStatus: http.StatusBadRequest},
+		{name: "multiple values", body: validBody + `{}`, contentType: "application/json", wantStatus: http.StatusBadRequest},
+		{name: "missing tool", body: `{"connection_id":"aws-prod","server_id":"aws","risk":"read_only"}`, contentType: "application/json", wantStatus: http.StatusBadRequest},
+		{name: "oversized body", body: strings.Repeat(" ", maxRequestBody+1), contentType: "application/json", wantStatus: http.StatusRequestEntityTooLarge},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rec := postAgentToolRoute(mux, "demo", run.ID, test.body, test.contentType)
+			if rec.Code != test.wantStatus {
+				t.Fatalf("status = %d, want %d, body = %s", rec.Code, test.wantStatus, rec.Body.String())
+			}
+		})
+	}
+	if fake.calls != 0 {
+		t.Fatalf("Route calls = %d, want none for invalid requests", fake.calls)
+	}
+}
+
+func TestAgentToolRouteSanitizesRouterErrors(t *testing.T) {
+	root, store, run := agentToolRouteFixture(t, "codex")
+	fake := &fakeAgentToolRouter{err: errors.New("token=router-secret")}
+	mux := agentToolRouteMux(root, store, fake)
+
+	rec := postAgentToolRoute(mux, "demo", run.ID, `{
+		"connection_id":"aws-prod",
+		"server_id":"aws",
+		"tool_name":"list_buckets",
+		"risk":"read_only"
+	}`, "application/json")
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d, body = %s", rec.Code, http.StatusInternalServerError, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "router-secret") {
+		t.Fatalf("response leaked router error: %s", rec.Body.String())
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1052,6 +1052,7 @@ func writeAgentProviderProfileSaveError(w http.ResponseWriter, operation string,
 type RouterOptions struct {
 	MCPAirlock               *mcpairlock.Manager
 	AgentRuns                *agentruns.Store
+	AgentToolRouter          AgentToolRouter
 	AgentProviderProfiles    *agentproviderconnections.Manager
 	AppVersion               string
 	LocalAgentProviders      func() []agentproviders.LocalProviderStatus
@@ -1221,6 +1222,7 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 	})
 
 	registerAgentRunRoutes(mux, projectsDir, agentRuns)
+	registerAgentToolRouteRoutes(mux, projectsDir, agentRuns, opts.AgentToolRouter)
 
 	// Resource catalog — returns all resources for a tool, optionally filtered by provider
 	mux.HandleFunc("GET /api/catalog", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

- add a strict, authorization-only Agent Tool Route endpoint
- derive project, provider, and mode from the server-owned Agent Run
- record and return routing decisions without invoking tools or reading credentials
- require a bounded Idempotency-Key and coalesce concurrent retries
- reject conflicting key reuse, malformed input, cross-project runs, and unsafe error details

## Scope

This slice intentionally excludes startup composition, policy administration, credential access, and MCP tool execution. Those remain separate review-friendly slices.

## Validation

- go test -race ./internal/api -run TestAgentToolRoute
- go test ./internal/...
- go vet ./internal/...
- git diff --check

Part of #107.