### PR TITLE
Wire guarded MCP executor at startup

### DIFF
--- a/cmd/server/agent_routing.go
+++ b/cmd/server/agent_routing.go
@@ -11,9 +11,14 @@ type agentRoutingServices struct {
 	runs     *agentruns.Store
 	policies *agentrouting.PolicyStore
 	router   *agentrouting.Router
+	executor *agentrouting.Executor
 }
 
-func newAgentRoutingServices(projectsDir string, evaluator agentrouting.ToolEvaluator) (*agentRoutingServices, error) {
+func newAgentRoutingServices(
+	projectsDir string,
+	evaluator agentrouting.ToolEvaluator,
+	invoke agentrouting.ToolInvokeFunc,
+) (*agentRoutingServices, error) {
 	runs := agentruns.NewStore()
 	policies, err := agentrouting.NewPersistentPolicyStore(projectsDir)
 	if err != nil {
@@ -31,9 +36,14 @@ func newAgentRoutingServices(projectsDir string, evaluator agentrouting.ToolEval
 	if err != nil {
 		return nil, fmt.Errorf("create tool route router: %w", err)
 	}
+	executor, err := agentrouting.NewExecutor(router, invoke)
+	if err != nil {
+		return nil, fmt.Errorf("create guarded tool route executor: %w", err)
+	}
 	return &agentRoutingServices{
 		runs:     runs,
 		policies: policies,
 		router:   router,
+		executor: executor,
 	}, nil
 }

--- a/cmd/server/agent_routing_test.go
+++ b/cmd/server/agent_routing_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -14,23 +15,32 @@ import (
 
 type countingToolEvaluator struct {
 	calls int
+	entry mcpairlock.ToolInventoryEntry
+	err   error
 }
 
 func (e *countingToolEvaluator) EvaluateTool(_, _, _ string) (mcpairlock.ToolInventoryEntry, error) {
 	e.calls++
-	return mcpairlock.ToolInventoryEntry{}, errors.New("unexpected Airlock evaluation")
+	return e.entry, e.err
 }
 
 func TestNewAgentRoutingServicesRequiresToolEvaluator(t *testing.T) {
-	_, err := newAgentRoutingServices(t.TempDir(), nil)
+	_, err := newAgentRoutingServices(t.TempDir(), nil, successfulToolInvoker)
 	if !errors.Is(err, agentrouting.ErrToolEvaluatorRequired) {
 		t.Fatalf("newAgentRoutingServices(nil) error = %v, want %v", err, agentrouting.ErrToolEvaluatorRequired)
 	}
 }
 
+func TestNewAgentRoutingServicesRequiresToolInvoker(t *testing.T) {
+	_, err := newAgentRoutingServices(t.TempDir(), &countingToolEvaluator{}, nil)
+	if !errors.Is(err, agentrouting.ErrToolInvokerRequired) {
+		t.Fatalf("newAgentRoutingServices(nil invoker) error = %v, want %v", err, agentrouting.ErrToolInvokerRequired)
+	}
+}
+
 func TestNewAgentRoutingServicesFailsClosedAndAuditsMissingPolicy(t *testing.T) {
 	evaluator := &countingToolEvaluator{}
-	services, err := newAgentRoutingServices(t.TempDir(), evaluator)
+	services, err := newAgentRoutingServices(t.TempDir(), evaluator, successfulToolInvoker)
 	if err != nil {
 		t.Fatalf("newAgentRoutingServices(): %v", err)
 	}
@@ -81,8 +91,83 @@ func TestNewAgentRoutingServicesRejectsCorruptPolicyStore(t *testing.T) {
 		t.Fatalf("WriteFile(): %v", err)
 	}
 
-	_, err := newAgentRoutingServices(root, &countingToolEvaluator{})
+	_, err := newAgentRoutingServices(root, &countingToolEvaluator{}, successfulToolInvoker)
 	if !errors.Is(err, agentrouting.ErrInvalidPolicyStore) {
 		t.Fatalf("newAgentRoutingServices() error = %v, want ErrInvalidPolicyStore", err)
 	}
+}
+
+func TestNewAgentRoutingServicesComposesGuardedExecutor(t *testing.T) {
+	request := agentrouting.Request{
+		Project:      "demo",
+		ProviderID:   "codex",
+		ConnectionID: "aws-prod",
+		ServerID:     "aws",
+		ToolName:     "list_buckets",
+		Mode:         agentruns.ModeReadOnly,
+		Risk:         mcpairlock.RiskReadOnly,
+	}
+	evaluator := &countingToolEvaluator{entry: mcpairlock.ToolInventoryEntry{
+		ServerID: request.ServerID,
+		Name:     request.ToolName,
+		Risk:     request.Risk,
+		Decision: mcpairlock.ToolDecision{
+			Status:          "allowed",
+			Allowed:         true,
+			Risk:            request.Risk,
+			UntrustedOutput: true,
+		},
+	}}
+	invocations := 0
+	services, err := newAgentRoutingServices(t.TempDir(), evaluator, func(_ context.Context, call mcpairlock.ToolCallRequest) (mcpairlock.ToolCallResult, error) {
+		invocations++
+		if call.ServerID != request.ServerID || call.ToolName != request.ToolName {
+			t.Fatalf("tool call = %+v, want exact authorized route", call)
+		}
+		return mcpairlock.NewToolCallResult([]byte("inventory ready"), false), nil
+	})
+	if err != nil {
+		t.Fatalf("newAgentRoutingServices(): %v", err)
+	}
+	if err := services.policies.Save(agentrouting.PolicyScope{
+		Project:    request.Project,
+		ProviderID: request.ProviderID,
+	}, agentrouting.Policy{Rules: []agentrouting.Rule{{
+		Project:          request.Project,
+		ProviderID:       request.ProviderID,
+		ConnectionID:     request.ConnectionID,
+		ServerID:         request.ServerID,
+		ToolName:         request.ToolName,
+		Modes:            []agentruns.Mode{request.Mode},
+		Risk:             request.Risk,
+		Effect:           agentrouting.EffectAllow,
+		ApprovalRequired: false,
+	}}}); err != nil {
+		t.Fatalf("Save(): %v", err)
+	}
+	run, err := services.runs.Create(agentruns.CreateRequest{
+		Project:    request.Project,
+		Prompt:     "inventory the project",
+		ProviderID: request.ProviderID,
+		Mode:       request.Mode,
+	})
+	if err != nil {
+		t.Fatalf("Create(): %v", err)
+	}
+	arguments, err := mcpairlock.ParseToolCallArguments([]byte(`{"region":"us-east-1"}`))
+	if err != nil {
+		t.Fatalf("ParseToolCallArguments(): %v", err)
+	}
+
+	result, err := services.executor.Execute(context.Background(), run.ID, request, arguments)
+	if err != nil {
+		t.Fatalf("Execute(): %v", err)
+	}
+	if !result.Invoked || result.Result == nil || result.Result.Output != "inventory ready" || invocations != 1 || evaluator.calls != 1 {
+		t.Fatalf("Execute() = %+v, invocations = %d, evaluations = %d", result, invocations, evaluator.calls)
+	}
+}
+
+func successfulToolInvoker(context.Context, mcpairlock.ToolCallRequest) (mcpairlock.ToolCallResult, error) {
+	return mcpairlock.NewToolCallResult(nil, false), nil
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -107,7 +107,11 @@ func runServer() error {
 			log.Printf("mcp airlock cleanup: %v", err)
 		}
 	}()
-	agentRouting, err := newAgentRoutingServices(*projectsDir, mcpAirlock)
+	agentRouting, err := newAgentRoutingServices(
+		*projectsDir,
+		mcpAirlock,
+		mcpAirlock.ToolInvocationCapability(),
+	)
 	if err != nil {
 		return fmt.Errorf("initialize Agent Hub tool routing: %w", err)
 	}

--- a/internal/mcpairlock/tool_invoker.go
+++ b/internal/mcpairlock/tool_invoker.go
@@ -58,9 +58,19 @@ func WithToolCallTimeout(timeout time.Duration) Option {
 	}
 }
 
+// ToolInvocationCapability returns the isolated transport function for
+// composition behind a policy-enforcing executor. It performs no
+// authorization and must never be exposed directly through an API handler.
+func (m *Manager) ToolInvocationCapability() func(context.Context, ToolCallRequest) (ToolCallResult, error) {
+	if m == nil {
+		return nil
+	}
+	return m.invokeTool
+}
+
 // invokeTool runs one previously authorized MCP tool request in a fresh stdio
-// process. It remains package-scoped until routing and authorization are
-// composed behind one fail-closed executor.
+// process. The direct method stays package-scoped; startup deliberately hands
+// its function capability to the fail-closed routing executor.
 func (m *Manager) invokeTool(ctx context.Context, request ToolCallRequest) (result ToolCallResult, returnErr error) {
 	if m == nil || m.toolLauncher == nil {
 		return ToolCallResult{}, ErrToolSessionLaunch

--- a/internal/mcpairlock/tool_invoker_test.go
+++ b/internal/mcpairlock/tool_invoker_test.go
@@ -20,8 +20,9 @@ func TestManagerInvokeToolUsesIsolatedSanitizedProcess(t *testing.T) {
 	const inheritedSecret = "do-not-forward"
 	t.Setenv("AWS_SECRET_ACCESS_KEY", inheritedSecret)
 	manager := newToolInvokerManager(t, "mcp-tool-helper")
+	invoke := manager.ToolInvocationCapability()
 
-	result, err := manager.invokeTool(context.Background(), testToolCallRequest(t))
+	result, err := invoke(context.Background(), testToolCallRequest(t))
 	if err != nil {
 		t.Fatalf("InvokeTool: %v", err)
 	}
@@ -37,6 +38,13 @@ func TestManagerInvokeToolUsesIsolatedSanitizedProcess(t *testing.T) {
 	}
 	if strings.Contains(result.Output, inheritedSecret) {
 		t.Fatalf("tool process inherited cloud credential: %+v", result)
+	}
+}
+
+func TestNilManagerHasNoToolInvocationCapability(t *testing.T) {
+	var manager *Manager
+	if capability := manager.ToolInvocationCapability(); capability != nil {
+		t.Fatal("nil manager returned a tool invocation capability")
 	}
 }
 


### PR DESCRIPTION
## Summary
- expose a nil-safe, transport-only Airlock invocation capability for guarded composition
- construct the Agent Routing executor alongside its router during server startup
- verify allowed calls reach the injected transport only through the guarded executor

## Security boundary
- no execution endpoint or frontend surface is added
- the transport capability is not passed into RouterOptions or an API handler
- authorization, run-state revalidation, one-shot process isolation, and output validation remain in force

## Validation
- GOCACHE=/private/tmp/iacstudio-go-cache go test -race ./cmd/... ./internal/...
- GOCACHE=/private/tmp/iacstudio-go-cache go vet ./cmd/... ./internal/...
- git diff --check

Part of #107