### PR TITLE
Add replay-safe MCP execution attempts

### DIFF
--- a/internal/api/agent_tool_execution_idempotency.go
+++ b/internal/api/agent_tool_execution_idempotency.go
@@ -14,9 +14,10 @@ import (
 const maxAgentToolExecutionReplayEntries = 64
 
 var (
-	errAgentToolExecutionIdempotencyConflict = errors.New("idempotency key reused for a different tool execution")
-	errAgentToolExecutionAttemptCapacity     = errors.New("tool execution idempotency capacity reached")
-	errAgentToolExecutionRequiresReadOnly    = errors.New("tool execution idempotency supports read-only routes only")
+	errAgentToolExecutionIdempotencyConflict   = errors.New("idempotency key reused for a different tool execution")
+	errAgentToolExecutionInvalidIdempotencyKey = errors.New("invalid tool execution idempotency key")
+	errAgentToolExecutionAttemptCapacity       = errors.New("tool execution idempotency capacity reached")
+	errAgentToolExecutionRequiresReadOnly      = errors.New("tool execution idempotency supports read-only routes only")
 )
 
 type agentToolExecutionAttemptKey struct {
@@ -73,6 +74,9 @@ func (s *agentToolExecutionAttemptStore) execute(
 	}
 	if execute == nil {
 		return agentrouting.ExecutionResult{}, false, agentrouting.ErrToolInvokerRequired
+	}
+	if !validAgentToolRouteIdempotencyKey(idempotencyKey) {
+		return agentrouting.ExecutionResult{}, false, errAgentToolExecutionInvalidIdempotencyKey
 	}
 	if request.Risk != mcpairlock.RiskReadOnly {
 		return agentrouting.ExecutionResult{}, false, errAgentToolExecutionRequiresReadOnly

--- a/internal/api/agent_tool_execution_idempotency.go
+++ b/internal/api/agent_tool_execution_idempotency.go
@@ -1,0 +1,217 @@
+package api
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"sync"
+
+	"github.com/iac-studio/iac-studio/internal/agentrouting"
+	"github.com/iac-studio/iac-studio/internal/mcpairlock"
+)
+
+const maxAgentToolExecutionReplayEntries = 64
+
+var (
+	errAgentToolExecutionIdempotencyConflict = errors.New("idempotency key reused for a different tool execution")
+	errAgentToolExecutionAttemptCapacity     = errors.New("tool execution idempotency capacity reached")
+	errAgentToolExecutionRequiresReadOnly    = errors.New("tool execution idempotency supports read-only routes only")
+)
+
+type agentToolExecutionAttemptKey struct {
+	runID string
+	key   string
+}
+
+type agentToolExecutionAttempt struct {
+	fingerprint [sha256.Size]byte
+	done        chan struct{}
+	decision    agentrouting.Decision
+	invoked     bool
+	result      mcpairlock.ToolCallResult
+	hasResult   bool
+	err         error
+}
+
+// agentToolExecutionAttemptStore coalesces concurrent retries and retains a
+// bounded replay window for successful read-only tool executions. Write-side
+// execution requires a durable approval and idempotency contract instead.
+type agentToolExecutionAttemptStore struct {
+	mu         sync.Mutex
+	entries    map[agentToolExecutionAttemptKey]*agentToolExecutionAttempt
+	completed  []agentToolExecutionAttemptKey
+	maxEntries int
+}
+
+func newAgentToolExecutionAttemptStore(maxEntries int) *agentToolExecutionAttemptStore {
+	if maxEntries <= 0 {
+		maxEntries = 1
+	}
+	if maxEntries > maxAgentToolExecutionReplayEntries {
+		maxEntries = maxAgentToolExecutionReplayEntries
+	}
+	return &agentToolExecutionAttemptStore{
+		entries:    make(map[agentToolExecutionAttemptKey]*agentToolExecutionAttempt),
+		maxEntries: maxEntries,
+	}
+}
+
+func (s *agentToolExecutionAttemptStore) execute(
+	ctx context.Context,
+	runID string,
+	idempotencyKey string,
+	request agentrouting.Request,
+	arguments mcpairlock.ToolCallArguments,
+	execute func() (agentrouting.ExecutionResult, error),
+) (agentrouting.ExecutionResult, bool, error) {
+	if ctx == nil {
+		return agentrouting.ExecutionResult{}, false, agentrouting.ErrToolExecutionContext
+	}
+	if err := ctx.Err(); err != nil {
+		return agentrouting.ExecutionResult{}, false, err
+	}
+	if execute == nil {
+		return agentrouting.ExecutionResult{}, false, agentrouting.ErrToolInvokerRequired
+	}
+	if request.Risk != mcpairlock.RiskReadOnly {
+		return agentrouting.ExecutionResult{}, false, errAgentToolExecutionRequiresReadOnly
+	}
+	fingerprint, err := agentToolExecutionFingerprint(request, arguments)
+	if err != nil {
+		return agentrouting.ExecutionResult{}, false, err
+	}
+	key := agentToolExecutionAttemptKey{runID: runID, key: idempotencyKey}
+
+	s.mu.Lock()
+	if attempt, ok := s.entries[key]; ok {
+		if attempt.fingerprint != fingerprint {
+			s.mu.Unlock()
+			return agentrouting.ExecutionResult{}, false, errAgentToolExecutionIdempotencyConflict
+		}
+		done := attempt.done
+		s.mu.Unlock()
+
+		select {
+		case <-done:
+			if attempt.err != nil {
+				return agentrouting.ExecutionResult{}, true, attempt.err
+			}
+			return replayAgentToolExecution(attempt), true, nil
+		case <-ctx.Done():
+			return agentrouting.ExecutionResult{}, true, ctx.Err()
+		}
+	}
+	if !s.makeRoomLocked() {
+		s.mu.Unlock()
+		return agentrouting.ExecutionResult{}, false, errAgentToolExecutionAttemptCapacity
+	}
+	attempt := &agentToolExecutionAttempt{
+		fingerprint: fingerprint,
+		done:        make(chan struct{}),
+	}
+	s.entries[key] = attempt
+	s.mu.Unlock()
+
+	result, err := execute()
+	if err == nil {
+		if validationErr := validateAgentToolExecutionResult(result); validationErr != nil {
+			result = agentrouting.ExecutionResult{}
+			err = validationErr
+		}
+	}
+
+	s.mu.Lock()
+	attempt.err = err
+	if err == nil {
+		attempt.decision = result.Route.Decision
+		attempt.invoked = result.Invoked
+		if result.Result != nil {
+			attempt.result = *result.Result
+			attempt.hasResult = true
+		}
+		s.completed = append(s.completed, key)
+	} else {
+		delete(s.entries, key)
+	}
+	close(attempt.done)
+	s.mu.Unlock()
+
+	return result, false, err
+}
+
+func validateAgentToolExecutionResult(result agentrouting.ExecutionResult) error {
+	if err := result.Route.Decision.Validate(); err != nil {
+		return agentrouting.ErrInvalidToolExecution
+	}
+	if result.Route.Decision.Status != agentrouting.DecisionAllowed {
+		if result.Invoked || result.Result != nil {
+			return agentrouting.ErrInvalidToolExecution
+		}
+		return nil
+	}
+	if !result.Invoked || result.Result == nil {
+		return agentrouting.ErrInvalidToolExecution
+	}
+	if err := result.Result.Validate(); err != nil {
+		return agentrouting.ErrInvalidToolExecution
+	}
+	return nil
+}
+
+func (s *agentToolExecutionAttemptStore) makeRoomLocked() bool {
+	for len(s.entries) >= s.maxEntries && len(s.completed) > 0 {
+		oldest := s.completed[0]
+		s.completed = s.completed[1:]
+		delete(s.entries, oldest)
+	}
+	return len(s.entries) < s.maxEntries
+}
+
+func replayAgentToolExecution(attempt *agentToolExecutionAttempt) agentrouting.ExecutionResult {
+	result := agentrouting.ExecutionResult{
+		Route: agentrouting.RouteResult{
+			Decision: attempt.decision,
+		},
+		Invoked: attempt.invoked,
+	}
+	if attempt.hasResult {
+		replayed := attempt.result
+		result.Result = &replayed
+	}
+	return result
+}
+
+func agentToolExecutionFingerprint(
+	request agentrouting.Request,
+	arguments mcpairlock.ToolCallArguments,
+) ([sha256.Size]byte, error) {
+	if err := request.Validate(); err != nil {
+		return [sha256.Size]byte{}, err
+	}
+	encodedArguments, err := arguments.MarshalJSON()
+	if err != nil {
+		return [sha256.Size]byte{}, err
+	}
+
+	hash := sha256.New()
+	for _, value := range [][]byte{
+		[]byte(request.Project),
+		[]byte(request.ProviderID),
+		[]byte(request.ConnectionID),
+		[]byte(request.ServerID),
+		[]byte(request.ToolName),
+		[]byte(request.Mode),
+		[]byte(request.Risk),
+		encodedArguments,
+	} {
+		var length [8]byte
+		binary.BigEndian.PutUint64(length[:], uint64(len(value)))
+		_, _ = hash.Write(length[:])
+		_, _ = hash.Write(value)
+	}
+
+	var fingerprint [sha256.Size]byte
+	copy(fingerprint[:], hash.Sum(nil))
+	return fingerprint, nil
+}

--- a/internal/api/agent_tool_execution_idempotency.go
+++ b/internal/api/agent_tool_execution_idempotency.go
@@ -132,11 +132,11 @@ func (s *agentToolExecutionAttemptStore) execute(
 		}()
 		result, err = execute()
 	}()
-	if err == nil {
-		if validationErr := validateAgentToolExecutionResult(result); validationErr != nil {
-			result = agentrouting.ExecutionResult{}
-			err = validationErr
-		}
+	if err != nil {
+		result = agentrouting.ExecutionResult{}
+	} else if validationErr := validateAgentToolExecutionResult(result); validationErr != nil {
+		result = agentrouting.ExecutionResult{}
+		err = validationErr
 	}
 
 	s.mu.Lock()

--- a/internal/api/agent_tool_execution_idempotency.go
+++ b/internal/api/agent_tool_execution_idempotency.go
@@ -18,6 +18,7 @@ var (
 	errAgentToolExecutionInvalidIdempotencyKey = errors.New("invalid tool execution idempotency key")
 	errAgentToolExecutionAttemptCapacity       = errors.New("tool execution idempotency capacity reached")
 	errAgentToolExecutionRequiresReadOnly      = errors.New("tool execution idempotency supports read-only routes only")
+	errAgentToolExecutionCallbackPanicked      = errors.New("tool execution callback panicked")
 )
 
 type agentToolExecutionAttemptKey struct {
@@ -117,7 +118,20 @@ func (s *agentToolExecutionAttemptStore) execute(
 	s.entries[key] = attempt
 	s.mu.Unlock()
 
-	result, err := execute()
+	var result agentrouting.ExecutionResult
+	func() {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				s.mu.Lock()
+				attempt.err = errAgentToolExecutionCallbackPanicked
+				delete(s.entries, key)
+				close(attempt.done)
+				s.mu.Unlock()
+				panic(recovered)
+			}
+		}()
+		result, err = execute()
+	}()
 	if err == nil {
 		if validationErr := validateAgentToolExecutionResult(result); validationErr != nil {
 			result = agentrouting.ExecutionResult{}

--- a/internal/api/agent_tool_execution_idempotency_test.go
+++ b/internal/api/agent_tool_execution_idempotency_test.go
@@ -131,6 +131,62 @@ func TestAgentToolExecutionAttemptStoreReleasesFailedAttempts(t *testing.T) {
 	}
 }
 
+func TestAgentToolExecutionAttemptStoreReleasesPanickedAttempts(t *testing.T) {
+	store := newAgentToolExecutionAttemptStore(1)
+	request := testAgentToolExecutionRequest()
+	arguments := testAgentToolExecutionArguments(t, `{}`)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	recovered := make(chan any, 1)
+
+	go func() {
+		defer func() {
+			recovered <- recover()
+		}()
+		_, _, _ = store.execute(context.Background(), "run_000001", "panicked", request, arguments, func() (agentrouting.ExecutionResult, error) {
+			close(started)
+			<-release
+			panic("callback failure")
+		})
+	}()
+	<-started
+
+	key := agentToolExecutionAttemptKey{runID: "run_000001", key: "panicked"}
+	store.mu.Lock()
+	attempt := store.entries[key]
+	store.mu.Unlock()
+	if attempt == nil {
+		t.Fatal("in-flight attempt was not registered")
+	}
+
+	close(release)
+	if got := <-recovered; got != "callback failure" {
+		t.Fatalf("recovered panic = %v, want original value", got)
+	}
+	select {
+	case <-attempt.done:
+		if !errors.Is(attempt.err, errAgentToolExecutionCallbackPanicked) {
+			t.Fatalf("waiter error = %v, want stable panic error", attempt.err)
+		}
+	default:
+		t.Fatal("panicked attempt did not release waiters")
+	}
+
+	store.mu.Lock()
+	_, retained := store.entries[key]
+	store.mu.Unlock()
+	if retained {
+		t.Fatal("panicked attempt remained in replay store")
+	}
+
+	got, replayed, err := store.execute(context.Background(), "run_000001", "panicked", request, arguments, func() (agentrouting.ExecutionResult, error) {
+		return testAgentToolExecutionResult("retried"), nil
+	})
+	if err != nil || replayed || got.Result == nil || got.Result.Output != "retried" {
+		t.Fatalf("retry result = %+v, replayed = %t, error = %v; want fresh valid execution", got, replayed, err)
+	}
+}
+
 func TestAgentToolExecutionAttemptStoreRejectsWriteRisk(t *testing.T) {
 	store := newAgentToolExecutionAttemptStore(1)
 	request := testAgentToolExecutionRequest()

--- a/internal/api/agent_tool_execution_idempotency_test.go
+++ b/internal/api/agent_tool_execution_idempotency_test.go
@@ -1,0 +1,271 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/iac-studio/iac-studio/internal/agentrouting"
+	"github.com/iac-studio/iac-studio/internal/mcpairlock"
+)
+
+type agentToolExecutionAttemptOutcome struct {
+	result   agentrouting.ExecutionResult
+	replayed bool
+	err      error
+}
+
+func TestAgentToolExecutionAttemptStoreCoalescesConcurrentRetries(t *testing.T) {
+	store := newAgentToolExecutionAttemptStore(2)
+	request := testAgentToolExecutionRequest()
+	arguments := testAgentToolExecutionArguments(t, `{"bucket":"reports"}`)
+	want := testAgentToolExecutionResult("reports\n")
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var calls atomic.Int32
+	execute := func() (agentrouting.ExecutionResult, error) {
+		if calls.Add(1) == 1 {
+			close(started)
+		}
+		<-release
+		return want, nil
+	}
+
+	results := make(chan agentToolExecutionAttemptOutcome, 2)
+	run := func() {
+		result, replayed, err := store.execute(
+			context.Background(),
+			"run_000001",
+			"same-attempt",
+			request,
+			arguments,
+			execute,
+		)
+		results <- agentToolExecutionAttemptOutcome{result: result, replayed: replayed, err: err}
+	}
+	go run()
+	<-started
+	go run()
+	close(release)
+
+	replayed := 0
+	for range 2 {
+		outcome := <-results
+		if outcome.err != nil {
+			t.Fatalf("execute error = %v", outcome.err)
+		}
+		if outcome.result.Result == nil || outcome.result.Result.Output != "reports" {
+			t.Fatalf("execute result = %+v, want sanitized output", outcome.result)
+		}
+		if outcome.replayed {
+			replayed++
+			if outcome.result.Route.Run.ID != "" {
+				t.Fatalf("replayed run = %+v, want caller-hydrated run", outcome.result.Route.Run)
+			}
+		}
+	}
+	if calls.Load() != 1 || replayed != 1 {
+		t.Fatalf("execution calls = %d, replayed responses = %d; want 1, 1", calls.Load(), replayed)
+	}
+}
+
+func TestAgentToolExecutionAttemptStoreRejectsChangedArguments(t *testing.T) {
+	store := newAgentToolExecutionAttemptStore(2)
+	request := testAgentToolExecutionRequest()
+	firstArguments := testAgentToolExecutionArguments(t, `{"bucket":"reports"}`)
+	secondArguments := testAgentToolExecutionArguments(t, `{"bucket":"audit"}`)
+	var calls atomic.Int32
+	execute := func() (agentrouting.ExecutionResult, error) {
+		calls.Add(1)
+		return testAgentToolExecutionResult("ok"), nil
+	}
+
+	if _, replayed, err := store.execute(context.Background(), "run_000001", "same-key", request, firstArguments, execute); err != nil || replayed {
+		t.Fatalf("first execute error = %v, replayed = %t; want fresh success", err, replayed)
+	}
+	if _, replayed, err := store.execute(context.Background(), "run_000001", "same-key", request, secondArguments, execute); !errors.Is(err, errAgentToolExecutionIdempotencyConflict) || replayed {
+		t.Fatalf("changed arguments error = %v, replayed = %t; want idempotency conflict", err, replayed)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("execution calls = %d, want 1", calls.Load())
+	}
+}
+
+func TestAgentToolExecutionAttemptStoreRejectsChangedScope(t *testing.T) {
+	store := newAgentToolExecutionAttemptStore(2)
+	request := testAgentToolExecutionRequest()
+	arguments := testAgentToolExecutionArguments(t, `{}`)
+	execute := func() (agentrouting.ExecutionResult, error) {
+		return testAgentToolExecutionResult("ok"), nil
+	}
+
+	if _, _, err := store.execute(context.Background(), "run_000001", "same-key", request, arguments, execute); err != nil {
+		t.Fatalf("first execute: %v", err)
+	}
+	request.ConnectionID = "aws-stage"
+	if _, replayed, err := store.execute(context.Background(), "run_000001", "same-key", request, arguments, execute); !errors.Is(err, errAgentToolExecutionIdempotencyConflict) || replayed {
+		t.Fatalf("changed scope error = %v, replayed = %t; want idempotency conflict", err, replayed)
+	}
+}
+
+func TestAgentToolExecutionAttemptStoreReleasesFailedAttempts(t *testing.T) {
+	store := newAgentToolExecutionAttemptStore(1)
+	request := testAgentToolExecutionRequest()
+	arguments := testAgentToolExecutionArguments(t, `{}`)
+	wantErr := errors.New("temporary execution failure")
+
+	if _, replayed, err := store.execute(context.Background(), "run_000001", "retryable", request, arguments, func() (agentrouting.ExecutionResult, error) {
+		return agentrouting.ExecutionResult{}, wantErr
+	}); !errors.Is(err, wantErr) || replayed {
+		t.Fatalf("first execute error = %v, replayed = %t; want retryable failure", err, replayed)
+	}
+
+	want := testAgentToolExecutionResult("ok")
+	got, replayed, err := store.execute(context.Background(), "run_000001", "retryable", request, arguments, func() (agentrouting.ExecutionResult, error) {
+		return want, nil
+	})
+	if err != nil || replayed || got.Result == nil || got.Result.Output != "ok" {
+		t.Fatalf("second execute = %+v, replayed = %t, error = %v; want fresh success", got, replayed, err)
+	}
+}
+
+func TestAgentToolExecutionAttemptStoreRejectsWriteRisk(t *testing.T) {
+	store := newAgentToolExecutionAttemptStore(1)
+	request := testAgentToolExecutionRequest()
+	request.Risk = mcpairlock.RiskCloudMutation
+	request.Mode = "approved_execute"
+	arguments := testAgentToolExecutionArguments(t, `{}`)
+	var called atomic.Bool
+
+	_, replayed, err := store.execute(context.Background(), "run_000001", "write", request, arguments, func() (agentrouting.ExecutionResult, error) {
+		called.Store(true)
+		return agentrouting.ExecutionResult{}, nil
+	})
+	if !errors.Is(err, errAgentToolExecutionRequiresReadOnly) || replayed {
+		t.Fatalf("write execution error = %v, replayed = %t; want read-only rejection", err, replayed)
+	}
+	if called.Load() {
+		t.Fatal("write execution callback was called")
+	}
+}
+
+func TestAgentToolExecutionAttemptStoreRejectsCanceledContext(t *testing.T) {
+	store := newAgentToolExecutionAttemptStore(1)
+	request := testAgentToolExecutionRequest()
+	arguments := testAgentToolExecutionArguments(t, `{}`)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	var called atomic.Bool
+
+	_, replayed, err := store.execute(ctx, "run_000001", "canceled", request, arguments, func() (agentrouting.ExecutionResult, error) {
+		called.Store(true)
+		return agentrouting.ExecutionResult{}, nil
+	})
+	if !errors.Is(err, context.Canceled) || replayed {
+		t.Fatalf("canceled execution error = %v, replayed = %t; want context cancellation", err, replayed)
+	}
+	if called.Load() {
+		t.Fatal("canceled execution callback was called")
+	}
+}
+
+func TestAgentToolExecutionAttemptStoreReleasesInvalidResults(t *testing.T) {
+	store := newAgentToolExecutionAttemptStore(1)
+	request := testAgentToolExecutionRequest()
+	arguments := testAgentToolExecutionArguments(t, `{}`)
+
+	if result, replayed, err := store.execute(context.Background(), "run_000001", "invalid", request, arguments, func() (agentrouting.ExecutionResult, error) {
+		return agentrouting.ExecutionResult{
+			Route: agentrouting.RouteResult{
+				Decision: agentrouting.Decision{
+					Status:          agentrouting.DecisionAllowed,
+					Reason:          agentrouting.ReasonAllowed,
+					Allowed:         true,
+					UntrustedOutput: true,
+				},
+			},
+		}, nil
+	}); !errors.Is(err, agentrouting.ErrInvalidToolExecution) ||
+		replayed ||
+		result.Invoked ||
+		result.Result != nil ||
+		result.Route.Decision != (agentrouting.Decision{}) ||
+		result.Route.Run.ID != "" {
+		t.Fatalf("invalid result = %+v, replayed = %t, error = %v; want zero invalid execution", result, replayed, err)
+	}
+
+	got, replayed, err := store.execute(context.Background(), "run_000001", "invalid", request, arguments, func() (agentrouting.ExecutionResult, error) {
+		return testAgentToolExecutionResult("retried"), nil
+	})
+	if err != nil || replayed || got.Result == nil || got.Result.Output != "retried" {
+		t.Fatalf("retry result = %+v, replayed = %t, error = %v; want fresh valid execution", got, replayed, err)
+	}
+}
+
+func TestAgentToolExecutionAttemptStoreCapsReplayEntries(t *testing.T) {
+	store := newAgentToolExecutionAttemptStore(maxAgentToolExecutionReplayEntries + 1)
+	if store.maxEntries != maxAgentToolExecutionReplayEntries {
+		t.Fatalf("max entries = %d, want hard cap %d", store.maxEntries, maxAgentToolExecutionReplayEntries)
+	}
+}
+
+func TestAgentToolExecutionAttemptStoreReplaysIndependentResult(t *testing.T) {
+	store := newAgentToolExecutionAttemptStore(1)
+	request := testAgentToolExecutionRequest()
+	arguments := testAgentToolExecutionArguments(t, `{}`)
+	execute := func() (agentrouting.ExecutionResult, error) {
+		return testAgentToolExecutionResult("original"), nil
+	}
+
+	if _, _, err := store.execute(context.Background(), "run_000001", "replay", request, arguments, execute); err != nil {
+		t.Fatalf("first execute: %v", err)
+	}
+	first, replayed, err := store.execute(context.Background(), "run_000001", "replay", request, arguments, execute)
+	if err != nil || !replayed || first.Result == nil {
+		t.Fatalf("first replay = %+v, replayed = %t, error = %v", first, replayed, err)
+	}
+	first.Result.Output = "mutated"
+
+	second, replayed, err := store.execute(context.Background(), "run_000001", "replay", request, arguments, execute)
+	if err != nil || !replayed || second.Result == nil || second.Result.Output != "original" {
+		t.Fatalf("second replay = %+v, replayed = %t, error = %v; want independent result", second, replayed, err)
+	}
+}
+
+func testAgentToolExecutionRequest() agentrouting.Request {
+	return agentrouting.Request{
+		Project:      "demo",
+		ProviderID:   "codex",
+		ConnectionID: "aws-prod",
+		ServerID:     "aws",
+		ToolName:     "list_buckets",
+		Mode:         "read_only",
+		Risk:         mcpairlock.RiskReadOnly,
+	}
+}
+
+func testAgentToolExecutionArguments(t *testing.T, raw string) mcpairlock.ToolCallArguments {
+	t.Helper()
+	arguments, err := mcpairlock.ParseToolCallArguments([]byte(raw))
+	if err != nil {
+		t.Fatalf("parse tool arguments: %v", err)
+	}
+	return arguments
+}
+
+func testAgentToolExecutionResult(output string) agentrouting.ExecutionResult {
+	result := mcpairlock.NewToolCallResult([]byte(output), false)
+	return agentrouting.ExecutionResult{
+		Route: agentrouting.RouteResult{
+			Decision: agentrouting.Decision{
+				Status:          agentrouting.DecisionAllowed,
+				Reason:          agentrouting.ReasonAllowed,
+				Allowed:         true,
+				UntrustedOutput: true,
+			},
+		},
+		Invoked: true,
+		Result:  &result,
+	}
+}

--- a/internal/api/agent_tool_execution_idempotency_test.go
+++ b/internal/api/agent_tool_execution_idempotency_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -147,6 +148,34 @@ func TestAgentToolExecutionAttemptStoreRejectsWriteRisk(t *testing.T) {
 	}
 	if called.Load() {
 		t.Fatal("write execution callback was called")
+	}
+}
+
+func TestAgentToolExecutionAttemptStoreRejectsInvalidIdempotencyKeys(t *testing.T) {
+	store := newAgentToolExecutionAttemptStore(1)
+	request := testAgentToolExecutionRequest()
+	arguments := testAgentToolExecutionArguments(t, `{}`)
+	invalidKeys := []string{
+		"",
+		" retry",
+		strings.Repeat("a", maxAgentToolRouteIdempotencyKeyLength+1),
+		"r\u00e9try",
+	}
+
+	for _, key := range invalidKeys {
+		t.Run(key, func(t *testing.T) {
+			var called atomic.Bool
+			_, replayed, err := store.execute(context.Background(), "run_000001", key, request, arguments, func() (agentrouting.ExecutionResult, error) {
+				called.Store(true)
+				return agentrouting.ExecutionResult{}, nil
+			})
+			if !errors.Is(err, errAgentToolExecutionInvalidIdempotencyKey) || replayed {
+				t.Fatalf("invalid key error = %v, replayed = %t; want validation failure", err, replayed)
+			}
+			if called.Load() {
+				t.Fatal("invalid idempotency key reached execution callback")
+			}
+		})
 	}
 }
 

--- a/internal/api/agent_tool_execution_idempotency_test.go
+++ b/internal/api/agent_tool_execution_idempotency_test.go
@@ -116,10 +116,16 @@ func TestAgentToolExecutionAttemptStoreReleasesFailedAttempts(t *testing.T) {
 	arguments := testAgentToolExecutionArguments(t, `{}`)
 	wantErr := errors.New("temporary execution failure")
 
-	if _, replayed, err := store.execute(context.Background(), "run_000001", "retryable", request, arguments, func() (agentrouting.ExecutionResult, error) {
-		return agentrouting.ExecutionResult{}, wantErr
-	}); !errors.Is(err, wantErr) || replayed {
-		t.Fatalf("first execute error = %v, replayed = %t; want retryable failure", err, replayed)
+	failed, replayed, err := store.execute(context.Background(), "run_000001", "retryable", request, arguments, func() (agentrouting.ExecutionResult, error) {
+		return testAgentToolExecutionResult("partial"), wantErr
+	})
+	if !errors.Is(err, wantErr) ||
+		replayed ||
+		failed.Invoked ||
+		failed.Result != nil ||
+		failed.Route.Decision != (agentrouting.Decision{}) ||
+		failed.Route.Run.ID != "" {
+		t.Fatalf("first execute = %+v, error = %v, replayed = %t; want zero retryable failure", failed, err, replayed)
 	}
 
 	want := testAgentToolExecutionResult("ok")


### PR DESCRIPTION
## Summary
- coalesce concurrent retries for future read-only MCP tool execution
- bind each idempotency key to the exact run, scoped route, and normalized argument digest
- retain a hard-capped replay window containing only validated, sanitized outcomes
- release failed attempts so transient errors remain retryable

## Security boundary
- non-read-only routes are rejected before the execution callback
- raw tool arguments are hashed and never retained by the replay store
- malformed successful results are discarded and never cached or returned
- no HTTP endpoint, credential injection, or write execution is added in this slice

## Validation
- `GOCACHE=/private/tmp/iacstudio-go-cache go test -race ./internal/api -run AgentToolExecutionAttemptStore -count=20`
- `GOCACHE=/private/tmp/iacstudio-go-cache go test -race ./internal/api`
- `GOCACHE=/private/tmp/iacstudio-go-cache go vet ./internal/api`
- `git diff --cached --check`

Part of #107.