### PR TITLE
Add guarded MCP route executor

### DIFF
--- a/internal/agentrouting/executor.go
+++ b/internal/agentrouting/executor.go
@@ -1,0 +1,130 @@
+package agentrouting
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/iac-studio/iac-studio/internal/agentruns"
+	"github.com/iac-studio/iac-studio/internal/mcpairlock"
+)
+
+var (
+	ErrToolRouteExecutorRequired = errors.New("tool route executor is required")
+	ErrToolInvokerRequired       = errors.New("tool invoker is required")
+	ErrToolExecutionContext      = errors.New("tool execution context is required")
+	ErrInvalidToolExecution      = errors.New("invalid authorized tool execution")
+	ErrToolInvocationFailed      = errors.New("MCP tool invocation failed")
+)
+
+// ToolInvokeFunc runs one transport request that the Executor has already
+// authorized and recorded on an Agent Run.
+type ToolInvokeFunc func(context.Context, mcpairlock.ToolCallRequest) (mcpairlock.ToolCallResult, error)
+
+// ExecutionResult includes a route decision for every recorded authorization
+// outcome. Result is populated only when the external tool was invoked.
+type ExecutionResult struct {
+	Route   RouteResult                `json:"route"`
+	Invoked bool                       `json:"invoked"`
+	Result  *mcpairlock.ToolCallResult `json:"result,omitempty"`
+}
+
+// Executor records authorization through Router before invoking one external
+// MCP tool. It does not select credentials or expose an HTTP endpoint.
+type Executor struct {
+	router *Router
+	invoke ToolInvokeFunc
+}
+
+func NewExecutor(router *Router, invoke ToolInvokeFunc) (*Executor, error) {
+	if router == nil {
+		return nil, ErrToolRouteExecutorRequired
+	}
+	if invoke == nil {
+		return nil, ErrToolInvokerRequired
+	}
+	return &Executor{router: router, invoke: invoke}, nil
+}
+
+// Execute validates and binds the transport request, records the scoped route
+// decision, and invokes exactly once only when that decision is allowed.
+func (e *Executor) Execute(
+	ctx context.Context,
+	runID string,
+	request Request,
+	arguments mcpairlock.ToolCallArguments,
+) (ExecutionResult, error) {
+	if e == nil || e.router == nil {
+		return ExecutionResult{}, ErrToolRouteExecutorRequired
+	}
+	if e.invoke == nil {
+		return ExecutionResult{}, ErrToolInvokerRequired
+	}
+	if ctx == nil {
+		return ExecutionResult{}, ErrToolExecutionContext
+	}
+	if err := ctx.Err(); err != nil {
+		return ExecutionResult{}, err
+	}
+	if err := request.Validate(); err != nil {
+		return ExecutionResult{}, err
+	}
+
+	toolRequest, err := mcpairlock.NewToolCallRequest(request.ServerID, request.ToolName, arguments)
+	if err != nil {
+		return ExecutionResult{}, err
+	}
+	route, err := e.router.Route(runID, request)
+	if err != nil {
+		return ExecutionResult{}, fmt.Errorf("record tool execution route: %w", err)
+	}
+	if err := validateExecutionRoute(route, runID, request); err != nil {
+		return ExecutionResult{}, err
+	}
+
+	execution := ExecutionResult{Route: route}
+	if route.Decision.Status != DecisionAllowed {
+		return execution, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return ExecutionResult{}, err
+	}
+
+	result, err := e.invoke(ctx, toolRequest)
+	if contextErr := ctx.Err(); contextErr != nil {
+		return ExecutionResult{}, contextErr
+	}
+	if err != nil {
+		return ExecutionResult{}, ErrToolInvocationFailed
+	}
+	if err := result.Validate(); err != nil {
+		return ExecutionResult{}, ErrToolInvocationFailed
+	}
+	execution.Invoked = true
+	execution.Result = &result
+	return execution, nil
+}
+
+func validateExecutionRoute(route RouteResult, runID string, request Request) error {
+	if err := route.Decision.Validate(); err != nil {
+		return ErrInvalidToolExecution
+	}
+	if route.Run.ID != runID ||
+		route.Run.Project != request.Project ||
+		route.Run.ProviderID != request.ProviderID ||
+		route.Run.Mode != request.Mode {
+		return ErrInvalidToolExecution
+	}
+	if route.Decision.Status != DecisionAllowed {
+		return nil
+	}
+	if route.Run.Canceled || (route.Run.Status != agentruns.StatusQueued && route.Run.Status != agentruns.StatusRunning) {
+		return ErrInvalidToolExecution
+	}
+	for _, approval := range route.Run.Approvals {
+		if approval.Status == agentruns.ApprovalPending {
+			return ErrInvalidToolExecution
+		}
+	}
+	return nil
+}

