### PR TITLE
Add read-only MCP execution handler

### DIFF
--- a/internal/api/agent_tool_executions.go
+++ b/internal/api/agent_tool_executions.go
@@ -1,0 +1,181 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log"
+	"net/http"
+
+	"github.com/iac-studio/iac-studio/internal/agentrouting"
+	"github.com/iac-studio/iac-studio/internal/agentruns"
+	"github.com/iac-studio/iac-studio/internal/mcpairlock"
+)
+
+// AgentToolExecutor is the guarded execution boundary exposed to the API.
+// Implementations remain responsible for authorization, audit recording, and
+// output validation before returning a result.
+type AgentToolExecutor interface {
+	Execute(
+		context.Context,
+		string,
+		agentrouting.Request,
+		mcpairlock.ToolCallArguments,
+	) (agentrouting.ExecutionResult, error)
+}
+
+type agentToolExecutionRequest struct {
+	ConnectionID string                       `json:"connection_id"`
+	ServerID     string                       `json:"server_id"`
+	ToolName     string                       `json:"tool_name"`
+	Arguments    mcpairlock.ToolCallArguments `json:"arguments"`
+}
+
+func registerAgentToolExecutionRoutes(
+	mux *http.ServeMux,
+	projectsDir string,
+	store *agentruns.Store,
+	executor AgentToolExecutor,
+) {
+	if executor == nil {
+		return
+	}
+	attempts := newAgentToolExecutionAttemptStore(maxAgentToolExecutionReplayEntries)
+
+	mux.HandleFunc("POST /api/projects/{name}/agent-runs/{id}/tool-routes/execute", func(w http.ResponseWriter, r *http.Request) {
+		limitBody(w, r)
+		if !requireJSONContentType(w, r) {
+			return
+		}
+		idempotencyKey, ok := requireAgentToolRouteIdempotencyKey(w, r)
+		if !ok {
+			return
+		}
+		run, routeRequest, arguments, ok := readAgentToolExecutionRequest(w, r, projectsDir, store)
+		if !ok {
+			return
+		}
+
+		result, replayed, err := attempts.execute(
+			r.Context(),
+			run.ID,
+			idempotencyKey,
+			routeRequest,
+			arguments,
+			func() (agentrouting.ExecutionResult, error) {
+				current, ok := store.Get(run.ID)
+				if !ok || !agentToolExecutionRunIsActive(current) {
+					return agentrouting.ExecutionResult{}, agentrouting.ErrInvalidToolExecution
+				}
+				return executor.Execute(r.Context(), run.ID, routeRequest, arguments)
+			},
+		)
+		if err != nil {
+			writeAgentToolExecutionError(w, err)
+			return
+		}
+		if replayed {
+			current, ok := store.Get(run.ID)
+			if !ok {
+				http.Error(w, "agent run not found", http.StatusNotFound)
+				return
+			}
+			result.Route.Run = current
+			w.Header().Set("Idempotency-Replayed", "true")
+		}
+		setAgentRunJSONHeader(w)
+		_ = json.NewEncoder(w).Encode(result)
+	})
+}
+
+func readAgentToolExecutionRequest(
+	w http.ResponseWriter,
+	r *http.Request,
+	projectsDir string,
+	store *agentruns.Store,
+) (agentruns.Run, agentrouting.Request, mcpairlock.ToolCallArguments, bool) {
+	name := r.PathValue("name")
+	if !requireExistingAgentRunProject(w, projectsDir, name) {
+		return agentruns.Run{}, agentrouting.Request{}, mcpairlock.ToolCallArguments{}, false
+	}
+	run, ok := store.Get(r.PathValue("id"))
+	if !ok || run.Project != name {
+		http.Error(w, "agent run not found", http.StatusNotFound)
+		return agentruns.Run{}, agentrouting.Request{}, mcpairlock.ToolCallArguments{}, false
+	}
+	if run.ProviderID == "" {
+		http.Error(w, "agent run provider is not configured", http.StatusConflict)
+		return agentruns.Run{}, agentrouting.Request{}, mcpairlock.ToolCallArguments{}, false
+	}
+	var req agentToolExecutionRequest
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&req); err != nil {
+		writeAgentToolRouteBodyError(w, err)
+		return agentruns.Run{}, agentrouting.Request{}, mcpairlock.ToolCallArguments{}, false
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		writeAgentToolRouteBodyError(w, err)
+		return agentruns.Run{}, agentrouting.Request{}, mcpairlock.ToolCallArguments{}, false
+	}
+
+	request := agentrouting.Request{
+		Project:      run.Project,
+		ProviderID:   run.ProviderID,
+		ConnectionID: req.ConnectionID,
+		ServerID:     req.ServerID,
+		ToolName:     req.ToolName,
+		Mode:         run.Mode,
+		Risk:         mcpairlock.RiskReadOnly,
+	}
+	if err := request.Validate(); err != nil {
+		http.Error(w, "invalid tool execution request", http.StatusBadRequest)
+		return agentruns.Run{}, agentrouting.Request{}, mcpairlock.ToolCallArguments{}, false
+	}
+	if _, err := req.Arguments.MarshalJSON(); err != nil {
+		http.Error(w, "invalid tool execution arguments", http.StatusBadRequest)
+		return agentruns.Run{}, agentrouting.Request{}, mcpairlock.ToolCallArguments{}, false
+	}
+	return run, request, req.Arguments, true
+}
+
+func agentToolExecutionRunIsActive(run agentruns.Run) bool {
+	if run.Canceled || (run.Status != agentruns.StatusQueued && run.Status != agentruns.StatusRunning) {
+		return false
+	}
+	for _, approval := range run.Approvals {
+		if approval.Status == agentruns.ApprovalPending {
+			return false
+		}
+	}
+	return true
+}
+
+func writeAgentToolExecutionError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, errAgentToolExecutionIdempotencyConflict):
+		http.Error(w, "idempotency key was already used for a different tool execution", http.StatusConflict)
+	case errors.Is(err, errAgentToolExecutionInvalidIdempotencyKey),
+		errors.Is(err, agentrouting.ErrInvalidRequest),
+		errors.Is(err, mcpairlock.ErrInvalidToolCallArguments),
+		errors.Is(err, mcpairlock.ErrInvalidToolCallRequest):
+		http.Error(w, "invalid tool execution request", http.StatusBadRequest)
+	case errors.Is(err, errAgentToolExecutionAttemptCapacity):
+		http.Error(w, "tool execution is temporarily unavailable", http.StatusServiceUnavailable)
+	case errors.Is(err, agentruns.ErrNotFound):
+		http.Error(w, "agent run not found", http.StatusNotFound)
+	case errors.Is(err, agentruns.ErrTerminated),
+		errors.Is(err, agentrouting.ErrRunScopeMismatch),
+		errors.Is(err, agentrouting.ErrInvalidDecision),
+		errors.Is(err, agentrouting.ErrInvalidToolExecution):
+		http.Error(w, "agent run cannot execute this tool route", http.StatusConflict)
+	case errors.Is(err, agentrouting.ErrToolInvocationFailed):
+		http.Error(w, "MCP tool invocation failed", http.StatusBadGateway)
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		http.Error(w, "tool execution request canceled", http.StatusRequestTimeout)
+	default:
+		log.Printf("agent tool execution failed (%T)", agentToolRouteRootError(err))
+		http.Error(w, "agent tool execution failed", http.StatusInternalServerError)
+	}
+}

