### PR TITLE
Expose read-only Agent Hub routing policies

### DIFF
--- a/cmd/server/agent_routing.go
+++ b/cmd/server/agent_routing.go
@@ -8,8 +8,9 @@ import (
 )
 
 type agentRoutingServices struct {
-	runs   *agentruns.Store
-	router *agentrouting.Router
+	runs     *agentruns.Store
+	policies *agentrouting.PolicyStore
+	router   *agentrouting.Router
 }
 
 func newAgentRoutingServices(evaluator agentrouting.ToolEvaluator) (*agentRoutingServices, error) {
@@ -28,7 +29,8 @@ func newAgentRoutingServices(evaluator agentrouting.ToolEvaluator) (*agentRoutin
 		return nil, fmt.Errorf("create tool route router: %w", err)
 	}
 	return &agentRoutingServices{
-		runs:   runs,
-		router: router,
+		runs:     runs,
+		policies: policies,
+		router:   router,
 	}, nil
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -114,10 +114,11 @@ func runServer() error {
 
 	// Build router
 	router := api.NewRouterWithOptions(hub, fw, aiClient, safeRun, *projectsDir, api.RouterOptions{
-		MCPAirlock:      mcpAirlock,
-		AgentRuns:       agentRouting.runs,
-		AgentToolRouter: agentRouting.router,
-		AppVersion:      AppVersion,
+		MCPAirlock:        mcpAirlock,
+		AgentRuns:         agentRouting.runs,
+		AgentToolPolicies: agentRouting.policies,
+		AgentToolRouter:   agentRouting.router,
+		AppVersion:        AppVersion,
 	})
 
 	// Serve embedded frontend

--- a/internal/api/agent_runs.go
+++ b/internal/api/agent_runs.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"errors"
+	"log"
 	"net/http"
 	"os"
 
@@ -168,7 +169,8 @@ func setAgentRunJSONHeader(w http.ResponseWriter) {
 func requireExistingAgentRunProject(w http.ResponseWriter, projectsDir, name string) bool {
 	projectPath, err := safeProjectPath(projectsDir, name)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		log.Printf("agent project path validation failed: %v", err)
+		http.Error(w, "invalid project", http.StatusBadRequest)
 		return false
 	}
 	info, err := os.Stat(projectPath)
@@ -177,7 +179,8 @@ func requireExistingAgentRunProject(w http.ResponseWriter, projectsDir, name str
 		return false
 	}
 	if err != nil {
-		http.Error(w, "stat project: "+err.Error(), http.StatusInternalServerError)
+		log.Printf("agent project stat failed: %v", err)
+		http.Error(w, "project lookup failed", http.StatusInternalServerError)
 		return false
 	}
 	if !info.IsDir() {

--- a/internal/api/agent_tool_policies.go
+++ b/internal/api/agent_tool_policies.go
@@ -1,0 +1,59 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+
+	"github.com/iac-studio/iac-studio/internal/agentrouting"
+)
+
+const maxAgentToolPolicyProviderIDLength = 128
+
+// AgentToolPolicyReader returns detached policy snapshots for exact scopes.
+type AgentToolPolicyReader interface {
+	Get(scope agentrouting.PolicyScope) (agentrouting.Policy, error)
+}
+
+type agentToolPolicyResponse struct {
+	Scope  agentrouting.PolicyScope `json:"scope"`
+	Policy agentrouting.Policy      `json:"policy"`
+}
+
+func registerAgentToolPolicyRoutes(mux *http.ServeMux, projectsDir string, policies AgentToolPolicyReader) {
+	if policies == nil {
+		return
+	}
+	mux.HandleFunc("GET /api/projects/{name}/agent-routing/policies/{provider}", func(w http.ResponseWriter, r *http.Request) {
+		project := r.PathValue("name")
+		if !requireExistingAgentRunProject(w, projectsDir, project) {
+			return
+		}
+		providerID := r.PathValue("provider")
+		if len(providerID) > maxAgentToolPolicyProviderIDLength || safePathSegment(providerID) != nil {
+			http.Error(w, "invalid agent tool policy provider", http.StatusBadRequest)
+			return
+		}
+		scope := agentrouting.PolicyScope{Project: project, ProviderID: providerID}
+		policy, err := policies.Get(scope)
+		if err != nil {
+			writeAgentToolPolicyReadError(w, err)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(agentToolPolicyResponse{Scope: scope, Policy: policy})
+	})
+}
+
+func writeAgentToolPolicyReadError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, agentrouting.ErrInvalidPolicyScope):
+		http.Error(w, "invalid agent tool policy scope", http.StatusBadRequest)
+	case errors.Is(err, agentrouting.ErrPolicyNotFound):
+		http.Error(w, "agent tool policy not found", http.StatusNotFound)
+	default:
+		log.Printf("agent tool policy read failed (%T)", err)
+		http.Error(w, "agent tool policy read failed", http.StatusInternalServerError)
+	}
+}

--- a/internal/api/agent_tool_policies_test.go
+++ b/internal/api/agent_tool_policies_test.go
@@ -1,0 +1,113 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/iac-studio/iac-studio/internal/agentrouting"
+	"github.com/iac-studio/iac-studio/internal/agentruns"
+	"github.com/iac-studio/iac-studio/internal/mcpairlock"
+)
+
+type failingAgentToolPolicyReader struct {
+	err error
+}
+
+func (r failingAgentToolPolicyReader) Get(agentrouting.PolicyScope) (agentrouting.Policy, error) {
+	return agentrouting.Policy{}, r.err
+}
+
+func agentToolPolicyMux(root string, policies AgentToolPolicyReader) *http.ServeMux {
+	mux := http.NewServeMux()
+	registerAgentToolPolicyRoutes(mux, root, policies)
+	return mux
+}
+
+func testAgentToolPolicy() (agentrouting.PolicyScope, agentrouting.Policy) {
+	scope := agentrouting.PolicyScope{Project: "demo", ProviderID: "codex"}
+	return scope, agentrouting.Policy{Rules: []agentrouting.Rule{{
+		Project:      scope.Project,
+		ProviderID:   scope.ProviderID,
+		ConnectionID: "aws-prod",
+		ServerID:     "aws",
+		ToolName:     "list_buckets",
+		Modes:        []agentruns.Mode{agentruns.ModeReadOnly},
+		Risk:         mcpairlock.RiskReadOnly,
+		Effect:       agentrouting.EffectAllow,
+	}}}
+}
+
+func TestAgentToolPolicyRouteReturnsExactScopedPolicy(t *testing.T) {
+	root := scaffoldAgentRunProject(t)
+	scope, policy := testAgentToolPolicy()
+	store := agentrouting.NewPolicyStore()
+	if err := store.Save(scope, policy); err != nil {
+		t.Fatalf("Save(): %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/projects/demo/agent-routing/policies/codex", nil)
+	rec := httptest.NewRecorder()
+	agentToolPolicyMux(root, store).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	requireJSONResponse(t, rec)
+	var response agentToolPolicyResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Scope != scope || len(response.Policy.Rules) != 1 || response.Policy.Rules[0].ToolName != "list_buckets" {
+		t.Fatalf("response = %+v, want exact scoped policy", response)
+	}
+}
+
+func TestAgentToolPolicyRouteDoesNotFallBackAcrossScopes(t *testing.T) {
+	root := scaffoldAgentRunProject(t)
+	scope, policy := testAgentToolPolicy()
+	store := agentrouting.NewPolicyStore()
+	if err := store.Save(scope, policy); err != nil {
+		t.Fatalf("Save(): %v", err)
+	}
+
+	for _, path := range []string{
+		"/api/projects/other/agent-routing/policies/codex",
+		"/api/projects/demo/agent-routing/policies/claude",
+	} {
+		rec := httptest.NewRecorder()
+		agentToolPolicyMux(root, store).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("%s status = %d, want %d, body = %s", path, rec.Code, http.StatusNotFound, rec.Body.String())
+		}
+	}
+}
+
+func TestAgentToolPolicyRouteRejectsInvalidScopeAndSanitizesErrors(t *testing.T) {
+	root := scaffoldAgentRunProject(t)
+	tests := []struct {
+		name   string
+		path   string
+		reader AgentToolPolicyReader
+		status int
+	}{
+		{name: "missing project", path: "/api/projects/missing/agent-routing/policies/codex", reader: agentrouting.NewPolicyStore(), status: http.StatusNotFound},
+		{name: "invalid provider", path: "/api/projects/demo/agent-routing/policies/bad.provider", reader: agentrouting.NewPolicyStore(), status: http.StatusBadRequest},
+		{name: "long provider", path: "/api/projects/demo/agent-routing/policies/" + strings.Repeat("x", maxAgentToolPolicyProviderIDLength+1), reader: agentrouting.NewPolicyStore(), status: http.StatusBadRequest},
+		{name: "reader failure", path: "/api/projects/demo/agent-routing/policies/codex", reader: failingAgentToolPolicyReader{err: errors.New("token=policy-secret")}, status: http.StatusInternalServerError},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			agentToolPolicyMux(root, test.reader).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, test.path, nil))
+			if rec.Code != test.status {
+				t.Fatalf("status = %d, want %d, body = %s", rec.Code, test.status, rec.Body.String())
+			}
+			if strings.Contains(rec.Body.String(), "policy-secret") {
+				t.Fatalf("response leaked reader error: %s", rec.Body.String())
+			}
+		})
+	}
+}

