### PR TITLE
Add guarded Agent Hub policy writes

### DIFF
--- a/internal/api/agent_tool_policies.go
+++ b/internal/api/agent_tool_policies.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"errors"
+	"io"
 	"log"
 	"net/http"
 
@@ -16,34 +17,109 @@ type AgentToolPolicyReader interface {
 	Get(scope agentrouting.PolicyScope) (agentrouting.Policy, error)
 }
 
+// AgentToolPolicyStore reads and replaces exact scoped policy snapshots.
+type AgentToolPolicyStore interface {
+	AgentToolPolicyReader
+	Save(scope agentrouting.PolicyScope, policy agentrouting.Policy) error
+}
+
 type agentToolPolicyResponse struct {
 	Scope  agentrouting.PolicyScope `json:"scope"`
 	Policy agentrouting.Policy      `json:"policy"`
 }
 
-func registerAgentToolPolicyRoutes(mux *http.ServeMux, projectsDir string, policies AgentToolPolicyReader) {
+func registerAgentToolPolicyRoutes(mux *http.ServeMux, projectsDir string, policies AgentToolPolicyStore) {
 	if policies == nil {
 		return
 	}
 	mux.HandleFunc("GET /api/projects/{name}/agent-routing/policies/{provider}", func(w http.ResponseWriter, r *http.Request) {
-		project := r.PathValue("name")
-		if !requireExistingAgentRunProject(w, projectsDir, project) {
+		scope, ok := agentToolPolicyScope(w, r, projectsDir)
+		if !ok {
 			return
 		}
-		providerID := r.PathValue("provider")
-		if len(providerID) > maxAgentToolPolicyProviderIDLength || safePathSegment(providerID) != nil {
-			http.Error(w, "invalid agent tool policy provider", http.StatusBadRequest)
-			return
-		}
-		scope := agentrouting.PolicyScope{Project: project, ProviderID: providerID}
 		policy, err := policies.Get(scope)
 		if err != nil {
 			writeAgentToolPolicyReadError(w, err)
 			return
 		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(agentToolPolicyResponse{Scope: scope, Policy: policy})
+		writeAgentToolPolicyResponse(w, scope, policy)
 	})
+
+	mux.HandleFunc("PUT /api/projects/{name}/agent-routing/policies/{provider}", func(w http.ResponseWriter, r *http.Request) {
+		limitBody(w, r)
+		if !requireJSONContentType(w, r) {
+			return
+		}
+		scope, ok := agentToolPolicyScope(w, r, projectsDir)
+		if !ok {
+			return
+		}
+
+		var policy agentrouting.Policy
+		decoder := json.NewDecoder(r.Body)
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(&policy); err != nil {
+			writeAgentToolPolicyBodyError(w, err)
+			return
+		}
+		if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+			writeAgentToolPolicyBodyError(w, err)
+			return
+		}
+		if policy.Rules == nil {
+			http.Error(w, "invalid request body", http.StatusBadRequest)
+			return
+		}
+		if err := policies.Save(scope, policy); err != nil {
+			writeAgentToolPolicySaveError(w, err)
+			return
+		}
+		saved, err := policies.Get(scope)
+		if err != nil {
+			writeAgentToolPolicyReadError(w, err)
+			return
+		}
+		writeAgentToolPolicyResponse(w, scope, saved)
+	})
+}
+
+func agentToolPolicyScope(w http.ResponseWriter, r *http.Request, projectsDir string) (agentrouting.PolicyScope, bool) {
+	project := r.PathValue("name")
+	if !requireExistingAgentRunProject(w, projectsDir, project) {
+		return agentrouting.PolicyScope{}, false
+	}
+	providerID := r.PathValue("provider")
+	if len(providerID) > maxAgentToolPolicyProviderIDLength || safePathSegment(providerID) != nil {
+		http.Error(w, "invalid agent tool policy provider", http.StatusBadRequest)
+		return agentrouting.PolicyScope{}, false
+	}
+	return agentrouting.PolicyScope{Project: project, ProviderID: providerID}, true
+}
+
+func writeAgentToolPolicyResponse(w http.ResponseWriter, scope agentrouting.PolicyScope, policy agentrouting.Policy) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(agentToolPolicyResponse{Scope: scope, Policy: policy})
+}
+
+func writeAgentToolPolicyBodyError(w http.ResponseWriter, err error) {
+	var maxBytes *http.MaxBytesError
+	if errors.As(err, &maxBytes) {
+		http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+		return
+	}
+	http.Error(w, "invalid request body", http.StatusBadRequest)
+}
+
+func writeAgentToolPolicySaveError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, agentrouting.ErrInvalidPolicyScope),
+		errors.Is(err, agentrouting.ErrInvalidRule),
+		errors.Is(err, agentrouting.ErrPolicyScopeMismatch):
+		http.Error(w, "invalid agent tool policy", http.StatusBadRequest)
+	default:
+		log.Printf("agent tool policy save failed (%T)", err)
+		http.Error(w, "agent tool policy save failed", http.StatusInternalServerError)
+	}
 }
 
 func writeAgentToolPolicyReadError(w http.ResponseWriter, err error) {

--- a/internal/api/agent_tool_policies_test.go
+++ b/internal/api/agent_tool_policies_test.go
@@ -15,15 +15,19 @@ import (
 	"github.com/iac-studio/iac-studio/internal/mcpairlock"
 )
 
-type failingAgentToolPolicyReader struct {
+type failingAgentToolPolicyStore struct {
 	err error
 }
 
-func (r failingAgentToolPolicyReader) Get(agentrouting.PolicyScope) (agentrouting.Policy, error) {
+func (r failingAgentToolPolicyStore) Get(agentrouting.PolicyScope) (agentrouting.Policy, error) {
 	return agentrouting.Policy{}, r.err
 }
 
-func agentToolPolicyMux(root string, policies AgentToolPolicyReader) *http.ServeMux {
+func (r failingAgentToolPolicyStore) Save(agentrouting.PolicyScope, agentrouting.Policy) error {
+	return r.err
+}
+
+func agentToolPolicyMux(root string, policies AgentToolPolicyStore) *http.ServeMux {
 	mux := http.NewServeMux()
 	registerAgentToolPolicyRoutes(mux, root, policies)
 	return mux
@@ -92,13 +96,13 @@ func TestAgentToolPolicyRouteRejectsInvalidScopeAndSanitizesErrors(t *testing.T)
 	tests := []struct {
 		name   string
 		path   string
-		reader AgentToolPolicyReader
+		reader AgentToolPolicyStore
 		status int
 	}{
 		{name: "missing project", path: "/api/projects/missing/agent-routing/policies/codex", reader: agentrouting.NewPolicyStore(), status: http.StatusNotFound},
 		{name: "invalid provider", path: "/api/projects/demo/agent-routing/policies/bad.provider", reader: agentrouting.NewPolicyStore(), status: http.StatusBadRequest},
 		{name: "long provider", path: "/api/projects/demo/agent-routing/policies/" + strings.Repeat("x", maxAgentToolPolicyProviderIDLength+1), reader: agentrouting.NewPolicyStore(), status: http.StatusBadRequest},
-		{name: "reader failure", path: "/api/projects/demo/agent-routing/policies/codex", reader: failingAgentToolPolicyReader{err: errors.New("token=policy-secret")}, status: http.StatusInternalServerError},
+		{name: "reader failure", path: "/api/projects/demo/agent-routing/policies/codex", reader: failingAgentToolPolicyStore{err: errors.New("token=policy-secret")}, status: http.StatusInternalServerError},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -111,6 +115,108 @@ func TestAgentToolPolicyRouteRejectsInvalidScopeAndSanitizesErrors(t *testing.T)
 				t.Fatalf("response leaked reader error: %s", rec.Body.String())
 			}
 		})
+	}
+}
+
+func TestAgentToolPolicyRouteSavesExactScopedPolicy(t *testing.T) {
+	root := scaffoldAgentRunProject(t)
+	scope, policy := testAgentToolPolicy()
+	store, err := agentrouting.NewPersistentPolicyStore(root)
+	if err != nil {
+		t.Fatalf("NewPersistentPolicyStore(): %v", err)
+	}
+	body, err := json.Marshal(policy)
+	if err != nil {
+		t.Fatalf("Marshal(): %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPut, "/api/projects/demo/agent-routing/policies/codex", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	agentToolPolicyMux(root, store).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	requireJSONResponse(t, rec)
+	var response agentToolPolicyResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Scope != scope || len(response.Policy.Rules) != 1 || response.Policy.Rules[0].ToolName != "list_buckets" {
+		t.Fatalf("response = %+v, want saved exact scoped policy", response)
+	}
+
+	restarted, err := agentrouting.NewPersistentPolicyStore(root)
+	if err != nil {
+		t.Fatalf("NewPersistentPolicyStore(restart): %v", err)
+	}
+	stored, err := restarted.Get(scope)
+	if err != nil {
+		t.Fatalf("Get(restarted): %v", err)
+	}
+	if len(stored.Rules) != 1 || stored.Rules[0].ToolName != "list_buckets" {
+		t.Fatalf("restarted policy = %+v, want saved policy", stored)
+	}
+}
+
+func TestAgentToolPolicyRouteRejectsInvalidWrites(t *testing.T) {
+	root := scaffoldAgentRunProject(t)
+	_, policy := testAgentToolPolicy()
+	crossScoped := policy
+	crossScoped.Rules = append([]agentrouting.Rule(nil), policy.Rules...)
+	crossScoped.Rules[0].Project = "other"
+	crossScopedBody, err := json.Marshal(crossScoped)
+	if err != nil {
+		t.Fatalf("Marshal(crossScoped): %v", err)
+	}
+
+	tests := []struct {
+		name        string
+		body        string
+		contentType string
+		status      int
+	}{
+		{name: "cross-scoped rule", body: string(crossScopedBody), contentType: "application/json", status: http.StatusBadRequest},
+		{name: "unknown field", body: `{"rules":[],"scope":{"project":"other"}}`, contentType: "application/json", status: http.StatusBadRequest},
+		{name: "trailing value", body: `{"rules":[]} {}`, contentType: "application/json", status: http.StatusBadRequest},
+		{name: "missing rules", body: `{}`, contentType: "application/json", status: http.StatusBadRequest},
+		{name: "null rules", body: `{"rules":null}`, contentType: "application/json", status: http.StatusBadRequest},
+		{name: "null policy", body: `null`, contentType: "application/json", status: http.StatusBadRequest},
+		{name: "wrong content type", body: `{"rules":[]}`, contentType: "text/plain", status: http.StatusUnsupportedMediaType},
+		{name: "oversized", body: `{"rules":[]}` + strings.Repeat(" ", maxRequestBody), contentType: "application/json", status: http.StatusRequestEntityTooLarge},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store := agentrouting.NewPolicyStore()
+			req := httptest.NewRequest(http.MethodPut, "/api/projects/demo/agent-routing/policies/codex", strings.NewReader(test.body))
+			req.Header.Set("Content-Type", test.contentType)
+			rec := httptest.NewRecorder()
+			agentToolPolicyMux(root, store).ServeHTTP(rec, req)
+			if rec.Code != test.status {
+				t.Fatalf("status = %d, want %d, body = %s", rec.Code, test.status, rec.Body.String())
+			}
+			if _, err := store.Get(agentrouting.PolicyScope{Project: "demo", ProviderID: "codex"}); !errors.Is(err, agentrouting.ErrPolicyNotFound) {
+				t.Fatalf("Get() error = %v, want ErrPolicyNotFound", err)
+			}
+		})
+	}
+}
+
+func TestAgentToolPolicyRouteSanitizesSaveErrors(t *testing.T) {
+	root := scaffoldAgentRunProject(t)
+	_, policy := testAgentToolPolicy()
+	body, err := json.Marshal(policy)
+	if err != nil {
+		t.Fatalf("Marshal(): %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPut, "/api/projects/demo/agent-routing/policies/codex", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	agentToolPolicyMux(root, failingAgentToolPolicyStore{err: errors.New("token=policy-secret")}).ServeHTTP(rec, req)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d, body = %s", rec.Code, http.StatusInternalServerError, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "policy-secret") {
+		t.Fatalf("response leaked save error: %s", rec.Body.String())
 	}
 }
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1052,7 +1052,7 @@ func writeAgentProviderProfileSaveError(w http.ResponseWriter, operation string,
 type RouterOptions struct {
 	MCPAirlock               *mcpairlock.Manager
 	AgentRuns                *agentruns.Store
-	AgentToolPolicies        AgentToolPolicyReader
+	AgentToolPolicies        AgentToolPolicyStore
 	AgentToolRouter          AgentToolRouter
 	AgentProviderProfiles    *agentproviderconnections.Manager
 	AppVersion               string


### PR DESCRIPTION
## Summary
- add a strict `PUT /api/projects/{project}/agent-routing/policies/{provider}` endpoint
- derive project/provider scope exclusively from the request path
- persist validated policy snapshots and return the saved detached representation
- preserve the existing exact-scope read endpoint

## Security
- reject unknown fields, trailing JSON, implicit/null rule sets, oversized bodies, and cross-scope rules
- keep non-read-only allow rules behind the existing approval requirement
- sanitize storage and validation failures in API responses
- do not invoke MCP tools, access cloud credentials, or change Agent Run state

## Validation
- `GOCACHE=/private/tmp/iacstudio-go-cache go test -race ./internal/api -run TestAgentToolPolicy`
- `GOCACHE=/private/tmp/iacstudio-go-cache go test -race ./internal/api ./internal/agentrouting ./cmd/server`
- `GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/... ./cmd/...`
- `GOCACHE=/private/tmp/iacstudio-go-cache go vet ./internal/api ./internal/agentrouting ./cmd/server`
- Windows amd64 test-binary compilation for `./internal/api` and `./cmd/server`

Part of #107