--- a/internal/api/agent_tool_executions.go
+++ b/internal/api/agent_tool_executions.go
@@ -64,9 +64,8 @@ func registerAgentToolExecutionRoutes(
 			routeRequest,
 			arguments,
 			func() (agentrouting.ExecutionResult, error) {
-				current, ok := store.Get(run.ID)
-				if !ok || !agentToolExecutionRunIsActive(current) {
-					return agentrouting.ExecutionResult{}, agentrouting.ErrInvalidToolExecution
+				if err := requireActiveAgentToolExecutionRun(store, run.ID); err != nil {
+					return agentrouting.ExecutionResult{}, err
 				}
 				return executor.Execute(r.Context(), run.ID, routeRequest, arguments)
 			},
@@ -150,6 +149,17 @@ func agentToolExecutionRunIsActive(run agentruns.Run) bool {
 		}
 	}
 	return true
+}
+
+func requireActiveAgentToolExecutionRun(store *agentruns.Store, runID string) error {
+	run, ok := store.Get(runID)
+	if !ok {
+		return agentruns.ErrNotFound
+	}
+	if !agentToolExecutionRunIsActive(run) {
+		return agentrouting.ErrInvalidToolExecution
+	}
+	return nil
 }
 
 func writeAgentToolExecutionError(w http.ResponseWriter, err error) {

--- a/internal/api/agent_tool_executions.go
+++ b/internal/api/agent_tool_executions.go
@@ -172,8 +172,10 @@ func writeAgentToolExecutionError(w http.ResponseWriter, err error) {
 		http.Error(w, "agent run cannot execute this tool route", http.StatusConflict)
 	case errors.Is(err, agentrouting.ErrToolInvocationFailed):
 		http.Error(w, "MCP tool invocation failed", http.StatusBadGateway)
-	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+	case errors.Is(err, context.Canceled):
 		http.Error(w, "tool execution request canceled", http.StatusRequestTimeout)
+	case errors.Is(err, context.DeadlineExceeded):
+		http.Error(w, "tool execution request timed out", http.StatusGatewayTimeout)
 	default:
 		log.Printf("agent tool execution failed (%T)", agentToolRouteRootError(err))
 		http.Error(w, "agent tool execution failed", http.StatusInternalServerError)

--- a/internal/api/agent_tool_executions_test.go
+++ b/internal/api/agent_tool_executions_test.go
@@ -1,0 +1,266 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/iac-studio/iac-studio/internal/agentrouting"
+	"github.com/iac-studio/iac-studio/internal/agentruns"
+	"github.com/iac-studio/iac-studio/internal/mcpairlock"
+)
+
+type fakeAgentToolExecutor struct {
+	result    agentrouting.ExecutionResult
+	err       error
+	calls     int
+	runID     string
+	request   agentrouting.Request
+	arguments mcpairlock.ToolCallArguments
+}
+
+func (f *fakeAgentToolExecutor) Execute(
+	_ context.Context,
+	runID string,
+	request agentrouting.Request,
+	arguments mcpairlock.ToolCallArguments,
+) (agentrouting.ExecutionResult, error) {
+	f.calls++
+	f.runID = runID
+	f.request = request
+	f.arguments = arguments
+	return f.result, f.err
+}
+
+func agentToolExecutionMux(root string, store *agentruns.Store, executor AgentToolExecutor) *http.ServeMux {
+	mux := http.NewServeMux()
+	registerAgentToolExecutionRoutes(mux, root, store, executor)
+	return mux
+}
+
+func postAgentToolExecution(
+	mux *http.ServeMux,
+	project string,
+	runID string,
+	body string,
+	contentType string,
+	idempotencyKey string,
+) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/projects/"+project+"/agent-runs/"+runID+"/tool-routes/execute",
+		strings.NewReader(body),
+	)
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	if idempotencyKey != "" {
+		req.Header.Set(agentToolRouteIdempotencyHeader, idempotencyKey)
+	}
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestAgentToolExecutionUsesServerOwnedReadOnlyScope(t *testing.T) {
+	root, store, run := agentToolRouteFixture(t, "codex")
+	wantResult := mcpairlock.NewToolCallResult([]byte("reports\n"), false)
+	wantDecision := agentrouting.Decision{
+		Status:          agentrouting.DecisionAllowed,
+		Reason:          agentrouting.ReasonAllowed,
+		Allowed:         true,
+		UntrustedOutput: true,
+	}
+	fake := &fakeAgentToolExecutor{result: agentrouting.ExecutionResult{
+		Route:   agentrouting.RouteResult{Decision: wantDecision, Run: run},
+		Invoked: true,
+		Result:  &wantResult,
+	}}
+	mux := agentToolExecutionMux(root, store, fake)
+
+	rec := postAgentToolExecution(mux, "demo", run.ID, `{
+		"connection_id":"aws-prod",
+		"server_id":"aws",
+		"tool_name":"list_buckets",
+		"arguments":{"bucket":"reports","limit":10}
+	}`, "application/json", "execution-1")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	requireJSONResponse(t, rec)
+	wantRequest := agentrouting.Request{
+		Project:      "demo",
+		ProviderID:   "codex",
+		ConnectionID: "aws-prod",
+		ServerID:     "aws",
+		ToolName:     "list_buckets",
+		Mode:         agentruns.ModeReadOnly,
+		Risk:         mcpairlock.RiskReadOnly,
+	}
+	if fake.calls != 1 || fake.runID != run.ID || fake.request != wantRequest {
+		t.Fatalf("Execute calls = %d, run = %q, request = %+v; want one server-scoped call", fake.calls, fake.runID, fake.request)
+	}
+	if !bytes.Equal(fake.arguments.Bytes(), []byte(`{"bucket":"reports","limit":10}`)) {
+		t.Fatalf("arguments = %s, want normalized object", fake.arguments.Bytes())
+	}
+
+	var response agentrouting.ExecutionResult
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !response.Invoked || response.Result == nil || *response.Result != wantResult {
+		t.Fatalf("response = %+v, want validated tool result", response)
+	}
+	if response.Route.Decision != wantDecision || response.Route.Run.ID != run.ID {
+		t.Fatalf("route = %+v, want audited execution route", response.Route)
+	}
+}
+
+func TestAgentToolExecutionRejectsClientScopeAndInactiveRuns(t *testing.T) {
+	root, store, run := agentToolRouteFixture(t, "codex")
+	fake := &fakeAgentToolExecutor{}
+	mux := agentToolExecutionMux(root, store, fake)
+
+	clientScope := postAgentToolExecution(mux, "demo", run.ID, `{
+		"connection_id":"aws-prod",
+		"server_id":"aws",
+		"tool_name":"list_buckets",
+		"arguments":{},
+		"risk":"cloud_mutation"
+	}`, "application/json", "client-scope")
+	if clientScope.Code != http.StatusBadRequest {
+		t.Fatalf("client scope status = %d, want %d, body = %s", clientScope.Code, http.StatusBadRequest, clientScope.Body.String())
+	}
+
+	if _, err := store.AddApproval(run.ID, agentruns.ApprovalGate{
+		Kind:    agentruns.ApprovalMCPNetwork,
+		Summary: "approve inventory",
+	}); err != nil {
+		t.Fatalf("AddApproval(): %v", err)
+	}
+	inactive := postAgentToolExecution(mux, "demo", run.ID, `{
+		"connection_id":"aws-prod",
+		"server_id":"aws",
+		"tool_name":"list_buckets",
+		"arguments":{}
+	}`, "application/json", "inactive")
+	if inactive.Code != http.StatusConflict {
+		t.Fatalf("inactive status = %d, want %d, body = %s", inactive.Code, http.StatusConflict, inactive.Body.String())
+	}
+	if fake.calls != 0 {
+		t.Fatalf("Execute calls = %d, want none for rejected requests", fake.calls)
+	}
+}
+
+func TestAgentToolExecutionRejectsInvalidRequests(t *testing.T) {
+	root, store, run := agentToolRouteFixture(t, "codex")
+	fake := &fakeAgentToolExecutor{}
+	mux := agentToolExecutionMux(root, store, fake)
+	validBody := `{"connection_id":"aws-prod","server_id":"aws","tool_name":"list_buckets","arguments":{}}`
+
+	tests := []struct {
+		name        string
+		body        string
+		contentType string
+		key         string
+		wantStatus  int
+	}{
+		{name: "missing content type", body: validBody, key: "attempt", wantStatus: http.StatusUnsupportedMediaType},
+		{name: "missing idempotency key", body: validBody, contentType: "application/json", wantStatus: http.StatusBadRequest},
+		{name: "missing arguments", body: `{"connection_id":"aws-prod","server_id":"aws","tool_name":"list_buckets"}`, contentType: "application/json", key: "attempt", wantStatus: http.StatusBadRequest},
+		{name: "scalar arguments", body: `{"connection_id":"aws-prod","server_id":"aws","tool_name":"list_buckets","arguments":true}`, contentType: "application/json", key: "attempt", wantStatus: http.StatusBadRequest},
+		{name: "multiple values", body: validBody + `{}`, contentType: "application/json", key: "attempt", wantStatus: http.StatusBadRequest},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rec := postAgentToolExecution(mux, "demo", run.ID, test.body, test.contentType, test.key)
+			if rec.Code != test.wantStatus {
+				t.Fatalf("status = %d, want %d, body = %s", rec.Code, test.wantStatus, rec.Body.String())
+			}
+		})
+	}
+	if fake.calls != 0 {
+		t.Fatalf("Execute calls = %d, want none for invalid requests", fake.calls)
+	}
+}
+
+func TestAgentToolExecutionReplaysWithoutDuplicateInvocation(t *testing.T) {
+	root, store, run := agentToolRouteFixture(t, "codex")
+	result := mcpairlock.NewToolCallResult([]byte("reports"), false)
+	fake := &fakeAgentToolExecutor{result: agentrouting.ExecutionResult{
+		Route: agentrouting.RouteResult{
+			Decision: agentrouting.Decision{
+				Status:          agentrouting.DecisionAllowed,
+				Reason:          agentrouting.ReasonAllowed,
+				Allowed:         true,
+				UntrustedOutput: true,
+			},
+			Run: run,
+		},
+		Invoked: true,
+		Result:  &result,
+	}}
+	mux := agentToolExecutionMux(root, store, fake)
+	body := `{"connection_id":"aws-prod","server_id":"aws","tool_name":"list_buckets","arguments":{"bucket":"reports"}}`
+
+	first := postAgentToolExecution(mux, "demo", run.ID, body, "application/json", "same-execution")
+	second := postAgentToolExecution(mux, "demo", run.ID, body, "application/json", "same-execution")
+	if first.Code != http.StatusOK || second.Code != http.StatusOK {
+		t.Fatalf("statuses = %d, %d; want two successful responses", first.Code, second.Code)
+	}
+	if second.Header().Get("Idempotency-Replayed") != "true" {
+		t.Fatalf("replay header = %q, want true", second.Header().Get("Idempotency-Replayed"))
+	}
+	if fake.calls != 1 {
+		t.Fatalf("Execute calls = %d, want one", fake.calls)
+	}
+	if _, err := store.SetStatus(run.ID, agentruns.StatusCompleted); err != nil {
+		t.Fatalf("SetStatus(completed): %v", err)
+	}
+	terminalReplay := postAgentToolExecution(mux, "demo", run.ID, body, "application/json", "same-execution")
+	if terminalReplay.Code != http.StatusOK || terminalReplay.Header().Get("Idempotency-Replayed") != "true" {
+		t.Fatalf("terminal replay status = %d, replay header = %q, body = %s", terminalReplay.Code, terminalReplay.Header().Get("Idempotency-Replayed"), terminalReplay.Body.String())
+	}
+	var replayed agentrouting.ExecutionResult
+	if err := json.Unmarshal(terminalReplay.Body.Bytes(), &replayed); err != nil {
+		t.Fatalf("decode terminal replay: %v", err)
+	}
+	if replayed.Route.Run.Status != agentruns.StatusCompleted || fake.calls != 1 {
+		t.Fatalf("replayed run status = %q, Execute calls = %d; want current terminal state and one call", replayed.Route.Run.Status, fake.calls)
+	}
+
+	conflictBody := `{"connection_id":"aws-prod","server_id":"aws","tool_name":"list_buckets","arguments":{"bucket":"audit"}}`
+	conflict := postAgentToolExecution(mux, "demo", run.ID, conflictBody, "application/json", "same-execution")
+	if conflict.Code != http.StatusConflict {
+		t.Fatalf("conflict status = %d, want %d, body = %s", conflict.Code, http.StatusConflict, conflict.Body.String())
+	}
+	if fake.calls != 1 {
+		t.Fatalf("Execute calls = %d, want none after conflicting key reuse", fake.calls)
+	}
+}
+
+func TestAgentToolExecutionSanitizesExecutorErrors(t *testing.T) {
+	root, store, run := agentToolRouteFixture(t, "codex")
+	fake := &fakeAgentToolExecutor{err: errors.New("token=executor-secret")}
+	mux := agentToolExecutionMux(root, store, fake)
+
+	rec := postAgentToolExecution(
+		mux,
+		"demo",
+		run.ID,
+		`{"connection_id":"aws-prod","server_id":"aws","tool_name":"list_buckets","arguments":{}}`,
+		"application/json",
+		"failing-execution",
+	)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d, body = %s", rec.Code, http.StatusInternalServerError, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "executor-secret") {
+		t.Fatalf("response leaked executor error: %s", rec.Body.String())
+	}
+}

