### PR TITLE
Add bounded MCP tool-call contract

### DIFF
--- a/internal/mcpairlock/registry.go
+++ b/internal/mcpairlock/registry.go
@@ -23,6 +23,7 @@ var (
 	ErrUnknownServer = errors.New("mcp airlock server not found")
 
 	secretPatterns = []*regexp.Regexp{
+		regexp.MustCompile(`(?is)-----BEGIN [A-Z0-9 ]*PRIVATE KEY(?: BLOCK)?-----.*?(?:-----END [A-Z0-9 ]*PRIVATE KEY(?: BLOCK)?-----|\z)`),
 		regexp.MustCompile(`(?i)(aws_secret_access_key|secret_access_key|session_token|client_secret|access_token|refresh_token|private_key|token)\s*[:=]\s*["']?[^"'\s]+`),
 		regexp.MustCompile(`AKIA[0-9A-Z]{12,}`),
 		regexp.MustCompile(`ASIA[0-9A-Z]{12,}`),

--- a/internal/mcpairlock/tool_call.go
+++ b/internal/mcpairlock/tool_call.go
@@ -223,7 +223,7 @@ func truncateUTF8(value string, limit int) (string, bool) {
 }
 
 // ToolInvoker is the transport boundary implemented by a later stdio MCP
-// slice. Callers must authorize and audit the route before invoking it.
+// client. Callers must authorize and audit the route before invoking it.
 type ToolInvoker interface {
 	InvokeTool(context.Context, ToolCallRequest) (ToolCallResult, error)
 }

--- a/internal/mcpairlock/tool_call.go
+++ b/internal/mcpairlock/tool_call.go
@@ -107,6 +107,23 @@ type ToolCallRequest struct {
 	Arguments ToolCallArguments `json:"arguments"`
 }
 
+func (r *ToolCallRequest) UnmarshalJSON(input []byte) error {
+	if r == nil {
+		return fmt.Errorf("%w: nil destination", ErrInvalidToolCallRequest)
+	}
+	type wireRequest ToolCallRequest
+	var decoded wireRequest
+	if err := json.Unmarshal(input, &decoded); err != nil {
+		return fmt.Errorf("%w: decode: %w", ErrInvalidToolCallRequest, err)
+	}
+	request := ToolCallRequest(decoded)
+	if err := request.Validate(); err != nil {
+		return err
+	}
+	*r = request
+	return nil
+}
+
 func NewToolCallRequest(serverID, toolName string, arguments ToolCallArguments) (ToolCallRequest, error) {
 	request := ToolCallRequest{
 		ServerID:  serverID,

--- a/internal/mcpairlock/tool_call.go
+++ b/internal/mcpairlock/tool_call.go
@@ -13,9 +13,10 @@ import (
 )
 
 const (
-	maxToolCallArgumentsBytes  = 64 << 10
-	maxToolCallOutputBytes     = 256 << 10
-	maxToolCallIdentifierBytes = 256
+	maxToolCallArgumentsBytes       = 64 << 10
+	maxToolCallOutputBytes          = 256 << 10
+	toolCallRedactionLookaheadBytes = 512
+	maxToolCallIdentifierBytes      = 256
 )
 
 var (
@@ -32,11 +33,11 @@ type ToolCallArguments struct {
 
 // ParseToolCallArguments validates and snapshots one bounded JSON object.
 func ParseToolCallArguments(input []byte) (ToolCallArguments, error) {
-	if len(input) == 0 {
-		return ToolCallArguments{}, fmt.Errorf("%w: JSON object is required", ErrInvalidToolCallArguments)
-	}
 	if len(input) > maxToolCallArgumentsBytes {
 		return ToolCallArguments{}, fmt.Errorf("%w: payload exceeds %d bytes", ErrInvalidToolCallArguments, maxToolCallArgumentsBytes)
+	}
+	if len(bytes.TrimSpace(input)) == 0 {
+		return ToolCallArguments{}, fmt.Errorf("%w: JSON object is required", ErrInvalidToolCallArguments)
 	}
 
 	decoder := json.NewDecoder(bytes.NewReader(input))
@@ -163,23 +164,31 @@ type ToolCallResult struct {
 	Truncated       bool   `json:"truncated"`
 }
 
-// NewToolCallResult redacts known credential patterns before applying the
-// output bound so truncation cannot expose the beginning of a secret value.
+// NewToolCallResult scans only a bounded prefix plus a small lookahead. Known
+// credential patterns are redacted before the final output bound is applied.
 func NewToolCallResult(output []byte, isError bool) ToolCallResult {
-	sanitized := strings.TrimSpace(strings.ToValidUTF8(string(output), "\uFFFD"))
+	truncated := len(output) > maxToolCallOutputBytes
+	processingLimit := maxToolCallOutputBytes + toolCallRedactionLookaheadBytes
+	if len(output) > processingLimit {
+		output = output[:processingLimit]
+	}
+
+	sanitized := strings.ToValidUTF8(string(output), "\uFFFD")
 	redacted := false
 	for _, pattern := range secretPatterns {
 		replacement := pattern.ReplaceAllString(sanitized, "[REDACTED]")
 		redacted = redacted || replacement != sanitized
 		sanitized = replacement
 	}
-	sanitized, truncated := truncateUTF8(sanitized, maxToolCallOutputBytes)
+	var encodingTruncated bool
+	sanitized, encodingTruncated = truncateUTF8(sanitized, maxToolCallOutputBytes)
+	sanitized = strings.TrimSpace(sanitized)
 	return ToolCallResult{
 		Output:          sanitized,
 		IsError:         isError,
 		UntrustedOutput: true,
 		Redacted:        redacted,
-		Truncated:       truncated,
+		Truncated:       truncated || encodingTruncated,
 	}
 }
 

--- a/internal/mcpairlock/tool_call.go
+++ b/internal/mcpairlock/tool_call.go
@@ -1,0 +1,219 @@
+package mcpairlock
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+const (
+	maxToolCallArgumentsBytes  = 64 << 10
+	maxToolCallOutputBytes     = 256 << 10
+	maxToolCallIdentifierBytes = 256
+)
+
+var (
+	ErrInvalidToolCallArguments = errors.New("invalid MCP tool call arguments")
+	ErrInvalidToolCallRequest   = errors.New("invalid MCP tool call request")
+	ErrInvalidToolCallResult    = errors.New("invalid MCP tool call result")
+)
+
+// ToolCallArguments is an immutable, normalized JSON object passed to one MCP
+// tool. Object-only arguments avoid ambiguous null, scalar, and array payloads.
+type ToolCallArguments struct {
+	encoded []byte
+}
+
+// ParseToolCallArguments validates and snapshots one bounded JSON object.
+func ParseToolCallArguments(input []byte) (ToolCallArguments, error) {
+	if len(input) == 0 {
+		return ToolCallArguments{}, fmt.Errorf("%w: JSON object is required", ErrInvalidToolCallArguments)
+	}
+	if len(input) > maxToolCallArgumentsBytes {
+		return ToolCallArguments{}, fmt.Errorf("%w: payload exceeds %d bytes", ErrInvalidToolCallArguments, maxToolCallArgumentsBytes)
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(input))
+	decoder.UseNumber()
+	var decoded any
+	if err := decoder.Decode(&decoded); err != nil {
+		return ToolCallArguments{}, fmt.Errorf("%w: %v", ErrInvalidToolCallArguments, err)
+	}
+	object, ok := decoded.(map[string]any)
+	if !ok {
+		return ToolCallArguments{}, fmt.Errorf("%w: top-level value must be an object", ErrInvalidToolCallArguments)
+	}
+	if err := requireJSONEOF(decoder); err != nil {
+		return ToolCallArguments{}, err
+	}
+
+	encoded, err := json.Marshal(object)
+	if err != nil {
+		return ToolCallArguments{}, fmt.Errorf("%w: normalize object: %v", ErrInvalidToolCallArguments, err)
+	}
+	if len(encoded) > maxToolCallArgumentsBytes {
+		return ToolCallArguments{}, fmt.Errorf("%w: normalized payload exceeds %d bytes", ErrInvalidToolCallArguments, maxToolCallArgumentsBytes)
+	}
+	return ToolCallArguments{encoded: encoded}, nil
+}
+
+func requireJSONEOF(decoder *json.Decoder) error {
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return fmt.Errorf("%w: multiple JSON values are not allowed", ErrInvalidToolCallArguments)
+		}
+		return fmt.Errorf("%w: trailing data: %v", ErrInvalidToolCallArguments, err)
+	}
+	return nil
+}
+
+// Bytes returns a copy of the normalized JSON object.
+func (a ToolCallArguments) Bytes() []byte {
+	return append([]byte(nil), a.encoded...)
+}
+
+func (a ToolCallArguments) MarshalJSON() ([]byte, error) {
+	if len(a.encoded) == 0 {
+		return nil, fmt.Errorf("%w: JSON object is required", ErrInvalidToolCallArguments)
+	}
+	return a.Bytes(), nil
+}
+
+func (a *ToolCallArguments) UnmarshalJSON(input []byte) error {
+	if a == nil {
+		return fmt.Errorf("%w: nil destination", ErrInvalidToolCallArguments)
+	}
+	parsed, err := ParseToolCallArguments(input)
+	if err != nil {
+		return err
+	}
+	a.encoded = parsed.Bytes()
+	return nil
+}
+
+// ToolCallRequest is the transport-only input for a previously authorized MCP
+// tool route. The routing layer remains responsible for project, provider,
+// connection, mode, approval, and audit enforcement.
+type ToolCallRequest struct {
+	ServerID  string            `json:"server_id"`
+	ToolName  string            `json:"tool_name"`
+	Arguments ToolCallArguments `json:"arguments"`
+}
+
+func NewToolCallRequest(serverID, toolName string, arguments ToolCallArguments) (ToolCallRequest, error) {
+	request := ToolCallRequest{
+		ServerID:  serverID,
+		ToolName:  toolName,
+		Arguments: ToolCallArguments{encoded: arguments.Bytes()},
+	}
+	if err := request.Validate(); err != nil {
+		return ToolCallRequest{}, err
+	}
+	return request, nil
+}
+
+func (r ToolCallRequest) Validate() error {
+	if err := validateToolCallIdentifier("server_id", r.ServerID); err != nil {
+		return err
+	}
+	if err := validateToolCallIdentifier("tool_name", r.ToolName); err != nil {
+		return err
+	}
+	if _, err := r.Arguments.MarshalJSON(); err != nil {
+		return fmt.Errorf("%w: arguments: %w", ErrInvalidToolCallRequest, err)
+	}
+	return nil
+}
+
+func validateToolCallIdentifier(name, value string) error {
+	if strings.TrimSpace(value) == "" {
+		return fmt.Errorf("%w: %s is required", ErrInvalidToolCallRequest, name)
+	}
+	if strings.TrimSpace(value) != value {
+		return fmt.Errorf("%w: %s must not contain leading or trailing whitespace", ErrInvalidToolCallRequest, name)
+	}
+	if !utf8.ValidString(value) {
+		return fmt.Errorf("%w: %s must be valid UTF-8", ErrInvalidToolCallRequest, name)
+	}
+	if len(value) > maxToolCallIdentifierBytes {
+		return fmt.Errorf("%w: %s exceeds %d bytes", ErrInvalidToolCallRequest, name, maxToolCallIdentifierBytes)
+	}
+	for _, char := range value {
+		if unicode.IsControl(char) {
+			return fmt.Errorf("%w: %s must not contain control characters", ErrInvalidToolCallRequest, name)
+		}
+	}
+	return nil
+}
+
+// ToolCallResult contains sanitized external output. Output remains untrusted
+// even after redaction and must not be interpreted as instructions.
+type ToolCallResult struct {
+	Output          string `json:"output"`
+	IsError         bool   `json:"is_error"`
+	UntrustedOutput bool   `json:"untrusted_output"`
+	Redacted        bool   `json:"redacted"`
+	Truncated       bool   `json:"truncated"`
+}
+
+// NewToolCallResult redacts known credential patterns before applying the
+// output bound so truncation cannot expose the beginning of a secret value.
+func NewToolCallResult(output []byte, isError bool) ToolCallResult {
+	sanitized := strings.TrimSpace(strings.ToValidUTF8(string(output), "\uFFFD"))
+	redacted := false
+	for _, pattern := range secretPatterns {
+		replacement := pattern.ReplaceAllString(sanitized, "[REDACTED]")
+		redacted = redacted || replacement != sanitized
+		sanitized = replacement
+	}
+	sanitized, truncated := truncateUTF8(sanitized, maxToolCallOutputBytes)
+	return ToolCallResult{
+		Output:          sanitized,
+		IsError:         isError,
+		UntrustedOutput: true,
+		Redacted:        redacted,
+		Truncated:       truncated,
+	}
+}
+
+func (r ToolCallResult) Validate() error {
+	if !r.UntrustedOutput {
+		return fmt.Errorf("%w: external output must remain untrusted", ErrInvalidToolCallResult)
+	}
+	if !utf8.ValidString(r.Output) {
+		return fmt.Errorf("%w: output must be valid UTF-8", ErrInvalidToolCallResult)
+	}
+	if len(r.Output) > maxToolCallOutputBytes {
+		return fmt.Errorf("%w: output exceeds %d bytes", ErrInvalidToolCallResult, maxToolCallOutputBytes)
+	}
+	for _, pattern := range secretPatterns {
+		if pattern.MatchString(r.Output) {
+			return fmt.Errorf("%w: output contains a recognized credential pattern", ErrInvalidToolCallResult)
+		}
+	}
+	return nil
+}
+
+func truncateUTF8(value string, limit int) (string, bool) {
+	if len(value) <= limit {
+		return value, false
+	}
+	end := limit
+	for end > 0 && !utf8.ValidString(value[:end]) {
+		end--
+	}
+	return value[:end], true
+}
+
+// ToolInvoker is the transport boundary implemented by a later stdio MCP
+// slice. Callers must authorize and audit the route before invoking it.
+type ToolInvoker interface {
+	InvokeTool(context.Context, ToolCallRequest) (ToolCallResult, error)
+}

--- a/internal/mcpairlock/tool_call.go
+++ b/internal/mcpairlock/tool_call.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"strings"
-	"unicode"
 	"unicode/utf8"
 )
 
@@ -16,7 +15,7 @@ const (
 	maxToolCallArgumentsBytes       = 64 << 10
 	maxToolCallOutputBytes          = 256 << 10
 	toolCallRedactionLookaheadBytes = 512
-	maxToolCallIdentifierBytes      = 256
+	maxToolCallIdentifierBytes      = 128
 )
 
 var (
@@ -121,10 +120,10 @@ func NewToolCallRequest(serverID, toolName string, arguments ToolCallArguments) 
 }
 
 func (r ToolCallRequest) Validate() error {
-	if err := validateToolCallIdentifier("server_id", r.ServerID); err != nil {
+	if err := validateToolCallIdentifier("server_id", r.ServerID, false); err != nil {
 		return err
 	}
-	if err := validateToolCallIdentifier("tool_name", r.ToolName); err != nil {
+	if err := validateToolCallIdentifier("tool_name", r.ToolName, true); err != nil {
 		return err
 	}
 	if _, err := r.Arguments.MarshalJSON(); err != nil {
@@ -133,22 +132,24 @@ func (r ToolCallRequest) Validate() error {
 	return nil
 }
 
-func validateToolCallIdentifier(name, value string) error {
+func validateToolCallIdentifier(name, value string, allowSlash bool) error {
 	if strings.TrimSpace(value) == "" {
 		return fmt.Errorf("%w: %s is required", ErrInvalidToolCallRequest, name)
 	}
 	if strings.TrimSpace(value) != value {
 		return fmt.Errorf("%w: %s must not contain leading or trailing whitespace", ErrInvalidToolCallRequest, name)
 	}
-	if !utf8.ValidString(value) {
-		return fmt.Errorf("%w: %s must be valid UTF-8", ErrInvalidToolCallRequest, name)
-	}
 	if len(value) > maxToolCallIdentifierBytes {
 		return fmt.Errorf("%w: %s exceeds %d bytes", ErrInvalidToolCallRequest, name, maxToolCallIdentifierBytes)
 	}
-	for _, char := range value {
-		if unicode.IsControl(char) {
-			return fmt.Errorf("%w: %s must not contain control characters", ErrInvalidToolCallRequest, name)
+	for i := 0; i < len(value); i++ {
+		char := value[i]
+		allowed := isASCIIAlpha(char) || (char >= '0' && char <= '9') || strings.ContainsRune("._-", rune(char))
+		if allowSlash && char == '/' {
+			allowed = true
+		}
+		if !allowed {
+			return fmt.Errorf("%w: %s contains a character outside the ASCII identifier allowlist", ErrInvalidToolCallRequest, name)
 		}
 	}
 	return nil

--- a/internal/mcpairlock/tool_call.go
+++ b/internal/mcpairlock/tool_call.go
@@ -43,7 +43,7 @@ func ParseToolCallArguments(input []byte) (ToolCallArguments, error) {
 	decoder.UseNumber()
 	var decoded any
 	if err := decoder.Decode(&decoded); err != nil {
-		return ToolCallArguments{}, fmt.Errorf("%w: %v", ErrInvalidToolCallArguments, err)
+		return ToolCallArguments{}, fmt.Errorf("%w: %w", ErrInvalidToolCallArguments, err)
 	}
 	object, ok := decoded.(map[string]any)
 	if !ok {
@@ -69,7 +69,7 @@ func requireJSONEOF(decoder *json.Decoder) error {
 		if err == nil {
 			return fmt.Errorf("%w: multiple JSON values are not allowed", ErrInvalidToolCallArguments)
 		}
-		return fmt.Errorf("%w: trailing data: %v", ErrInvalidToolCallArguments, err)
+		return fmt.Errorf("%w: trailing data: %w", ErrInvalidToolCallArguments, err)
 	}
 	return nil
 }

--- a/internal/mcpairlock/tool_call_test.go
+++ b/internal/mcpairlock/tool_call_test.go
@@ -1,0 +1,146 @@
+package mcpairlock
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestParseToolCallArgumentsNormalizesAndSnapshotsObject(t *testing.T) {
+	input := []byte(` { "z": 1, "nested": { "enabled": true }, "duplicate": "first", "duplicate": "second" } `)
+	arguments, err := ParseToolCallArguments(input)
+	if err != nil {
+		t.Fatalf("ParseToolCallArguments: %v", err)
+	}
+	input[3] = 'x'
+
+	want := `{"duplicate":"second","nested":{"enabled":true},"z":1}`
+	if got := string(arguments.Bytes()); got != want {
+		t.Fatalf("arguments = %s, want %s", got, want)
+	}
+	copyOfArguments := arguments.Bytes()
+	copyOfArguments[0] = '['
+	if got := string(arguments.Bytes()); got != want {
+		t.Fatalf("mutating Bytes result changed arguments to %s", got)
+	}
+
+	marshaled, err := json.Marshal(arguments)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if string(marshaled) != want {
+		t.Fatalf("marshaled arguments = %s, want %s", marshaled, want)
+	}
+}
+
+func TestParseToolCallArgumentsRejectsUnsafeShapes(t *testing.T) {
+	oversized := []byte(`{"value":"` + strings.Repeat("x", maxToolCallArgumentsBytes) + `"}`)
+	tests := []struct {
+		name  string
+		input []byte
+	}{
+		{name: "empty", input: nil},
+		{name: "null", input: []byte(`null`)},
+		{name: "array", input: []byte(`[]`)},
+		{name: "scalar", input: []byte(`"value"`)},
+		{name: "trailing value", input: []byte(`{} {}`)},
+		{name: "invalid", input: []byte(`{"value":`)},
+		{name: "oversized", input: oversized},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := ParseToolCallArguments(test.input)
+			if !errors.Is(err, ErrInvalidToolCallArguments) {
+				t.Fatalf("error = %v, want ErrInvalidToolCallArguments", err)
+			}
+		})
+	}
+}
+
+func TestToolCallArgumentsUnmarshalKeepsPriorValueOnFailure(t *testing.T) {
+	arguments, err := ParseToolCallArguments([]byte(`{"safe":true}`))
+	if err != nil {
+		t.Fatalf("ParseToolCallArguments: %v", err)
+	}
+	if err := json.Unmarshal([]byte(`[]`), &arguments); !errors.Is(err, ErrInvalidToolCallArguments) {
+		t.Fatalf("Unmarshal error = %v, want ErrInvalidToolCallArguments", err)
+	}
+	if got := string(arguments.Bytes()); got != `{"safe":true}` {
+		t.Fatalf("arguments changed after failed unmarshal: %s", got)
+	}
+}
+
+func TestToolCallRequestValidatesExactIdentifiersAndSnapshotsArguments(t *testing.T) {
+	arguments, err := ParseToolCallArguments([]byte(`{"workspace":"demo"}`))
+	if err != nil {
+		t.Fatalf("ParseToolCallArguments: %v", err)
+	}
+	request, err := NewToolCallRequest("terraform", "plan_workspace", arguments)
+	if err != nil {
+		t.Fatalf("NewToolCallRequest: %v", err)
+	}
+	arguments.encoded[0] = '['
+	if err := request.Validate(); err != nil {
+		t.Fatalf("snapshotted request Validate: %v", err)
+	}
+
+	tests := []ToolCallRequest{
+		{ToolName: "plan_workspace", Arguments: request.Arguments},
+		{ServerID: " terraform", ToolName: "plan_workspace", Arguments: request.Arguments},
+		{ServerID: "terraform", ToolName: "plan\nworkspace", Arguments: request.Arguments},
+		{ServerID: "terraform", ToolName: strings.Repeat("x", maxToolCallIdentifierBytes+1), Arguments: request.Arguments},
+		{ServerID: "terraform", ToolName: "plan_workspace"},
+	}
+	for i, invalid := range tests {
+		if err := invalid.Validate(); !errors.Is(err, ErrInvalidToolCallRequest) {
+			t.Fatalf("invalid request %d error = %v, want ErrInvalidToolCallRequest", i, err)
+		}
+	}
+}
+
+func TestNewToolCallResultRedactsBoundsAndMarksOutputUntrusted(t *testing.T) {
+	secret := "aws_secret_access_key=not-for-output"
+	result := NewToolCallResult([]byte("prefix "+secret+" "+strings.Repeat("x", maxToolCallOutputBytes)), false)
+	if strings.Contains(result.Output, "not-for-output") || !strings.Contains(result.Output, "[REDACTED]") {
+		t.Fatalf("result did not redact secret: %q", result.Output[:64])
+	}
+	if !result.UntrustedOutput || !result.Redacted || !result.Truncated {
+		t.Fatalf("result flags = untrusted:%v redacted:%v truncated:%v", result.UntrustedOutput, result.Redacted, result.Truncated)
+	}
+	if len(result.Output) > maxToolCallOutputBytes || !utf8.ValidString(result.Output) {
+		t.Fatalf("result output is not bounded valid UTF-8")
+	}
+	if err := result.Validate(); err != nil {
+		t.Fatalf("result Validate: %v", err)
+	}
+}
+
+func TestNewToolCallResultTruncatesAtUTF8Boundary(t *testing.T) {
+	output := strings.Repeat("x", maxToolCallOutputBytes-1) + "€"
+	result := NewToolCallResult([]byte(output), true)
+	if !result.IsError || !result.Truncated {
+		t.Fatalf("result flags = is_error:%v truncated:%v", result.IsError, result.Truncated)
+	}
+	if !utf8.ValidString(result.Output) || len(result.Output) != maxToolCallOutputBytes-1 {
+		t.Fatalf("output is not safely truncated: bytes=%d valid=%v", len(result.Output), utf8.ValidString(result.Output))
+	}
+	if err := result.Validate(); err != nil {
+		t.Fatalf("result Validate: %v", err)
+	}
+}
+
+func TestToolCallResultValidateRejectsUnsafeOutput(t *testing.T) {
+	tests := []ToolCallResult{
+		{Output: "safe"},
+		{Output: "token=exposed", UntrustedOutput: true},
+		{Output: strings.Repeat("x", maxToolCallOutputBytes+1), UntrustedOutput: true},
+		{Output: string([]byte{0xff}), UntrustedOutput: true},
+	}
+	for i, result := range tests {
+		if err := result.Validate(); !errors.Is(err, ErrInvalidToolCallResult) {
+			t.Fatalf("unsafe result %d error = %v, want ErrInvalidToolCallResult", i, err)
+		}
+	}
+}

--- a/internal/mcpairlock/tool_call_test.go
+++ b/internal/mcpairlock/tool_call_test.go
@@ -93,11 +93,21 @@ func TestToolCallRequestValidatesExactIdentifiersAndSnapshotsArguments(t *testin
 	if err := request.Validate(); err != nil {
 		t.Fatalf("snapshotted request Validate: %v", err)
 	}
+	namespaced, err := NewToolCallRequest("terraform-official", "provider.plan/read_only-v2", request.Arguments)
+	if err != nil {
+		t.Fatalf("namespaced NewToolCallRequest: %v", err)
+	}
+	if err := namespaced.Validate(); err != nil {
+		t.Fatalf("namespaced request Validate: %v", err)
+	}
 
 	tests := []ToolCallRequest{
 		{ToolName: "plan_workspace", Arguments: request.Arguments},
 		{ServerID: " terraform", ToolName: "plan_workspace", Arguments: request.Arguments},
 		{ServerID: "terraform", ToolName: "plan\nworkspace", Arguments: request.Arguments},
+		{ServerID: "terraform", ToolName: "plan\u200bworkspace", Arguments: request.Arguments},
+		{ServerID: "terraform", ToolName: "pl\u0430n_workspace", Arguments: request.Arguments},
+		{ServerID: "terraform/official", ToolName: "plan_workspace", Arguments: request.Arguments},
 		{ServerID: "terraform", ToolName: strings.Repeat("x", maxToolCallIdentifierBytes+1), Arguments: request.Arguments},
 		{ServerID: "terraform", ToolName: "plan_workspace"},
 	}
@@ -126,7 +136,7 @@ func TestNewToolCallResultRedactsBoundsAndMarksOutputUntrusted(t *testing.T) {
 }
 
 func TestNewToolCallResultTruncatesAtUTF8Boundary(t *testing.T) {
-	output := strings.Repeat("x", maxToolCallOutputBytes-1) + "€"
+	output := strings.Repeat("x", maxToolCallOutputBytes-1) + "\u20ac"
 	result := NewToolCallResult([]byte(output), true)
 	if !result.IsError || !result.Truncated {
 		t.Fatalf("result flags = is_error:%v truncated:%v", result.IsError, result.Truncated)

--- a/internal/mcpairlock/tool_call_test.go
+++ b/internal/mcpairlock/tool_call_test.go
@@ -118,6 +118,30 @@ func TestToolCallRequestValidatesExactIdentifiersAndSnapshotsArguments(t *testin
 	}
 }
 
+func TestToolCallRequestUnmarshalValidatesEntireRequest(t *testing.T) {
+	var request ToolCallRequest
+	if err := json.Unmarshal([]byte(`{"server_id":"terraform","tool_name":"plan_workspace","arguments":{"workspace":"demo"}}`), &request); err != nil {
+		t.Fatalf("Unmarshal valid request: %v", err)
+	}
+	if got := string(request.Arguments.Bytes()); got != `{"workspace":"demo"}` {
+		t.Fatalf("arguments = %s, want normalized object", got)
+	}
+
+	tests := []string{
+		`{"server_id":" terraform","tool_name":"plan_workspace","arguments":{}}`,
+		`{"server_id":"terraform","tool_name":"plan workspace","arguments":{}}`,
+		`{"server_id":"terraform","tool_name":"plan_workspace","arguments":[]}`,
+	}
+	for i, input := range tests {
+		if err := json.Unmarshal([]byte(input), &request); !errors.Is(err, ErrInvalidToolCallRequest) {
+			t.Fatalf("invalid request %d error = %v, want ErrInvalidToolCallRequest", i, err)
+		}
+		if request.ServerID != "terraform" || request.ToolName != "plan_workspace" || string(request.Arguments.Bytes()) != `{"workspace":"demo"}` {
+			t.Fatalf("invalid request %d changed destination: %+v", i, request)
+		}
+	}
+}
+
 func TestNewToolCallResultRedactsBoundsAndMarksOutputUntrusted(t *testing.T) {
 	secret := "aws_secret_access_key=not-for-output"
 	result := NewToolCallResult([]byte("prefix "+secret+" "+strings.Repeat("x", maxToolCallOutputBytes)), false)

--- a/internal/mcpairlock/tool_call_test.go
+++ b/internal/mcpairlock/tool_call_test.go
@@ -42,6 +42,7 @@ func TestParseToolCallArgumentsRejectsUnsafeShapes(t *testing.T) {
 		input []byte
 	}{
 		{name: "empty", input: nil},
+		{name: "whitespace", input: []byte(" \n\t ")},
 		{name: "null", input: []byte(`null`)},
 		{name: "array", input: []byte(`[]`)},
 		{name: "scalar", input: []byte(`"value"`)},
@@ -56,6 +57,13 @@ func TestParseToolCallArgumentsRejectsUnsafeShapes(t *testing.T) {
 				t.Fatalf("error = %v, want ErrInvalidToolCallArguments", err)
 			}
 		})
+	}
+}
+
+func TestParseToolCallArgumentsExplainsWhitespaceOnlyInput(t *testing.T) {
+	_, err := ParseToolCallArguments([]byte(" \n\t "))
+	if !errors.Is(err, ErrInvalidToolCallArguments) || !strings.Contains(err.Error(), "JSON object is required") {
+		t.Fatalf("error = %v, want required JSON object error", err)
 	}
 }
 
@@ -125,6 +133,27 @@ func TestNewToolCallResultTruncatesAtUTF8Boundary(t *testing.T) {
 	}
 	if !utf8.ValidString(result.Output) || len(result.Output) != maxToolCallOutputBytes-1 {
 		t.Fatalf("output is not safely truncated: bytes=%d valid=%v", len(result.Output), utf8.ValidString(result.Output))
+	}
+	if err := result.Validate(); err != nil {
+		t.Fatalf("result Validate: %v", err)
+	}
+}
+
+func TestNewToolCallResultMarksOversizedWhitespaceTruncated(t *testing.T) {
+	result := NewToolCallResult([]byte(strings.Repeat(" ", maxToolCallOutputBytes+1)), false)
+	if !result.Truncated || result.Output != "" {
+		t.Fatalf("result = output:%q truncated:%v, want empty truncated output", result.Output, result.Truncated)
+	}
+	if err := result.Validate(); err != nil {
+		t.Fatalf("result Validate: %v", err)
+	}
+}
+
+func TestNewToolCallResultRedactsCredentialAcrossOutputBoundary(t *testing.T) {
+	output := strings.Repeat("x", maxToolCallOutputBytes-8) + "AKIA123456789012 tail"
+	result := NewToolCallResult([]byte(output), false)
+	if !result.Redacted || !result.Truncated || strings.Contains(result.Output, "AKIA") {
+		t.Fatalf("result flags = redacted:%v truncated:%v; output tail = %q", result.Redacted, result.Truncated, result.Output[len(result.Output)-32:])
 	}
 	if err := result.Validate(); err != nil {
 		t.Fatalf("result Validate: %v", err)

--- a/internal/mcpairlock/tool_call_test.go
+++ b/internal/mcpairlock/tool_call_test.go
@@ -67,6 +67,14 @@ func TestParseToolCallArgumentsExplainsWhitespaceOnlyInput(t *testing.T) {
 	}
 }
 
+func TestParseToolCallArgumentsPreservesJSONDecodeError(t *testing.T) {
+	_, err := ParseToolCallArguments([]byte(`{"value": invalid}`))
+	var syntaxError *json.SyntaxError
+	if !errors.Is(err, ErrInvalidToolCallArguments) || !errors.As(err, &syntaxError) {
+		t.Fatalf("error = %v, want argument classification wrapping json.SyntaxError", err)
+	}
+}
+
 func TestToolCallArgumentsUnmarshalKeepsPriorValueOnFailure(t *testing.T) {
 	arguments, err := ParseToolCallArguments([]byte(`{"safe":true}`))
 	if err != nil {
@@ -194,10 +202,36 @@ func TestNewToolCallResultRedactsCredentialAcrossOutputBoundary(t *testing.T) {
 	}
 }
 
+func TestNewToolCallResultRedactsMultilinePrivateKey(t *testing.T) {
+	output := "prefix private_key: -----BEGIN RSA PRIVATE KEY-----\nsecret-material\n-----END RSA PRIVATE KEY----- safe suffix"
+	result := NewToolCallResult([]byte(output), false)
+	if !result.Redacted || strings.Contains(result.Output, "secret-material") || strings.Contains(result.Output, "PRIVATE KEY") {
+		t.Fatalf("result did not redact private key: %q", result.Output)
+	}
+	if !strings.Contains(result.Output, "safe suffix") {
+		t.Fatalf("result removed content after private key: %q", result.Output)
+	}
+	if err := result.Validate(); err != nil {
+		t.Fatalf("result Validate: %v", err)
+	}
+}
+
+func TestNewToolCallResultRedactsTruncatedPrivateKeyAcrossOutputBoundary(t *testing.T) {
+	output := strings.Repeat("x", maxToolCallOutputBytes-12) + "-----BEGIN OPENSSH PRIVATE KEY-----\nsecret-material-without-end-marker"
+	result := NewToolCallResult([]byte(output), false)
+	if !result.Redacted || !result.Truncated || strings.Contains(result.Output, "secret-material") || strings.Contains(result.Output, "PRIVATE KEY") {
+		t.Fatalf("result flags = redacted:%v truncated:%v; output tail = %q", result.Redacted, result.Truncated, result.Output[len(result.Output)-32:])
+	}
+	if err := result.Validate(); err != nil {
+		t.Fatalf("result Validate: %v", err)
+	}
+}
+
 func TestToolCallResultValidateRejectsUnsafeOutput(t *testing.T) {
 	tests := []ToolCallResult{
 		{Output: "safe"},
 		{Output: "token=exposed", UntrustedOutput: true},
+		{Output: "-----BEGIN PRIVATE KEY-----\nsecret-material\n-----END PRIVATE KEY-----", UntrustedOutput: true},
 		{Output: strings.Repeat("x", maxToolCallOutputBytes+1), UntrustedOutput: true},
 		{Output: string([]byte{0xff}), UntrustedOutput: true},
 	}


### PR DESCRIPTION
## Summary

- add immutable, normalized JSON-object arguments for external MCP calls
- validate exact bounded server and tool identifiers
- return bounded, redacted output that remains explicitly untrusted
- define the transport interface without exposing execution, credentials, or cloud writes

## Security boundary

This PR only defines the transport-neutral contract. Authorization, approval, and audit remain in Agent Hub routing, and no external process or MCP tool is invoked here.

## Validation

- `GOCACHE=/private/tmp/iacstudio-go-cache go test -race ./internal/mcpairlock`
- `GOCACHE=/private/tmp/iacstudio-go-cache go test ./...`

Part of #107.