### PR TITLE
Show Agent Hub tool permissions

### DIFF
--- a/web/src/components/Chat/ChatPanel.test.tsx
+++ b/web/src/components/Chat/ChatPanel.test.tsx
@@ -8,6 +8,7 @@ import { ChatPanel } from './ChatPanel';
 const listLocalAgentProvidersMock = vi.hoisted(() => vi.fn());
 const listAgentProviderConnectionsMock = vi.hoisted(() => vi.fn());
 const listAgentProviderConnectionProfilesMock = vi.hoisted(() => vi.fn());
+const getAgentToolPolicyMock = vi.hoisted(() => vi.fn());
 const listAgentRunsMock = vi.hoisted(() => vi.fn());
 const createAgentRunMock = vi.hoisted(() => vi.fn());
 const getAgentRunMock = vi.hoisted(() => vi.fn());
@@ -19,6 +20,7 @@ vi.mock('../../api', () => ({
     listLocalAgentProviders: listLocalAgentProvidersMock,
     listAgentProviderConnections: listAgentProviderConnectionsMock,
     listAgentProviderConnectionProfiles: listAgentProviderConnectionProfilesMock,
+    getAgentToolPolicy: getAgentToolPolicyMock,
     listAgentRuns: listAgentRunsMock,
     createAgentRun: createAgentRunMock,
     getAgentRun: getAgentRunMock,
@@ -87,6 +89,8 @@ describe('ChatPanel', () => {
     listAgentProviderConnectionsMock.mockReturnValue(new Promise(() => {}));
     listAgentProviderConnectionProfilesMock.mockReset();
     listAgentProviderConnectionProfilesMock.mockReturnValue(new Promise(() => {}));
+    getAgentToolPolicyMock.mockReset();
+    getAgentToolPolicyMock.mockReturnValue(new Promise(() => {}));
     listAgentRunsMock.mockReset();
     listAgentRunsMock.mockResolvedValue([]);
     createAgentRunMock.mockReset();
@@ -359,6 +363,72 @@ describe('ChatPanel', () => {
     fireEvent.click(within(codexPanel).getByRole('button', { name: /Managed Codex token/ }));
     const enterpriseDetails = within(codexPanel).getByRole('region', { name: 'Managed Codex token details' });
     expect(within(enterpriseDetails).getByRole('button', { name: 'Use enterprise policy' })).toBeDisabled();
+  });
+
+  it('shows exact scoped tool permissions for the selected provider', async () => {
+    getAgentToolPolicyMock.mockResolvedValueOnce({
+      scope: { project: 'demo', provider_id: 'codex' },
+      policy: {
+        rules: [
+          {
+            project: 'demo',
+            provider_id: 'codex',
+            connection_id: 'aws-prod',
+            server_id: 'aws-official',
+            tool_name: 'list_resources',
+            modes: ['read_only'],
+            risk: 'read_only',
+            effect: 'allow',
+          },
+          {
+            project: 'demo',
+            provider_id: 'codex',
+            connection_id: 'aws-prod',
+            server_id: 'aws-official',
+            tool_name: 'apply_change',
+            modes: ['approved_execute'],
+            risk: 'cloud_mutation',
+            effect: 'deny',
+          },
+        ],
+      },
+    });
+
+    render(<ChatPanel {...baseProps} projectName="demo" />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Codex' }));
+
+    await waitFor(() => {
+      expect(getAgentToolPolicyMock).toHaveBeenCalledWith('demo', 'codex');
+    });
+
+    const codexPanel = screen.getByRole('tabpanel', { name: 'Codex' });
+    const permissions = within(codexPanel).getByRole('region', { name: 'Codex CLI tool permissions' });
+    expect(within(permissions).getByText('1 allowed')).toBeInTheDocument();
+    expect(within(permissions).getByText('1 denied')).toBeInTheDocument();
+    expect(within(permissions).getByText('aws-official / list_resources')).toBeInTheDocument();
+    expect(within(permissions).getByText('aws-official / apply_change')).toBeInTheDocument();
+
+    fireEvent.click(within(codexPanel).getByRole('button', { name: /OpenAI API/ }));
+    await waitFor(() => {
+      expect(getAgentToolPolicyMock).toHaveBeenLastCalledWith('demo', 'codex-openai-api');
+    });
+    const nextPermissions = within(codexPanel).getByRole('region', { name: 'OpenAI API tool permissions' });
+    expect(within(nextPermissions).getByText('Checking scoped tool permissions...')).toBeInTheDocument();
+    expect(within(nextPermissions).queryByText('aws-official / list_resources')).not.toBeInTheDocument();
+  });
+
+  it('shows missing policies as blocked without exposing request details', async () => {
+    getAgentToolPolicyMock.mockRejectedValueOnce({ status: 404, message: 'sensitive backend detail' });
+
+    render(<ChatPanel {...baseProps} projectName="demo" />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Codex' }));
+
+    const codexPanel = screen.getByRole('tabpanel', { name: 'Codex' });
+    const permissions = within(codexPanel).getByRole('region', { name: 'Codex CLI tool permissions' });
+    await waitFor(() => {
+      expect(within(permissions).getByText('No scoped policy. MCP tool access is blocked.')).toBeInTheDocument();
+    });
+    expect(within(permissions).queryByText(/sensitive backend detail/)).not.toBeInTheDocument();
   });
 
   it('includes detected local provider details in the selected provider panel', async () => {

--- a/web/src/components/Chat/ChatPanel.test.tsx
+++ b/web/src/components/Chat/ChatPanel.test.tsx
@@ -407,6 +407,7 @@ describe('ChatPanel', () => {
     expect(within(permissions).getByText('1 denied')).toBeInTheDocument();
     expect(within(permissions).getByText('aws-official / list_resources')).toBeInTheDocument();
     expect(within(permissions).getByText('aws-official / apply_change')).toBeInTheDocument();
+    expect(within(permissions).queryByRole('status')).not.toBeInTheDocument();
 
     fireEvent.click(within(codexPanel).getByRole('button', { name: /OpenAI API/ }));
     await waitFor(() => {
@@ -471,6 +472,38 @@ describe('ChatPanel', () => {
       expect(within(permissions).getByText('Policy unavailable. MCP tool access remains blocked.')).toBeInTheDocument();
     });
     expect(within(permissions).queryByText('injected_tool')).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ['modes', { modes: null }],
+    ['risk', { risk: null }],
+  ])('blocks access when a policy rule has malformed %s', async (_field, override) => {
+    getAgentToolPolicyMock.mockResolvedValueOnce({
+      scope: { project: 'demo', provider_id: 'codex' },
+      policy: {
+        rules: [{
+          project: 'demo',
+          provider_id: 'codex',
+          connection_id: 'c1',
+          server_id: 'srv',
+          tool_name: 'malformed_tool',
+          modes: ['read_only'],
+          risk: 'read_only',
+          effect: 'allow',
+          ...override,
+        }],
+      },
+    });
+
+    render(<ChatPanel {...baseProps} projectName="demo" />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Codex' }));
+
+    const codexPanel = screen.getByRole('tabpanel', { name: 'Codex' });
+    const permissions = within(codexPanel).getByRole('region', { name: 'Codex CLI tool permissions' });
+    await waitFor(() => {
+      expect(within(permissions).getByText('Policy unavailable. MCP tool access remains blocked.')).toBeInTheDocument();
+    });
+    expect(within(permissions).queryByText('malformed_tool')).not.toBeInTheDocument();
   });
 
   it('blocks access when the scoped policy has no allowed routes', async () => {

--- a/web/src/components/Chat/ChatPanel.test.tsx
+++ b/web/src/components/Chat/ChatPanel.test.tsx
@@ -2,7 +2,7 @@ import { createRef } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 
-import type { AgentRun, AgentRunSummary } from '../../api';
+import type { AgentRun, AgentRunSummary, AgentToolPolicyResponse } from '../../api';
 import { ChatPanel } from './ChatPanel';
 
 const listLocalAgentProvidersMock = vi.hoisted(() => vi.fn());
@@ -429,6 +429,113 @@ describe('ChatPanel', () => {
       expect(within(permissions).getByText('No scoped policy. MCP tool access is blocked.')).toBeInTheDocument();
     });
     expect(within(permissions).queryByText(/sensitive backend detail/)).not.toBeInTheDocument();
+  });
+
+  it('shows server errors as policy unavailable without exposing error details', async () => {
+    getAgentToolPolicyMock.mockRejectedValueOnce({ status: 503, message: 'gateway timeout' });
+
+    render(<ChatPanel {...baseProps} projectName="demo" />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Codex' }));
+
+    const codexPanel = screen.getByRole('tabpanel', { name: 'Codex' });
+    const permissions = within(codexPanel).getByRole('region', { name: 'Codex CLI tool permissions' });
+    await waitFor(() => {
+      expect(within(permissions).getByText('Policy unavailable. MCP tool access remains blocked.')).toBeInTheDocument();
+    });
+    expect(within(permissions).queryByText(/gateway timeout/)).not.toBeInTheDocument();
+  });
+
+  it('blocks access when the policy response scope does not match the request', async () => {
+    getAgentToolPolicyMock.mockResolvedValueOnce({
+      scope: { project: 'other-project', provider_id: 'codex' },
+      policy: {
+        rules: [{
+          project: 'other-project',
+          provider_id: 'codex',
+          connection_id: 'c1',
+          server_id: 'srv',
+          tool_name: 'injected_tool',
+          modes: ['read_only'],
+          risk: 'read_only',
+          effect: 'allow',
+        }],
+      },
+    });
+
+    render(<ChatPanel {...baseProps} projectName="demo" />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Codex' }));
+
+    const codexPanel = screen.getByRole('tabpanel', { name: 'Codex' });
+    const permissions = within(codexPanel).getByRole('region', { name: 'Codex CLI tool permissions' });
+    await waitFor(() => {
+      expect(within(permissions).getByText('Policy unavailable. MCP tool access remains blocked.')).toBeInTheDocument();
+    });
+    expect(within(permissions).queryByText('injected_tool')).not.toBeInTheDocument();
+  });
+
+  it('blocks access when the scoped policy has no allowed routes', async () => {
+    getAgentToolPolicyMock.mockResolvedValueOnce({
+      scope: { project: 'demo', provider_id: 'codex' },
+      policy: { rules: [] },
+    });
+
+    render(<ChatPanel {...baseProps} projectName="demo" />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Codex' }));
+
+    const codexPanel = screen.getByRole('tabpanel', { name: 'Codex' });
+    const permissions = within(codexPanel).getByRole('region', { name: 'Codex CLI tool permissions' });
+    await waitFor(() => {
+      expect(within(permissions).getByText('No routes allowed. MCP tool access is blocked.')).toBeInTheDocument();
+    });
+    expect(within(permissions).getByText('0 allowed')).toBeInTheDocument();
+    expect(within(permissions).getByText('0 denied')).toBeInTheDocument();
+  });
+
+  it('discards stale tool-policy responses when the provider tab changes', async () => {
+    let resolveStaleCodex!: (_response: AgentToolPolicyResponse) => void;
+    getAgentToolPolicyMock.mockImplementationOnce(
+      () => new Promise(resolve => { resolveStaleCodex = resolve; }),
+    );
+
+    render(<ChatPanel {...baseProps} projectName="demo" />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Codex' }));
+
+    await waitFor(() => {
+      expect(getAgentToolPolicyMock).toHaveBeenCalledWith('demo', 'codex');
+    });
+
+    // Switch tab — the in-flight Codex request is now cancelled
+    fireEvent.click(screen.getByRole('tab', { name: 'Claude Code' }));
+    await waitFor(() => {
+      expect(getAgentToolPolicyMock).toHaveBeenCalledWith('demo', 'claude');
+    });
+
+    // Deliver the stale Codex response after the switch
+    await act(async () => {
+      resolveStaleCodex({
+        scope: { project: 'demo', provider_id: 'codex' },
+        policy: {
+          rules: [{
+            project: 'demo',
+            provider_id: 'codex',
+            connection_id: 'c1',
+            server_id: 'srv',
+            tool_name: 'stale_tool',
+            modes: ['read_only'],
+            risk: 'read_only',
+            effect: 'allow',
+          }],
+        },
+      });
+      await Promise.resolve();
+    });
+
+    const claudePanel = screen.getByRole('tabpanel', { name: 'Claude Code' });
+    const permissions = within(claudePanel).getByRole('region', { name: 'Claude Code CLI tool permissions' });
+    // Stale codex data must never appear in the Claude tab
+    expect(within(permissions).queryByText('stale_tool')).not.toBeInTheDocument();
+    // Claude's own request is still loading (default never-resolving mock)
+    expect(within(permissions).getByText('Checking scoped tool permissions...')).toBeInTheDocument();
   });
 
   it('includes detected local provider details in the selected provider panel', async () => {

--- a/web/src/components/Chat/ChatPanel.tsx
+++ b/web/src/components/Chat/ChatPanel.tsx
@@ -482,7 +482,7 @@ function ToolPolicySummary({
           </>
         )}
       </div>
-      {message && <div style={hubStyles.toolPolicyMessage}>{message}</div>}
+      <div role="status" style={message ? hubStyles.toolPolicyMessage : undefined}>{message}</div>
       {rules.map((rule, index) => (
         <div
           key={`${rule.connection_id}:${rule.server_id}:${rule.tool_name}:${index}`}

--- a/web/src/components/Chat/ChatPanel.tsx
+++ b/web/src/components/Chat/ChatPanel.tsx
@@ -74,6 +74,16 @@ const TASK_MODES = [
 ] as const;
 const AGENT_RUN_REFRESH_INTERVAL_MS = 5000;
 const IDLE_AGENT_TOOL_POLICY_VIEW: AgentToolPolicyView = { status: 'idle' };
+const AGENT_TOOL_POLICY_MODES = new Set(['read_only', 'propose_only', 'approved_execute']);
+const AGENT_TOOL_POLICY_RISKS = new Set([
+  'read_only',
+  'generate_code',
+  'modify_workspace',
+  'cloud_mutation',
+  'secret_sensitive',
+  'destructive',
+  'unknown',
+]);
 
 const AGENT_HUB_STORAGE_KEYS = {
   activeTab: 'iac-studio.agentHub.activeTab',
@@ -433,10 +443,41 @@ function matchesToolPolicyScope(
     response?.scope?.project === project
     && response.scope.provider_id === providerId
     && Array.isArray(response.policy?.rules)
-    && response.policy.rules.every(rule => (
-      rule.project === project && rule.provider_id === providerId
-    ))
+    && response.policy.rules.every(rule => matchesToolPolicyRule(rule, project, providerId))
   );
+}
+
+function matchesToolPolicyRule(value: unknown, project: string, providerId: string) {
+  if (!value || typeof value !== 'object') return false;
+  const rule = value as Record<string, unknown>;
+  const modes = rule.modes;
+  const risk = rule.risk;
+  const effect = rule.effect;
+  const approvalRequired = rule.approval_required;
+
+  if (
+    rule.project !== project
+    || rule.provider_id !== providerId
+    || !validPolicyField(rule.connection_id)
+    || !validPolicyField(rule.server_id)
+    || !validPolicyField(rule.tool_name)
+    || !Array.isArray(modes)
+    || modes.length === 0
+    || !modes.every(mode => typeof mode === 'string' && AGENT_TOOL_POLICY_MODES.has(mode))
+    || typeof risk !== 'string'
+    || !AGENT_TOOL_POLICY_RISKS.has(risk)
+    || (effect !== 'allow' && effect !== 'deny')
+    || (approvalRequired !== undefined && typeof approvalRequired !== 'boolean')
+  ) {
+    return false;
+  }
+  if (effect === 'deny') return approvalRequired !== true;
+  if (risk === 'unknown') return false;
+  return risk === 'read_only' || approvalRequired === true;
+}
+
+function validPolicyField(value: unknown) {
+  return typeof value === 'string' && value.length > 0 && value.trim() === value;
 }
 
 function toolPolicyViewForScope(
@@ -482,7 +523,7 @@ function ToolPolicySummary({
           </>
         )}
       </div>
-      <div role="status" style={message ? hubStyles.toolPolicyMessage : undefined}>{message}</div>
+      {message && <div role="status" style={hubStyles.toolPolicyMessage}>{message}</div>}
       {rules.map((rule, index) => (
         <div
           key={`${rule.connection_id}:${rule.server_id}:${rule.tool_name}:${index}`}

--- a/web/src/components/Chat/ChatPanel.tsx
+++ b/web/src/components/Chat/ChatPanel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { CSSProperties, KeyboardEvent, ReactNode, RefObject } from 'react';
 
-import { api, type AgentProviderConnectionDefinition, type AgentProviderConnectionProfile, type AgentRun, type AgentRunApprovalDecision, type AgentRunMode, type AgentRunSummary, type LocalAgentProviderStatus } from '../../api';
+import { api, type AgentProviderConnectionDefinition, type AgentProviderConnectionProfile, type AgentRun, type AgentRunApprovalDecision, type AgentRunMode, type AgentRunSummary, type AgentToolPolicyResponse, type LocalAgentProviderStatus } from '../../api';
 import { S } from '../../styles';
 
 export interface ChatMessage {
@@ -47,6 +47,10 @@ type ProviderLane =
 type ProviderActionLabel = 'Configure API' | 'Use enterprise policy' | 'Use local CLI';
 type ProviderDefinition = { name: string; lane: ProviderLane; state: ProviderState; note: string; localProviderId?: string };
 type RunProviderIdentity = { id: string; label: string };
+type AgentToolPolicyView =
+  | { status: 'idle' }
+  | { status: 'loading' | 'missing' | 'error'; project: string; providerId: string }
+  | { status: 'ready'; project: string; providerId: string; response: AgentToolPolicyResponse };
 
 const PROVIDER_TABS: ProviderTab[] = ['codex', 'claude', 'gemini', 'copilot', 'local', 'mcp'];
 
@@ -69,6 +73,7 @@ const TASK_MODES = [
   'Prepare deploy',
 ] as const;
 const AGENT_RUN_REFRESH_INTERVAL_MS = 5000;
+const IDLE_AGENT_TOOL_POLICY_VIEW: AgentToolPolicyView = { status: 'idle' };
 
 const AGENT_HUB_STORAGE_KEYS = {
   activeTab: 'iac-studio.agentHub.activeTab',
@@ -247,6 +252,13 @@ const hubStyles: Record<string, CSSProperties> = {
   providerActions: { display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', marginTop: 10 },
   providerActionButton: { borderWidth: 1, borderStyle: 'solid', borderColor: 'var(--border-soft)', borderRadius: 6, background: 'var(--bg-elev-3)', color: 'var(--text-muted)', cursor: 'not-allowed', fontSize: 11, fontFamily: 'DM Sans', fontWeight: 700, padding: '6px 9px', opacity: 0.72 },
   providerActionHint: { color: '#77847d', fontSize: 11 },
+  toolPolicy: { borderTop: '1px solid var(--border-soft)', marginTop: 10, paddingTop: 8 },
+  toolPolicyHead: { display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' },
+  toolPolicyTitle: { color: 'var(--text-main)', fontSize: 11, fontWeight: 700, textTransform: 'uppercase', letterSpacing: 0.4, marginRight: 'auto' },
+  toolPolicyMessage: { color: 'var(--text-muted)', fontSize: 11, lineHeight: 1.4, marginTop: 6 },
+  toolPolicyRule: { borderTop: '1px solid var(--border-soft)', paddingTop: 7, marginTop: 7, minWidth: 0 },
+  toolPolicyRuleName: { color: 'var(--text-main)', fontSize: 11, fontWeight: 700, overflowWrap: 'anywhere' },
+  toolPolicyRuleMeta: { color: 'var(--text-muted)', fontFamily: 'JetBrains Mono', fontSize: 10, lineHeight: 1.4, marginTop: 3, overflowWrap: 'anywhere' },
   connectionCatalog: { gridColumn: '1 / -1', borderTop: '1px solid var(--border-soft)', paddingTop: 10, marginTop: 2, display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(210px, 1fr))', gap: 8 },
   connectionCatalogIntro: { gridColumn: '1 / -1', color: 'var(--text-muted)', fontSize: 12, lineHeight: 1.45 },
   connectionCard: { borderWidth: 1, borderStyle: 'solid', borderColor: 'var(--border-main)', borderRadius: 8, background: 'rgba(23, 29, 27, 0.68)', padding: 10, minWidth: 0 },
@@ -403,16 +415,107 @@ function providerIdentityForRunId(providerId?: string): RunProviderIdentity | nu
   return { id: providerId, label: providerId };
 }
 
+function hasHTTPStatus(err: unknown, status: number) {
+  return (
+    typeof err === 'object'
+    && err !== null
+    && 'status' in err
+    && (err as { status?: unknown }).status === status
+  );
+}
+
+function matchesToolPolicyScope(
+  response: AgentToolPolicyResponse,
+  project: string,
+  providerId: string,
+) {
+  return (
+    response?.scope?.project === project
+    && response.scope.provider_id === providerId
+    && Array.isArray(response.policy?.rules)
+    && response.policy.rules.every(rule => (
+      rule.project === project && rule.provider_id === providerId
+    ))
+  );
+}
+
+function toolPolicyViewForScope(
+  view: AgentToolPolicyView,
+  project: string | undefined,
+  providerId: string,
+): AgentToolPolicyView {
+  if (!project) return IDLE_AGENT_TOOL_POLICY_VIEW;
+  if (view.status !== 'idle' && view.project === project && view.providerId === providerId) {
+    return view;
+  }
+  return { status: 'loading', project, providerId };
+}
+
+function ToolPolicySummary({
+  providerName,
+  view,
+}: {
+  providerName: string;
+  view: AgentToolPolicyView;
+}) {
+  const rules = view.status === 'ready' ? view.response.policy.rules : [];
+  const allowed = rules.filter(rule => rule.effect === 'allow').length;
+  const denied = rules.filter(rule => rule.effect === 'deny').length;
+  const approvals = rules.filter(rule => rule.approval_required).length;
+
+  let message = '';
+  if (view.status === 'idle') message = 'Project scope required. MCP tool access is blocked.';
+  if (view.status === 'loading') message = 'Checking scoped tool permissions...';
+  if (view.status === 'missing') message = 'No scoped policy. MCP tool access is blocked.';
+  if (view.status === 'error') message = 'Policy unavailable. MCP tool access remains blocked.';
+  if (view.status === 'ready' && rules.length === 0) message = 'No routes allowed. MCP tool access is blocked.';
+
+  return (
+    <section style={hubStyles.toolPolicy} aria-label={`${providerName} tool permissions`}>
+      <div style={hubStyles.toolPolicyHead}>
+        <span style={hubStyles.toolPolicyTitle}>Tool permissions</span>
+        {view.status === 'ready' && (
+          <>
+            <span style={hubStyles.badge}>{allowed} allowed</span>
+            <span style={hubStyles.badge}>{denied} denied</span>
+            <span style={hubStyles.badge}>{approvals} approvals</span>
+          </>
+        )}
+      </div>
+      {message && <div style={hubStyles.toolPolicyMessage}>{message}</div>}
+      {rules.map((rule, index) => (
+        <div
+          key={`${rule.connection_id}:${rule.server_id}:${rule.tool_name}:${index}`}
+          style={hubStyles.toolPolicyRule}
+        >
+          <div style={hubStyles.toolPolicyHead}>
+            <span style={{ ...hubStyles.toolPolicyRuleName, flex: 1 }}>
+              {rule.server_id} / {rule.tool_name}
+            </span>
+            <span style={hubStyles.badge}>{rule.effect}</span>
+            {rule.approval_required && <span style={hubStyles.badge}>approval required</span>}
+          </div>
+          <div style={hubStyles.toolPolicyRuleMeta}>
+            {rule.connection_id} · {rule.modes.map(mode => mode.replaceAll('_', ' ')).join(', ')} · {rule.risk.replaceAll('_', ' ')}
+          </div>
+        </div>
+      ))}
+    </section>
+  );
+}
+
 function ProviderDetails({
   provider,
   displayState,
   displayNote,
   localStatus,
+  toolPolicyView,
 }: {
   provider: ProviderDefinition;
   displayState: ProviderState;
   displayNote: string;
   localStatus?: LocalAgentProviderStatus;
+  toolPolicyView: AgentToolPolicyView;
 }) {
   const details = localStatusDetails(provider.localProviderId, localStatus);
   return (
@@ -452,6 +555,7 @@ function ProviderDetails({
           ))}
         </div>
       )}
+      <ToolPolicySummary providerName={provider.name} view={toolPolicyView} />
       <div role="group" style={hubStyles.providerActions} aria-label={`${provider.name} actions`}>
         <button
           type="button"
@@ -595,6 +699,7 @@ function ProviderGroup({
   localProviders,
   connectionProviders,
   connectionProfiles,
+  toolPolicyView,
   selectedProviderName,
   onSelectProvider,
 }: {
@@ -603,6 +708,7 @@ function ProviderGroup({
   localProviders: Record<string, LocalAgentProviderStatus>;
   connectionProviders: AgentProviderConnectionDefinition[];
   connectionProfiles: AgentProviderConnectionProfile[];
+  toolPolicyView: AgentToolPolicyView;
   selectedProviderName?: string;
   onSelectProvider: (tab: ProviderTab, providerName: string) => void;
 }) {
@@ -671,6 +777,7 @@ function ProviderGroup({
         displayState={selectedDisplay.state}
         displayNote={selectedDisplay.note}
         localStatus={selectedLocalStatus}
+        toolPolicyView={toolPolicyView}
       />
       <ConnectionCatalog title={group.title} providers={visibleConnectionProviders} />
       <SavedConnectionProfiles title={group.title} profiles={visibleConnectionProfiles} />
@@ -1198,6 +1305,7 @@ export function ChatPanel({
   const [localProviders, setLocalProviders] = useState<Record<string, LocalAgentProviderStatus>>({});
   const [connectionProviders, setConnectionProviders] = useState<AgentProviderConnectionDefinition[]>([]);
   const [connectionProfiles, setConnectionProfiles] = useState<AgentProviderConnectionProfile[]>([]);
+  const [toolPolicyView, setToolPolicyView] = useState<AgentToolPolicyView>(IDLE_AGENT_TOOL_POLICY_VIEW);
   const [agentRuns, setAgentRuns] = useState<AgentRunSummary[]>([]);
   const [agentRunsLoading, setAgentRunsLoading] = useState(false);
   const [agentRunsError, setAgentRunsError] = useState<string | null>(null);
@@ -1274,6 +1382,39 @@ export function ChatPanel({
     [runProviderTab, selectedProviders],
   );
   const hasActiveAgentRuns = agentRuns.some(run => !isTerminalAgentRun(run.status));
+
+  useEffect(() => {
+    if (!projectName || !isProviderTab(activeTab)) {
+      setToolPolicyView(IDLE_AGENT_TOOL_POLICY_VIEW);
+      return;
+    }
+
+    let cancelled = false;
+    const requestProject = projectName;
+    const requestProvider = runProviderId;
+    const requestScope = { project: requestProject, providerId: requestProvider };
+    setToolPolicyView({ status: 'loading', ...requestScope });
+    api.getAgentToolPolicy(requestProject, requestProvider)
+      .then(response => {
+        if (cancelled) return;
+        if (!matchesToolPolicyScope(response, requestProject, requestProvider)) {
+          setToolPolicyView({ status: 'error', ...requestScope });
+          return;
+        }
+        setToolPolicyView({ status: 'ready', response, ...requestScope });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setToolPolicyView({
+          status: hasHTTPStatus(err, 404) ? 'missing' : 'error',
+          ...requestScope,
+        });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeTab, projectName, runProviderId]);
 
   const panelStyle = (tab: AgentHubTab) => (
     activeTab === tab ? hubStyles.tabPanel : hubStyles.hiddenTabPanel
@@ -1705,6 +1846,9 @@ export function ChatPanel({
               localProviders={localProviders}
               connectionProviders={connectionProviders}
               connectionProfiles={connectionProfiles}
+              toolPolicyView={activeTab === tab
+                ? toolPolicyViewForScope(toolPolicyView, projectName, runProviderId)
+                : IDLE_AGENT_TOOL_POLICY_VIEW}
               selectedProviderName={selectedProviders[tab]}
               onSelectProvider={selectProvider}
             />


### PR DESCRIPTION
## Summary
- fetch the exact project/provider routing policy when an Agent Hub provider is active
- show allowed, denied, and approval-required tool routes in the selected provider details
- keep missing, malformed, failed, and stale policy states visibly fail-closed

## Validation
- `npm test -- --run` (218 tests)
- `npm test -- --run src/components/Chat/ChatPanel.test.tsx` (45 tests after final stale-state change)
- `npm run lint` (no errors; existing warnings remain)
- `npm run build`

Part of #107