### PR TITLE
Add guarded MCP route decision preview

### DIFF
--- a/internal/agentrouting/router.go
+++ b/internal/agentrouting/router.go
@@ -42,6 +42,9 @@ func (r *Router) Preview(request Request) (Decision, error) {
 	if r == nil || r.authorizer == nil {
 		return Decision{}, ErrAuthorizerRequired
 	}
+	if err := request.Validate(); err != nil {
+		return Decision{}, err
+	}
 	decision := r.authorizer.Authorize(request)
 	if err := decision.Validate(); err != nil {
 		return Decision{}, fmt.Errorf("validate tool route preview: %w", err)

--- a/internal/agentrouting/router.go
+++ b/internal/agentrouting/router.go
@@ -36,6 +36,19 @@ func NewRouter(authorizer *Authorizer, recorder *RunRecorder) (*Router, error) {
 	return &Router{authorizer: authorizer, recorder: recorder}, nil
 }
 
+// Preview evaluates one fully scoped tool route without recording the outcome
+// or invoking an external MCP tool.
+func (r *Router) Preview(request Request) (Decision, error) {
+	if r == nil || r.authorizer == nil {
+		return Decision{}, ErrAuthorizerRequired
+	}
+	decision := r.authorizer.Authorize(request)
+	if err := decision.Validate(); err != nil {
+		return Decision{}, fmt.Errorf("validate tool route preview: %w", err)
+	}
+	return decision, nil
+}
+
 // Route authorizes one fully scoped tool route and records the outcome before
 // returning it. Recorder failures return a zero result so callers cannot act
 // on an authorization decision that was not audited.

--- a/internal/agentrouting/router_test.go
+++ b/internal/agentrouting/router_test.go
@@ -2,11 +2,36 @@ package agentrouting
 
 import (
 	"errors"
+	"reflect"
 	"testing"
 
 	"github.com/iac-studio/iac-studio/internal/agentruns"
 	"github.com/iac-studio/iac-studio/internal/mcpairlock"
 )
+
+func TestRouterPreviewsWithoutRecording(t *testing.T) {
+	policy, request, airlock := readOnlyEvaluation()
+	router, evaluator, store, run := routerFixture(t, policy, request, airlock)
+	before, ok := store.Get(run.ID)
+	if !ok {
+		t.Fatalf("Get(%q) returned no run", run.ID)
+	}
+
+	decision, err := router.Preview(request)
+	if err != nil {
+		t.Fatalf("Preview(): %v", err)
+	}
+	if decision.Status != DecisionAllowed || !decision.Allowed {
+		t.Fatalf("Preview() = %+v, want allowed decision", decision)
+	}
+	after, ok := store.Get(run.ID)
+	if !ok || !reflect.DeepEqual(after, before) {
+		t.Fatalf("run mutated by Preview(): before=%+v after=%+v", before, after)
+	}
+	if evaluator.calls != 1 {
+		t.Fatalf("EvaluateTool calls = %d, want one read-only evaluation", evaluator.calls)
+	}
+}
 
 func routerFixture(t *testing.T, policy Policy, request Request, airlock mcpairlock.ToolDecision) (*Router, *fakeToolEvaluator, *agentruns.Store, agentruns.Run) {
 	t.Helper()
@@ -144,6 +169,9 @@ func TestRouterRejectsMissingDependencies(t *testing.T) {
 		t.Fatalf("NewRouter(nil recorder) error = %v, want ErrRunRecorderRequired", err)
 	}
 	var nilRouter *Router
+	if _, err := nilRouter.Preview(request); !errors.Is(err, ErrAuthorizerRequired) {
+		t.Fatalf("nil Preview() error = %v, want ErrAuthorizerRequired", err)
+	}
 	if _, err := nilRouter.Route("run_000001", request); !errors.Is(err, ErrAuthorizerRequired) {
 		t.Fatalf("nil Route() error = %v, want ErrAuthorizerRequired", err)
 	}

--- a/internal/agentrouting/router_test.go
+++ b/internal/agentrouting/router_test.go
@@ -33,6 +33,31 @@ func TestRouterPreviewsWithoutRecording(t *testing.T) {
 	}
 }
 
+func TestRouterPreviewRejectsInvalidRequestBeforeAuthorization(t *testing.T) {
+	policy, request, airlock := readOnlyEvaluation()
+	router, evaluator, store, run := routerFixture(t, policy, request, airlock)
+	before, ok := store.Get(run.ID)
+	if !ok {
+		t.Fatalf("Get(%q) returned no run", run.ID)
+	}
+	request.ToolName = ""
+
+	decision, err := router.Preview(request)
+	if !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("Preview() error = %v, want ErrInvalidRequest", err)
+	}
+	if decision != (Decision{}) {
+		t.Fatalf("Preview() decision = %+v, want zero decision", decision)
+	}
+	after, ok := store.Get(run.ID)
+	if !ok || !reflect.DeepEqual(after, before) {
+		t.Fatalf("run mutated by invalid preview: before=%+v after=%+v", before, after)
+	}
+	if evaluator.calls != 0 {
+		t.Fatalf("EvaluateTool calls = %d, want none for an invalid request", evaluator.calls)
+	}
+}
+
 func routerFixture(t *testing.T, policy Policy, request Request, airlock mcpairlock.ToolDecision) (*Router, *fakeToolEvaluator, *agentruns.Store, agentruns.Run) {
 	t.Helper()
 	evaluator := &fakeToolEvaluator{entry: evaluationEntry(request, airlock)}

--- a/internal/api/agent_tool_routes.go
+++ b/internal/api/agent_tool_routes.go
@@ -12,9 +12,10 @@ import (
 	"github.com/iac-studio/iac-studio/internal/mcpairlock"
 )
 
-// AgentToolRouter authorizes and records one fully scoped tool route without
+// AgentToolRouter previews or records one fully scoped tool route without
 // invoking the external tool.
 type AgentToolRouter interface {
+	Preview(request agentrouting.Request) (agentrouting.Decision, error)
 	Route(runID string, request agentrouting.Request) (agentrouting.RouteResult, error)
 }
 
@@ -45,43 +46,8 @@ func registerAgentToolRouteRoutes(
 		if !ok {
 			return
 		}
-		name := r.PathValue("name")
-		if !requireExistingAgentRunProject(w, projectsDir, name) {
-			return
-		}
-		run, ok := store.Get(r.PathValue("id"))
-		if !ok || run.Project != name {
-			http.Error(w, "agent run not found", http.StatusNotFound)
-			return
-		}
-		if run.ProviderID == "" {
-			http.Error(w, "agent run provider is not configured", http.StatusConflict)
-			return
-		}
-
-		var req agentToolRouteAuthorizeRequest
-		decoder := json.NewDecoder(r.Body)
-		decoder.DisallowUnknownFields()
-		if err := decoder.Decode(&req); err != nil {
-			writeAgentToolRouteBodyError(w, err)
-			return
-		}
-		if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
-			writeAgentToolRouteBodyError(w, err)
-			return
-		}
-
-		routeRequest := agentrouting.Request{
-			Project:      run.Project,
-			ProviderID:   run.ProviderID,
-			ConnectionID: req.ConnectionID,
-			ServerID:     req.ServerID,
-			ToolName:     req.ToolName,
-			Mode:         run.Mode,
-			Risk:         req.Risk,
-		}
-		if err := routeRequest.Validate(); err != nil {
-			http.Error(w, "invalid tool route request", http.StatusBadRequest)
+		run, routeRequest, ok := readAgentToolRouteRequest(w, r, projectsDir, store)
+		if !ok {
 			return
 		}
 
@@ -104,6 +70,89 @@ func registerAgentToolRouteRoutes(
 		setAgentRunJSONHeader(w)
 		_ = json.NewEncoder(w).Encode(result)
 	})
+
+	mux.HandleFunc("POST /api/projects/{name}/agent-runs/{id}/tool-routes/preview", func(w http.ResponseWriter, r *http.Request) {
+		limitBody(w, r)
+		if !requireJSONContentType(w, r) {
+			return
+		}
+		run, routeRequest, ok := readAgentToolRouteRequest(w, r, projectsDir, store)
+		if !ok {
+			return
+		}
+		if agentToolRouteRunIsTerminal(run.Status) {
+			http.Error(w, "agent run cannot preview this tool route", http.StatusConflict)
+			return
+		}
+
+		decision, err := router.Preview(routeRequest)
+		if err == nil {
+			err = decision.Validate()
+		}
+		if err != nil {
+			writeAgentToolRoutePreviewError(w, err)
+			return
+		}
+		setAgentRunJSONHeader(w)
+		_ = json.NewEncoder(w).Encode(map[string]agentrouting.Decision{"decision": decision})
+	})
+}
+
+func readAgentToolRouteRequest(
+	w http.ResponseWriter,
+	r *http.Request,
+	projectsDir string,
+	store *agentruns.Store,
+) (agentruns.Run, agentrouting.Request, bool) {
+	name := r.PathValue("name")
+	if !requireExistingAgentRunProject(w, projectsDir, name) {
+		return agentruns.Run{}, agentrouting.Request{}, false
+	}
+	run, ok := store.Get(r.PathValue("id"))
+	if !ok || run.Project != name {
+		http.Error(w, "agent run not found", http.StatusNotFound)
+		return agentruns.Run{}, agentrouting.Request{}, false
+	}
+	if run.ProviderID == "" {
+		http.Error(w, "agent run provider is not configured", http.StatusConflict)
+		return agentruns.Run{}, agentrouting.Request{}, false
+	}
+
+	var req agentToolRouteAuthorizeRequest
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&req); err != nil {
+		writeAgentToolRouteBodyError(w, err)
+		return agentruns.Run{}, agentrouting.Request{}, false
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		writeAgentToolRouteBodyError(w, err)
+		return agentruns.Run{}, agentrouting.Request{}, false
+	}
+
+	request := agentrouting.Request{
+		Project:      run.Project,
+		ProviderID:   run.ProviderID,
+		ConnectionID: req.ConnectionID,
+		ServerID:     req.ServerID,
+		ToolName:     req.ToolName,
+		Mode:         run.Mode,
+		Risk:         req.Risk,
+	}
+	if err := request.Validate(); err != nil {
+		http.Error(w, "invalid tool route request", http.StatusBadRequest)
+		return agentruns.Run{}, agentrouting.Request{}, false
+	}
+	return run, request, true
+}
+
+func agentToolRouteRunIsTerminal(status agentruns.Status) bool {
+	switch status {
+	case agentruns.StatusCompleted, agentruns.StatusFailed, agentruns.StatusCanceled:
+		return true
+	default:
+		return false
+	}
 }
 
 func writeAgentToolRouteBodyError(w http.ResponseWriter, err error) {
@@ -133,6 +182,15 @@ func writeAgentToolRouteError(w http.ResponseWriter, err error) {
 		log.Printf("agent tool route authorization failed (%T)", agentToolRouteRootError(err))
 		http.Error(w, "agent tool route authorization failed", http.StatusInternalServerError)
 	}
+}
+
+func writeAgentToolRoutePreviewError(w http.ResponseWriter, err error) {
+	if errors.Is(err, agentrouting.ErrInvalidRequest) {
+		http.Error(w, "invalid tool route request", http.StatusBadRequest)
+		return
+	}
+	log.Printf("agent tool route preview failed (%T)", agentToolRouteRootError(err))
+	http.Error(w, "agent tool route preview failed", http.StatusInternalServerError)
 }
 
 func agentToolRouteRootError(err error) error {

--- a/internal/api/agent_tool_routes_test.go
+++ b/internal/api/agent_tool_routes_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -15,12 +16,16 @@ import (
 )
 
 type fakeAgentToolRouter struct {
-	result  agentrouting.RouteResult
-	err     error
-	route   func(string, agentrouting.Request) (agentrouting.RouteResult, error)
-	calls   int
-	runID   string
-	request agentrouting.Request
+	result         agentrouting.RouteResult
+	err            error
+	route          func(string, agentrouting.Request) (agentrouting.RouteResult, error)
+	calls          int
+	runID          string
+	request        agentrouting.Request
+	previewResult  agentrouting.Decision
+	previewErr     error
+	previewCalls   int
+	previewRequest agentrouting.Request
 }
 
 type agentToolRouteTestRootError struct{}
@@ -37,6 +42,12 @@ func (f *fakeAgentToolRouter) Route(runID string, request agentrouting.Request) 
 		return f.route(runID, request)
 	}
 	return f.result, f.err
