### PR TITLE
Mount Agent Hub route preview in Runs

### DIFF
--- a/web/src/components/Chat/ChatPanel.test.tsx
+++ b/web/src/components/Chat/ChatPanel.test.tsx
@@ -15,6 +15,7 @@ const createAgentRunMock = vi.hoisted(() => vi.fn());
 const getAgentRunMock = vi.hoisted(() => vi.fn());
 const cancelAgentRunMock = vi.hoisted(() => vi.fn());
 const decideAgentRunApprovalMock = vi.hoisted(() => vi.fn());
+const previewAgentToolRouteMock = vi.hoisted(() => vi.fn());
 
 vi.mock('../../api', () => ({
   api: {
@@ -28,6 +29,7 @@ vi.mock('../../api', () => ({
     getAgentRun: getAgentRunMock,
     cancelAgentRun: cancelAgentRunMock,
     decideAgentRunApproval: decideAgentRunApprovalMock,
+    previewAgentToolRoute: previewAgentToolRouteMock,
   },
 }));
 
@@ -105,6 +107,16 @@ describe('ChatPanel', () => {
     cancelAgentRunMock.mockResolvedValue({});
     decideAgentRunApprovalMock.mockReset();
     decideAgentRunApprovalMock.mockResolvedValue({});
+    previewAgentToolRouteMock.mockReset();
+    previewAgentToolRouteMock.mockResolvedValue({
+      decision: {
+        status: 'denied',
+        reason: 'airlock_blocked',
+        allowed: false,
+        approval_required: false,
+        untrusted_output: true,
+      },
+    });
     window.localStorage.clear();
   });
 
@@ -1472,6 +1484,84 @@ describe('ChatPanel', () => {
 
     fireEvent.click(within(details).getByRole('button', { name: 'Close details for run_000001' }));
     expect(within(runsPanel).queryByRole('region', { name: 'run_000001 details' })).not.toBeInTheDocument();
+  });
+
+  it('scopes the tool route preview to the selected active run', async () => {
+    listAgentRunsMock.mockResolvedValueOnce([
+      agentRunSummaryFixture({ id: 'run_000001', status: 'running', prompt_preview: 'Run one' }),
+      agentRunSummaryFixture({ id: 'run_000002', status: 'running', prompt_preview: 'Run two' }),
+    ]);
+    getAgentRunMock.mockImplementation((_project: string, id: string) => Promise.resolve(
+      agentRunFixture({ id, status: 'running', prompt_preview: id === 'run_000001' ? 'Run one' : 'Run two' }),
+    ));
+
+    render(<ChatPanel {...baseProps} projectName="demo" />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Runs' }));
+    const runsPanel = screen.getByRole('tabpanel', { name: 'Runs' });
+
+    await waitFor(() => {
+      expect(within(runsPanel).getByRole('button', { name: 'View details for run_000001' })).toBeInTheDocument();
+    });
+    fireEvent.click(within(runsPanel).getByRole('button', { name: 'View details for run_000001' }));
+
+    let preview = await within(runsPanel).findByRole('region', { name: 'Tool route preview' });
+    expect(within(preview).getByText('run_000001')).toBeInTheDocument();
+    fireEvent.change(within(preview).getByLabelText('Connection'), { target: { value: 'stale-connection' } });
+
+    fireEvent.click(within(runsPanel).getByRole('button', { name: 'View details for run_000002' }));
+    await waitFor(() => {
+      preview = within(runsPanel).getByRole('region', { name: 'Tool route preview' });
+      expect(within(preview).getByText('run_000002')).toBeInTheDocument();
+    });
+    expect(within(preview).getByLabelText('Connection')).toHaveValue('');
+
+    fireEvent.change(within(preview).getByLabelText('Connection'), { target: { value: 'aws-prod' } });
+    fireEvent.change(within(preview).getByLabelText('MCP server'), { target: { value: 'aws-official' } });
+    fireEvent.change(within(preview).getByLabelText('Tool'), { target: { value: 'list_resources' } });
+    fireEvent.click(within(preview).getByRole('button', { name: 'Preview access' }));
+
+    await waitFor(() => {
+      expect(previewAgentToolRouteMock).toHaveBeenCalledWith('demo', 'run_000002', {
+        connection_id: 'aws-prod',
+        server_id: 'aws-official',
+        tool_name: 'list_resources',
+        risk: 'read_only',
+      });
+    });
+
+    const details = within(runsPanel).getByRole('region', { name: 'run_000002 details' });
+    fireEvent.click(within(details).getByRole('button', { name: 'Close details for run_000002' }));
+    expect(within(runsPanel).queryByRole('region', { name: 'Tool route preview' })).not.toBeInTheDocument();
+  });
+
+  it.each([
+    {
+      reason: 'terminal',
+      summary: agentRunSummaryFixture({ id: 'run_000001', status: 'completed' }),
+      detail: agentRunFixture({ id: 'run_000001', status: 'completed' }),
+    },
+    {
+      reason: 'cross-project',
+      summary: agentRunSummaryFixture({ id: 'run_000001', status: 'running' }),
+      detail: agentRunFixture({ id: 'run_000001', project: 'other', status: 'running' }),
+    },
+  ])('keeps the tool route preview hidden for $reason run details', async ({ summary, detail }) => {
+    listAgentRunsMock.mockResolvedValueOnce([summary]);
+    getAgentRunMock.mockResolvedValueOnce(detail);
+
+    render(<ChatPanel {...baseProps} projectName="demo" />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Runs' }));
+    const runsPanel = screen.getByRole('tabpanel', { name: 'Runs' });
+
+    await waitFor(() => {
+      expect(within(runsPanel).getByRole('button', { name: 'View details for run_000001' })).toBeInTheDocument();
+    });
+    fireEvent.click(within(runsPanel).getByRole('button', { name: 'View details for run_000001' }));
+
+    await waitFor(() => {
+      expect(within(runsPanel).getByRole('region', { name: 'run_000001 details' })).toBeInTheDocument();
+    });
+    expect(within(runsPanel).queryByRole('region', { name: 'Tool route preview' })).not.toBeInTheDocument();
   });
 
   it('shows empty-state messages for run details without logs, patches, or approvals', async () => {

--- a/web/src/components/Chat/ChatPanel.test.tsx
+++ b/web/src/components/Chat/ChatPanel.test.tsx
@@ -1534,20 +1534,9 @@ describe('ChatPanel', () => {
     expect(within(runsPanel).queryByRole('region', { name: 'Tool route preview' })).not.toBeInTheDocument();
   });
 
-  it.each([
-    {
-      reason: 'terminal',
-      summary: agentRunSummaryFixture({ id: 'run_000001', status: 'completed' }),
-      detail: agentRunFixture({ id: 'run_000001', status: 'completed' }),
-    },
-    {
-      reason: 'cross-project',
-      summary: agentRunSummaryFixture({ id: 'run_000001', status: 'running' }),
-      detail: agentRunFixture({ id: 'run_000001', project: 'other', status: 'running' }),
-    },
-  ])('keeps the tool route preview hidden for $reason run details', async ({ summary, detail }) => {
-    listAgentRunsMock.mockResolvedValueOnce([summary]);
-    getAgentRunMock.mockResolvedValueOnce(detail);
+  it('keeps the tool route preview hidden for terminal run details', async () => {
+    listAgentRunsMock.mockResolvedValueOnce([agentRunSummaryFixture({ id: 'run_000001', status: 'completed' })]);
+    getAgentRunMock.mockResolvedValueOnce(agentRunFixture({ id: 'run_000001', status: 'completed' }));
 
     render(<ChatPanel {...baseProps} projectName="demo" />);
     fireEvent.click(screen.getByRole('tab', { name: 'Runs' }));
@@ -1561,6 +1550,36 @@ describe('ChatPanel', () => {
     await waitFor(() => {
       expect(within(runsPanel).getByRole('region', { name: 'run_000001 details' })).toBeInTheDocument();
     });
+    expect(within(runsPanel).queryByRole('region', { name: 'Tool route preview' })).not.toBeInTheDocument();
+  });
+
+  it.each([
+    {
+      reason: 'cross-project',
+      detail: agentRunFixture({ id: 'run_000001', project: 'other', status: 'running' }),
+    },
+    {
+      reason: 'wrong-id',
+      detail: agentRunFixture({ id: 'run_000009', status: 'running' }),
+    },
+  ])('fails closed for $reason run detail responses', async ({ detail }) => {
+    const summary = agentRunSummaryFixture({ id: 'run_000001', status: 'running' });
+    listAgentRunsMock.mockResolvedValueOnce([summary]);
+    getAgentRunMock.mockResolvedValueOnce(detail);
+
+    render(<ChatPanel {...baseProps} projectName="demo" />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Runs' }));
+    const runsPanel = screen.getByRole('tabpanel', { name: 'Runs' });
+
+    await waitFor(() => {
+      expect(within(runsPanel).getByRole('button', { name: 'View details for run_000001' })).toBeInTheDocument();
+    });
+    fireEvent.click(within(runsPanel).getByRole('button', { name: 'View details for run_000001' }));
+
+    await waitFor(() => {
+      expect(within(runsPanel).getByRole('alert')).toBeInTheDocument();
+    });
+    expect(within(runsPanel).queryByRole('region', { name: 'run_000001 details' })).not.toBeInTheDocument();
     expect(within(runsPanel).queryByRole('region', { name: 'Tool route preview' })).not.toBeInTheDocument();
   });
 

--- a/web/src/components/Chat/ChatPanel.tsx
+++ b/web/src/components/Chat/ChatPanel.tsx
@@ -1036,6 +1036,10 @@ function agentRunDetailErrorMessage(err: unknown) {
   return 'agent run detail failed';
 }
 
+function isExactRunDetailResponse(run: AgentRun, project: string, id: string) {
+  return run.project === project && run.id === id;
+}
+
 function RunDetailSection({
   title,
   empty,
@@ -1801,7 +1805,11 @@ export function ChatPanel({
       api.getAgentRun(requestProjectName, requestRunId)
         .then(run => {
           if (!isCurrentDetailPoll()) return;
-          setSelectedRunId(run.id);
+          if (!isExactRunDetailResponse(run, requestProjectName, requestRunId)) {
+            setSelectedRun(null);
+            setDetailError('agent run detail failed');
+            return;
+          }
           setSelectedRun(run);
           setDetailError(null);
         })
@@ -1865,7 +1873,11 @@ export function ChatPanel({
     api.getAgentRun(requestProjectName, id)
       .then(run => {
         if (!isCurrentDetailRequest()) return;
-        setSelectedRunId(run.id);
+        if (!isExactRunDetailResponse(run, requestProjectName, id)) {
+          setSelectedRun(null);
+          setDetailError('agent run detail failed');
+          return;
+        }
         setSelectedRun(run);
       })
       .catch((err: unknown) => {

--- a/web/src/components/Chat/ChatPanel.tsx
+++ b/web/src/components/Chat/ChatPanel.tsx
@@ -4,6 +4,7 @@ import { Pencil, Save, X } from 'lucide-react';
 
 import { api, type AgentProviderConnectionDefinition, type AgentProviderConnectionProfile, type AgentRun, type AgentRunApprovalDecision, type AgentRunMode, type AgentRunSummary, type AgentToolPolicy, type AgentToolPolicyResponse, type LocalAgentProviderStatus } from '../../api';
 import { S } from '../../styles';
+import { ToolRoutePreviewPanel } from './ToolRoutePreviewPanel';
 
 export interface ChatMessage {
   role: string;
@@ -1424,6 +1425,12 @@ function RunsPanel({
       </div>
     );
   }
+  const routePreviewScope = selectedRun
+    && selectedRunId === selectedRun.id
+    && selectedRun.project === projectName
+    && !isTerminalAgentRun(selectedRun.status)
+    ? { projectName, runId: selectedRun.id }
+    : null;
   return (
     <div style={hubStyles.runsPanel} aria-label={`${projectName} agent runs`}>
       <RunQueueCard
@@ -1476,6 +1483,13 @@ function RunsPanel({
           loadingRunId={detailLoadingRunId}
           error={detailError}
           onClose={onCloseDetails}
+        />
+      )}
+      {routePreviewScope && (
+        <ToolRoutePreviewPanel
+          key={`${routePreviewScope.projectName}:${routePreviewScope.runId}`}
+          projectName={routePreviewScope.projectName}
+          runId={routePreviewScope.runId}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- mount the guarded tool-route preview beside selected Agent Run details
- expose it only for an exact project/run match while the run is non-terminal
- reset preview form state when users switch runs and remove it when details close
- keep terminal and cross-project detail responses fail-closed

## Validation
- `npm test -- --run src/components/Chat/ChatPanel.test.tsx` (57 tests)
- `npm test -- --run` (237 tests)
- `npm run lint -- --quiet`
- `npm run build`
- `git diff --check`

Part of #107.