### PR TITLE
Wire Agent Hub routing into server startup

### DIFF
--- a/cmd/server/agent_routing.go
+++ b/cmd/server/agent_routing.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/iac-studio/iac-studio/internal/agentrouting"
+	"github.com/iac-studio/iac-studio/internal/agentruns"
+)
+
+type agentRoutingServices struct {
+	runs   *agentruns.Store
+	router *agentrouting.Router
+}
+
+func newAgentRoutingServices(evaluator agentrouting.ToolEvaluator) (*agentRoutingServices, error) {
+	runs := agentruns.NewStore()
+	policies := agentrouting.NewPolicyStore()
+	authorizer, err := agentrouting.NewStoreAuthorizer(policies, evaluator)
+	if err != nil {
+		return nil, fmt.Errorf("create tool route authorizer: %w", err)
+	}
+	recorder, err := agentrouting.NewRunRecorder(runs)
+	if err != nil {
+		return nil, fmt.Errorf("create tool route recorder: %w", err)
+	}
+	router, err := agentrouting.NewRouter(authorizer, recorder)
+	if err != nil {
+		return nil, fmt.Errorf("create tool route router: %w", err)
+	}
+	return &agentRoutingServices{
+		runs:   runs,
+		router: router,
+	}, nil
+}

--- a/cmd/server/agent_routing_test.go
+++ b/cmd/server/agent_routing_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/iac-studio/iac-studio/internal/agentrouting"
+	"github.com/iac-studio/iac-studio/internal/agentruns"
+	"github.com/iac-studio/iac-studio/internal/mcpairlock"
+)
+
+type countingToolEvaluator struct {
+	calls int
+}
+
+func (e *countingToolEvaluator) EvaluateTool(_, _, _ string) (mcpairlock.ToolInventoryEntry, error) {
+	e.calls++
+	return mcpairlock.ToolInventoryEntry{}, errors.New("unexpected Airlock evaluation")
+}
+
+func TestNewAgentRoutingServicesRequiresToolEvaluator(t *testing.T) {
+	_, err := newAgentRoutingServices(nil)
+	if !errors.Is(err, agentrouting.ErrToolEvaluatorRequired) {
+		t.Fatalf("newAgentRoutingServices(nil) error = %v, want %v", err, agentrouting.ErrToolEvaluatorRequired)
+	}
+}
+
+func TestNewAgentRoutingServicesFailsClosedAndAuditsMissingPolicy(t *testing.T) {
+	evaluator := &countingToolEvaluator{}
+	services, err := newAgentRoutingServices(evaluator)
+	if err != nil {
+		t.Fatalf("newAgentRoutingServices(): %v", err)
+	}
+	run, err := services.runs.Create(agentruns.CreateRequest{
+		Project:    "demo",
+		Prompt:     "inventory the project",
+		ProviderID: "codex",
+		Mode:       agentruns.ModeReadOnly,
+	})
+	if err != nil {
+		t.Fatalf("Create(): %v", err)
+	}
+
+	result, err := services.router.Route(run.ID, agentrouting.Request{
+		Project:      run.Project,
+		ProviderID:   run.ProviderID,
+		ConnectionID: "aws-prod",
+		ServerID:     "aws",
+		ToolName:     "list_buckets",
+		Mode:         run.Mode,
+		Risk:         mcpairlock.RiskReadOnly,
+	})
+	if err != nil {
+		t.Fatalf("Route(): %v", err)
+	}
+	if result.Decision.Status != agentrouting.DecisionDenied || result.Decision.Reason != agentrouting.ReasonPolicyUnavailable {
+		t.Fatalf("decision = %+v, want denied %q", result.Decision, agentrouting.ReasonPolicyUnavailable)
+	}
+	if result.Run.Status != agentruns.StatusFailed || !strings.Contains(result.Run.Error, string(agentrouting.ReasonPolicyUnavailable)) {
+		t.Fatalf("recorded run = %+v, want audited policy denial", result.Run)
+	}
+	stored, ok := services.runs.Get(run.ID)
+	if !ok || stored.Status != agentruns.StatusFailed || stored.Error != result.Run.Error {
+		t.Fatalf("stored run = %+v, found = %t; want recorded result", stored, ok)
+	}
+	if evaluator.calls != 0 {
+		t.Fatalf("Airlock evaluation calls = %d, want none without a scoped policy", evaluator.calls)
+	}
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -40,6 +40,13 @@ var AppVersion = "0.1.0"
 var frontendFS embed.FS
 
 func main() {
+	if err := runServer(); err != nil {
+		log.Printf("server startup failed: %v", err)
+		os.Exit(1)
+	}
+}
+
+func runServer() error {
 	host := flag.String("host", "127.0.0.1", "Host to bind to")
 	port := flag.Int("port", 3000, "Port to listen on")
 	projectsDir := flag.String("projects-dir", defaultProjectsDir(), "Directory for IaC projects")
@@ -102,8 +109,7 @@ func main() {
 	}()
 	agentRouting, err := newAgentRoutingServices(mcpAirlock)
 	if err != nil {
-		log.Printf("initialize Agent Hub tool routing: %v", err)
-		return
+		return fmt.Errorf("initialize Agent Hub tool routing: %w", err)
 	}
 
 	// Build router
@@ -144,6 +150,7 @@ func main() {
 	if err := server.Shutdown(shutdownCtx); err != nil {
 		log.Printf("shutdown: %v", err)
 	}
+	return nil
 }
 
 func defaultProjectsDir() string {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -100,11 +100,17 @@ func main() {
 			log.Printf("mcp airlock cleanup: %v", err)
 		}
 	}()
+	agentRouting, err := newAgentRoutingServices(mcpAirlock)
+	if err != nil {
+		log.Fatalf("initialize Agent Hub tool routing: %v", err)
+	}
 
 	// Build router
 	router := api.NewRouterWithOptions(hub, fw, aiClient, safeRun, *projectsDir, api.RouterOptions{
-		MCPAirlock: mcpAirlock,
-		AppVersion: AppVersion,
+		MCPAirlock:      mcpAirlock,
+		AgentRuns:       agentRouting.runs,
+		AgentToolRouter: agentRouting.router,
+		AppVersion:      AppVersion,
 	})
 
 	// Serve embedded frontend

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -102,7 +102,8 @@ func main() {
 	}()
 	agentRouting, err := newAgentRoutingServices(mcpAirlock)
 	if err != nil {
-		log.Fatalf("initialize Agent Hub tool routing: %v", err)
+		log.Printf("initialize Agent Hub tool routing: %v", err)
+		return
 	}
 
 	// Build router


### PR DESCRIPTION
## Summary

- compose the shared Agent Runs store, scoped policy store, MCP Airlock authorizer, and audit recorder at server startup
- inject the composed run store and tool router into the production API router
- verify missing scoped policies deny and audit authorization without consulting Airlock

## Security

The policy store starts empty, so the newly active authorization endpoint remains fail-closed. This slice does not invoke MCP tools, read cloud credentials, or expose policy mutation.

## Validation

- `go test ./cmd/... ./internal/... -race`
- `go vet ./cmd/server ./internal/agentrouting`

Refs #107