### PR TITLE
Add bounded MCP tool-call codec

### DIFF
--- a/internal/mcpairlock/tool_call_codec.go
+++ b/internal/mcpairlock/tool_call_codec.go
@@ -16,6 +16,7 @@ const (
 	toolCallInitializeID        = 1
 	toolCallInvocationID        = 2
 	maxToolCallWireMessageBytes = 2 << 20
+	maxToolCallWireSessionBytes = 4 << 20
 	maxToolCallWireMessages     = 32
 )
 
@@ -24,11 +25,11 @@ const (
 var ErrInvalidToolCallResponse = errors.New("invalid MCP tool call response")
 
 type toolCallRPCMessage struct {
-	JSONRPC string            `json:"jsonrpc"`
-	ID      json.RawMessage   `json:"id,omitempty"`
-	Method  string            `json:"method,omitempty"`
-	Result  json.RawMessage   `json:"result,omitempty"`
-	Error   *toolCallRPCError `json:"error,omitempty"`
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method,omitempty"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   json.RawMessage `json:"error,omitempty"`
 }
 
 type toolCallRPCError struct {
@@ -67,7 +68,8 @@ func runToolCallSession(ctx context.Context, serverOutput io.Reader, serverInput
 	scanner := bufio.NewScanner(serverOutput)
 	scanner.Buffer(make([]byte, 0, 64*1024), maxToolCallWireMessageBytes)
 	remainingMessages := maxToolCallWireMessages
-	_, rpcErr, err := readToolCallRPCResponse(ctx, scanner, toolCallInitializeID, &remainingMessages)
+	remainingBytes := maxToolCallWireSessionBytes
+	_, rpcErr, err := readToolCallRPCResponse(ctx, scanner, toolCallInitializeID, &remainingMessages, &remainingBytes)
 	if err != nil {
 		return ToolCallResult{}, err
 	}
@@ -82,7 +84,7 @@ func runToolCallSession(ctx context.Context, serverOutput io.Reader, serverInput
 	if err := flushToolCallWriter(serverInput, "tools/call request"); err != nil {
 		return ToolCallResult{}, err
 	}
-	resultJSON, rpcErr, err := readToolCallRPCResponse(ctx, scanner, toolCallInvocationID, &remainingMessages)
+	resultJSON, rpcErr, err := readToolCallRPCResponse(ctx, scanner, toolCallInvocationID, &remainingMessages, &remainingBytes)
 	if err != nil {
 		return ToolCallResult{}, err
 	}
@@ -137,7 +139,7 @@ func flushToolCallWriter(writer io.Writer, operation string) error {
 	return nil
 }
 
-func readToolCallRPCResponse(ctx context.Context, scanner *bufio.Scanner, expectedID int, remainingMessages *int) (json.RawMessage, *toolCallRPCError, error) {
+func readToolCallRPCResponse(ctx context.Context, scanner *bufio.Scanner, expectedID int, remainingMessages, remainingBytes *int) (json.RawMessage, *toolCallRPCError, error) {
 	for *remainingMessages > 0 {
 		if err := ctx.Err(); err != nil {
 			return nil, nil, err
@@ -149,6 +151,10 @@ func readToolCallRPCResponse(ctx context.Context, scanner *bufio.Scanner, expect
 			}
 			return nil, nil, fmt.Errorf("%w: response %d not received: %w", ErrInvalidToolCallResponse, expectedID, io.ErrUnexpectedEOF)
 		}
+		if len(scanner.Bytes()) > *remainingBytes {
+			return nil, nil, fmt.Errorf("%w: response byte limit exceeded", ErrInvalidToolCallResponse)
+		}
+		*remainingBytes -= len(scanner.Bytes())
 		line := bytes.TrimSpace(scanner.Bytes())
 		if len(line) == 0 {
 			continue
@@ -172,11 +178,22 @@ func readToolCallRPCResponse(ctx context.Context, scanner *bufio.Scanner, expect
 		if responseID != expectedID {
 			return nil, nil, fmt.Errorf("%w: unexpected response id %d, want %d", ErrInvalidToolCallResponse, responseID, expectedID)
 		}
-		hasResult := len(bytes.TrimSpace(message.Result)) > 0 && !bytes.Equal(bytes.TrimSpace(message.Result), []byte("null"))
-		if hasResult == (message.Error != nil) {
+		hasResult := len(bytes.TrimSpace(message.Result)) > 0
+		hasError := len(bytes.TrimSpace(message.Error)) > 0
+		if hasResult == hasError {
 			return nil, nil, fmt.Errorf("%w: response must contain exactly one of result or error", ErrInvalidToolCallResponse)
 		}
-		return message.Result, message.Error, nil
+		if hasError {
+			var rpcErr toolCallRPCError
+			if bytes.Equal(bytes.TrimSpace(message.Error), []byte("null")) {
+				return nil, nil, fmt.Errorf("%w: error must be an object", ErrInvalidToolCallResponse)
+			}
+			if err := json.Unmarshal(message.Error, &rpcErr); err != nil {
+				return nil, nil, fmt.Errorf("%w: decode response error: %w", ErrInvalidToolCallResponse, err)
+			}
+			return nil, &rpcErr, nil
+		}
+		return message.Result, nil, nil
 	}
 	return nil, nil, fmt.Errorf("%w: response message limit exceeded", ErrInvalidToolCallResponse)
 }

--- a/internal/mcpairlock/tool_call_codec.go
+++ b/internal/mcpairlock/tool_call_codec.go
@@ -37,6 +37,10 @@ type toolCallRPCError struct {
 	Message string `json:"message"`
 }
 
+type toolCallInitializeResult struct {
+	ProtocolVersion string `json:"protocolVersion"`
+}
+
 type toolCallWireResult struct {
 	Content []struct {
 		Type string `json:"type"`
@@ -69,13 +73,16 @@ func runToolCallSession(ctx context.Context, serverOutput io.Reader, serverInput
 	scanner.Buffer(make([]byte, 0, 64*1024), maxToolCallWireMessageBytes)
 	remainingMessages := maxToolCallWireMessages
 	remainingBytes := maxToolCallWireSessionBytes
-	_, rpcErr, err := readToolCallRPCResponse(ctx, scanner, toolCallInitializeID, &remainingMessages, &remainingBytes)
+	initializeJSON, rpcErr, err := readToolCallRPCResponse(ctx, scanner, toolCallInitializeID, &remainingMessages, &remainingBytes)
 	if err != nil {
 		return ToolCallResult{}, err
 	}
 	if rpcErr != nil {
 		result := newToolCallRPCErrorResult(rpcErr)
 		return ToolCallResult{}, fmt.Errorf("%w: initialize failed: %s", ErrInvalidToolCallResponse, result.Output)
+	}
+	if err := validateToolCallInitializeResult(initializeJSON); err != nil {
+		return ToolCallResult{}, err
 	}
 
 	if err := writeToolCallInvocation(encoder, request); err != nil {
@@ -135,6 +142,20 @@ func flushToolCallWriter(writer io.Writer, operation string) error {
 	}
 	if err := flusher.Flush(); err != nil {
 		return fmt.Errorf("flush %s: %w", operation, err)
+	}
+	return nil
+}
+
+func validateToolCallInitializeResult(input json.RawMessage) error {
+	if bytes.Equal(bytes.TrimSpace(input), []byte("null")) {
+		return fmt.Errorf("%w: initialize result must be an object", ErrInvalidToolCallResponse)
+	}
+	var result toolCallInitializeResult
+	if err := json.Unmarshal(input, &result); err != nil {
+		return fmt.Errorf("%w: decode initialize result: %w", ErrInvalidToolCallResponse, err)
+	}
+	if result.ProtocolVersion != toolCallProtocolVersion {
+		return fmt.Errorf("%w: initialize protocol version is unsupported", ErrInvalidToolCallResponse)
 	}
 	return nil
 }

--- a/internal/mcpairlock/tool_call_codec.go
+++ b/internal/mcpairlock/tool_call_codec.go
@@ -60,6 +60,9 @@ func runToolCallSession(ctx context.Context, serverOutput io.Reader, serverInput
 	if err := writeToolCallInitialize(encoder); err != nil {
 		return ToolCallResult{}, err
 	}
+	if err := flushToolCallWriter(serverInput, "initialize request"); err != nil {
+		return ToolCallResult{}, err
+	}
 
 	scanner := bufio.NewScanner(serverOutput)
 	scanner.Buffer(make([]byte, 0, 64*1024), maxToolCallWireMessageBytes)
@@ -74,6 +77,9 @@ func runToolCallSession(ctx context.Context, serverOutput io.Reader, serverInput
 	}
 
 	if err := writeToolCallInvocation(encoder, request); err != nil {
+		return ToolCallResult{}, err
+	}
+	if err := flushToolCallWriter(serverInput, "tools/call request"); err != nil {
 		return ToolCallResult{}, err
 	}
 	resultJSON, rpcErr, err := readToolCallRPCResponse(ctx, scanner, toolCallInvocationID, &remainingMessages)
@@ -120,6 +126,17 @@ func writeToolCallInvocation(encoder *json.Encoder, request ToolCallRequest) err
 	return nil
 }
 
+func flushToolCallWriter(writer io.Writer, operation string) error {
+	flusher, ok := writer.(interface{ Flush() error })
+	if !ok {
+		return nil
+	}
+	if err := flusher.Flush(); err != nil {
+		return fmt.Errorf("flush %s: %w", operation, err)
+	}
+	return nil
+}
+
 func readToolCallRPCResponse(ctx context.Context, scanner *bufio.Scanner, expectedID int, remainingMessages *int) (json.RawMessage, *toolCallRPCError, error) {
 	for *remainingMessages > 0 {
 		if err := ctx.Err(); err != nil {
@@ -149,8 +166,11 @@ func readToolCallRPCResponse(ctx context.Context, scanner *bufio.Scanner, expect
 		}
 
 		var responseID int
-		if err := json.Unmarshal(message.ID, &responseID); err != nil || responseID != expectedID {
-			return nil, nil, fmt.Errorf("%w: unexpected response id", ErrInvalidToolCallResponse)
+		if err := json.Unmarshal(message.ID, &responseID); err != nil {
+			return nil, nil, fmt.Errorf("%w: decode response id: %w", ErrInvalidToolCallResponse, err)
+		}
+		if responseID != expectedID {
+			return nil, nil, fmt.Errorf("%w: unexpected response id %d, want %d", ErrInvalidToolCallResponse, responseID, expectedID)
 		}
 		hasResult := len(bytes.TrimSpace(message.Result)) > 0 && !bytes.Equal(bytes.TrimSpace(message.Result), []byte("null"))
 		if hasResult == (message.Error != nil) {

--- a/internal/mcpairlock/tool_call_codec.go
+++ b/internal/mcpairlock/tool_call_codec.go
@@ -1,0 +1,191 @@
+package mcpairlock
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+const (
+	toolCallProtocolVersion     = "2025-06-18"
+	toolCallInitializeID        = 1
+	toolCallInvocationID        = 2
+	maxToolCallWireMessageBytes = 2 << 20
+	maxToolCallWireMessages     = 32
+)
+
+// ErrInvalidToolCallResponse classifies malformed, mismatched, or unsupported
+// responses received from an external MCP server.
+var ErrInvalidToolCallResponse = errors.New("invalid MCP tool call response")
+
+type toolCallRPCMessage struct {
+	JSONRPC string            `json:"jsonrpc"`
+	ID      json.RawMessage   `json:"id,omitempty"`
+	Method  string            `json:"method,omitempty"`
+	Result  json.RawMessage   `json:"result,omitempty"`
+	Error   *toolCallRPCError `json:"error,omitempty"`
+}
+
+type toolCallRPCError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+type toolCallWireResult struct {
+	Content []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	} `json:"content"`
+	IsError bool `json:"isError,omitempty"`
+}
+
+// runToolCallSession exchanges one MCP tools/call request over an already
+// connected newline-delimited stream. The process adapter owns cancellation
+// and stream closure; this codec owns protocol and payload bounds.
+func runToolCallSession(ctx context.Context, serverOutput io.Reader, serverInput io.Writer, request ToolCallRequest) (ToolCallResult, error) {
+	if err := request.Validate(); err != nil {
+		return ToolCallResult{}, err
+	}
+	if err := ctx.Err(); err != nil {
+		return ToolCallResult{}, err
+	}
+
+	encoder := json.NewEncoder(serverInput)
+	encoder.SetEscapeHTML(false)
+	if err := writeToolCallInitialize(encoder); err != nil {
+		return ToolCallResult{}, err
+	}
+
+	scanner := bufio.NewScanner(serverOutput)
+	scanner.Buffer(make([]byte, 0, 64*1024), maxToolCallWireMessageBytes)
+	remainingMessages := maxToolCallWireMessages
+	_, rpcErr, err := readToolCallRPCResponse(ctx, scanner, toolCallInitializeID, &remainingMessages)
+	if err != nil {
+		return ToolCallResult{}, err
+	}
+	if rpcErr != nil {
+		result := newToolCallRPCErrorResult(rpcErr)
+		return ToolCallResult{}, fmt.Errorf("%w: initialize failed: %s", ErrInvalidToolCallResponse, result.Output)
+	}
+
+	if err := writeToolCallInvocation(encoder, request); err != nil {
+		return ToolCallResult{}, err
+	}
+	resultJSON, rpcErr, err := readToolCallRPCResponse(ctx, scanner, toolCallInvocationID, &remainingMessages)
+	if err != nil {
+		return ToolCallResult{}, err
+	}
+	if rpcErr != nil {
+		return newToolCallRPCErrorResult(rpcErr), nil
+	}
+	return decodeToolCallWireResult(resultJSON)
+}
+
+func writeToolCallInitialize(encoder *json.Encoder) error {
+	if err := encoder.Encode(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      toolCallInitializeID,
+		"method":  "initialize",
+		"params": map[string]any{
+			"protocolVersion": toolCallProtocolVersion,
+			"capabilities":    map[string]any{},
+			"clientInfo":      map[string]any{"name": "iac-studio-airlock", "version": "0"},
+		},
+	}); err != nil {
+		return fmt.Errorf("write initialize request: %w", err)
+	}
+	return nil
+}
+
+func writeToolCallInvocation(encoder *json.Encoder, request ToolCallRequest) error {
+	if err := encoder.Encode(map[string]any{"jsonrpc": "2.0", "method": "notifications/initialized"}); err != nil {
+		return fmt.Errorf("write initialized notification: %w", err)
+	}
+	if err := encoder.Encode(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      toolCallInvocationID,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name":      request.ToolName,
+			"arguments": json.RawMessage(request.Arguments.Bytes()),
+		},
+	}); err != nil {
+		return fmt.Errorf("write tools/call request: %w", err)
+	}
+	return nil
+}
+
+func readToolCallRPCResponse(ctx context.Context, scanner *bufio.Scanner, expectedID int, remainingMessages *int) (json.RawMessage, *toolCallRPCError, error) {
+	for *remainingMessages > 0 {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
+		*remainingMessages = *remainingMessages - 1
+		if !scanner.Scan() {
+			if err := scanner.Err(); err != nil {
+				return nil, nil, fmt.Errorf("%w: read response: %w", ErrInvalidToolCallResponse, err)
+			}
+			return nil, nil, fmt.Errorf("%w: response %d not received: %w", ErrInvalidToolCallResponse, expectedID, io.ErrUnexpectedEOF)
+		}
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+
+		var message toolCallRPCMessage
+		if err := json.Unmarshal(line, &message); err != nil {
+			return nil, nil, fmt.Errorf("%w: decode response: %w", ErrInvalidToolCallResponse, err)
+		}
+		if message.JSONRPC != "2.0" {
+			return nil, nil, fmt.Errorf("%w: unsupported JSON-RPC version", ErrInvalidToolCallResponse)
+		}
+		if len(message.ID) == 0 && message.Method != "" {
+			continue
+		}
+
+		var responseID int
+		if err := json.Unmarshal(message.ID, &responseID); err != nil || responseID != expectedID {
+			return nil, nil, fmt.Errorf("%w: unexpected response id", ErrInvalidToolCallResponse)
+		}
+		hasResult := len(bytes.TrimSpace(message.Result)) > 0 && !bytes.Equal(bytes.TrimSpace(message.Result), []byte("null"))
+		if hasResult == (message.Error != nil) {
+			return nil, nil, fmt.Errorf("%w: response must contain exactly one of result or error", ErrInvalidToolCallResponse)
+		}
+		return message.Result, message.Error, nil
+	}
+	return nil, nil, fmt.Errorf("%w: response message limit exceeded", ErrInvalidToolCallResponse)
+}
+
+func decodeToolCallWireResult(input json.RawMessage) (ToolCallResult, error) {
+	var wireResult toolCallWireResult
+	if err := json.Unmarshal(input, &wireResult); err != nil {
+		return ToolCallResult{}, fmt.Errorf("%w: decode tools/call result: %w", ErrInvalidToolCallResponse, err)
+	}
+	texts := make([]string, 0, len(wireResult.Content))
+	for _, content := range wireResult.Content {
+		if content.Type == "text" {
+			texts = append(texts, content.Text)
+		}
+	}
+	if len(texts) == 0 {
+		return ToolCallResult{}, fmt.Errorf("%w: tools/call result has no text content", ErrInvalidToolCallResponse)
+	}
+	result := NewToolCallResult([]byte(strings.Join(texts, "\n")), wireResult.IsError)
+	if err := result.Validate(); err != nil {
+		return ToolCallResult{}, err
+	}
+	return result, nil
+}
+
+func newToolCallRPCErrorResult(rpcErr *toolCallRPCError) ToolCallResult {
+	message := strings.TrimSpace(rpcErr.Message)
+	if message == "" {
+		message = fmt.Sprintf("MCP error %d", rpcErr.Code)
+	}
+	return NewToolCallResult([]byte(message), true)
+}

--- a/internal/mcpairlock/tool_call_codec_test.go
+++ b/internal/mcpairlock/tool_call_codec_test.go
@@ -1,10 +1,13 @@
 package mcpairlock
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
 	"strings"
 	"testing"
 )
@@ -52,6 +55,21 @@ func TestRunToolCallSessionWritesHandshakeAndSanitizesText(t *testing.T) {
 	}
 }
 
+func TestRunToolCallSessionFlushesBufferedRequests(t *testing.T) {
+	requests := newStagedToolCallWriter()
+	responses := &stagedToolCallResponses{writer: requests}
+
+	if _, err := runToolCallSession(context.Background(), responses, requests, testToolCallRequest(t)); err != nil {
+		t.Fatalf("runToolCallSession: %v", err)
+	}
+	if requests.flushes != 2 {
+		t.Fatalf("flush count = %d, want 2", requests.flushes)
+	}
+	if lines := strings.Split(strings.TrimSpace(requests.buffer.String()), "\n"); len(lines) != 3 {
+		t.Fatalf("flushed request count = %d, want 3: %s", len(lines), requests.buffer.String())
+	}
+}
+
 func TestRunToolCallSessionSanitizesRPCError(t *testing.T) {
 	responses := toolCallInitializeResponse + "\n" + `{"jsonrpc":"2.0","id":2,"error":{"code":-32603,"message":"client_secret=do-not-leak"}}`
 	result, err := runToolCallSession(context.Background(), strings.NewReader(responses), &bytes.Buffer{}, testToolCallRequest(t))
@@ -78,11 +96,13 @@ func TestRunToolCallSessionRejectsInvalidResponses(t *testing.T) {
 	oversized := toolCallInitializeResponse + "\n" + strings.Repeat("x", maxToolCallWireMessageBytes+1)
 	notifications := strings.Repeat(`{"jsonrpc":"2.0","method":"notifications/progress"}`+"\n", maxToolCallWireMessages)
 	tests := []struct {
-		name      string
-		responses string
+		name          string
+		responses     string
+		errorContains string
 	}{
 		{name: "malformed JSON", responses: "not-json"},
-		{name: "wrong response id", responses: `{"jsonrpc":"2.0","id":9,"result":{}}`},
+		{name: "invalid response id", responses: `{"jsonrpc":"2.0","id":"one","result":{}}`, errorContains: "decode response id"},
+		{name: "wrong response id", responses: `{"jsonrpc":"2.0","id":9,"result":{}}`, errorContains: "unexpected response id 9, want 1"},
 		{name: "unsupported version", responses: `{"jsonrpc":"1.0","id":1,"result":{}}`},
 		{name: "oversized response", responses: oversized},
 		{name: "message limit", responses: notifications},
@@ -92,6 +112,9 @@ func TestRunToolCallSessionRejectsInvalidResponses(t *testing.T) {
 			_, err := runToolCallSession(context.Background(), strings.NewReader(test.responses), &bytes.Buffer{}, testToolCallRequest(t))
 			if !errors.Is(err, ErrInvalidToolCallResponse) {
 				t.Fatalf("error = %v, want ErrInvalidToolCallResponse", err)
+			}
+			if test.errorContains != "" && !strings.Contains(err.Error(), test.errorContains) {
+				t.Fatalf("error = %q, want substring %q", err, test.errorContains)
 			}
 		})
 	}
@@ -108,4 +131,47 @@ func testToolCallRequest(t *testing.T) ToolCallRequest {
 		t.Fatalf("NewToolCallRequest: %v", err)
 	}
 	return request
+}
+
+type stagedToolCallWriter struct {
+	buffer   bytes.Buffer
+	buffered *bufio.Writer
+	flushes  int
+}
+
+func newStagedToolCallWriter() *stagedToolCallWriter {
+	writer := &stagedToolCallWriter{}
+	writer.buffered = bufio.NewWriter(&writer.buffer)
+	return writer
+}
+
+func (w *stagedToolCallWriter) Write(input []byte) (int, error) {
+	return w.buffered.Write(input)
+}
+
+func (w *stagedToolCallWriter) Flush() error {
+	w.flushes++
+	return w.buffered.Flush()
+}
+
+type stagedToolCallResponses struct {
+	writer *stagedToolCallWriter
+	stage  int
+}
+
+func (r *stagedToolCallResponses) Read(output []byte) (int, error) {
+	if r.stage >= 2 {
+		return 0, io.EOF
+	}
+	wantFlushes := r.stage + 1
+	if r.writer.flushes != wantFlushes {
+		return 0, fmt.Errorf("flush count before response %d = %d, want %d", r.stage+1, r.writer.flushes, wantFlushes)
+	}
+	responses := []string{
+		toolCallInitializeResponse,
+		`{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"safe"}]}}`,
+	}
+	response := responses[r.stage] + "\n"
+	r.stage++
+	return copy(output, response), nil
 }

--- a/internal/mcpairlock/tool_call_codec_test.go
+++ b/internal/mcpairlock/tool_call_codec_test.go
@@ -95,6 +95,7 @@ func TestRunToolCallSessionRejectsInvalidRequestBeforeWriting(t *testing.T) {
 func TestRunToolCallSessionRejectsInvalidResponses(t *testing.T) {
 	oversized := toolCallInitializeResponse + "\n" + strings.Repeat("x", maxToolCallWireMessageBytes+1)
 	notifications := strings.Repeat(`{"jsonrpc":"2.0","method":"notifications/progress"}`+"\n", maxToolCallWireMessages)
+	largeNotification := `{"jsonrpc":"2.0","method":"notifications/progress","params":{"data":"` + strings.Repeat("x", 1<<20) + `"}}` + "\n"
 	tests := []struct {
 		name          string
 		responses     string
@@ -104,7 +105,10 @@ func TestRunToolCallSessionRejectsInvalidResponses(t *testing.T) {
 		{name: "invalid response id", responses: `{"jsonrpc":"2.0","id":"one","result":{}}`, errorContains: "decode response id"},
 		{name: "wrong response id", responses: `{"jsonrpc":"2.0","id":9,"result":{}}`, errorContains: "unexpected response id 9, want 1"},
 		{name: "unsupported version", responses: `{"jsonrpc":"1.0","id":1,"result":{}}`},
+		{name: "result and error", responses: `{"jsonrpc":"2.0","id":1,"result":null,"error":{"code":-32603,"message":"bad"}}`, errorContains: "exactly one of result or error"},
+		{name: "null error", responses: `{"jsonrpc":"2.0","id":1,"error":null}`, errorContains: "error must be an object"},
 		{name: "oversized response", responses: oversized},
+		{name: "session byte limit", responses: strings.Repeat(largeNotification, 5), errorContains: "response byte limit exceeded"},
 		{name: "message limit", responses: notifications},
 	}
 	for _, test := range tests {

--- a/internal/mcpairlock/tool_call_codec_test.go
+++ b/internal/mcpairlock/tool_call_codec_test.go
@@ -105,6 +105,8 @@ func TestRunToolCallSessionRejectsInvalidResponses(t *testing.T) {
 		{name: "invalid response id", responses: `{"jsonrpc":"2.0","id":"one","result":{}}`, errorContains: "decode response id"},
 		{name: "wrong response id", responses: `{"jsonrpc":"2.0","id":9,"result":{}}`, errorContains: "unexpected response id 9, want 1"},
 		{name: "unsupported version", responses: `{"jsonrpc":"1.0","id":1,"result":{}}`},
+		{name: "null initialize result", responses: `{"jsonrpc":"2.0","id":1,"result":null}`, errorContains: "initialize result must be an object"},
+		{name: "unsupported initialize protocol", responses: `{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05"}}`, errorContains: "initialize protocol version is unsupported"},
 		{name: "result and error", responses: `{"jsonrpc":"2.0","id":1,"result":null,"error":{"code":-32603,"message":"bad"}}`, errorContains: "exactly one of result or error"},
 		{name: "null error", responses: `{"jsonrpc":"2.0","id":1,"error":null}`, errorContains: "error must be an object"},
 		{name: "oversized response", responses: oversized},

--- a/internal/mcpairlock/tool_call_codec_test.go
+++ b/internal/mcpairlock/tool_call_codec_test.go
@@ -1,0 +1,111 @@
+package mcpairlock
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+const toolCallInitializeResponse = `{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{},"serverInfo":{"name":"test","version":"1"}}}`
+
+func TestRunToolCallSessionWritesHandshakeAndSanitizesText(t *testing.T) {
+	request := testToolCallRequest(t)
+	responses := strings.Join([]string{
+		toolCallInitializeResponse,
+		`{"jsonrpc":"2.0","method":"notifications/progress","params":{}}`,
+		`{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"prefix token=do-not-leak"},{"type":"text","text":"safe"}],"isError":false}}`,
+	}, "\n")
+	var requests bytes.Buffer
+	result, err := runToolCallSession(context.Background(), strings.NewReader(responses), &requests, request)
+	if err != nil {
+		t.Fatalf("runToolCallSession: %v", err)
+	}
+	if !result.UntrustedOutput || !result.Redacted || result.IsError || strings.Contains(result.Output, "do-not-leak") || !strings.Contains(result.Output, "safe") {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+
+	lines := strings.Split(strings.TrimSpace(requests.String()), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("request count = %d, want 3: %s", len(lines), requests.String())
+	}
+	wantMethods := []string{"initialize", "notifications/initialized", "tools/call"}
+	for i, line := range lines {
+		var message struct {
+			Method string `json:"method"`
+			Params struct {
+				Name      string         `json:"name"`
+				Arguments map[string]any `json:"arguments"`
+			} `json:"params"`
+		}
+		if err := json.Unmarshal([]byte(line), &message); err != nil {
+			t.Fatalf("decode request %d: %v", i, err)
+		}
+		if message.Method != wantMethods[i] {
+			t.Fatalf("request %d method = %q, want %q", i, message.Method, wantMethods[i])
+		}
+		if i == 2 && (message.Params.Name != request.ToolName || message.Params.Arguments["workspace"] != "demo") {
+			t.Fatalf("tools/call params = %+v", message.Params)
+		}
+	}
+}
+
+func TestRunToolCallSessionSanitizesRPCError(t *testing.T) {
+	responses := toolCallInitializeResponse + "\n" + `{"jsonrpc":"2.0","id":2,"error":{"code":-32603,"message":"client_secret=do-not-leak"}}`
+	result, err := runToolCallSession(context.Background(), strings.NewReader(responses), &bytes.Buffer{}, testToolCallRequest(t))
+	if err != nil {
+		t.Fatalf("runToolCallSession: %v", err)
+	}
+	if !result.IsError || !result.Redacted || !result.UntrustedOutput || strings.Contains(result.Output, "do-not-leak") {
+		t.Fatalf("unexpected RPC error result: %+v", result)
+	}
+}
+
+func TestRunToolCallSessionRejectsInvalidRequestBeforeWriting(t *testing.T) {
+	var requests bytes.Buffer
+	_, err := runToolCallSession(context.Background(), strings.NewReader(""), &requests, ToolCallRequest{})
+	if !errors.Is(err, ErrInvalidToolCallRequest) {
+		t.Fatalf("error = %v, want ErrInvalidToolCallRequest", err)
+	}
+	if requests.Len() != 0 {
+		t.Fatalf("invalid request wrote %d bytes", requests.Len())
+	}
+}
+
+func TestRunToolCallSessionRejectsInvalidResponses(t *testing.T) {
+	oversized := toolCallInitializeResponse + "\n" + strings.Repeat("x", maxToolCallWireMessageBytes+1)
+	notifications := strings.Repeat(`{"jsonrpc":"2.0","method":"notifications/progress"}`+"\n", maxToolCallWireMessages)
+	tests := []struct {
+		name      string
+		responses string
+	}{
+		{name: "malformed JSON", responses: "not-json"},
+		{name: "wrong response id", responses: `{"jsonrpc":"2.0","id":9,"result":{}}`},
+		{name: "unsupported version", responses: `{"jsonrpc":"1.0","id":1,"result":{}}`},
+		{name: "oversized response", responses: oversized},
+		{name: "message limit", responses: notifications},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := runToolCallSession(context.Background(), strings.NewReader(test.responses), &bytes.Buffer{}, testToolCallRequest(t))
+			if !errors.Is(err, ErrInvalidToolCallResponse) {
+				t.Fatalf("error = %v, want ErrInvalidToolCallResponse", err)
+			}
+		})
+	}
+}
+
+func testToolCallRequest(t *testing.T) ToolCallRequest {
+	t.Helper()
+	arguments, err := ParseToolCallArguments([]byte(`{"workspace":"demo"}`))
+	if err != nil {
+		t.Fatalf("ParseToolCallArguments: %v", err)
+	}
+	request, err := NewToolCallRequest("terraform-official", "provider.plan/read_only-v2", arguments)
+	if err != nil {
+		t.Fatalf("NewToolCallRequest: %v", err)
+	}
+	return request
+}


### PR DESCRIPTION
## Summary

- encode the MCP initialize, initialized, and tools/call sequence over injected streams
- require JSON-RPC 2.0 and exact response IDs while bounding message size and count
- convert text results and protocol errors into redacted, explicitly untrusted ToolCallResult values
- reject invalid requests before any wire output

## Scope boundary

This PR is stream-only. It does not launch processes, expose an API, route agent requests, inject credentials, or permit cloud writes. A later slice will connect this codec to a sanitized one-shot stdio process.

## Validation

- GOCACHE=/private/tmp/iacstudio-go-cache go test -race ./internal/mcpairlock
- GOCACHE=/private/tmp/iacstudio-go-cache go test ./cmd/... ./internal/... -race
- GOCACHE=/private/tmp/iacstudio-go-cache go test ./...
- GOCACHE=/private/tmp/iacstudio-go-cache go vet ./internal/mcpairlock

Part of #107.