--- a/internal/api/agent_tool_policies_test.go
+++ b/internal/api/agent_tool_policies_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -109,5 +111,23 @@ func TestAgentToolPolicyRouteRejectsInvalidScopeAndSanitizesErrors(t *testing.T)
 				t.Fatalf("response leaked reader error: %s", rec.Body.String())
 			}
 		})
+	}
+}
+
+func TestAgentToolPolicyRouteSanitizesProjectFilesystemErrors(t *testing.T) {
+	root := t.TempDir()
+	missingTarget := filepath.Join(root, "private-policy-target")
+	if err := os.Symlink(missingTarget, filepath.Join(root, "demo")); err != nil {
+		t.Fatalf("Symlink(): %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	agentToolPolicyMux(root, agentrouting.NewPolicyStore()).ServeHTTP(rec,
+		httptest.NewRequest(http.MethodGet, "/api/projects/demo/agent-routing/policies/codex", nil))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d, body = %s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), root) || strings.Contains(rec.Body.String(), missingTarget) {
+		t.Fatalf("response leaked filesystem path: %s", rec.Body.String())
 	}
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1052,6 +1052,7 @@ func writeAgentProviderProfileSaveError(w http.ResponseWriter, operation string,
 type RouterOptions struct {
 	MCPAirlock               *mcpairlock.Manager
 	AgentRuns                *agentruns.Store
+	AgentToolPolicies        AgentToolPolicyReader
 	AgentToolRouter          AgentToolRouter
 	AgentProviderProfiles    *agentproviderconnections.Manager
 	AppVersion               string
@@ -1222,6 +1223,7 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 	})
 
 	registerAgentRunRoutes(mux, projectsDir, agentRuns)
+	registerAgentToolPolicyRoutes(mux, projectsDir, opts.AgentToolPolicies)
 	registerAgentToolRouteRoutes(mux, projectsDir, agentRuns, opts.AgentToolRouter)
 
 	// Resource catalog — returns all resources for a tool, optionally filtered by provider


### PR DESCRIPTION
## Summary

- retain the production Agent Hub policy store and inject it into the API router
- expose `GET /api/projects/{project}/agent-routing/policies/{provider}`
- return only exact project/provider snapshots with no fallback
- validate provider path tokens and sanitize policy reader errors

## Security

This endpoint is read-only and exposes routing rules, not credentials or MCP output. Missing scopes return 404, invalid identifiers fail before store access, and internal reader errors are not returned to clients.

## Validation

- `go test ./cmd/... ./internal/... -race`
- `go vet ./cmd/server ./internal/api ./internal/agentrouting`

Refs #107