### PR TITLE
Persist Agent Hub routing policies

### DIFF
--- a/cmd/server/agent_routing.go
+++ b/cmd/server/agent_routing.go
@@ -13,9 +13,12 @@ type agentRoutingServices struct {
 	router   *agentrouting.Router
 }
 
-func newAgentRoutingServices(evaluator agentrouting.ToolEvaluator) (*agentRoutingServices, error) {
+func newAgentRoutingServices(projectsDir string, evaluator agentrouting.ToolEvaluator) (*agentRoutingServices, error) {
 	runs := agentruns.NewStore()
-	policies := agentrouting.NewPolicyStore()
+	policies, err := agentrouting.NewPersistentPolicyStore(projectsDir)
+	if err != nil {
+		return nil, fmt.Errorf("load tool route policies: %w", err)
+	}
 	authorizer, err := agentrouting.NewStoreAuthorizer(policies, evaluator)
 	if err != nil {
 		return nil, fmt.Errorf("create tool route authorizer: %w", err)

--- a/cmd/server/agent_routing_test.go
+++ b/cmd/server/agent_routing_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -20,7 +22,7 @@ func (e *countingToolEvaluator) EvaluateTool(_, _, _ string) (mcpairlock.ToolInv
 }
 
 func TestNewAgentRoutingServicesRequiresToolEvaluator(t *testing.T) {
-	_, err := newAgentRoutingServices(nil)
+	_, err := newAgentRoutingServices(t.TempDir(), nil)
 	if !errors.Is(err, agentrouting.ErrToolEvaluatorRequired) {
 		t.Fatalf("newAgentRoutingServices(nil) error = %v, want %v", err, agentrouting.ErrToolEvaluatorRequired)
 	}
@@ -28,7 +30,7 @@ func TestNewAgentRoutingServicesRequiresToolEvaluator(t *testing.T) {
 
 func TestNewAgentRoutingServicesFailsClosedAndAuditsMissingPolicy(t *testing.T) {
 	evaluator := &countingToolEvaluator{}
-	services, err := newAgentRoutingServices(evaluator)
+	services, err := newAgentRoutingServices(t.TempDir(), evaluator)
 	if err != nil {
 		t.Fatalf("newAgentRoutingServices(): %v", err)
 	}
@@ -66,5 +68,21 @@ func TestNewAgentRoutingServicesFailsClosedAndAuditsMissingPolicy(t *testing.T) 
 	}
 	if evaluator.calls != 0 {
 		t.Fatalf("Airlock evaluation calls = %d, want none without a scoped policy", evaluator.calls)
+	}
+}
+
+func TestNewAgentRoutingServicesRejectsCorruptPolicyStore(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, ".iac-studio")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("MkdirAll(): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "agent-routing-policies.json"), []byte("{"), 0o600); err != nil {
+		t.Fatalf("WriteFile(): %v", err)
+	}
+
+	_, err := newAgentRoutingServices(root, &countingToolEvaluator{})
+	if !errors.Is(err, agentrouting.ErrInvalidPolicyStore) {
+		t.Fatalf("newAgentRoutingServices() error = %v, want ErrInvalidPolicyStore", err)
 	}
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -107,7 +107,7 @@ func runServer() error {
 			log.Printf("mcp airlock cleanup: %v", err)
 		}
 	}()
-	agentRouting, err := newAgentRoutingServices(mcpAirlock)
+	agentRouting, err := newAgentRoutingServices(*projectsDir, mcpAirlock)
 	if err != nil {
 		return fmt.Errorf("initialize Agent Hub tool routing: %w", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/hashicorp/hcl/v2 v2.22.0
 	github.com/open-policy-agent/opa v1.15.2
 	github.com/zclconf/go-cty v1.15.0
+	golang.org/x/sys v0.41.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -42,7 +43,6 @@ require (
 	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/mod v0.32.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 	golang.org/x/tools v0.41.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect

--- a/internal/agentrouting/atomic_replace_unix.go
+++ b/internal/agentrouting/atomic_replace_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package agentrouting
+
+import "os"
+
+func replacePolicyStoreFile(source, destination string) error {
+	return os.Rename(source, destination)
+}

--- a/internal/agentrouting/atomic_replace_windows.go
+++ b/internal/agentrouting/atomic_replace_windows.go
@@ -1,0 +1,42 @@
+//go:build windows
+
+package agentrouting
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+const (
+	movePolicyFileReplaceExisting = 0x1
+	movePolicyFileWriteThrough    = 0x8
+)
+
+var (
+	policyKernel32        = syscall.NewLazyDLL("kernel32.dll")
+	policyProcMoveFileExW = policyKernel32.NewProc("MoveFileExW")
+)
+
+func replacePolicyStoreFile(source, destination string) error {
+	from, err := syscall.UTF16PtrFromString(source)
+	if err != nil {
+		return err
+	}
+	to, err := syscall.UTF16PtrFromString(destination)
+	if err != nil {
+		return err
+	}
+	result, _, callErr := syscall.SyscallN(
+		policyProcMoveFileExW.Addr(),
+		uintptr(unsafe.Pointer(from)),
+		uintptr(unsafe.Pointer(to)),
+		uintptr(movePolicyFileReplaceExisting|movePolicyFileWriteThrough),
+	)
+	if result == 0 {
+		if callErr != syscall.Errno(0) {
+			return callErr
+		}
+		return syscall.EINVAL
+	}
+	return nil
+}

--- a/internal/agentrouting/policy_store.go
+++ b/internal/agentrouting/policy_store.go
@@ -62,7 +62,7 @@ func (s *PolicyStore) Save(scope PolicyScope, policy Policy) error {
 	// snapshot during filesystem I/O.
 	s.persistMu.Lock()
 	defer s.persistMu.Unlock()
-	next := s.snapshotPolicies()
+	var next map[PolicyScope]Policy
 	if s.path != "" {
 		if err := persistPolicyStoreLocked(s.path, scope, snapshot); err != nil {
 			return fmt.Errorf("persist tool route policies: %w", err)
@@ -73,6 +73,7 @@ func (s *PolicyStore) Save(scope PolicyScope, policy Policy) error {
 		}
 		next = loaded
 	} else {
+		next = s.snapshotPolicies()
 		next[scope] = snapshot
 	}
 	s.mu.Lock()

--- a/internal/agentrouting/policy_store.go
+++ b/internal/agentrouting/policy_store.go
@@ -58,36 +58,28 @@ func (s *PolicyStore) Save(scope PolicyScope, policy Policy) error {
 		}
 	}
 
-	// Serialize writers while allowing readers to keep using the last durable
-	// snapshot during filesystem I/O.
+	if s.path == "" {
+		s.mu.Lock()
+		if s.policies == nil {
+			s.policies = make(map[PolicyScope]Policy)
+		}
+		s.policies[scope] = snapshot
+		s.mu.Unlock()
+		return nil
+	}
+
+	// Serialize persistent writers while allowing readers to keep using the
+	// last durable snapshot during filesystem I/O.
 	s.persistMu.Lock()
 	defer s.persistMu.Unlock()
-	var next map[PolicyScope]Policy
-	if s.path != "" {
-		persisted, err := persistPolicyStoreLocked(s.path, scope, snapshot)
-		if err != nil {
-			return fmt.Errorf("persist tool route policies: %w", err)
-		}
-		next = persisted
-	} else {
-		next = s.snapshotPolicies()
-		next[scope] = snapshot
+	persisted, err := persistPolicyStoreLocked(s.path, scope, snapshot)
+	if err != nil {
+		return fmt.Errorf("persist tool route policies: %w", err)
 	}
 	s.mu.Lock()
-	s.policies = next
+	s.policies = persisted
 	s.mu.Unlock()
 	return nil
-}
-
-func (s *PolicyStore) snapshotPolicies() map[PolicyScope]Policy {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	next := make(map[PolicyScope]Policy, len(s.policies)+1)
-	for storedScope, storedPolicy := range s.policies {
-		next[storedScope] = storedPolicy
-	}
-	return next
 }
 
 // Get returns a detached policy snapshot for one exact project/provider scope.

--- a/internal/agentrouting/policy_store.go
+++ b/internal/agentrouting/policy_store.go
@@ -64,14 +64,11 @@ func (s *PolicyStore) Save(scope PolicyScope, policy Policy) error {
 	defer s.persistMu.Unlock()
 	var next map[PolicyScope]Policy
 	if s.path != "" {
-		if err := persistPolicyStoreLocked(s.path, scope, snapshot); err != nil {
+		persisted, err := persistPolicyStoreLocked(s.path, scope, snapshot)
+		if err != nil {
 			return fmt.Errorf("persist tool route policies: %w", err)
 		}
-		loaded, err := loadPolicyStore(s.path)
-		if err != nil {
-			return fmt.Errorf("reload tool route policies: %w", err)
-		}
-		next = loaded
+		next = persisted
 	} else {
 		next = s.snapshotPolicies()
 		next[scope] = snapshot

--- a/internal/agentrouting/policy_store.go
+++ b/internal/agentrouting/policy_store.go
@@ -30,8 +30,10 @@ func (s PolicyScope) Validate() error {
 // PolicyStore keeps validated, immutable policy snapshots by exact project
 // and provider scope. Missing policies fail closed with ErrPolicyNotFound.
 type PolicyStore struct {
-	mu       sync.RWMutex
-	policies map[PolicyScope]Policy
+	mu        sync.RWMutex
+	persistMu sync.Mutex
+	policies  map[PolicyScope]Policy
+	path      string
 }
 
 func NewPolicyStore() *PolicyStore {
@@ -56,12 +58,25 @@ func (s *PolicyStore) Save(scope PolicyScope, policy Policy) error {
 		}
 	}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.policies == nil {
-		s.policies = make(map[PolicyScope]Policy)
+	// Serialize writers while allowing readers to keep using the last durable
+	// snapshot during filesystem I/O.
+	s.persistMu.Lock()
+	defer s.persistMu.Unlock()
+	s.mu.RLock()
+	next := make(map[PolicyScope]Policy, len(s.policies)+1)
+	for storedScope, storedPolicy := range s.policies {
+		next[storedScope] = storedPolicy
 	}
-	s.policies[scope] = snapshot
+	s.mu.RUnlock()
+	next[scope] = snapshot
+	if s.path != "" {
+		if err := persistPolicyStore(s.path, next); err != nil {
+			return fmt.Errorf("persist tool route policies: %w", err)
+		}
+	}
+	s.mu.Lock()
+	s.policies = next
+	s.mu.Unlock()
 	return nil
 }
 

--- a/internal/agentrouting/policy_store.go
+++ b/internal/agentrouting/policy_store.go
@@ -62,22 +62,34 @@ func (s *PolicyStore) Save(scope PolicyScope, policy Policy) error {
 	// snapshot during filesystem I/O.
 	s.persistMu.Lock()
 	defer s.persistMu.Unlock()
-	s.mu.RLock()
-	next := make(map[PolicyScope]Policy, len(s.policies)+1)
-	for storedScope, storedPolicy := range s.policies {
-		next[storedScope] = storedPolicy
-	}
-	s.mu.RUnlock()
-	next[scope] = snapshot
+	next := s.snapshotPolicies()
 	if s.path != "" {
-		if err := persistPolicyStore(s.path, next); err != nil {
+		if err := persistPolicyStoreLocked(s.path, scope, snapshot); err != nil {
 			return fmt.Errorf("persist tool route policies: %w", err)
 		}
+		loaded, err := loadPolicyStore(s.path)
+		if err != nil {
+			return fmt.Errorf("reload tool route policies: %w", err)
+		}
+		next = loaded
+	} else {
+		next[scope] = snapshot
 	}
 	s.mu.Lock()
 	s.policies = next
 	s.mu.Unlock()
 	return nil
+}
+
+func (s *PolicyStore) snapshotPolicies() map[PolicyScope]Policy {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	next := make(map[PolicyScope]Policy, len(s.policies)+1)
+	for storedScope, storedPolicy := range s.policies {
+		next[storedScope] = storedPolicy
+	}
+	return next
 }
 
 // Get returns a detached policy snapshot for one exact project/provider scope.

--- a/internal/agentrouting/policy_store_directory_unix.go
+++ b/internal/agentrouting/policy_store_directory_unix.go
@@ -1,0 +1,33 @@
+//go:build !windows
+
+package agentrouting
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func openPolicyStoreDirFile(path string) (*os.File, error) {
+	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW|unix.O_DIRECTORY, 0)
+	if err != nil {
+		return nil, err
+	}
+	handle := os.NewFile(uintptr(fd), path)
+	if handle == nil {
+		_ = unix.Close(fd)
+		return nil, errors.New("create policy store directory handle")
+	}
+	info, err := handle.Stat()
+	if err != nil {
+		_ = handle.Close()
+		return nil, fmt.Errorf("inspect policy store directory: %w", err)
+	}
+	if !info.IsDir() {
+		_ = handle.Close()
+		return nil, errors.New("policy store path is not a directory")
+	}
+	return handle, nil
+}

--- a/internal/agentrouting/policy_store_directory_windows.go
+++ b/internal/agentrouting/policy_store_directory_windows.go
@@ -1,0 +1,46 @@
+//go:build windows
+
+package agentrouting
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func openPolicyStoreDirFile(path string) (*os.File, error) {
+	pathPointer, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return nil, err
+	}
+	handle, err := windows.CreateFile(
+		pathPointer,
+		windows.GENERIC_READ|windows.WRITE_DAC,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_FLAG_BACKUP_SEMANTICS|windows.FILE_FLAG_OPEN_REPARSE_POINT,
+		0,
+	)
+	if err != nil {
+		return nil, err
+	}
+	var info windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(handle, &info); err != nil {
+		_ = windows.CloseHandle(handle)
+		return nil, fmt.Errorf("inspect policy store directory: %w", err)
+	}
+	if info.FileAttributes&windows.FILE_ATTRIBUTE_DIRECTORY == 0 ||
+		info.FileAttributes&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+		_ = windows.CloseHandle(handle)
+		return nil, errors.New("policy store path is not a real directory")
+	}
+	file := os.NewFile(uintptr(handle), path)
+	if file == nil {
+		_ = windows.CloseHandle(handle)
+		return nil, errors.New("create policy store directory handle")
+	}
+	return file, nil
+}

--- a/internal/agentrouting/policy_store_file_unix.go
+++ b/internal/agentrouting/policy_store_file_unix.go
@@ -1,0 +1,25 @@
+//go:build !windows
+
+package agentrouting
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func openPolicyStoreDataFile(path string) (*os.File, error) {
+	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW|unix.O_NONBLOCK, 0)
+	if err != nil {
+		if err == unix.ELOOP {
+			return nil, ErrInvalidPolicyStore
+		}
+		return nil, err
+	}
+	handle := os.NewFile(uintptr(fd), path)
+	if handle == nil {
+		_ = unix.Close(fd)
+		return nil, ErrInvalidPolicyStore
+	}
+	return handle, nil
+}

--- a/internal/agentrouting/policy_store_file_unix.go
+++ b/internal/agentrouting/policy_store_file_unix.go
@@ -16,6 +16,15 @@ func openPolicyStoreDataFile(path string) (*os.File, error) {
 		}
 		return nil, err
 	}
+	var stat unix.Stat_t
+	if err := unix.Fstat(fd, &stat); err != nil {
+		_ = unix.Close(fd)
+		return nil, err
+	}
+	if stat.Nlink != 1 {
+		_ = unix.Close(fd)
+		return nil, ErrInvalidPolicyStore
+	}
 	handle := os.NewFile(uintptr(fd), path)
 	if handle == nil {
 		_ = unix.Close(fd)

--- a/internal/agentrouting/policy_store_file_windows.go
+++ b/internal/agentrouting/policy_store_file_windows.go
@@ -30,7 +30,8 @@ func openPolicyStoreDataFile(path string) (*os.File, error) {
 		_ = windows.CloseHandle(handle)
 		return nil, err
 	}
-	if info.FileAttributes&(windows.FILE_ATTRIBUTE_DIRECTORY|windows.FILE_ATTRIBUTE_REPARSE_POINT) != 0 {
+	if info.FileAttributes&(windows.FILE_ATTRIBUTE_DIRECTORY|windows.FILE_ATTRIBUTE_REPARSE_POINT) != 0 ||
+		info.NumberOfLinks != 1 {
 		_ = windows.CloseHandle(handle)
 		return nil, ErrInvalidPolicyStore
 	}

--- a/internal/agentrouting/policy_store_file_windows.go
+++ b/internal/agentrouting/policy_store_file_windows.go
@@ -16,7 +16,7 @@ func openPolicyStoreDataFile(path string) (*os.File, error) {
 	handle, err := windows.CreateFile(
 		pathPointer,
 		windows.GENERIC_READ|windows.WRITE_DAC,
-		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
 		nil,
 		windows.OPEN_EXISTING,
 		windows.FILE_ATTRIBUTE_NORMAL|windows.FILE_FLAG_OPEN_REPARSE_POINT,

--- a/internal/agentrouting/policy_store_file_windows.go
+++ b/internal/agentrouting/policy_store_file_windows.go
@@ -1,0 +1,43 @@
+//go:build windows
+
+package agentrouting
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func openPolicyStoreDataFile(path string) (*os.File, error) {
+	pathPointer, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return nil, err
+	}
+	handle, err := windows.CreateFile(
+		pathPointer,
+		windows.GENERIC_READ|windows.WRITE_DAC,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_ATTRIBUTE_NORMAL|windows.FILE_FLAG_OPEN_REPARSE_POINT,
+		0,
+	)
+	if err != nil {
+		return nil, err
+	}
+	var info windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(handle, &info); err != nil {
+		_ = windows.CloseHandle(handle)
+		return nil, err
+	}
+	if info.FileAttributes&(windows.FILE_ATTRIBUTE_DIRECTORY|windows.FILE_ATTRIBUTE_REPARSE_POINT) != 0 {
+		_ = windows.CloseHandle(handle)
+		return nil, ErrInvalidPolicyStore
+	}
+	file := os.NewFile(uintptr(handle), path)
+	if file == nil {
+		_ = windows.CloseHandle(handle)
+		return nil, ErrInvalidPolicyStore
+	}
+	return file, nil
+}

--- a/internal/agentrouting/policy_store_file_windows_test.go
+++ b/internal/agentrouting/policy_store_file_windows_test.go
@@ -1,0 +1,39 @@
+//go:build windows
+
+package agentrouting
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestOpenPolicyStoreDataFileAllowsAtomicReplacement(t *testing.T) {
+	dir := t.TempDir()
+	destination := filepath.Join(dir, "policies.json")
+	if err := os.WriteFile(destination, []byte("old"), 0o600); err != nil {
+		t.Fatalf("WriteFile(destination): %v", err)
+	}
+
+	reader, err := openPolicyStoreDataFile(destination)
+	if err != nil {
+		t.Fatalf("openPolicyStoreDataFile(): %v", err)
+	}
+	defer reader.Close()
+
+	source := filepath.Join(dir, "replacement.json")
+	if err := os.WriteFile(source, []byte("new"), 0o600); err != nil {
+		t.Fatalf("WriteFile(source): %v", err)
+	}
+	if err := replacePolicyStoreFile(source, destination); err != nil {
+		t.Fatalf("replacePolicyStoreFile() with open reader: %v", err)
+	}
+
+	data, err := os.ReadFile(destination)
+	if err != nil {
+		t.Fatalf("ReadFile(destination): %v", err)
+	}
+	if string(data) != "new" {
+		t.Fatalf("destination contents = %q, want new", data)
+	}
+}

--- a/internal/agentrouting/policy_store_lock_unix.go
+++ b/internal/agentrouting/policy_store_lock_unix.go
@@ -1,0 +1,23 @@
+//go:build !windows
+
+package agentrouting
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func lockPolicyStoreFile(handle *os.File) error {
+	if err := syscall.Flock(int(handle.Fd()), syscall.LOCK_EX); err != nil {
+		return fmt.Errorf("lock policy store: %w", err)
+	}
+	return nil
+}
+
+func unlockPolicyStoreFile(handle *os.File) error {
+	if err := syscall.Flock(int(handle.Fd()), syscall.LOCK_UN); err != nil {
+		return fmt.Errorf("unlock policy store: %w", err)
+	}
+	return nil
+}

--- a/internal/agentrouting/policy_store_lock_unix.go
+++ b/internal/agentrouting/policy_store_lock_unix.go
@@ -14,6 +14,15 @@ func openPolicyStoreLockFile(path string) (*os.File, error) {
 	if err != nil {
 		return nil, err
 	}
+	var stat unix.Stat_t
+	if err := unix.Fstat(fd, &stat); err != nil {
+		_ = unix.Close(fd)
+		return nil, fmt.Errorf("inspect policy store lock: %w", err)
+	}
+	if stat.Nlink != 1 {
+		_ = unix.Close(fd)
+		return nil, fmt.Errorf("policy store lock must have exactly one hard link")
+	}
 	handle := os.NewFile(uintptr(fd), path)
 	if handle == nil {
 		_ = unix.Close(fd)

--- a/internal/agentrouting/policy_store_lock_unix.go
+++ b/internal/agentrouting/policy_store_lock_unix.go
@@ -5,18 +5,41 @@ package agentrouting
 import (
 	"fmt"
 	"os"
-	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
+func openPolicyStoreLockFile(path string) (*os.File, error) {
+	fd, err := unix.Open(path, unix.O_CREAT|unix.O_RDWR|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	handle := os.NewFile(uintptr(fd), path)
+	if handle == nil {
+		_ = unix.Close(fd)
+		return nil, fmt.Errorf("create policy store lock handle")
+	}
+	info, err := handle.Stat()
+	if err != nil {
+		_ = handle.Close()
+		return nil, fmt.Errorf("inspect policy store lock: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		_ = handle.Close()
+		return nil, fmt.Errorf("policy store lock is not a regular file")
+	}
+	return handle, nil
+}
+
 func lockPolicyStoreFile(handle *os.File) error {
-	if err := syscall.Flock(int(handle.Fd()), syscall.LOCK_EX); err != nil {
+	if err := unix.Flock(int(handle.Fd()), unix.LOCK_EX); err != nil {
 		return fmt.Errorf("lock policy store: %w", err)
 	}
 	return nil
 }
 
 func unlockPolicyStoreFile(handle *os.File) error {
-	if err := syscall.Flock(int(handle.Fd()), syscall.LOCK_UN); err != nil {
+	if err := unix.Flock(int(handle.Fd()), unix.LOCK_UN); err != nil {
 		return fmt.Errorf("unlock policy store: %w", err)
 	}
 	return nil

--- a/internal/agentrouting/policy_store_lock_windows.go
+++ b/internal/agentrouting/policy_store_lock_windows.go
@@ -5,61 +5,38 @@ package agentrouting
 import (
 	"fmt"
 	"os"
-	"syscall"
-	"unsafe"
-)
 
-var (
-	policyProcLockFileEx   = policyKernel32.NewProc("LockFileEx")
-	policyProcUnlockFileEx = policyKernel32.NewProc("UnlockFileEx")
+	"golang.org/x/sys/windows"
 )
-
-type policyOverlapped struct {
-	internal     uintptr
-	internalHigh uintptr
-	offset       uint32
-	offsetHigh   uint32
-	eventHandle  syscall.Handle
-}
 
 func lockPolicyStoreFile(handle *os.File) error {
 	if _, err := handle.WriteAt([]byte{0}, 0); err != nil {
 		return fmt.Errorf("prepare policy store lock: %w", err)
 	}
-	var overlapped policyOverlapped
-	result, _, callErr := syscall.SyscallN(
-		policyProcLockFileEx.Addr(),
-		handle.Fd(),
-		uintptr(0),
-		uintptr(0),
-		uintptr(1),
-		uintptr(0),
-		uintptr(unsafe.Pointer(&overlapped)),
-	)
-	if result == 0 {
-		if callErr != syscall.Errno(0) {
-			return fmt.Errorf("lock policy store: %w", callErr)
-		}
-		return fmt.Errorf("lock policy store: %w", syscall.EINVAL)
+	var overlapped windows.Overlapped
+	if err := windows.LockFileEx(
+		windows.Handle(handle.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK,
+		0,
+		1,
+		0,
+		&overlapped,
+	); err != nil {
+		return fmt.Errorf("lock policy store: %w", err)
 	}
 	return nil
 }
 
 func unlockPolicyStoreFile(handle *os.File) error {
-	var overlapped policyOverlapped
-	result, _, callErr := syscall.SyscallN(
-		policyProcUnlockFileEx.Addr(),
-		handle.Fd(),
-		uintptr(0),
-		uintptr(1),
-		uintptr(0),
-		uintptr(unsafe.Pointer(&overlapped)),
-	)
-	if result == 0 {
-		if callErr != syscall.Errno(0) {
-			return fmt.Errorf("unlock policy store: %w", callErr)
-		}
-		return fmt.Errorf("unlock policy store: %w", syscall.EINVAL)
+	var overlapped windows.Overlapped
+	if err := windows.UnlockFileEx(
+		windows.Handle(handle.Fd()),
+		0,
+		1,
+		0,
+		&overlapped,
+	); err != nil {
+		return fmt.Errorf("unlock policy store: %w", err)
 	}
 	return nil
 }

--- a/internal/agentrouting/policy_store_lock_windows.go
+++ b/internal/agentrouting/policy_store_lock_windows.go
@@ -1,0 +1,65 @@
+//go:build windows
+
+package agentrouting
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+var (
+	policyProcLockFileEx   = policyKernel32.NewProc("LockFileEx")
+	policyProcUnlockFileEx = policyKernel32.NewProc("UnlockFileEx")
+)
+
+type policyOverlapped struct {
+	internal     uintptr
+	internalHigh uintptr
+	offset       uint32
+	offsetHigh   uint32
+	eventHandle  syscall.Handle
+}
+
+func lockPolicyStoreFile(handle *os.File) error {
+	if _, err := handle.WriteAt([]byte{0}, 0); err != nil {
+		return fmt.Errorf("prepare policy store lock: %w", err)
+	}
+	var overlapped policyOverlapped
+	result, _, callErr := syscall.SyscallN(
+		policyProcLockFileEx.Addr(),
+		handle.Fd(),
+		uintptr(0),
+		uintptr(0),
+		uintptr(1),
+		uintptr(0),
+		uintptr(unsafe.Pointer(&overlapped)),
+	)
+	if result == 0 {
+		if callErr != syscall.Errno(0) {
+			return fmt.Errorf("lock policy store: %w", callErr)
+		}
+		return fmt.Errorf("lock policy store: %w", syscall.EINVAL)
+	}
+	return nil
+}
+
+func unlockPolicyStoreFile(handle *os.File) error {
+	var overlapped policyOverlapped
+	result, _, callErr := syscall.SyscallN(
+		policyProcUnlockFileEx.Addr(),
+		handle.Fd(),
+		uintptr(0),
+		uintptr(1),
+		uintptr(0),
+		uintptr(unsafe.Pointer(&overlapped)),
+	)
+	if result == 0 {
+		if callErr != syscall.Errno(0) {
+			return fmt.Errorf("unlock policy store: %w", callErr)
+		}
+		return fmt.Errorf("unlock policy store: %w", syscall.EINVAL)
+	}
+	return nil
+}

--- a/internal/agentrouting/policy_store_lock_windows.go
+++ b/internal/agentrouting/policy_store_lock_windows.go
@@ -31,9 +31,10 @@ func openPolicyStoreLockFile(path string) (*os.File, error) {
 		_ = windows.CloseHandle(handle)
 		return nil, fmt.Errorf("inspect policy store lock: %w", err)
 	}
-	if info.FileAttributes&(windows.FILE_ATTRIBUTE_DIRECTORY|windows.FILE_ATTRIBUTE_REPARSE_POINT) != 0 {
+	if info.FileAttributes&(windows.FILE_ATTRIBUTE_DIRECTORY|windows.FILE_ATTRIBUTE_REPARSE_POINT) != 0 ||
+		info.NumberOfLinks != 1 {
 		_ = windows.CloseHandle(handle)
-		return nil, fmt.Errorf("policy store lock is not a regular file")
+		return nil, fmt.Errorf("policy store lock must be a single-link regular file")
 	}
 	file := os.NewFile(uintptr(handle), path)
 	if file == nil {

--- a/internal/agentrouting/policy_store_lock_windows.go
+++ b/internal/agentrouting/policy_store_lock_windows.go
@@ -9,6 +9,40 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+func openPolicyStoreLockFile(path string) (*os.File, error) {
+	pathPointer, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return nil, err
+	}
+	handle, err := windows.CreateFile(
+		pathPointer,
+		windows.GENERIC_READ|windows.GENERIC_WRITE|windows.WRITE_DAC,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE,
+		nil,
+		windows.OPEN_ALWAYS,
+		windows.FILE_ATTRIBUTE_NORMAL|windows.FILE_FLAG_OPEN_REPARSE_POINT,
+		0,
+	)
+	if err != nil {
+		return nil, err
+	}
+	var info windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(handle, &info); err != nil {
+		_ = windows.CloseHandle(handle)
+		return nil, fmt.Errorf("inspect policy store lock: %w", err)
+	}
+	if info.FileAttributes&(windows.FILE_ATTRIBUTE_DIRECTORY|windows.FILE_ATTRIBUTE_REPARSE_POINT) != 0 {
+		_ = windows.CloseHandle(handle)
+		return nil, fmt.Errorf("policy store lock is not a regular file")
+	}
+	file := os.NewFile(uintptr(handle), path)
+	if file == nil {
+		_ = windows.CloseHandle(handle)
+		return nil, fmt.Errorf("create policy store lock handle")
+	}
+	return file, nil
+}
+
 func lockPolicyStoreFile(handle *os.File) error {
 	if _, err := handle.WriteAt([]byte{0}, 0); err != nil {
 		return fmt.Errorf("prepare policy store lock: %w", err)

--- a/internal/agentrouting/policy_store_permissions_unix.go
+++ b/internal/agentrouting/policy_store_permissions_unix.go
@@ -1,0 +1,11 @@
+//go:build !windows
+
+package agentrouting
+
+func securePolicyStoreDir(string) error {
+	return nil
+}
+
+func securePolicyStoreFile(string) error {
+	return nil
+}

--- a/internal/agentrouting/policy_store_permissions_unix.go
+++ b/internal/agentrouting/policy_store_permissions_unix.go
@@ -11,3 +11,7 @@ func securePolicyStoreDir(path string) error {
 func securePolicyStoreFile(path string) error {
 	return os.Chmod(path, 0o600)
 }
+
+func securePolicyStoreHandle(handle *os.File) error {
+	return handle.Chmod(0o600)
+}

--- a/internal/agentrouting/policy_store_permissions_unix.go
+++ b/internal/agentrouting/policy_store_permissions_unix.go
@@ -4,12 +4,12 @@ package agentrouting
 
 import "os"
 
-func securePolicyStoreDir(path string) error {
-	return os.Chmod(path, 0o700)
-}
-
 func securePolicyStoreFile(path string) error {
 	return os.Chmod(path, 0o600)
+}
+
+func securePolicyStoreDirHandle(handle *os.File) error {
+	return handle.Chmod(0o700)
 }
 
 func securePolicyStoreHandle(handle *os.File) error {

--- a/internal/agentrouting/policy_store_permissions_unix.go
+++ b/internal/agentrouting/policy_store_permissions_unix.go
@@ -2,10 +2,12 @@
 
 package agentrouting
 
-func securePolicyStoreDir(string) error {
-	return nil
+import "os"
+
+func securePolicyStoreDir(path string) error {
+	return os.Chmod(path, 0o700)
 }
 
-func securePolicyStoreFile(string) error {
-	return nil
+func securePolicyStoreFile(path string) error {
+	return os.Chmod(path, 0o600)
 }

--- a/internal/agentrouting/policy_store_permissions_windows.go
+++ b/internal/agentrouting/policy_store_permissions_windows.go
@@ -4,6 +4,7 @@ package agentrouting
 
 import (
 	"fmt"
+	"os"
 
 	"golang.org/x/sys/windows"
 )
@@ -17,26 +18,9 @@ func securePolicyStoreFile(path string) error {
 }
 
 func securePolicyStoreObject(path string, inheritance uint32) error {
-	currentUser, err := currentPolicyStoreUserSID()
+	acl, err := policyStoreACL(inheritance)
 	if err != nil {
 		return err
-	}
-	administrators, err := windows.CreateWellKnownSid(windows.WinBuiltinAdministratorsSid)
-	if err != nil {
-		return fmt.Errorf("resolve administrators SID: %w", err)
-	}
-	system, err := windows.CreateWellKnownSid(windows.WinLocalSystemSid)
-	if err != nil {
-		return fmt.Errorf("resolve local system SID: %w", err)
-	}
-
-	acl, err := windows.ACLFromEntries([]windows.EXPLICIT_ACCESS{
-		policyStoreAccessEntry(currentUser, windows.TRUSTEE_IS_USER, inheritance),
-		policyStoreAccessEntry(administrators, windows.TRUSTEE_IS_GROUP, inheritance),
-		policyStoreAccessEntry(system, windows.TRUSTEE_IS_USER, inheritance),
-	}, nil)
-	if err != nil {
-		return fmt.Errorf("build policy store ACL: %w", err)
 	}
 	if err := windows.SetNamedSecurityInfo(
 		path,
@@ -50,6 +34,50 @@ func securePolicyStoreObject(path string, inheritance uint32) error {
 		return fmt.Errorf("apply policy store ACL: %w", err)
 	}
 	return nil
+}
+
+func securePolicyStoreHandle(handle *os.File) error {
+	acl, err := policyStoreACL(0)
+	if err != nil {
+		return err
+	}
+	if err := windows.SetSecurityInfo(
+		windows.Handle(handle.Fd()),
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION,
+		nil,
+		nil,
+		acl,
+		nil,
+	); err != nil {
+		return fmt.Errorf("apply policy store ACL: %w", err)
+	}
+	return nil
+}
+
+func policyStoreACL(inheritance uint32) (*windows.ACL, error) {
+	currentUser, err := currentPolicyStoreUserSID()
+	if err != nil {
+		return nil, err
+	}
+	administrators, err := windows.CreateWellKnownSid(windows.WinBuiltinAdministratorsSid)
+	if err != nil {
+		return nil, fmt.Errorf("resolve administrators SID: %w", err)
+	}
+	system, err := windows.CreateWellKnownSid(windows.WinLocalSystemSid)
+	if err != nil {
+		return nil, fmt.Errorf("resolve local system SID: %w", err)
+	}
+
+	acl, err := windows.ACLFromEntries([]windows.EXPLICIT_ACCESS{
+		policyStoreAccessEntry(currentUser, windows.TRUSTEE_IS_USER, inheritance),
+		policyStoreAccessEntry(administrators, windows.TRUSTEE_IS_GROUP, inheritance),
+		policyStoreAccessEntry(system, windows.TRUSTEE_IS_USER, inheritance),
+	}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build policy store ACL: %w", err)
+	}
+	return acl, nil
 }
 
 func policyStoreAccessEntry(sid *windows.SID, trusteeType windows.TRUSTEE_TYPE, inheritance uint32) windows.EXPLICIT_ACCESS {

--- a/internal/agentrouting/policy_store_permissions_windows.go
+++ b/internal/agentrouting/policy_store_permissions_windows.go
@@ -33,7 +33,7 @@ func securePolicyStoreObject(path string, inheritance uint32) error {
 	acl, err := windows.ACLFromEntries([]windows.EXPLICIT_ACCESS{
 		policyStoreAccessEntry(currentUser, windows.TRUSTEE_IS_USER, inheritance),
 		policyStoreAccessEntry(administrators, windows.TRUSTEE_IS_GROUP, inheritance),
-		policyStoreAccessEntry(system, windows.TRUSTEE_IS_GROUP, inheritance),
+		policyStoreAccessEntry(system, windows.TRUSTEE_IS_USER, inheritance),
 	}, nil)
 	if err != nil {
 		return fmt.Errorf("build policy store ACL: %w", err)

--- a/internal/agentrouting/policy_store_permissions_windows.go
+++ b/internal/agentrouting/policy_store_permissions_windows.go
@@ -1,0 +1,78 @@
+//go:build windows
+
+package agentrouting
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/windows"
+)
+
+func securePolicyStoreDir(path string) error {
+	return securePolicyStoreObject(path, windows.SUB_CONTAINERS_AND_OBJECTS_INHERIT)
+}
+
+func securePolicyStoreFile(path string) error {
+	return securePolicyStoreObject(path, 0)
+}
+
+func securePolicyStoreObject(path string, inheritance uint32) error {
+	currentUser, err := currentPolicyStoreUserSID()
+	if err != nil {
+		return err
+	}
+	administrators, err := windows.CreateWellKnownSid(windows.WinBuiltinAdministratorsSid)
+	if err != nil {
+		return fmt.Errorf("resolve administrators SID: %w", err)
+	}
+	system, err := windows.CreateWellKnownSid(windows.WinLocalSystemSid)
+	if err != nil {
+		return fmt.Errorf("resolve local system SID: %w", err)
+	}
+
+	acl, err := windows.ACLFromEntries([]windows.EXPLICIT_ACCESS{
+		policyStoreAccessEntry(currentUser, windows.TRUSTEE_IS_USER, inheritance),
+		policyStoreAccessEntry(administrators, windows.TRUSTEE_IS_GROUP, inheritance),
+		policyStoreAccessEntry(system, windows.TRUSTEE_IS_GROUP, inheritance),
+	}, nil)
+	if err != nil {
+		return fmt.Errorf("build policy store ACL: %w", err)
+	}
+	if err := windows.SetNamedSecurityInfo(
+		path,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION,
+		nil,
+		nil,
+		acl,
+		nil,
+	); err != nil {
+		return fmt.Errorf("apply policy store ACL: %w", err)
+	}
+	return nil
+}
+
+func policyStoreAccessEntry(sid *windows.SID, trusteeType windows.TRUSTEE_TYPE, inheritance uint32) windows.EXPLICIT_ACCESS {
+	return windows.EXPLICIT_ACCESS{
+		AccessPermissions: windows.ACCESS_MASK(windows.GENERIC_ALL),
+		AccessMode:        windows.GRANT_ACCESS,
+		Inheritance:       inheritance,
+		Trustee: windows.TRUSTEE{
+			TrusteeForm:  windows.TRUSTEE_IS_SID,
+			TrusteeType:  trusteeType,
+			TrusteeValue: windows.TrusteeValueFromSID(sid),
+		},
+	}
+}
+
+func currentPolicyStoreUserSID() (*windows.SID, error) {
+	user, err := windows.GetCurrentProcessToken().GetTokenUser()
+	if err != nil {
+		return nil, fmt.Errorf("resolve current user SID: %w", err)
+	}
+	sid, err := user.User.Sid.Copy()
+	if err != nil {
+		return nil, fmt.Errorf("copy current user SID: %w", err)
+	}
+	return sid, nil
+}

--- a/internal/agentrouting/policy_store_permissions_windows.go
+++ b/internal/agentrouting/policy_store_permissions_windows.go
@@ -9,10 +9,6 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-func securePolicyStoreDir(path string) error {
-	return securePolicyStoreObject(path, windows.SUB_CONTAINERS_AND_OBJECTS_INHERIT)
-}
-
 func securePolicyStoreFile(path string) error {
 	return securePolicyStoreObject(path, 0)
 }
@@ -37,7 +33,15 @@ func securePolicyStoreObject(path string, inheritance uint32) error {
 }
 
 func securePolicyStoreHandle(handle *os.File) error {
-	acl, err := policyStoreACL(0)
+	return securePolicyStoreHandleWithInheritance(handle, 0)
+}
+
+func securePolicyStoreDirHandle(handle *os.File) error {
+	return securePolicyStoreHandleWithInheritance(handle, windows.SUB_CONTAINERS_AND_OBJECTS_INHERIT)
+}
+
+func securePolicyStoreHandleWithInheritance(handle *os.File, inheritance uint32) error {
+	acl, err := policyStoreACL(inheritance)
 	if err != nil {
 		return err
 	}

--- a/internal/agentrouting/policy_store_persistence.go
+++ b/internal/agentrouting/policy_store_persistence.go
@@ -39,8 +39,8 @@ func NewPersistentPolicyStore(projectsDir string) (*PolicyStore, error) {
 	if strings.TrimSpace(projectsDir) == "" {
 		return nil, ErrPolicyStorePathRequired
 	}
-	// Preserve the configured path exactly; leading and trailing spaces are
-	// valid filesystem path characters.
+	// Keep whitespace in the configured path; spaces are valid filesystem path
+	// characters.
 	path := filepath.Join(filepath.Clean(projectsDir), ".iac-studio", policyStoreFileName)
 	if err := secureExistingPolicyStoreDir(filepath.Dir(path), true); err != nil {
 		return nil, err
@@ -145,28 +145,31 @@ func persistPolicyStore(path string, policies map[PolicyScope]Policy) error {
 	return nil
 }
 
-func persistPolicyStoreLocked(path string, scope PolicyScope, policy Policy) error {
+func persistPolicyStoreLocked(path string, scope PolicyScope, policy Policy) (map[PolicyScope]Policy, error) {
 	dir := filepath.Dir(path)
 	if err := ensurePolicyStoreDir(dir); err != nil {
-		return err
+		return nil, err
 	}
 
 	lock, err := openPolicyStoreLock(path)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer func() { _ = lock.Close() }()
 	if err := lockPolicyStoreFile(lock); err != nil {
-		return err
+		return nil, err
 	}
 	defer func() { _ = unlockPolicyStoreFile(lock) }()
 
 	policies, err := loadPolicyStore(path)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	policies[scope] = clonePolicy(policy)
-	return persistPolicyStore(path, policies)
+	if err := persistPolicyStore(path, policies); err != nil {
+		return nil, err
+	}
+	return policies, nil
 }
 
 func ensurePolicyStoreDir(dir string) error {

--- a/internal/agentrouting/policy_store_persistence.go
+++ b/internal/agentrouting/policy_store_persistence.go
@@ -69,7 +69,7 @@ func loadPolicyStore(path string) (map[PolicyScope]Policy, error) {
 	decoder := json.NewDecoder(io.LimitReader(file, maxPolicyStoreBytes+1))
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(&snapshot); err != nil {
-		return nil, fmt.Errorf("%w: decode snapshot", ErrInvalidPolicyStore)
+		return nil, fmt.Errorf("%w: decode snapshot: %v", ErrInvalidPolicyStore, err)
 	}
 	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
 		return nil, fmt.Errorf("%w: trailing data", ErrInvalidPolicyStore)
@@ -214,11 +214,11 @@ func writePolicyStoreAtomic(path string, data []byte) error {
 
 func openPolicyStoreLock(path string) (*os.File, error) {
 	lockPath := path + ".lock"
-	handle, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	handle, err := openPolicyStoreLockFile(lockPath)
 	if err != nil {
 		return nil, fmt.Errorf("open policy store lock: %w", err)
 	}
-	if err := securePolicyStoreFile(lockPath); err != nil {
+	if err := securePolicyStoreHandle(handle); err != nil {
 		_ = handle.Close()
 		return nil, fmt.Errorf("secure policy store lock: %w", err)
 	}

--- a/internal/agentrouting/policy_store_persistence.go
+++ b/internal/agentrouting/policy_store_persistence.go
@@ -1,0 +1,187 @@
+package agentrouting
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const (
+	policyStoreFileName = "agent-routing-policies.json"
+	policyStoreVersion  = 1
+	maxPolicyStoreBytes = 4 << 20
+)
+
+var (
+	ErrPolicyStorePathRequired = errors.New("tool route policy store path is required")
+	ErrInvalidPolicyStore      = errors.New("invalid persisted tool route policy store")
+)
+
+type persistedPolicyStore struct {
+	Version  int                     `json:"version"`
+	Policies []persistedScopedPolicy `json:"policies"`
+}
+
+type persistedScopedPolicy struct {
+	Scope  PolicyScope `json:"scope"`
+	Policy Policy      `json:"policy"`
+}
+
+// NewPersistentPolicyStore loads validated routing policies from the shared
+// IaC Studio data directory. Missing storage starts empty; malformed storage
+// fails startup rather than silently discarding authorization policy.
+func NewPersistentPolicyStore(projectsDir string) (*PolicyStore, error) {
+	if strings.TrimSpace(projectsDir) == "" {
+		return nil, ErrPolicyStorePathRequired
+	}
+	path := filepath.Join(filepath.Clean(projectsDir), ".iac-studio", policyStoreFileName)
+	policies, err := loadPolicyStore(path)
+	if err != nil {
+		return nil, err
+	}
+	return &PolicyStore{policies: policies, path: path}, nil
+}
+
+func loadPolicyStore(path string) (map[PolicyScope]Policy, error) {
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return make(map[PolicyScope]Policy), nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("inspect tool route policy store: %w", err)
+	}
+	if !info.Mode().IsRegular() || info.Size() > maxPolicyStoreBytes {
+		return nil, ErrInvalidPolicyStore
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open tool route policy store: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	var snapshot persistedPolicyStore
+	decoder := json.NewDecoder(io.LimitReader(file, maxPolicyStoreBytes+1))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&snapshot); err != nil {
+		return nil, fmt.Errorf("%w: decode snapshot", ErrInvalidPolicyStore)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return nil, fmt.Errorf("%w: trailing data", ErrInvalidPolicyStore)
+	}
+	if snapshot.Version != policyStoreVersion {
+		return nil, fmt.Errorf("%w: unsupported version", ErrInvalidPolicyStore)
+	}
+
+	policies := make(map[PolicyScope]Policy, len(snapshot.Policies))
+	for index, entry := range snapshot.Policies {
+		if err := validateStoredPolicy(entry); err != nil {
+			return nil, fmt.Errorf("%w: policy[%d]: %v", ErrInvalidPolicyStore, index, err)
+		}
+		if _, exists := policies[entry.Scope]; exists {
+			return nil, fmt.Errorf("%w: duplicate policy scope", ErrInvalidPolicyStore)
+		}
+		policies[entry.Scope] = clonePolicy(entry.Policy)
+	}
+	return policies, nil
+}
+
+func validateStoredPolicy(entry persistedScopedPolicy) error {
+	if err := entry.Scope.Validate(); err != nil {
+		return err
+	}
+	if err := entry.Policy.Validate(); err != nil {
+		return err
+	}
+	for _, rule := range entry.Policy.Rules {
+		if rule.Project != entry.Scope.Project || rule.ProviderID != entry.Scope.ProviderID {
+			return ErrPolicyScopeMismatch
+		}
+	}
+	return nil
+}
+
+func persistPolicyStore(path string, policies map[PolicyScope]Policy) error {
+	snapshot := persistedPolicyStore{
+		Version:  policyStoreVersion,
+		Policies: make([]persistedScopedPolicy, 0, len(policies)),
+	}
+	for scope, policy := range policies {
+		snapshot.Policies = append(snapshot.Policies, persistedScopedPolicy{
+			Scope:  scope,
+			Policy: clonePolicy(policy),
+		})
+	}
+	sort.Slice(snapshot.Policies, func(i, j int) bool {
+		if snapshot.Policies[i].Scope.Project == snapshot.Policies[j].Scope.Project {
+			return snapshot.Policies[i].Scope.ProviderID < snapshot.Policies[j].Scope.ProviderID
+		}
+		return snapshot.Policies[i].Scope.Project < snapshot.Policies[j].Scope.Project
+	})
+
+	data, err := json.MarshalIndent(snapshot, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal tool route policy store: %w", err)
+	}
+	if len(data)+1 > maxPolicyStoreBytes {
+		return fmt.Errorf("%w: snapshot exceeds size limit", ErrInvalidPolicyStore)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create tool route policy directory: %w", err)
+	}
+	if err := writePolicyStoreAtomic(path, append(data, '\n')); err != nil {
+		return err
+	}
+	return nil
+}
+
+func writePolicyStoreAtomic(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temporary policy store: %w", err)
+	}
+	tmpPath := tmp.Name()
+	keepTemp := true
+	defer func() {
+		if keepTemp {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("secure temporary policy store: %w", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temporary policy store: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync temporary policy store: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temporary policy store: %w", err)
+	}
+	if err := replacePolicyStoreFile(tmpPath, path); err != nil {
+		return fmt.Errorf("replace tool route policy store: %w", err)
+	}
+	keepTemp = false
+	syncPolicyStoreDirBestEffort(dir)
+	return nil
+}
+
+func syncPolicyStoreDirBestEffort(dir string) {
+	handle, err := os.Open(dir)
+	if err != nil {
+		return
+	}
+	defer func() { _ = handle.Close() }()
+	_ = handle.Sync()
+}

--- a/internal/agentrouting/policy_store_persistence.go
+++ b/internal/agentrouting/policy_store_persistence.go
@@ -145,8 +145,12 @@ func persistPolicyStore(path string, policies map[PolicyScope]Policy) error {
 }
 
 func persistPolicyStoreLocked(path string, scope PolicyScope, policy Policy) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("create tool route policy directory: %w", err)
+	}
+	if err := securePolicyStoreDir(dir); err != nil {
+		return fmt.Errorf("secure tool route policy directory: %w", err)
 	}
 
 	lock, err := openPolicyStoreLock(path)
@@ -213,6 +217,10 @@ func openPolicyStoreLock(path string) (*os.File, error) {
 	handle, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
 		return nil, fmt.Errorf("open policy store lock: %w", err)
+	}
+	if err := securePolicyStoreFile(lockPath); err != nil {
+		_ = handle.Close()
+		return nil, fmt.Errorf("secure policy store lock: %w", err)
 	}
 	return handle, nil
 }

--- a/internal/agentrouting/policy_store_persistence.go
+++ b/internal/agentrouting/policy_store_persistence.go
@@ -39,7 +39,12 @@ func NewPersistentPolicyStore(projectsDir string) (*PolicyStore, error) {
 	if strings.TrimSpace(projectsDir) == "" {
 		return nil, ErrPolicyStorePathRequired
 	}
+	// Preserve the configured path exactly; leading and trailing spaces are
+	// valid filesystem path characters.
 	path := filepath.Join(filepath.Clean(projectsDir), ".iac-studio", policyStoreFileName)
+	if err := secureExistingPolicyStoreDir(filepath.Dir(path), true); err != nil {
+		return nil, err
+	}
 	policies, err := loadPolicyStore(path)
 	if err != nil {
 		return nil, err
@@ -131,13 +136,6 @@ func persistPolicyStore(path string, policies map[PolicyScope]Policy) error {
 	if len(data)+1 > maxPolicyStoreBytes {
 		return fmt.Errorf("%w: snapshot exceeds size limit", ErrInvalidPolicyStore)
 	}
-	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return fmt.Errorf("create tool route policy directory: %w", err)
-	}
-	if err := securePolicyStoreDir(dir); err != nil {
-		return fmt.Errorf("secure tool route policy directory: %w", err)
-	}
 	if err := writePolicyStoreAtomic(path, append(data, '\n')); err != nil {
 		return err
 	}
@@ -146,11 +144,8 @@ func persistPolicyStore(path string, policies map[PolicyScope]Policy) error {
 
 func persistPolicyStoreLocked(path string, scope PolicyScope, policy Policy) error {
 	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return fmt.Errorf("create tool route policy directory: %w", err)
-	}
-	if err := securePolicyStoreDir(dir); err != nil {
-		return fmt.Errorf("secure tool route policy directory: %w", err)
+	if err := ensurePolicyStoreDir(dir); err != nil {
+		return err
 	}
 
 	lock, err := openPolicyStoreLock(path)
@@ -169,6 +164,31 @@ func persistPolicyStoreLocked(path string, scope PolicyScope, policy Policy) err
 	}
 	policies[scope] = clonePolicy(policy)
 	return persistPolicyStore(path, policies)
+}
+
+func ensurePolicyStoreDir(dir string) error {
+	if err := os.MkdirAll(filepath.Dir(dir), 0o700); err != nil {
+		return fmt.Errorf("create tool route policy parent directory: %w", err)
+	}
+	if err := os.Mkdir(dir, 0o700); err != nil && !errors.Is(err, os.ErrExist) {
+		return fmt.Errorf("create tool route policy directory: %w", err)
+	}
+	return secureExistingPolicyStoreDir(dir, false)
+}
+
+func secureExistingPolicyStoreDir(dir string, missingOK bool) error {
+	handle, err := openPolicyStoreDirFile(dir)
+	if missingOK && errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("%w: inspect policy store directory: %v", ErrInvalidPolicyStore, err)
+	}
+	defer func() { _ = handle.Close() }()
+	if err := securePolicyStoreDirHandle(handle); err != nil {
+		return fmt.Errorf("secure tool route policy directory: %w", err)
+	}
+	return nil
 }
 
 func writePolicyStoreAtomic(path string, data []byte) error {

--- a/internal/agentrouting/policy_store_persistence.go
+++ b/internal/agentrouting/policy_store_persistence.go
@@ -140,6 +140,29 @@ func persistPolicyStore(path string, policies map[PolicyScope]Policy) error {
 	return nil
 }
 
+func persistPolicyStoreLocked(path string, scope PolicyScope, policy Policy) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create tool route policy directory: %w", err)
+	}
+
+	lock, err := openPolicyStoreLock(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = lock.Close() }()
+	if err := lockPolicyStoreFile(lock); err != nil {
+		return err
+	}
+	defer func() { _ = unlockPolicyStoreFile(lock) }()
+
+	policies, err := loadPolicyStore(path)
+	if err != nil {
+		return err
+	}
+	policies[scope] = clonePolicy(policy)
+	return persistPolicyStore(path, policies)
+}
+
 func writePolicyStoreAtomic(path string, data []byte) error {
 	dir := filepath.Dir(path)
 	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
@@ -175,6 +198,15 @@ func writePolicyStoreAtomic(path string, data []byte) error {
 	keepTemp = false
 	syncPolicyStoreDirBestEffort(dir)
 	return nil
+}
+
+func openPolicyStoreLock(path string) (*os.File, error) {
+	lockPath := path + ".lock"
+	handle, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open policy store lock: %w", err)
+	}
+	return handle, nil
 }
 
 func syncPolicyStoreDirBestEffort(dir string) {

--- a/internal/agentrouting/policy_store_persistence.go
+++ b/internal/agentrouting/policy_store_persistence.go
@@ -53,22 +53,25 @@ func NewPersistentPolicyStore(projectsDir string) (*PolicyStore, error) {
 }
 
 func loadPolicyStore(path string) (map[PolicyScope]Policy, error) {
-	info, err := os.Lstat(path)
+	file, err := openPolicyStoreDataFile(path)
 	if errors.Is(err, os.ErrNotExist) {
 		return make(map[PolicyScope]Policy), nil
 	}
+	if err != nil {
+		return nil, fmt.Errorf("open tool route policy store: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	info, err := file.Stat()
 	if err != nil {
 		return nil, fmt.Errorf("inspect tool route policy store: %w", err)
 	}
 	if !info.Mode().IsRegular() || info.Size() > maxPolicyStoreBytes {
 		return nil, ErrInvalidPolicyStore
 	}
-
-	file, err := os.Open(path)
-	if err != nil {
-		return nil, fmt.Errorf("open tool route policy store: %w", err)
+	if err := securePolicyStoreHandle(file); err != nil {
+		return nil, fmt.Errorf("secure tool route policy store: %w", err)
 	}
-	defer func() { _ = file.Close() }()
 
 	var snapshot persistedPolicyStore
 	decoder := json.NewDecoder(io.LimitReader(file, maxPolicyStoreBytes+1))

--- a/internal/agentrouting/policy_store_persistence.go
+++ b/internal/agentrouting/policy_store_persistence.go
@@ -131,8 +131,12 @@ func persistPolicyStore(path string, policies map[PolicyScope]Policy) error {
 	if len(data)+1 > maxPolicyStoreBytes {
 		return fmt.Errorf("%w: snapshot exceeds size limit", ErrInvalidPolicyStore)
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("create tool route policy directory: %w", err)
+	}
+	if err := securePolicyStoreDir(dir); err != nil {
+		return fmt.Errorf("secure tool route policy directory: %w", err)
 	}
 	if err := writePolicyStoreAtomic(path, append(data, '\n')); err != nil {
 		return err
@@ -178,6 +182,10 @@ func writePolicyStoreAtomic(path string, data []byte) error {
 	}()
 
 	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("secure temporary policy store: %w", err)
+	}
+	if err := securePolicyStoreFile(tmpPath); err != nil {
 		_ = tmp.Close()
 		return fmt.Errorf("secure temporary policy store: %w", err)
 	}

--- a/internal/agentrouting/policy_store_persistence_test.go
+++ b/internal/agentrouting/policy_store_persistence_test.go
@@ -45,6 +45,47 @@ func TestPersistentPolicyStoreSurvivesRestart(t *testing.T) {
 	}
 }
 
+func TestPersistentPolicyStoreRehardensExistingLockFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows policy store security is ACL-based")
+	}
+	root := t.TempDir()
+	store, err := NewPersistentPolicyStore(root)
+	if err != nil {
+		t.Fatalf("NewPersistentPolicyStore(): %v", err)
+	}
+	scope, policy := validPolicyStoreInput()
+	if err := store.Save(scope, policy); err != nil {
+		t.Fatalf("Save(): %v", err)
+	}
+
+	dir := filepath.Join(root, ".iac-studio")
+	lockPath := filepath.Join(dir, policyStoreFileName+".lock")
+	if err := os.Chmod(dir, 0o777); err != nil {
+		t.Fatalf("Chmod(directory): %v", err)
+	}
+	if err := os.Chmod(lockPath, 0o666); err != nil {
+		t.Fatalf("Chmod(lock): %v", err)
+	}
+	if err := store.Save(scope, policy); err != nil {
+		t.Fatalf("Save() after permission change: %v", err)
+	}
+
+	assertFileMode(t, dir, 0o700)
+	assertFileMode(t, lockPath, 0o600)
+}
+
+func assertFileMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat(%q): %v", path, err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Fatalf("%s permissions = %o, want %o", path, got, want)
+	}
+}
+
 func TestPersistentPolicyStoreRejectsInvalidSnapshots(t *testing.T) {
 	scope, policy := validPolicyStoreInput()
 	crossScoped := persistedPolicyStore{

--- a/internal/agentrouting/policy_store_persistence_test.go
+++ b/internal/agentrouting/policy_store_persistence_test.go
@@ -75,6 +75,29 @@ func TestPersistentPolicyStoreRehardensExistingLockFile(t *testing.T) {
 	assertFileMode(t, lockPath, 0o600)
 }
 
+func TestPersistentPolicyStoreRehardensExistingFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows policy store security is ACL-based")
+	}
+	root := t.TempDir()
+	dir := filepath.Join(root, ".iac-studio")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("MkdirAll(): %v", err)
+	}
+	path := filepath.Join(dir, policyStoreFileName)
+	if err := os.WriteFile(path, []byte(`{"version":1,"policies":[]}`), 0o600); err != nil {
+		t.Fatalf("WriteFile(): %v", err)
+	}
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatalf("Chmod(): %v", err)
+	}
+
+	if _, err := NewPersistentPolicyStore(root); err != nil {
+		t.Fatalf("NewPersistentPolicyStore(): %v", err)
+	}
+	assertFileMode(t, path, 0o600)
+}
+
 func TestPersistentPolicyStoreRejectsSymlinkLockFile(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("creating symlinks on Windows may require elevated privileges")

--- a/internal/agentrouting/policy_store_persistence_test.go
+++ b/internal/agentrouting/policy_store_persistence_test.go
@@ -111,6 +111,52 @@ func TestPersistentPolicyStoreRejectsSymlinkLockFile(t *testing.T) {
 	assertFileMode(t, target, 0o644)
 }
 
+func TestPersistentPolicyStoreRejectsSymlinkDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("creating symlinks on Windows may require elevated privileges")
+	}
+
+	t.Run("startup", func(t *testing.T) {
+		root := t.TempDir()
+		target := t.TempDir()
+		if err := os.Chmod(target, 0o755); err != nil {
+			t.Fatalf("Chmod(target): %v", err)
+		}
+		if err := os.Symlink(target, filepath.Join(root, ".iac-studio")); err != nil {
+			t.Fatalf("Symlink(): %v", err)
+		}
+
+		if _, err := NewPersistentPolicyStore(root); !errors.Is(err, ErrInvalidPolicyStore) {
+			t.Fatalf("NewPersistentPolicyStore() error = %v, want ErrInvalidPolicyStore", err)
+		}
+		assertFileMode(t, target, 0o755)
+	})
+
+	t.Run("save", func(t *testing.T) {
+		root := t.TempDir()
+		store, err := NewPersistentPolicyStore(root)
+		if err != nil {
+			t.Fatalf("NewPersistentPolicyStore(): %v", err)
+		}
+		target := t.TempDir()
+		if err := os.Chmod(target, 0o755); err != nil {
+			t.Fatalf("Chmod(target): %v", err)
+		}
+		if err := os.Symlink(target, filepath.Join(root, ".iac-studio")); err != nil {
+			t.Fatalf("Symlink(): %v", err)
+		}
+
+		scope, policy := validPolicyStoreInput()
+		if err := store.Save(scope, policy); !errors.Is(err, ErrInvalidPolicyStore) {
+			t.Fatalf("Save() error = %v, want ErrInvalidPolicyStore", err)
+		}
+		if _, err := os.Stat(filepath.Join(target, policyStoreFileName)); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("policy file in symlink target error = %v, want not found", err)
+		}
+		assertFileMode(t, target, 0o755)
+	})
+}
+
 func assertFileMode(t *testing.T, path string, want os.FileMode) {
 	t.Helper()
 	info, err := os.Stat(path)

--- a/internal/agentrouting/policy_store_persistence_test.go
+++ b/internal/agentrouting/policy_store_persistence_test.go
@@ -192,6 +192,45 @@ func TestPersistentPolicyStoreConcurrentSavesSurviveRestart(t *testing.T) {
 	}
 }
 
+func TestPersistentPolicyStoreMergesLatestDurableSnapshotAcrossStores(t *testing.T) {
+	root := t.TempDir()
+	first, err := NewPersistentPolicyStore(root)
+	if err != nil {
+		t.Fatalf("NewPersistentPolicyStore(first): %v", err)
+	}
+	second, err := NewPersistentPolicyStore(root)
+	if err != nil {
+		t.Fatalf("NewPersistentPolicyStore(second): %v", err)
+	}
+
+	firstRule := validRule()
+	firstRule.Project = "project-a"
+	firstRule.ProviderID = "provider-a"
+	firstScope := PolicyScope{Project: firstRule.Project, ProviderID: firstRule.ProviderID}
+	if err := first.Save(firstScope, Policy{Rules: []Rule{firstRule}}); err != nil {
+		t.Fatalf("first.Save(): %v", err)
+	}
+
+	secondRule := validRule()
+	secondRule.Project = "project-b"
+	secondRule.ProviderID = "provider-b"
+	secondScope := PolicyScope{Project: secondRule.Project, ProviderID: secondRule.ProviderID}
+	if err := second.Save(secondScope, Policy{Rules: []Rule{secondRule}}); err != nil {
+		t.Fatalf("second.Save(): %v", err)
+	}
+
+	restarted, err := NewPersistentPolicyStore(root)
+	if err != nil {
+		t.Fatalf("NewPersistentPolicyStore(restarted): %v", err)
+	}
+	if _, err := restarted.Get(firstScope); err != nil {
+		t.Fatalf("Get(firstScope): %v", err)
+	}
+	if _, err := restarted.Get(secondScope); err != nil {
+		t.Fatalf("Get(secondScope): %v", err)
+	}
+}
+
 func TestPersistentPolicyStoreRequiresProjectsDirectory(t *testing.T) {
 	if _, err := NewPersistentPolicyStore("  "); !errors.Is(err, ErrPolicyStorePathRequired) {
 		t.Fatalf("NewPersistentPolicyStore(empty) error = %v, want ErrPolicyStorePathRequired", err)

--- a/internal/agentrouting/policy_store_persistence_test.go
+++ b/internal/agentrouting/policy_store_persistence_test.go
@@ -75,6 +75,42 @@ func TestPersistentPolicyStoreRehardensExistingLockFile(t *testing.T) {
 	assertFileMode(t, lockPath, 0o600)
 }
 
+func TestPersistentPolicyStoreRejectsSymlinkLockFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("creating symlinks on Windows may require elevated privileges")
+	}
+	root := t.TempDir()
+	dir := filepath.Join(root, ".iac-studio")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("MkdirAll(): %v", err)
+	}
+	target := filepath.Join(root, "target")
+	if err := os.WriteFile(target, []byte("unchanged"), 0o644); err != nil {
+		t.Fatalf("WriteFile(target): %v", err)
+	}
+	lockPath := filepath.Join(dir, policyStoreFileName+".lock")
+	if err := os.Symlink(target, lockPath); err != nil {
+		t.Fatalf("Symlink(): %v", err)
+	}
+
+	store, err := NewPersistentPolicyStore(root)
+	if err != nil {
+		t.Fatalf("NewPersistentPolicyStore(): %v", err)
+	}
+	scope, policy := validPolicyStoreInput()
+	if err := store.Save(scope, policy); err == nil {
+		t.Fatal("Save() succeeded with a symlink lock file")
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile(target): %v", err)
+	}
+	if string(data) != "unchanged" {
+		t.Fatalf("target contents = %q, want unchanged", data)
+	}
+	assertFileMode(t, target, 0o644)
+}
+
 func assertFileMode(t *testing.T, path string, want os.FileMode) {
 	t.Helper()
 	info, err := os.Stat(path)
@@ -134,6 +170,25 @@ func TestPersistentPolicyStoreRejectsInvalidSnapshots(t *testing.T) {
 				t.Fatalf("NewPersistentPolicyStore() error = %v, want ErrInvalidPolicyStore", err)
 			}
 		})
+	}
+}
+
+func TestPersistentPolicyStoreReportsDecodeFailure(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, ".iac-studio")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("MkdirAll(): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, policyStoreFileName), []byte(`{"version":1,"policies":[`), 0o600); err != nil {
+		t.Fatalf("WriteFile(): %v", err)
+	}
+
+	_, err := NewPersistentPolicyStore(root)
+	if !errors.Is(err, ErrInvalidPolicyStore) {
+		t.Fatalf("NewPersistentPolicyStore() error = %v, want ErrInvalidPolicyStore", err)
+	}
+	if !strings.Contains(err.Error(), "unexpected EOF") {
+		t.Fatalf("NewPersistentPolicyStore() error = %q, want decoder detail", err)
 	}
 }
 

--- a/internal/agentrouting/policy_store_persistence_test.go
+++ b/internal/agentrouting/policy_store_persistence_test.go
@@ -134,6 +134,65 @@ func TestPersistentPolicyStoreRejectsSymlinkLockFile(t *testing.T) {
 	assertFileMode(t, target, 0o644)
 }
 
+func TestPersistentPolicyStoreRejectsHardLinkedLockFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("hard-link behavior is covered by Windows handle metadata checks")
+	}
+	root := t.TempDir()
+	dir := filepath.Join(root, ".iac-studio")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("MkdirAll(): %v", err)
+	}
+	target := filepath.Join(root, "target")
+	if err := os.WriteFile(target, []byte("unchanged"), 0o644); err != nil {
+		t.Fatalf("WriteFile(target): %v", err)
+	}
+	lockPath := filepath.Join(dir, policyStoreFileName+".lock")
+	if err := os.Link(target, lockPath); err != nil {
+		t.Fatalf("Link(): %v", err)
+	}
+
+	store, err := NewPersistentPolicyStore(root)
+	if err != nil {
+		t.Fatalf("NewPersistentPolicyStore(): %v", err)
+	}
+	scope, policy := validPolicyStoreInput()
+	if err := store.Save(scope, policy); err == nil {
+		t.Fatal("Save() succeeded with a hard-linked lock file")
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile(target): %v", err)
+	}
+	if string(data) != "unchanged" {
+		t.Fatalf("target contents = %q, want unchanged", data)
+	}
+	assertFileMode(t, target, 0o644)
+}
+
+func TestPersistentPolicyStoreRejectsHardLinkedDataFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("hard-link behavior is covered by Windows handle metadata checks")
+	}
+	root := t.TempDir()
+	dir := filepath.Join(root, ".iac-studio")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("MkdirAll(): %v", err)
+	}
+	target := filepath.Join(root, "target")
+	if err := os.WriteFile(target, []byte(`{"version":1,"policies":[]}`), 0o644); err != nil {
+		t.Fatalf("WriteFile(target): %v", err)
+	}
+	if err := os.Link(target, filepath.Join(dir, policyStoreFileName)); err != nil {
+		t.Fatalf("Link(): %v", err)
+	}
+
+	if _, err := NewPersistentPolicyStore(root); !errors.Is(err, ErrInvalidPolicyStore) {
+		t.Fatalf("NewPersistentPolicyStore() error = %v, want ErrInvalidPolicyStore", err)
+	}
+	assertFileMode(t, target, 0o644)
+}
+
 func TestPersistentPolicyStoreRejectsSymlinkDirectory(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("creating symlinks on Windows may require elevated privileges")

--- a/internal/agentrouting/policy_store_persistence_test.go
+++ b/internal/agentrouting/policy_store_persistence_test.go
@@ -1,0 +1,199 @@
+package agentrouting
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestPersistentPolicyStoreSurvivesRestart(t *testing.T) {
+	root := t.TempDir()
+	scope, policy := validPolicyStoreInput()
+	store, err := NewPersistentPolicyStore(root)
+	if err != nil {
+		t.Fatalf("NewPersistentPolicyStore(): %v", err)
+	}
+	if err := store.Save(scope, policy); err != nil {
+		t.Fatalf("Save(): %v", err)
+	}
+
+	path := filepath.Join(root, ".iac-studio", policyStoreFileName)
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat(%q): %v", path, err)
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
+		t.Fatalf("policy store permissions = %o, want 600", info.Mode().Perm())
+	}
+
+	restarted, err := NewPersistentPolicyStore(root)
+	if err != nil {
+		t.Fatalf("NewPersistentPolicyStore() after restart: %v", err)
+	}
+	stored, err := restarted.Get(scope)
+	if err != nil {
+		t.Fatalf("Get(): %v", err)
+	}
+	if stored.Rules[0].Effect != policy.Rules[0].Effect || stored.Rules[0].ToolName != policy.Rules[0].ToolName {
+		t.Fatalf("reloaded policy = %+v, want %+v", stored, policy)
+	}
+}
+
+func TestPersistentPolicyStoreRejectsInvalidSnapshots(t *testing.T) {
+	scope, policy := validPolicyStoreInput()
+	crossScoped := persistedPolicyStore{
+		Version: policyStoreVersion,
+		Policies: []persistedScopedPolicy{{
+			Scope:  PolicyScope{Project: "other-project", ProviderID: scope.ProviderID},
+			Policy: policy,
+		}},
+	}
+	duplicate := persistedPolicyStore{
+		Version: policyStoreVersion,
+		Policies: []persistedScopedPolicy{
+			{Scope: scope, Policy: policy},
+			{Scope: scope, Policy: policy},
+		},
+	}
+	encode := func(snapshot persistedPolicyStore) []byte {
+		data, err := json.Marshal(snapshot)
+		if err != nil {
+			t.Fatalf("Marshal(): %v", err)
+		}
+		return data
+	}
+
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{name: "malformed JSON", data: []byte(`{"version":1,"policies":[`)},
+		{name: "unsupported version", data: []byte(`{"version":2,"policies":[]}`)},
+		{name: "unknown field", data: []byte(`{"version":1,"policies":[],"extra":true}`)},
+		{name: "cross-scoped rule", data: encode(crossScoped)},
+		{name: "duplicate scope", data: encode(duplicate)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			dir := filepath.Join(root, ".iac-studio")
+			if err := os.MkdirAll(dir, 0o700); err != nil {
+				t.Fatalf("MkdirAll(): %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(dir, policyStoreFileName), test.data, 0o600); err != nil {
+				t.Fatalf("WriteFile(): %v", err)
+			}
+			if _, err := NewPersistentPolicyStore(root); !errors.Is(err, ErrInvalidPolicyStore) {
+				t.Fatalf("NewPersistentPolicyStore() error = %v, want ErrInvalidPolicyStore", err)
+			}
+		})
+	}
+}
+
+func TestPersistentPolicyStoreFailedWriteKeepsActiveSnapshot(t *testing.T) {
+	scope, policy := validPolicyStoreInput()
+	store := NewPolicyStore()
+	if err := store.Save(scope, policy); err != nil {
+		t.Fatalf("Save(existing): %v", err)
+	}
+
+	blocker := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(blocker, []byte("blocked"), 0o600); err != nil {
+		t.Fatalf("WriteFile(blocker): %v", err)
+	}
+	store.path = filepath.Join(blocker, policyStoreFileName)
+	replacement := clonePolicy(policy)
+	replacement.Rules[0].Effect = EffectDeny
+	replacement.Rules[0].ApprovalRequired = false
+	if err := store.Save(scope, replacement); err == nil {
+		t.Fatal("Save(replacement) succeeded with an invalid storage path")
+	}
+
+	stored, err := store.Get(scope)
+	if err != nil {
+		t.Fatalf("Get(): %v", err)
+	}
+	if stored.Rules[0].Effect != EffectAllow {
+		t.Fatalf("failed persistence replaced active policy: %+v", stored)
+	}
+}
+
+func TestPersistentPolicyStoreRejectsOversizedSnapshotBeforeMutation(t *testing.T) {
+	scope, policy := validPolicyStoreInput()
+	store, err := NewPersistentPolicyStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewPersistentPolicyStore(): %v", err)
+	}
+	if err := store.Save(scope, policy); err != nil {
+		t.Fatalf("Save(existing): %v", err)
+	}
+
+	replacement := clonePolicy(policy)
+	replacement.Rules[0].ToolName = strings.Repeat("x", maxPolicyStoreBytes)
+	if err := store.Save(scope, replacement); !errors.Is(err, ErrInvalidPolicyStore) {
+		t.Fatalf("Save(oversized) error = %v, want ErrInvalidPolicyStore", err)
+	}
+	stored, err := store.Get(scope)
+	if err != nil {
+		t.Fatalf("Get(): %v", err)
+	}
+	if stored.Rules[0].ToolName != policy.Rules[0].ToolName {
+		t.Fatalf("oversized persistence replaced active policy")
+	}
+}
+
+func TestPersistentPolicyStoreConcurrentSavesSurviveRestart(t *testing.T) {
+	root := t.TempDir()
+	store, err := NewPersistentPolicyStore(root)
+	if err != nil {
+		t.Fatalf("NewPersistentPolicyStore(): %v", err)
+	}
+
+	const count = 12
+	var wg sync.WaitGroup
+	errs := make(chan error, count)
+	for index := range count {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			rule := validRule()
+			rule.Project = fmt.Sprintf("project-%02d", index)
+			rule.ProviderID = fmt.Sprintf("provider-%02d", index)
+			scope := PolicyScope{Project: rule.Project, ProviderID: rule.ProviderID}
+			errs <- store.Save(scope, Policy{Rules: []Rule{rule}})
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent Save(): %v", err)
+		}
+	}
+
+	restarted, err := NewPersistentPolicyStore(root)
+	if err != nil {
+		t.Fatalf("NewPersistentPolicyStore() after concurrent saves: %v", err)
+	}
+	for index := range count {
+		scope := PolicyScope{
+			Project:    fmt.Sprintf("project-%02d", index),
+			ProviderID: fmt.Sprintf("provider-%02d", index),
+		}
+		if _, err := restarted.Get(scope); err != nil {
+			t.Fatalf("Get(%+v): %v", scope, err)
+		}
+	}
+}
+
+func TestPersistentPolicyStoreRequiresProjectsDirectory(t *testing.T) {
+	if _, err := NewPersistentPolicyStore("  "); !errors.Is(err, ErrPolicyStorePathRequired) {
+		t.Fatalf("NewPersistentPolicyStore(empty) error = %v, want ErrPolicyStorePathRequired", err)
+	}
+}


### PR DESCRIPTION
## Summary
- load and persist exact project/provider routing-policy snapshots across server restarts
- validate versioned snapshots strictly and fail startup closed on corruption, duplicates, cross-scope rules, trailing data, or oversized files
- replace policy files atomically with private permissions on Unix and Windows
- keep readers on the last durable snapshot while serialized saves perform filesystem I/O

## Security
- active in-memory policy changes only after durable replacement succeeds
- malformed persisted policy is never silently discarded or treated as an empty allow policy
- storage is capped at 4 MiB and written with `0600` permissions
- this slice adds no policy mutation API, credential access, or MCP tool execution

## Validation
- `GOCACHE=/private/tmp/iacstudio-go-cache go test -race ./internal/agentrouting ./cmd/server`
- `GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/... ./cmd/...`
- `GOCACHE=/private/tmp/iacstudio-go-cache go vet ./internal/agentrouting ./cmd/server`
- Windows amd64 test-binary compilation for `./internal/agentrouting` and `./cmd/server`

Part of #107