### PR TITLE
Add Agent Hub routing policy client

### DIFF
--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -646,6 +646,46 @@ describe('api.agentRuns', () => {
   });
 });
 
+describe('api.agentToolPolicies', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('gets one exact project and provider routing policy', async () => {
+    const response = {
+      scope: {
+        project: 'demo',
+        provider_id: 'codex-cli',
+      },
+      policy: {
+        rules: [{
+          project: 'demo',
+          provider_id: 'codex-cli',
+          connection_id: 'aws-prod',
+          server_id: 'aws-official',
+          tool_name: 'list_resources',
+          modes: ['read_only'],
+          risk: 'read_only',
+          effect: 'allow',
+        }],
+      },
+    };
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(response), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(api.getAgentToolPolicy('demo', 'codex-cli')).resolves.toEqual(response);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/projects/demo/agent-routing/policies/codex-cli',
+    );
+  });
+});
+
 describe('api.listProjectStates', () => {
   afterEach(() => {
     vi.unstubAllGlobals();

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -409,6 +409,34 @@ export interface AgentRunsResponse {
   runs?: AgentRunSummary[] | null;
 }
 
+export type AgentToolPolicyEffect = 'allow' | 'deny';
+
+export interface AgentToolPolicyScope {
+  project: string;
+  provider_id: string;
+}
+
+export interface AgentToolPolicyRule {
+  project: string;
+  provider_id: string;
+  connection_id: string;
+  server_id: string;
+  tool_name: string;
+  modes: AgentRunMode[];
+  risk: MCPAirlockToolRisk;
+  effect: AgentToolPolicyEffect;
+  approval_required?: boolean;
+}
+
+export interface AgentToolPolicy {
+  rules: AgentToolPolicyRule[];
+}
+
+export interface AgentToolPolicyResponse {
+  scope: AgentToolPolicyScope;
+  policy: AgentToolPolicy;
+}
+
 export type PlanRiskLevel = 'safe' | 'risky' | 'destructive' | 'unknown';
 
 export interface PlanFieldChange {
@@ -797,6 +825,13 @@ export const api = {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ decision }),
       },
+    );
+    return (await check(res)).json();
+  },
+
+  async getAgentToolPolicy(projectName: string, providerId: string): Promise<AgentToolPolicyResponse> {
+    const res = await fetch(
+      `${BASE}/api/projects/${encodeURIComponent(projectName)}/agent-routing/policies/${encodeURIComponent(providerId)}`,
     );
     return (await check(res)).json();
   },


### PR DESCRIPTION
## Summary
- model the scoped Agent Hub tool-routing policy response in the web client
- add a typed client method for the exact project/provider read endpoint
- cover the request path and response contract with a focused test

## Validation
- `npm test -- --run src/api.test.ts`
- `npm run lint` (no errors; existing warnings remain)
- `npm run build`

Part of #107