+}
+
+func (f *fakeAgentToolRouter) Preview(request agentrouting.Request) (agentrouting.Decision, error) {
+	f.previewCalls++
+	f.previewRequest = request
+	return f.previewResult, f.previewErr
 }
 
 func agentToolRouteFixture(t *testing.T, providerID string) (string, *agentruns.Store, agentruns.Run) {
@@ -80,6 +91,132 @@ func postAgentToolRouteWithKey(mux *http.ServeMux, project, runID, body, content
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 	return rec
+}
+
+func postAgentToolRoutePreview(mux *http.ServeMux, project, runID, body, contentType string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/projects/"+project+"/agent-runs/"+runID+"/tool-routes/preview",
+		strings.NewReader(body),
+	)
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestAgentToolRoutePreviewUsesServerOwnedScopeWithoutMutation(t *testing.T) {
+	root, store, run := agentToolRouteFixture(t, "codex")
+	before, ok := store.Get(run.ID)
+	if !ok {
+		t.Fatalf("Get(%q) returned no run", run.ID)
+	}
+	wantDecision := agentrouting.Decision{
+		Status:          agentrouting.DecisionAllowed,
+		Reason:          agentrouting.ReasonAllowed,
+		Allowed:         true,
+		UntrustedOutput: true,
+	}
+	fake := &fakeAgentToolRouter{previewResult: wantDecision}
+	mux := agentToolRouteMux(root, store, fake)
+
+	rec := postAgentToolRoutePreview(mux, "demo", run.ID, `{
+		"connection_id":"aws-prod",
+		"server_id":"aws",
+		"tool_name":"list_buckets",
+		"risk":"read_only"
+	}`, "application/json")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("preview status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	requireJSONResponse(t, rec)
+	wantRequest := agentrouting.Request{
+		Project:      "demo",
+		ProviderID:   "codex",
+		ConnectionID: "aws-prod",
+		ServerID:     "aws",
+		ToolName:     "list_buckets",
+		Mode:         agentruns.ModeReadOnly,
+		Risk:         mcpairlock.RiskReadOnly,
+	}
+	if fake.previewCalls != 1 || fake.previewRequest != wantRequest || fake.calls != 0 {
+		t.Fatalf("Preview calls = %d, request = %+v, Route calls = %d; want one scoped preview only", fake.previewCalls, fake.previewRequest, fake.calls)
+	}
+	var response struct {
+		Decision agentrouting.Decision `json:"decision"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Decision != wantDecision {
+		t.Fatalf("preview decision = %+v, want %+v", response.Decision, wantDecision)
+	}
+	after, ok := store.Get(run.ID)
+	if !ok || !reflect.DeepEqual(after, before) {
+		t.Fatalf("run mutated by preview: before=%+v after=%+v", before, after)
+	}
+}
+
+func TestAgentToolRoutePreviewRejectsClientScopeAndTerminalRuns(t *testing.T) {
+	root, store, run := agentToolRouteFixture(t, "codex")
+	fake := &fakeAgentToolRouter{}
+	mux := agentToolRouteMux(root, store, fake)
+
+	clientScope := postAgentToolRoutePreview(mux, "demo", run.ID, `{
+		"connection_id":"aws-prod",
+		"server_id":"aws",
+		"tool_name":"list_buckets",
+		"risk":"read_only",
+		"mode":"approved_execute"
+	}`, "application/json")
+	if clientScope.Code != http.StatusBadRequest {
+		t.Fatalf("client scope status = %d, want %d, body = %s", clientScope.Code, http.StatusBadRequest, clientScope.Body.String())
+	}
+	if _, err := store.SetStatus(run.ID, agentruns.StatusCompleted); err != nil {
+		t.Fatalf("SetStatus(completed): %v", err)
+	}
+	terminal := postAgentToolRoutePreview(mux, "demo", run.ID, `{
+		"connection_id":"aws-prod",
+		"server_id":"aws",
+		"tool_name":"list_buckets",
+		"risk":"read_only"
+	}`, "application/json")
+	if terminal.Code != http.StatusConflict {
+		t.Fatalf("terminal status = %d, want %d, body = %s", terminal.Code, http.StatusConflict, terminal.Body.String())
+	}
+	if fake.previewCalls != 0 {
+		t.Fatalf("Preview calls = %d, want none for rejected requests", fake.previewCalls)
+	}
+}
+
+func TestAgentToolRoutePreviewSanitizesServiceFailures(t *testing.T) {
+	tests := []struct {
+		name string
+		fake *fakeAgentToolRouter
+	}{
+		{name: "service error", fake: &fakeAgentToolRouter{previewErr: errors.New("token=preview-secret")}},
+		{name: "invalid decision", fake: &fakeAgentToolRouter{}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root, store, run := agentToolRouteFixture(t, "codex")
+			mux := agentToolRouteMux(root, store, test.fake)
+			rec := postAgentToolRoutePreview(mux, "demo", run.ID, `{
+				"connection_id":"aws-prod",
+				"server_id":"aws",
+				"tool_name":"list_buckets",
+				"risk":"read_only"
+			}`, "application/json")
+			if rec.Code != http.StatusInternalServerError {
+				t.Fatalf("status = %d, want %d, body = %s", rec.Code, http.StatusInternalServerError, rec.Body.String())
+			}
+			if strings.Contains(rec.Body.String(), "preview-secret") {
+				t.Fatalf("response leaked preview error: %s", rec.Body.String())
+			}
+		})
+	}
 }
 
 func TestAgentToolRouteUsesServerOwnedRunScope(t *testing.T) {


### PR DESCRIPTION
## Summary
- add a run-scoped `POST /api/projects/{name}/agent-runs/{id}/tool-routes/preview` endpoint
- evaluate current routing policy and MCP Airlock inventory without recording a run mutation or invoking an MCP tool
- derive project, provider, and mode from the server-owned Agent Run; reject client scope fields and terminal runs
- validate decisions and sanitize preview failures before returning them

## Validation
- `go test ./internal/agentrouting ./internal/api -race`
- `go test ./internal/...`
- `go test ./cmd/... -race`
- `go vet ./internal/...`

Part of #107.