--- a/internal/api/agent_tool_executions_test.go
+++ b/internal/api/agent_tool_executions_test.go
@@ -300,3 +300,34 @@ func TestAgentToolExecutionDistinguishesCancellationAndTimeout(t *testing.T) {
 		})
 	}
 }
+
+func TestAgentToolExecutionRunRecheckReturnsNotFoundAfterEviction(t *testing.T) {
+	store := agentruns.NewStore(agentruns.WithMaxRuns(1))
+	first, err := store.Create(agentruns.CreateRequest{
+		Project:    "demo",
+		Prompt:     "inventory the project",
+		ProviderID: "codex",
+		Mode:       agentruns.ModeReadOnly,
+	})
+	if err != nil {
+		t.Fatalf("Create(first): %v", err)
+	}
+	if _, err := store.Create(agentruns.CreateRequest{
+		Project:    "demo",
+		Prompt:     "inventory another project",
+		ProviderID: "codex",
+		Mode:       agentruns.ModeReadOnly,
+	}); err != nil {
+		t.Fatalf("Create(second): %v", err)
+	}
+
+	err = requireActiveAgentToolExecutionRun(store, first.ID)
+	if !errors.Is(err, agentruns.ErrNotFound) {
+		t.Fatalf("run recheck error = %v, want %v", err, agentruns.ErrNotFound)
+	}
+	rec := httptest.NewRecorder()
+	writeAgentToolExecutionError(rec, err)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d, body = %s", rec.Code, http.StatusNotFound, rec.Body.String())
+	}
+}

