### PR TITLE
Add frontend MCP route preview client

### DIFF
--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -646,6 +646,45 @@ describe('api.agentRuns', () => {
   });
 });
 
+describe('api.agentToolRoutes', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('previews a run-scoped tool route without client-owned scope fields', async () => {
+    const response = {
+      decision: {
+        status: 'allowed',
+        reason: 'allowed',
+        allowed: true,
+        approval_required: false,
+        untrusted_output: true,
+      },
+    };
+    const input = {
+      connection_id: 'aws-prod',
+      server_id: 'aws-official',
+      tool_name: 'list_resources',
+      risk: 'read_only' as const,
+    };
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(response), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(api.previewAgentToolRoute('demo project', 'run/000001', input)).resolves.toEqual(response);
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/projects/demo%20project/agent-runs/run%2F000001/tool-routes/preview', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    });
+  });
+});
+
 describe('api.agentToolPolicies', () => {
   afterEach(() => {
     vi.unstubAllGlobals();

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -409,6 +409,43 @@ export interface AgentRunsResponse {
   runs?: AgentRunSummary[] | null;
 }
 
+export interface AgentToolRoutePreviewInput {
+  connection_id: string;
+  server_id: string;
+  tool_name: string;
+  risk: MCPAirlockToolRisk;
+}
+
+export type AgentToolRouteDecisionStatus = 'denied' | 'approval_required' | 'allowed';
+
+export type AgentToolRouteDecisionReason =
+  | 'invalid_request'
+  | 'invalid_policy'
+  | 'policy_unavailable'
+  | 'mode_risk_mismatch'
+  | 'no_matching_rule'
+  | 'policy_denied'
+  | 'airlock_unavailable'
+  | 'airlock_server_mismatch'
+  | 'airlock_tool_mismatch'
+  | 'airlock_risk_mismatch'
+  | 'invalid_airlock_decision'
+  | 'airlock_blocked'
+  | 'approval_required'
+  | 'allowed';
+
+export interface AgentToolRouteDecision {
+  status: AgentToolRouteDecisionStatus;
+  reason: AgentToolRouteDecisionReason;
+  allowed: boolean;
+  approval_required: boolean;
+  untrusted_output: boolean;
+}
+
+export interface AgentToolRoutePreviewResponse {
+  decision: AgentToolRouteDecision;
+}
+
 export type AgentToolPolicyEffect = 'allow' | 'deny';
 
 export interface AgentToolPolicyScope {
@@ -824,6 +861,22 @@ export const api = {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ decision }),
+      },
+    );
+    return (await check(res)).json();
+  },
+
+  async previewAgentToolRoute(
+    projectName: string,
+    id: string,
+    input: AgentToolRoutePreviewInput,
+  ): Promise<AgentToolRoutePreviewResponse> {
+    const res = await fetch(
+      `${BASE}/api/projects/${encodeURIComponent(projectName)}/agent-runs/${encodeURIComponent(id)}/tool-routes/preview`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
       },
     );
     return (await check(res)).json();


### PR DESCRIPTION
## Summary
- add typed frontend request and decision contracts for Agent Hub route previews
- add `previewAgentToolRoute` for the run-scoped backend endpoint
- keep project, provider, and mode out of the client request body
- verify exact URL encoding and JSON request shape

## Validation
- `npm test -- --run` (229 tests)
- `npm run build`
- `npm run lint` (no errors; 30 pre-existing warnings)

Part of #107.