### PR TITLE
Mount read-only MCP execution route

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -122,6 +122,7 @@ func runServer() error {
 		AgentRuns:         agentRouting.runs,
 		AgentToolPolicies: agentRouting.policies,
 		AgentToolRouter:   agentRouting.router,
+		AgentToolExecutor: agentRouting.executor,
 		AppVersion:        AppVersion,
 	})
 

--- a/internal/api/agent_tool_executions_test.go
+++ b/internal/api/agent_tool_executions_test.go
@@ -121,6 +121,43 @@ func TestAgentToolExecutionUsesServerOwnedReadOnlyScope(t *testing.T) {
 	}
 }
 
+func TestRouterOptionsMountAgentToolExecutionRoute(t *testing.T) {
+	root, store, run := agentToolRouteFixture(t, "codex")
+	result := mcpairlock.NewToolCallResult([]byte("reports\n"), false)
+	fake := &fakeAgentToolExecutor{result: agentrouting.ExecutionResult{
+		Route: agentrouting.RouteResult{
+			Decision: agentrouting.Decision{
+				Status:          agentrouting.DecisionAllowed,
+				Reason:          agentrouting.ReasonAllowed,
+				Allowed:         true,
+				UntrustedOutput: true,
+			},
+			Run: run,
+		},
+		Invoked: true,
+		Result:  &result,
+	}}
+	router := NewRouterWithOptions(nil, nil, nil, nil, root, RouterOptions{
+		AgentRuns:         store,
+		AgentToolExecutor: fake,
+	})
+
+	rec := postAgentToolExecution(
+		router,
+		"demo",
+		run.ID,
+		`{"connection_id":"aws-prod","server_id":"aws","tool_name":"list_buckets","arguments":{}}`,
+		"application/json",
+		"router-option-execution",
+	)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if fake.calls != 1 {
+		t.Fatalf("Execute calls = %d, want one", fake.calls)
+	}
+}
+
 func TestAgentToolExecutionRejectsClientScopeAndInactiveRuns(t *testing.T) {
 	root, store, run := agentToolRouteFixture(t, "codex")
 	fake := &fakeAgentToolExecutor{}

--- a/internal/api/agent_tool_executions_test.go
+++ b/internal/api/agent_tool_executions_test.go
@@ -156,6 +156,29 @@ func TestRouterOptionsMountAgentToolExecutionRoute(t *testing.T) {
 	if fake.calls != 1 {
 		t.Fatalf("Execute calls = %d, want one", fake.calls)
 	}
+	if fake.request.Risk != mcpairlock.RiskReadOnly {
+		t.Fatalf("risk = %v, want RiskReadOnly; RouterOptions path must not weaken the read-only security boundary", fake.request.Risk)
+	}
+}
+
+func TestRouterOptionsOmitsExecutionRouteWithoutExecutor(t *testing.T) {
+	root, store, run := agentToolRouteFixture(t, "codex")
+	router := NewRouterWithOptions(nil, nil, nil, nil, root, RouterOptions{
+		AgentRuns: store,
+		// AgentToolExecutor intentionally absent
+	})
+
+	rec := postAgentToolExecution(
+		router,
+		"demo",
+		run.ID,
+		`{"connection_id":"aws-prod","server_id":"aws","tool_name":"list_buckets","arguments":{}}`,
+		"application/json",
+		"absent-executor",
+	)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d (route must be absent when no executor is configured)", rec.Code, http.StatusNotFound)
+	}
 }
 
 func TestAgentToolExecutionRejectsClientScopeAndInactiveRuns(t *testing.T) {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1054,6 +1054,7 @@ type RouterOptions struct {
 	AgentRuns                *agentruns.Store
 	AgentToolPolicies        AgentToolPolicyStore
 	AgentToolRouter          AgentToolRouter
+	AgentToolExecutor        AgentToolExecutor
 	AgentProviderProfiles    *agentproviderconnections.Manager
 	AppVersion               string
 	LocalAgentProviders      func() []agentproviders.LocalProviderStatus
@@ -1225,6 +1226,7 @@ func NewRouterWithOptions(hub *Hub, fw *watcher.FileWatcher, aiClient *ai.Client
 	registerAgentRunRoutes(mux, projectsDir, agentRuns)
 	registerAgentToolPolicyRoutes(mux, projectsDir, opts.AgentToolPolicies)
 	registerAgentToolRouteRoutes(mux, projectsDir, agentRuns, opts.AgentToolRouter)
+	registerAgentToolExecutionRoutes(mux, projectsDir, agentRuns, opts.AgentToolExecutor)
 
 	// Resource catalog — returns all resources for a tool, optionally filtered by provider
 	mux.HandleFunc("GET /api/catalog", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- expose the guarded read-only MCP execution handler through the production router
- pass the startup-owned Agent Hub executor through `RouterOptions`
- add an integration test proving the production router invokes the configured executor

## Security boundary
- no execution or authorization policy changes
- the endpoint remains absent when no executor is configured
- project, provider, mode, and read-only risk remain server-owned

## Validation
- `GOCACHE=/private/tmp/iacstudio-go-cache go test -race ./internal/api ./cmd/server`
- `GOCACHE=/private/tmp/iacstudio-go-cache go test ./internal/...`
- `GOCACHE=/private/tmp/iacstudio-go-cache go vet ./internal/api ./cmd/server`
- `git diff --check`

Part of #107.