--- a/internal/api/agent_tool_executions_test.go
+++ b/internal/api/agent_tool_executions_test.go
@@ -264,3 +264,39 @@ func TestAgentToolExecutionSanitizesExecutorErrors(t *testing.T) {
 		t.Fatalf("response leaked executor error: %s", rec.Body.String())
 	}
 }
+
+func TestAgentToolExecutionDistinguishesCancellationAndTimeout(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		wantStatus int
+		wantBody   string
+	}{
+		{
+			name:       "request canceled",
+			err:        context.Canceled,
+			wantStatus: http.StatusRequestTimeout,
+			wantBody:   "tool execution request canceled\n",
+		},
+		{
+			name:       "deadline exceeded",
+			err:        context.DeadlineExceeded,
+			wantStatus: http.StatusGatewayTimeout,
+			wantBody:   "tool execution request timed out\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			writeAgentToolExecutionError(rec, test.err)
+
+			if rec.Code != test.wantStatus {
+				t.Fatalf("status = %d, want %d", rec.Code, test.wantStatus)
+			}
+			if rec.Body.String() != test.wantBody {
+				t.Fatalf("body = %q, want %q", rec.Body.String(), test.wantBody)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add an isolated Agent Hub HTTP handler for guarded read-only MCP tool execution
- derive project, provider, run mode, and read-only risk on the server
- require strict JSON and an Idempotency-Key before invoking the guarded executor
- replay validated outcomes without duplicate invocation, including after the run becomes terminal

## Security boundary
- clients cannot submit provider, mode, project, or risk fields
- only read-only routes can reach the executor
- fresh calls require an active run with no pending approvals
- executor errors are mapped to stable responses without exposing internal details
- the handler is not wired into RouterOptions or server startup in this slice

## Validation
- `GOCACHE=/private/tmp/iacstudio-go-cache go test -race ./internal/api -run AgentToolExecution -count=20`
- `GOCACHE=/private/tmp/iacstudio-go-cache go test -race ./internal/api`
- `GOCACHE=/private/tmp/iacstudio-go-cache go vet ./internal/api`
- `git diff --cached --check`

Part of #107.