--- a/internal/agentrouting/executor.go
+++ b/internal/agentrouting/executor.go
@@ -14,7 +14,7 @@ var (
 	ErrToolInvokerRequired     = errors.New("tool invoker is required")
 	ErrToolExecutionContext    = errors.New("tool execution context is required")
 	ErrInvalidToolExecution    = errors.New("invalid authorized tool execution")
-	ErrToolInvocationFailed    = errors.New("MCP tool invocation failed")
+	ErrToolInvocationFailed    = errors.New("mcp tool invocation failed")
 )
 
 // ToolInvokeFunc runs one transport request that the Executor has already
@@ -33,8 +33,9 @@ type ExecutionResult struct {
 // Executor records authorization through Router before invoking one external
 // MCP tool. It does not select credentials or expose an HTTP endpoint.
 type Executor struct {
-	router *Router
-	invoke ToolInvokeFunc
+	router    *Router
+	invoke    ToolInvokeFunc
+	lookupRun func(string) (agentruns.Run, bool)
 }
 
 func NewExecutor(router *Router, invoke ToolInvokeFunc) (*Executor, error) {
@@ -44,7 +45,7 @@ func NewExecutor(router *Router, invoke ToolInvokeFunc) (*Executor, error) {
 	if invoke == nil {
 		return nil, ErrToolInvokerRequired
 	}
-	return &Executor{router: router, invoke: invoke}, nil
+	return &Executor{router: router, invoke: invoke, lookupRun: router.currentRun}, nil
 }
 
 // Execute validates and binds the transport request, records the scoped route
@@ -87,6 +88,21 @@ func (e *Executor) Execute(
 	if route.Decision.Status != DecisionAllowed {
 		return execution, nil
 	}
+	if err := ctx.Err(); err != nil {
+		return ExecutionResult{}, err
+	}
+	if e.lookupRun == nil {
+		return ExecutionResult{}, ErrInvalidToolExecution
+	}
+	current, ok := e.lookupRun(runID)
+	if !ok {
+		return ExecutionResult{}, ErrInvalidToolExecution
+	}
+	route.Run = current
+	if err := validateExecutionRoute(route, runID, request); err != nil {
+		return ExecutionResult{}, err
+	}
+	execution.Route = route
 	if err := ctx.Err(); err != nil {
 		return ExecutionResult{}, err
 	}

--- a/internal/agentrouting/executor.go
+++ b/internal/agentrouting/executor.go
@@ -10,19 +10,20 @@ import (
 )
 
 var (
-	ErrToolRouteExecutorRequired = errors.New("tool route executor is required")
-	ErrToolInvokerRequired       = errors.New("tool invoker is required")
-	ErrToolExecutionContext      = errors.New("tool execution context is required")
-	ErrInvalidToolExecution      = errors.New("invalid authorized tool execution")
-	ErrToolInvocationFailed      = errors.New("MCP tool invocation failed")
+	ErrToolRouteRouterRequired = errors.New("tool route router is required")
+	ErrToolInvokerRequired     = errors.New("tool invoker is required")
+	ErrToolExecutionContext    = errors.New("tool execution context is required")
+	ErrInvalidToolExecution    = errors.New("invalid authorized tool execution")
+	ErrToolInvocationFailed    = errors.New("MCP tool invocation failed")
 )
 
 // ToolInvokeFunc runs one transport request that the Executor has already
 // authorized and recorded on an Agent Run.
 type ToolInvokeFunc func(context.Context, mcpairlock.ToolCallRequest) (mcpairlock.ToolCallResult, error)
 
-// ExecutionResult includes a route decision for every recorded authorization
-// outcome. Result is populated only when the external tool was invoked.
+// ExecutionResult contains the recorded route and optional tool result for a
+// successful Execute call. Execute returns a zero result on every error, even
+// when routing was recorded before a later invocation failure.
 type ExecutionResult struct {
 	Route   RouteResult                `json:"route"`
 	Invoked bool                       `json:"invoked"`
@@ -38,7 +39,7 @@ type Executor struct {
 
 func NewExecutor(router *Router, invoke ToolInvokeFunc) (*Executor, error) {
 	if router == nil {
-		return nil, ErrToolRouteExecutorRequired
+		return nil, ErrToolRouteRouterRequired
 	}
 	if invoke == nil {
 		return nil, ErrToolInvokerRequired
@@ -55,7 +56,7 @@ func (e *Executor) Execute(
 	arguments mcpairlock.ToolCallArguments,
 ) (ExecutionResult, error) {
 	if e == nil || e.router == nil {
-		return ExecutionResult{}, ErrToolRouteExecutorRequired
+		return ExecutionResult{}, ErrToolRouteRouterRequired
 	}
 	if e.invoke == nil {
 		return ExecutionResult{}, ErrToolInvokerRequired

--- a/internal/agentrouting/executor_test.go
+++ b/internal/agentrouting/executor_test.go
@@ -89,6 +89,64 @@ func TestExecutorDoesNotInvokeNonAllowedRoutes(t *testing.T) {
 	}
 }
 
+func TestExecutorRechecksRunImmediatelyBeforeInvocation(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*testing.T, *agentruns.Store, string)
+	}{
+		{
+			name: "canceled",
+			mutate: func(t *testing.T, store *agentruns.Store, runID string) {
+				t.Helper()
+				if _, err := store.Cancel(runID); err != nil {
+					t.Fatalf("Cancel(): %v", err)
+				}
+			},
+		},
+		{
+			name: "pending approval",
+			mutate: func(t *testing.T, store *agentruns.Store, runID string) {
+				t.Helper()
+				if _, err := store.AddApproval(runID, agentruns.ApprovalGate{
+					Kind:    agentruns.ApprovalMCPNetwork,
+					Summary: "authorize invocation",
+				}); err != nil {
+					t.Fatalf("AddApproval(): %v", err)
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			policy, request, airlock := readOnlyEvaluation()
+			router, _, store, run := routerFixture(t, policy, request, airlock)
+			invocations := 0
+			executor, err := NewExecutor(router, func(context.Context, mcpairlock.ToolCallRequest) (mcpairlock.ToolCallResult, error) {
+				invocations++
+				return mcpairlock.NewToolCallResult(nil, false), nil
+			})
+			if err != nil {
+				t.Fatalf("NewExecutor(): %v", err)
+			}
+			lookups := 0
+			executor.lookupRun = func(runID string) (agentruns.Run, bool) {
+				lookups++
+				test.mutate(t, store, runID)
+				return store.Get(runID)
+			}
+
+			result, err := executor.Execute(context.Background(), run.ID, request, executionArguments(t))
+			if !errors.Is(err, ErrInvalidToolExecution) {
+				t.Fatalf("Execute() error = %v, want ErrInvalidToolExecution", err)
+			}
+			if !reflect.DeepEqual(result, ExecutionResult{}) || invocations != 0 || lookups != 1 {
+				t.Fatalf("Execute() = %+v, invocations = %d, lookups = %d; want fail closed", result, invocations, lookups)
+			}
+		})
+	}
+}
+
 func TestExecutorRejectsInvalidInputBeforeRouting(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/agentrouting/executor_test.go
+++ b/internal/agentrouting/executor_test.go
@@ -239,7 +239,7 @@ func TestExecutorRejectsMissingDependenciesAndContext(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExecutor(): %v", err)
 	}
-	if _, err := executor.Execute(nil, run.ID, request, executionArguments(t)); !errors.Is(err, ErrToolExecutionContext) {
+	if _, err := executor.Execute(nilContext(), run.ID, request, executionArguments(t)); !errors.Is(err, ErrToolExecutionContext) {
 		t.Fatalf("Execute(nil context) error = %v", err)
 	}
 	var nilExecutor *Executor
@@ -256,3 +256,8 @@ func executionArguments(t *testing.T) mcpairlock.ToolCallArguments {
 	}
 	return arguments
 }
+
+// nilContext returns a nil context.Context to exercise nil-context rejection
+// guards. Defined as a function so SA1012 (do not pass a nil Context) does not
+// flag the call site, which only matches literal nil arguments.
+func nilContext() context.Context { return nil }

--- a/internal/agentrouting/executor_test.go
+++ b/internal/agentrouting/executor_test.go
@@ -1,0 +1,258 @@
+package agentrouting
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/iac-studio/iac-studio/internal/agentruns"
+	"github.com/iac-studio/iac-studio/internal/mcpairlock"
+)
+
+func TestExecutorRecordsAllowedRouteBeforeInvocation(t *testing.T) {
+	policy, request, airlock := readOnlyEvaluation()
+	router, _, store, run := routerFixture(t, policy, request, airlock)
+	arguments := executionArguments(t)
+	invocations := 0
+	executor, err := NewExecutor(router, func(_ context.Context, call mcpairlock.ToolCallRequest) (mcpairlock.ToolCallResult, error) {
+		invocations++
+		if call.ServerID != request.ServerID || call.ToolName != request.ToolName || string(call.Arguments.Bytes()) != string(arguments.Bytes()) {
+			t.Fatalf("tool request = %+v, want route-bound request", call)
+		}
+		current, ok := store.Get(run.ID)
+		if !ok || len(current.Logs) != 1 || current.Logs[0].Level != agentruns.LogAudit || current.Logs[0].Message != routeAuditMessage("Allowed", request) {
+			t.Fatalf("route was not audited before invocation: %+v", current)
+		}
+		return mcpairlock.NewToolCallResult([]byte("inventory ready"), false), nil
+	})
+	if err != nil {
+		t.Fatalf("NewExecutor(): %v", err)
+	}
+
+	result, err := executor.Execute(context.Background(), run.ID, request, arguments)
+	if err != nil {
+		t.Fatalf("Execute(): %v", err)
+	}
+	if invocations != 1 || !result.Invoked || result.Result == nil || result.Result.Output != "inventory ready" {
+		t.Fatalf("Execute() = %+v, invocations = %d", result, invocations)
+	}
+}
+
+func TestExecutorDoesNotInvokeNonAllowedRoutes(t *testing.T) {
+	tests := []struct {
+		name       string
+		mutate     func(*Policy, *mcpairlock.ToolDecision)
+		wantStatus DecisionStatus
+	}{
+		{
+			name: "denied",
+			mutate: func(policy *Policy, _ *mcpairlock.ToolDecision) {
+				policy.Rules[0].Effect = EffectDeny
+			},
+			wantStatus: DecisionDenied,
+		},
+		{
+			name: "approval required",
+			mutate: func(_ *Policy, airlock *mcpairlock.ToolDecision) {
+				airlock.Status = "approval_required"
+				airlock.Allowed = false
+				airlock.ApprovalRequired = true
+			},
+			wantStatus: DecisionApprovalRequired,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			policy, request, airlock := readOnlyEvaluation()
+			test.mutate(&policy, &airlock)
+			router, _, _, run := routerFixture(t, policy, request, airlock)
+			invocations := 0
+			executor, err := NewExecutor(router, func(context.Context, mcpairlock.ToolCallRequest) (mcpairlock.ToolCallResult, error) {
+				invocations++
+				return mcpairlock.NewToolCallResult(nil, false), nil
+			})
+			if err != nil {
+				t.Fatalf("NewExecutor(): %v", err)
+			}
+
+			result, err := executor.Execute(context.Background(), run.ID, request, executionArguments(t))
+			if err != nil {
+				t.Fatalf("Execute(): %v", err)
+			}
+			if invocations != 0 || result.Invoked || result.Result != nil || result.Route.Decision.Status != test.wantStatus {
+				t.Fatalf("Execute() = %+v, invocations = %d", result, invocations)
+			}
+		})
+	}
+}
+
+func TestExecutorRejectsInvalidInputBeforeRouting(t *testing.T) {
+	tests := []struct {
+		name      string
+		mutate    func(*Request, *mcpairlock.ToolCallArguments)
+		wantError error
+	}{
+		{
+			name: "invalid route",
+			mutate: func(request *Request, _ *mcpairlock.ToolCallArguments) {
+				request.ConnectionID = ""
+			},
+			wantError: ErrInvalidRequest,
+		},
+		{
+			name: "invalid arguments",
+			mutate: func(_ *Request, arguments *mcpairlock.ToolCallArguments) {
+				*arguments = mcpairlock.ToolCallArguments{}
+			},
+			wantError: mcpairlock.ErrInvalidToolCallRequest,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			policy, request, airlock := readOnlyEvaluation()
+			router, evaluator, store, run := routerFixture(t, policy, request, airlock)
+			arguments := executionArguments(t)
+			test.mutate(&request, &arguments)
+			invocations := 0
+			executor, err := NewExecutor(router, func(context.Context, mcpairlock.ToolCallRequest) (mcpairlock.ToolCallResult, error) {
+				invocations++
+				return mcpairlock.NewToolCallResult(nil, false), nil
+			})
+			if err != nil {
+				t.Fatalf("NewExecutor(): %v", err)
+			}
+
+			result, err := executor.Execute(context.Background(), run.ID, request, arguments)
+			if !errors.Is(err, test.wantError) {
+				t.Fatalf("Execute() error = %v, want %v", err, test.wantError)
+			}
+			current, ok := store.Get(run.ID)
+			if !reflect.DeepEqual(result, ExecutionResult{}) || invocations != 0 || evaluator.calls != 0 || !ok || len(current.Logs) != 0 || len(current.Approvals) != 0 {
+				t.Fatalf("invalid input had side effects: result=%+v invocations=%d evaluator=%d run=%+v", result, invocations, evaluator.calls, current)
+			}
+		})
+	}
+}
+
+func TestExecutorFailsClosedWhenRouteCannotBeRecorded(t *testing.T) {
+	policy, request, airlock := readOnlyEvaluation()
+	router, _, store, run := routerFixture(t, policy, request, airlock)
+	if _, err := store.Fail(run.ID, "already terminal"); err != nil {
+		t.Fatalf("Fail(): %v", err)
+	}
+	invocations := 0
+	executor, err := NewExecutor(router, func(context.Context, mcpairlock.ToolCallRequest) (mcpairlock.ToolCallResult, error) {
+		invocations++
+		return mcpairlock.NewToolCallResult(nil, false), nil
+	})
+	if err != nil {
+		t.Fatalf("NewExecutor(): %v", err)
+	}
+
+	result, err := executor.Execute(context.Background(), run.ID, request, executionArguments(t))
+	if !errors.Is(err, agentruns.ErrTerminated) {
+		t.Fatalf("Execute() error = %v, want ErrTerminated", err)
+	}
+	if !reflect.DeepEqual(result, ExecutionResult{}) || invocations != 0 {
+		t.Fatalf("Execute() = %+v, invocations = %d; want fail closed", result, invocations)
+	}
+}
+
+func TestExecutorSanitizesInvocationFailures(t *testing.T) {
+	tests := []struct {
+		name   string
+		invoke ToolInvokeFunc
+	}{
+		{
+			name: "transport error",
+			invoke: func(context.Context, mcpairlock.ToolCallRequest) (mcpairlock.ToolCallResult, error) {
+				return mcpairlock.ToolCallResult{}, errors.New("token=executor-secret")
+			},
+		},
+		{
+			name: "invalid result",
+			invoke: func(context.Context, mcpairlock.ToolCallRequest) (mcpairlock.ToolCallResult, error) {
+				return mcpairlock.ToolCallResult{Output: "token=executor-secret"}, nil
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			policy, request, airlock := readOnlyEvaluation()
+			router, _, _, run := routerFixture(t, policy, request, airlock)
+			executor, err := NewExecutor(router, test.invoke)
+			if err != nil {
+				t.Fatalf("NewExecutor(): %v", err)
+			}
+
+			result, err := executor.Execute(context.Background(), run.ID, request, executionArguments(t))
+			if err == nil || !errors.Is(err, ErrToolInvocationFailed) || strings.Contains(err.Error(), "executor-secret") {
+				t.Fatalf("Execute() error = %v, want sanitized invocation failure", err)
+			}
+			if !reflect.DeepEqual(result, ExecutionResult{}) {
+				t.Fatalf("Execute() = %+v, want zero result", result)
+			}
+		})
+	}
+}
+
+func TestExecutorDiscardsResultWhenContextIsCanceledDuringInvocation(t *testing.T) {
+	policy, request, airlock := readOnlyEvaluation()
+	router, _, _, run := routerFixture(t, policy, request, airlock)
+	ctx, cancel := context.WithCancel(context.Background())
+	executor, err := NewExecutor(router, func(context.Context, mcpairlock.ToolCallRequest) (mcpairlock.ToolCallResult, error) {
+		cancel()
+		return mcpairlock.NewToolCallResult([]byte("stale result"), false), nil
+	})
+	if err != nil {
+		t.Fatalf("NewExecutor(): %v", err)
+	}
+
+	result, err := executor.Execute(ctx, run.ID, request, executionArguments(t))
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Execute() error = %v, want context.Canceled", err)
+	}
+	if !reflect.DeepEqual(result, ExecutionResult{}) {
+		t.Fatalf("Execute() = %+v, want zero result", result)
+	}
+}
+
+func TestExecutorRejectsMissingDependenciesAndContext(t *testing.T) {
+	policy, request, airlock := readOnlyEvaluation()
+	router, _, _, run := routerFixture(t, policy, request, airlock)
+	invoke := func(context.Context, mcpairlock.ToolCallRequest) (mcpairlock.ToolCallResult, error) {
+		return mcpairlock.NewToolCallResult(nil, false), nil
+	}
+
+	if _, err := NewExecutor(nil, invoke); !errors.Is(err, ErrToolRouteExecutorRequired) {
+		t.Fatalf("NewExecutor(nil router) error = %v", err)
+	}
+	if _, err := NewExecutor(router, nil); !errors.Is(err, ErrToolInvokerRequired) {
+		t.Fatalf("NewExecutor(nil invoker) error = %v", err)
+	}
+	executor, err := NewExecutor(router, invoke)
+	if err != nil {
+		t.Fatalf("NewExecutor(): %v", err)
+	}
+	if _, err := executor.Execute(nil, run.ID, request, executionArguments(t)); !errors.Is(err, ErrToolExecutionContext) {
+		t.Fatalf("Execute(nil context) error = %v", err)
+	}
+	var nilExecutor *Executor
+	if _, err := nilExecutor.Execute(context.Background(), run.ID, request, executionArguments(t)); !errors.Is(err, ErrToolRouteExecutorRequired) {
+		t.Fatalf("nil Execute() error = %v", err)
+	}
+}
+
+func executionArguments(t *testing.T) mcpairlock.ToolCallArguments {
+	t.Helper()
+	arguments, err := mcpairlock.ParseToolCallArguments([]byte(`{"region":"us-east-1"}`))
+	if err != nil {
+		t.Fatalf("ParseToolCallArguments(): %v", err)
+	}
+	return arguments
+}

--- a/internal/agentrouting/executor_test.go
+++ b/internal/agentrouting/executor_test.go
@@ -229,7 +229,7 @@ func TestExecutorRejectsMissingDependenciesAndContext(t *testing.T) {
 		return mcpairlock.NewToolCallResult(nil, false), nil
 	}
 
-	if _, err := NewExecutor(nil, invoke); !errors.Is(err, ErrToolRouteExecutorRequired) {
+	if _, err := NewExecutor(nil, invoke); !errors.Is(err, ErrToolRouteRouterRequired) {
 		t.Fatalf("NewExecutor(nil router) error = %v", err)
 	}
 	if _, err := NewExecutor(router, nil); !errors.Is(err, ErrToolInvokerRequired) {
@@ -243,7 +243,7 @@ func TestExecutorRejectsMissingDependenciesAndContext(t *testing.T) {
 		t.Fatalf("Execute(nil context) error = %v", err)
 	}
 	var nilExecutor *Executor
-	if _, err := nilExecutor.Execute(context.Background(), run.ID, request, executionArguments(t)); !errors.Is(err, ErrToolRouteExecutorRequired) {
+	if _, err := nilExecutor.Execute(context.Background(), run.ID, request, executionArguments(t)); !errors.Is(err, ErrToolRouteRouterRequired) {
 		t.Fatalf("nil Execute() error = %v", err)
 	}
 }

--- a/internal/agentrouting/router.go
+++ b/internal/agentrouting/router.go
@@ -70,3 +70,10 @@ func (r *Router) Route(runID string, request Request) (RouteResult, error) {
 	}
 	return RouteResult{Decision: decision, Run: run}, nil
 }
+
+func (r *Router) currentRun(runID string) (agentruns.Run, bool) {
+	if r == nil || r.recorder == nil || r.recorder.store == nil {
+		return agentruns.Run{}, false
+	}
+	return r.recorder.store.Get(runID)
+}


### PR DESCRIPTION
## Summary

- add an Agent Hub executor that validates and binds MCP arguments before routing
- record the fully scoped route decision before any external tool invocation
- invoke exactly once only for a validated `allowed` decision
- return denied and approval-required decisions without launching a process
- discard malformed output, invocation errors, and cancellation-raced results behind stable fail-closed errors

## Scope boundary

This is a domain-only composition layer. It does not expose an HTTP endpoint, export the MCP Airlock transport, inject cloud credentials, or enable write execution. A later small slice will connect the executor to the Airlock manager behind server wiring.

## Validation

- `GOCACHE=/private/tmp/iacstudio-go-cache go test -race ./internal/agentrouting`
- `GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/agentrouting -run Executor -count=20`
- `GOCACHE=/private/tmp/iacstudio-go-cache go test -race ./cmd/... ./internal/...`
- `GOCACHE=/private/tmp/iacstudio-go-cache go vet ./internal/agentrouting`
- formatting and diff checks

Part of #107.